### PR TITLE
Force saucelabs to use varnish rather than squid as a proxy

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -147,7 +147,10 @@ module.exports = function(config) {
     sauceLabs: {
       testName: 'Ably-JS Javascript Tests',
       username: process.env.SAUCE_USERNAME || 'ably',
-      accessKey: process.env.SAUCE_ACCESS_KEY
+      accessKey: process.env.SAUCE_ACCESS_KEY,
+      connectOptions: {
+        vmVersion: 'dev-varnish'
+      }
     },
 
     // start these browsers


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/82.

Before: https://ci.ably.io/job/ably-js-browsers-min/99/consoleFull
After: https://ci.ably.io/job/ably-js-browsers-min/100/console

The tests still fail, but at least now they fail because IE and mobile safari suck, not because some websocket connections randomly fail.

@mattheworiordan @paddybyers 

![untitled](https://cloud.githubusercontent.com/assets/5908687/9083720/86732956-3b64-11e5-9307-3f542ecf41c6.png)
