### PR TITLE
Partial attack on IE11 ci tests

### DIFF
--- a/browser/lib/util/crypto.js
+++ b/browser/lib/util/crypto.js
@@ -12,11 +12,12 @@ var Crypto = (function() {
 	 * @param callback
 	 */
 	var generateRandom;
-	if(window.Uint32Array && window.crypto && window.crypto.getRandomValues) {
+	var browsercrypto = window.crypto || window.msCrypto; // mscrypto for IE11
+	if(window.Uint32Array && browsercrypto && browsercrypto.getRandomValues) {
 		var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
 		generateRandom = function(bytes, callback) {
 			var words = bytes / 4, nativeArray = (words == DEFAULT_BLOCKLENGTH_WORDS) ? blockRandomArray : new Uint32Array(words);
-			window.crypto.getRandomValues(nativeArray);
+			browsercrypto.getRandomValues(nativeArray);
 			callback(null, BufferUtils.toWordArray(nativeArray));
 		};
 	} else {

--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -124,6 +124,11 @@ var CometTransport = (function() {
 				this.recvRequest.abort();
 				this.recvRequest = null;
 			}
+			Transport.prototype.onDisconnect.call(this);
+			var self = this;
+			Utils.nextTick(function() {
+				self.emit('disposed');
+			})
 		}
 	};
 

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -5,10 +5,11 @@ var Transport = (function() {
 
 	/*
 	 * EventEmitter, generates the following events:
-	 * 
+	 *
 	 * event name       data
 	 * closed           error
 	 * failed           error
+	 * disposed
 	 * connected        null error, connectionKey
 	 * event            channel message object
 	 */

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -105,6 +105,7 @@ var WebSocketTransport = (function() {
 		delete this.wsConnection;
 		var err = wasClean ? null : new ErrorInfo('Unclean disconnection of websocket', 80003);
 		Transport.prototype.onDisconnect.call(this, err);
+		this.emit('disposed');
 	};
 
 	WebSocketTransport.prototype.onWsError = function(err) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -156,6 +156,7 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: Object.keys(customLaunchers),
+    captureTimeout: 360000,
     browserNoActivityTimeout: 3600000,
     customLaunchers: customLaunchers,
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
     sl_ie_11: {
       base: 'SauceLabs',
       browserName: 'internet explorer',
-      platform: 'Windows 8.1',
+      platform: 'Windows 10',
       version: '11'
     },
     sl_ie_10: {

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -3,8 +3,8 @@
 /* Shared test helper for the Jasmine test suite that simplifies
    the dependencies by providing common methods in a single dependency */
 
-define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module', 'spec/common/modules/testdata_module'],
-  function(testAppModule, clientModule, testDataModule) {
+define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module', 'spec/common/modules/testdata_module', 'async'],
+  function(testAppModule, clientModule, testDataModule, async) {
     var displayError = function(err) {
       if(typeof(err) == 'string')
         return err;
@@ -18,6 +18,58 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
         result += JSON.stringify(err.message);
 
       return result;
+    };
+
+    var monitorConnection = function(test, realtime) {
+      ['failed', 'suspended'].forEach(function(state) {
+        realtime.connection.on(state, function () {
+          test.ok(false, 'connection to server ' + state);
+          test.done();
+          realtime.close();
+        });
+      });
+    };
+
+    var closeAndFinish = function(test, realtime) {
+      if(typeof realtime === 'undefined') {
+        // Likely called in a catch block for an exception
+        // that occured before realtime was initialised
+        test.done();
+        return;
+      }
+      if(Object.prototype.toString.call(realtime) == '[object Array]') {
+        closeAndFinishSeveral(test, realtime);
+        return;
+      }
+      callbackOnClose(realtime, function(){ test.done(); })
+    };
+
+    function callbackOnClose(realtime, callback) {
+      if(realtime.connection.connectionManager.transport === null) {
+        console.log("No transport established; closing connection and calling test.done()")
+        realtime.close();
+        callback();
+        return;
+      }
+      realtime.connection.connectionManager.transport.on('disposed', function() {
+        console.log("Transport disposed; calling test.done()")
+        callback();
+      });
+      realtime.close();
+    }
+
+    function closeAndFinishSeveral(test, realtimeArray) {
+      async.map(realtimeArray, function(realtime, mapCb){
+        var parallelItem = function(parallelCb) {
+          callbackOnClose(realtime, function(){ parallelCb(); })
+        };
+        mapCb(null, parallelItem)
+      }, function(err, parallelItems) {
+        async.parallel(parallelItems, function() {
+          test.done();
+        });
+      }
+     )
     };
 
     /* Wraps all tests with a timeout so that they don't run indefinitely */
@@ -58,7 +110,9 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 
       loadTestData: testDataModule.loadTestData,
 
-      displayError: displayError,
-      withTimeout:  withTimeout
+      displayError:      displayError,
+      monitorConnection: monitorConnection,
+      closeAndFinish:    closeAndFinish,
+      withTimeout:       withTimeout
     };
   });

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -74,7 +74,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 
     /* Wraps all tests with a timeout so that they don't run indefinitely */
     var withTimeout = function(exports, defaultTimeout) {
-      var timeout = defaultTimeout || 25 * 1000;
+      var timeout = defaultTimeout || 60 * 1000;
 
       for (var needle in exports) {
         if (exports.hasOwnProperty(needle)) {

--- a/spec/realtime/channel.test.js
+++ b/spec/realtime/channel.test.js
@@ -2,7 +2,9 @@
 
 define(['ably', 'shared_helper'], function(Ably, helper) {
 	var exports = {},
-		displayError = helper.displayError;
+		displayError = helper.displayError,
+		closeAndFinish = helper.closeAndFinish,
+		monitorConnection = helper.monitorConnection;
 
 	exports.setupauth = function(test) {
 		test.expect(1);
@@ -32,22 +34,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 						test.ok(false, 'Attach failed with error: ' + err);
 					else
 						test.ok(true, 'Attach to channel 0 with no options');
-					test.done();
-					realtime.close();
+					closeAndFinish(test, realtime);
 				});
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function () {
-					test.ok(false, transport + ' connection to server failed');
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
+			closeAndFinish(test, realtime);
 		}
 	};
 
@@ -67,26 +60,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 						test.ok(false, 'Attach failed with error: ' + err);
 					else
 						test.ok(true, 'Attach to channel1 with no options');
-
-					setTimeout(function() {
-						test.done();
-
-					}, 3000);
-					realtime.close();
+					closeAndFinish(test, realtime);
 				});
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function () {
-					test.ok(false, transport + ' connection to server failed');
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
+			closeAndFinish(test, realtime);
 		}
 	};
 
@@ -105,21 +85,12 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					test.ok(false, 'Attach failed with error: ' + err);
 				else
 					test.ok(true, 'Attach to channel 0 with no options');
-				test.done();
-				realtime.close();
+				closeAndFinish(test, realtime);
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function () {
-					test.ok(false, transport + ' connection to server failed');
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
+			closeAndFinish(test, realtime);
 		}
 	};
 
@@ -137,36 +108,25 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				channel0.attach(function(err) {
 					if(err) {
 						test.ok(false, 'Attach failed with error: ' + err);
-						test.done();
-						realtime.close();
+						closeAndFinish(test, realtime);
 					}
 					channel0.detach(function(err) {
 						if(err) {
 							test.ok(false, 'Detach failed with error: ' + err);
-							test.done();
-							realtime.close();
+							closeAndFinish(test, realtime);
 						}
 						if(channel0.state == 'detached')
 							test.ok(true, 'Attach then detach to channel 0 with no options');
 						else
 							test.ok(false, 'Detach failed: State is '+channel0.state);
-						test.done();
-						realtime.close();
+						closeAndFinish(test, realtime);
 					});
 				});
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function () {
-					test.ok(false, transport + ' connection to server failed');
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
+			closeAndFinish(test, realtime);
 		}
 	};
 
@@ -186,28 +146,18 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 						test.ok(true, 'Attach failed as expected');
 						setTimeout(function() {
 							test.ok(realtime.connection.state === 'connected', 'Client should still be connected');
-							realtime.close();
-							test.done();
+							closeAndFinish(test, realtime);
 						}, 1000);
 						return;
 					}
 					test.ok(false, 'Unexpected attach success');
-					test.done();
+					closeAndFinish(test, realtime);
 				});
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function () {
-					test.ok(false, 'Connection to server ' + state);
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
-			realtime.close();
+			closeAndFinish(test, realtime);
 		}
 	};
 
@@ -226,28 +176,18 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 						test.ok(true, 'Attach failed as expected');
 						setTimeout(function() {
 							test.ok(realtime.connection.state === 'connected', 'Client should still be connected');
-							realtime.close();
-							test.done();
+							closeAndFinish(test, realtime);
 						}, 1000);
 						return;
 					}
 					test.ok(false, 'Unexpected attach success');
-					test.done();
+					closeAndFinish(test, realtime);
 				});
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function () {
-					test.ok(false, 'Connection to server ' + state);
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
-			realtime.close();
+			closeAndFinish(test, realtime);
 		}
 	};
 
@@ -271,33 +211,23 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 								test.ok(true, 'Attach (second attempt) failed as expected');
 								setTimeout(function() {
 									test.ok(realtime.connection.state === 'connected', 'Client should still be connected');
-									realtime.close();
-									test.done();
+									closeAndFinish(test, realtime);
 								}, 1000);
 								return;
 							}
 							test.ok(false, 'Unexpected attach (second attempt) success');
-							test.done();
+							closeAndFinish(test, realtime);
 						});
 						return;
 					}
 					test.ok(false, 'Unexpected attach success');
-					test.done();
+					closeAndFinish(test, realtime);
 				});
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function(stateChange) {
-					test.ok(false, 'Connection to server ' + state + '; reason = ' + stateChange.reason.message);
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
-			realtime.close();
+			closeAndFinish(test, realtime);
 		}
 	};
 
@@ -318,22 +248,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 							test.ok(false, 'Attach failed with error: ' + err);
 						else
 							test.ok(true, 'Attach to channel 3 with no options');
-						test.done();
-						realtime.close();
+						closeAndFinish(test, realtime);
 					});
 				});
-				var exitOnState = function(state) {
-					realtime.connection.on(state, function () {
-						test.ok(false, transport + ' connection to server failed');
-						test.done();
-						realtime.close();
-					});
-				};
-				exitOnState('failed');
-				exitOnState('suspended');
+				monitorConnection(test, realtime);
 			} catch(e) {
 				test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-				test.done();
+				closeAndFinish(test, realtime);
 			}
 		};
 
@@ -351,37 +272,26 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					channel5.attach(function(err) {
 						if(err) {
 							test.ok(false, 'Attach failed with error: ' + err);
-							test.done();
-							realtime.close();
+							closeAndFinish(test, realtime);
 						}
 						/* we can't get a callback on a detach, so set a timeout */
 						channel5.detach(function(err) {
 							if(err) {
 								test.ok(false, 'Attach failed with error: ' + err);
-								test.done();
-								realtime.close();
+								closeAndFinish(test, realtime);
 							}
 							if(channel5.state == 'detached')
 								test.ok(true, 'Attach then detach to channel 0 with no options');
 							else
 								test.ok(false, 'Detach failed');
-							test.done();
-							realtime.close();
+							closeAndFinish(test, realtime);
 						});
 					});
 				});
-				var exitOnState = function(state) {
-					realtime.connection.on(state, function () {
-						test.ok(false, transport + ' connection to server failed');
-						test.done();
-						realtime.close();
-					});
-				};
-				exitOnState('failed');
-				exitOnState('suspended');
+				monitorConnection(test, realtime);
 			} catch(e) {
 				test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-				test.done();
+				closeAndFinish(test, realtime);
 			}
 		};
 
@@ -401,22 +311,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 							test.ok(false, 'Attach failed with error: ' + err);
 						else
 							test.ok(true, 'Attach to channel 3 with no options');
-						test.done();
-						realtime.close();
+						closeAndFinish(test, realtime);
 					});
 				});
-				var exitOnState = function(state) {
-					realtime.connection.on(state, function () {
-						test.ok(false, transport + ' connection to server failed');
-						test.done();
-						realtime.close();
-					});
-				};
-				exitOnState('failed');
-				exitOnState('suspended');
+				monitorConnection(test, realtime);
 			} catch(e) {
 				test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-				test.done();
+				closeAndFinish(test, realtime);
 			}
 		};
 
@@ -434,37 +335,26 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					channel5.attach(function(err) {
 						if(err) {
 							test.ok(false, 'Attach failed with error: ' + err);
-							test.done();
-							realtime.close();
+							closeAndFinish(test, realtime);
 						}
 						/* we can't get a callback on a detach, so set a timeout */
 						channel5.detach(function(err) {
 							if(err) {
 								test.ok(false, 'Attach failed with error: ' + err);
-								test.done();
-								realtime.close();
+								closeAndFinish(test, realtime);
 							}
 							if(channel5.state == 'detached')
 								test.ok(true, 'Attach then detach to channel 0 with no options');
 							else
 								test.ok(false, 'Detach failed');
-							test.done();
-							realtime.close();
+							closeAndFinish(test, realtime);
 						});
 					});
 				});
-				var exitOnState = function(state) {
-					realtime.connection.on(state, function () {
-						test.ok(false, transport + ' connection to server failed');
-						test.done();
-						realtime.close();
-					});
-				};
-				exitOnState('failed');
-				exitOnState('suspended');
+				monitorConnection(test, realtime);
 			} catch(e) {
 				test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-				test.done();
+				closeAndFinish(test, realtime);
 			}
 		};
 	} else {
@@ -484,22 +374,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 							test.ok(false, 'Attach failed with error: ' + err);
 						else
 							test.ok(true, 'Attach to channel 3 with no options');
-						test.done();
-						realtime.close();
+						closeAndFinish(test, realtime);
 					});
 				});
-				var exitOnState = function(state) {
-					realtime.connection.on(state, function () {
-						test.ok(false, transport + ' connection to server failed');
-						test.done();
-						realtime.close();
-					});
-				};
-				exitOnState('failed');
-				exitOnState('suspended');
+				monitorConnection(test, realtime);
 			} catch(e) {
 				test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-				test.done();
+				closeAndFinish(test, realtime);
 			}
 		};
 
@@ -517,37 +398,26 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					channel5.attach(function(err) {
 						if(err) {
 							test.ok(false, 'Attach failed with error: ' + err);
-							test.done();
-							realtime.close();
+							closeAndFinish(test, realtime);
 						}
 						/* we can't get a callback on a detach, so set a timeout */
 						channel5.detach(function(err) {
 							if(err) {
 								test.ok(false, 'Attach failed with error: ' + err);
-								test.done();
-								realtime.close();
+								closeAndFinish(test, realtime);
 							}
 							if(channel5.state == 'detached')
 								test.ok(true, 'Attach then detach to channel 0 with no options');
 							else
 								test.ok(false, 'Detach failed');
-							test.done();
-							realtime.close();
+							closeAndFinish(test, realtime);
 						});
 					});
 				});
-				var exitOnState = function(state) {
-					realtime.connection.on(state, function () {
-						test.ok(false, transport + ' connection to server failed');
-						test.done();
-						realtime.close();
-					});
-				};
-				exitOnState('failed');
-				exitOnState('suspended');
+				monitorConnection(test, realtime);
 			} catch(e) {
 				test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-				test.done();
+				closeAndFinish(test, realtime);
 			}
 		};
 	}
@@ -566,8 +436,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				channel6.attach(function(err) {
 					if(err) {
 						test.ok(false, 'Attach failed with error: ' + err);
-						test.done();
-						realtime.close();
+						closeAndFinish(test, realtime);
 					}
 					try {
 						channel6.subscribe('event0', function() {});
@@ -575,33 +444,22 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 							try {
 								channel6.unsubscribe('event0', function() {});
 								test.ok(true, 'Subscribe then unsubscribe to channel6:event0 with no options');
-								test.done();
-								realtime.close();
+								closeAndFinish(test, realtime);
 							} catch(e) {
 								test.ok(false, 'Unsubscribe failed with error: ' + e.stack);
-								test.done();
-								realtime.close();
+								closeAndFinish(test, realtime);
 							}
 						}, 1000);
 					} catch(e) {
 						test.ok(false, 'Subscribe failed with error: ' + e);
-						test.done();
-						realtime.close();
+						closeAndFinish(test, realtime);
 					}
 				});
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function () {
-					test.ok(false, transport + ' connection to server failed');
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
+			closeAndFinish(test, realtime);
 		}
 	};
 

--- a/spec/realtime/crypto.test.js
+++ b/spec/realtime/crypto.test.js
@@ -354,7 +354,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var realtime = helper.AblyRealtime({ transports: ['web_socket'], useTextProtocol: text });
+		var realtime = helper.AblyRealtime({ transports: ['web_socket'], useBinaryProtocol: !text});
 		test.expect(iterations + 2);
 		var channelName = 'multiple_send_' + (text ? 'text_' : 'binary_') + iterations + '_' + delay,
 			channel = realtime.channels.get(channelName),

--- a/spec/realtime/crypto.test.js
+++ b/spec/realtime/crypto.test.js
@@ -6,7 +6,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		BufferUtils = Ably.Realtime.BufferUtils,
 		Crypto = Ably.Realtime.Crypto,
 		Message = Ably.Realtime.Message,
-		assetPath = (isBrowser && window.__karma__ && window.__karma__.start ? 'base/' : '') + 'spec/realtime/assets/';
+		assetPath = (isBrowser && window.__karma__ && window.__karma__.start ? 'base/' : '') + 'spec/realtime/assets/',
+		closeAndFinish = helper.closeAndFinish,
+		monitorConnection = helper.monitorConnection;
 
 	function attachChannels(channels, callback) {
 		async.map(channels, function(channel, cb) { channel.attach(cb); }, callback);
@@ -53,8 +55,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			Crypto.getDefaultParams(key, function(err, params) {
 				if(err) {
-					realtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, realtime);
 					return;
 				}
 				params.iv = iv;
@@ -76,8 +78,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					/* compare */
 					test.ok(compareMessage(testMessage, encryptedMessage));
 				}
-				test.done();
-				realtime.close();
+				closeAndFinish(test, realtime);
 			});
 		});
 	};
@@ -101,8 +102,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			Crypto.getDefaultParams(key, function(err, params) {
 				if(err) {
-					realtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, realtime);
 					return;
 				}
 				params.iv = iv;
@@ -124,8 +125,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					/* compare */
 					test.ok(compareMessage(testMessage, encryptedMessage));
 				}
-				test.done();
-				realtime.close();
+				closeAndFinish(test, realtime);
 			});
 		});
 	};
@@ -148,8 +148,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			Crypto.getDefaultParams(key, function(err, params) {
 				if(err) {
-					realtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, realtime);
 					return;
 				}
 				channel.setOptions({encrypted:true, cipherParams: params});
@@ -169,8 +169,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					/* compare */
 					test.ok(compareMessage(testMessage, encryptedMessage));
 				}
-				test.done();
-				realtime.close();
+				closeAndFinish(test, realtime);
 			});
 		});
 	};
@@ -193,8 +192,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			Crypto.getDefaultParams(key, function(err, params) {
 				if(err) {
-					realtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, realtime);
 					return;
 				}
 				channel.setOptions({encrypted:true, cipherParams: params});
@@ -214,8 +213,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					/* compare */
 					test.ok(compareMessage(testMessage, encryptedMessage));
 				}
-				test.done();
-				realtime.close();
+				closeAndFinish(test, realtime);
 			});
 		});
 	};
@@ -237,8 +235,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		Crypto.getDefaultParams(function(err, params) {
 			if(err) {
-				realtime.close();
 				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				closeAndFinish(test, realtime);
 				return;
 			}
 
@@ -246,8 +244,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			channel.setOptions({encrypted:true, cipherParams: params});
 			channel.subscribe('event0', function(msg) {
 				test.ok(msg.data == messageText);
-				realtime.close();
-				test.done();
+				closeAndFinish(test, realtime);
 			});
 			channel.publish('event0', messageText);
 		});
@@ -271,15 +268,14 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		Crypto.getDefaultParams(function(err, params) {
 			test.equal(params.algorithm, 'aes-128');
 			if(err) {
-				realtime.close();
 				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				closeAndFinish(test, realtime);
 				return;
 			}
 			channel.setOptions({encrypted:true, cipherParams: params});
 			channel.subscribe('event0', function(msg) {
 				test.ok(msg.data == messageText);
-				realtime.close();
-				test.done();
+				closeAndFinish(test, realtime);
 			});
 			channel.publish('event0', messageText);
 		});
@@ -304,15 +300,14 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			Crypto.getDefaultParams(key, function(err, params) {
 				test.equal(params.algorithm, 'aes-256');
 				if(err) {
-					realtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, realtime);
 					return;
 				}
 				channel.setOptions({encrypted:true, cipherParams: params});
 				channel.subscribe('event0', function(msg) {
 					test.ok(msg.data == messageText);
-					realtime.close();
-					test.done();
+					closeAndFinish(test, realtime);
 				});
 				channel.publish('event0', messageText);
 			});
@@ -338,15 +333,14 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			Crypto.getDefaultParams(key, function(err, params) {
 				test.equal(params.algorithm, 'aes-256');
 				if(err) {
-					realtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, realtime);
 					return;
 				}
 				channel.setOptions({encrypted:true, cipherParams: params});
 				channel.subscribe('event0', function(msg) {
 					test.ok(msg.data == messageText);
-					realtime.close();
-					test.done();
+					closeAndFinish(test, realtime);
 				});
 				channel.publish('event0', messageText);
 			});
@@ -370,8 +364,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			Crypto.getDefaultParams(key, function(err, params) {
 				test.equal(params.algorithm, 'aes-128');
 				if(err) {
-					realtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, realtime);
 					return;
 				}
 				channel.setOptions({encrypted:true, cipherParams: params});
@@ -397,13 +391,10 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				}
 				async.parallel([sendAll, recvAll], function(err) {
 					if(err) {
-						realtime.close();
 						test.ok(false, 'Error sending messages; err = ' + err);
-						return;
 					}
 					test.ok('Verify all messages received');
-					realtime.close();
-					test.done();
+					closeAndFinish(test, realtime);
 				});
 			});
 		});
@@ -439,9 +430,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			function(cb) { attachChannels([txChannel, rxChannel], cb); }
 		], function(err, res) {
 			if (err) {
-				rxRealtime.close();
-				txRealtime.close();
 				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
 			var params = res[0];
@@ -452,9 +442,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			rxChannel.subscribe('event0', function(msg) {
 				test.ok(msg.data == messageText);
-				rxRealtime.close();
-				txRealtime.close();
-				test.done();
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 			});
 			txChannel.publish('event0', messageText);
 		});
@@ -485,9 +473,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			function(cb) { attachChannels([txChannel, rxChannel], cb); }
 		], function(err, res) {
 			if (err) {
-				rxRealtime.close();
-				txRealtime.close();
 				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
 			var params = res[0];
@@ -498,9 +485,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			rxChannel.subscribe('event0', function(msg) {
 				test.ok(msg.data == messageText);
-				rxRealtime.close();
-				txRealtime.close();
-				test.done();
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 			});
 			txChannel.publish('event0', messageText);
 		});
@@ -533,9 +518,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			function(cb) { attachChannels([txChannel, rxChannel], cb); }
 		], function(err, res) {
 			if(err) {
-				rxRealtime.close();
-				txRealtime.close();
 				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
 			var txParams = res[0],
@@ -545,9 +529,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			rxChannel.setOptions({encrypted:true, cipherParams: rxParams});
 			rxChannel.subscribe('event0', function(msg) {
 				test.ok(msg.data != messageText);
-				rxRealtime.close();
-				txRealtime.close();
-				test.done();
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 			});
 			txChannel.publish('event0', messageText);
 		});
@@ -575,24 +557,20 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		attachChannels([txChannel, rxChannel], function(err) {
 			if(err) {
-				rxRealtime.close();
-				txRealtime.close();
 				test.ok(false, 'Unable to get attach channels; err = ' + err);
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
 			Crypto.getDefaultParams(function(err, rxParams) {
 				if(err) {
-					rxRealtime.close();
-					txRealtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, [txRealtime, rxRealtime]);
 					return;
 				}
 				rxChannel.setOptions({encrypted:true, cipherParams: rxParams});
 				rxChannel.subscribe('event0', function(msg) {
 					test.ok(msg.data == messageText);
-					rxRealtime.close();
-					txRealtime.close();
-					test.done();
+					closeAndFinish(test, [txRealtime, rxRealtime]);
 				});
 				txChannel.publish('event0', messageText);
 			});
@@ -621,24 +599,20 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		attachChannels([txChannel, rxChannel], function(err) {
 			if(err) {
-				rxRealtime.close();
-				txRealtime.close();
 				test.ok(false, 'Unable to get attach channels; err = ' + err);
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
 			Crypto.getDefaultParams(function(err, txParams) {
 				if(err) {
-					rxRealtime.close();
-					txRealtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, [txRealtime, rxRealtime]);
 					return;
 				}
 				txChannel.setOptions({encrypted:true, cipherParams: txParams});
 				rxChannel.subscribe('event0', function(msg) {
 					test.ok(msg.encoding.indexOf('cipher') > -1);
-					rxRealtime.close();
-					txRealtime.close();
-					test.done();
+					closeAndFinish(test, [txRealtime, rxRealtime]);
 				});
 				txChannel.publish('event0', messageText);
 			});
@@ -671,9 +645,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		var setInitialOptions = function(cb) {
 			Crypto.getDefaultParams(function(err, params) {
 				if(err) {
-					rxRealtime.close();
-					txRealtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, [txRealtime, rxRealtime]);
 					return;
 				}
 				firstParams = params;
@@ -696,9 +669,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		var createSecondKey = function(cb) {
 			Crypto.getDefaultParams(function(err, params) {
 				if(err) {
-					rxRealtime.close();
-					txRealtime.close();
 					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					closeAndFinish(test, [txRealtime, rxRealtime]);
 					return;
 				}
 				secondParams = params;
@@ -744,14 +716,10 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		], function(err) {
 			if(err) {
 				test.ok(false, 'Unexpected error running test; err = ' + err);
-				rxRealtime.close();
-				txRealtime.close();
-				test.done();
+				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
-			rxRealtime.close();
-			txRealtime.close();
-			test.done();
+			closeAndFinish(test, [txRealtime, rxRealtime]);
 		});
 	};
 

--- a/spec/realtime/crypto.test.js
+++ b/spec/realtime/crypto.test.js
@@ -356,7 +356,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		var realtime = helper.AblyRealtime({ transports: ['web_socket'], useTextProtocol: text });
 		test.expect(iterations + 2);
-		var channelName = 'multiple_send_' + iterations + '_' + delay,
+		var channelName = 'multiple_send_' + (text ? 'text_' : 'binary_') + iterations + '_' + delay,
 			channel = realtime.channels.get(channelName),
 			messageText = 'Test message (' + channelName + ')';
 

--- a/spec/realtime/event_emitter.test.js
+++ b/spec/realtime/event_emitter.test.js
@@ -2,7 +2,9 @@
 
 define(['ably', 'shared_helper'], function(Ably, helper) {
 	var exports = {},
-	displayError = helper.displayError;
+	displayError = helper.displayError,
+	closeAndFinish = helper.closeAndFinish,
+	monitorConnection = helper.monitorConnection;
 
 	exports.setupauth = function(test) {
 		test.expect(1);
@@ -42,7 +44,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					delete expectedConnectionEvents[index];
 					test.ok(true, this.event + ' connection event received');
 					if(this.event == 'closed') {
-						test.done();
+						closeAndFinish(test, realtime);
 					}
 				} else {
 					test.ok(false, 'Unexpected ' + this.event + ' event received');
@@ -71,23 +73,14 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				channel.attach(function(err) {
 					if(err) {
 						test.ok(false, 'Attach failed with error: ' + err);
-						test.done();
-						realtime.close();
+						closeAndFinish(test, realtime);
 					}
 				});
 			});
-			var exitOnState = function(state) {
-				realtime.connection.on(state, function () {
-					test.ok(false, transport + ' connection to server failed');
-					test.done();
-					realtime.close();
-				});
-			};
-			exitOnState('failed');
-			exitOnState('suspended');
+			monitorConnection(test, realtime);
 		} catch(e) {
 			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-			test.done();
+			closeAndFinish(test, realtime);
 		}
 	};
 

--- a/spec/realtime/message.test.js
+++ b/spec/realtime/message.test.js
@@ -3,6 +3,8 @@
 define(['ably', 'shared_helper'], function(Ably, helper) {
   var exports = {},
     displayError = helper.displayError,
+    closeAndFinish = helper.closeAndFinish,
+    monitorConnection = helper.monitorConnection,
     publishAtIntervals = function(numMessages, channel, dataFn, onPublish){
       for(var i = numMessages; i > 0; i--) {
         var helper = function(currentMessageNum) {
@@ -44,8 +46,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
         rtChannel.attach(function(err) {
           if(err) {
             test.ok(false, 'Attach failed with error: ' + err);
-            test.done();
-            realtime.close();
+            closeAndFinish(test, realtime);
             return;
           }
 
@@ -53,8 +54,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
           rtChannel.subscribe('event0', function(msg) {
             test.ok(true, 'Received event0');
             test.equal(msg.data, testMsg, 'Unexpected msg text received');
-            test.done();
-            realtime.close();
+            closeAndFinish(test, realtime);
           });
 
           /* publish event */
@@ -62,19 +62,10 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
           restChannel.publish('event0', testMsg);
         });
       });
-      var exitOnState = function(state) {
-        realtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          test.done();
-          realtime.close();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, realtime);
     } catch(e) {
       test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-      test.done();
-      realtime.close();
+      closeAndFinish(test, realtime);
     }
   };
 
@@ -84,8 +75,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
     var errorCallback = function(err){
       if(err) {
         test.ok(false, 'Error received by publish callback ' + err);
-        test.done();
-        realtime.close();
+        closeAndFinish(test, realtime);
         return;
       }
     };
@@ -123,8 +113,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
         rtChannel.attach(function(err) {
           if(err) {
             test.ok(false, 'Attach failed with error: ' + err);
-            test.done();
-            realtime.close();
+            closeAndFinish(test, realtime);
             return;
           }
 
@@ -167,13 +156,11 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
                 break;
               default:
                 test.ok(false, 'Unexpected message ' + msg.name + 'received');
-                test.done();
-                realtime.close();
+                closeAndFinish(test, realtime);
             }
 
             if (messagesReceived == testArguments.length) {
-              test.done();
-              realtime.close();
+              closeAndFinish(test, realtime);
             }
           });
 
@@ -184,19 +171,10 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
           }
         });
       });
-      var exitOnState = function(state) {
-        realtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          test.done();
-          realtime.close();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, realtime);
     } catch(e) {
       test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-      test.done();
-      realtime.close();
+      closeAndFinish(test, realtime);
     }
   };
 
@@ -224,8 +202,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
         rtChannel.attach(function(err) {
           if(err) {
             test.ok(false, 'Attach failed with error: ' + err);
-            test.done();
-            realtime.close();
+            closeAndFinish(test, realtime);
             return;
           }
 
@@ -240,23 +217,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
               test.equal(e.code, 40011, "Invalid data type exception raised");
             }
           }
-          test.done();
-          realtime.close();
+          closeAndFinish(test, realtime);
         });
       });
-      var exitOnState = function(state) {
-        realtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          test.done();
-          realtime.close();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, realtime);
     } catch(e) {
       test.ok(false, 'Channel attach failed with exception: ' + e.stack);
-      test.done();
-      realtime.close();
+      closeAndFinish(test, realtime);
     }
   };
 
@@ -273,9 +240,8 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
       test.ok(true, 'Received event0');
       test.notEqual(-1, messagesSent.indexOf(msg.data), 'Received unexpected message text');
       if(!--count) {
-        realtime.close();
         clearInterval(timer);
-        test.done();
+        closeAndFinish(test, realtime);
       }
     });
     var timer = setInterval(function() {
@@ -291,8 +257,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
     var cbCount = 10;
     var checkFinish = function() {
       if(count <= 0 && cbCount <= 0) {
-        test.done();
-        realtime.close();
+        closeAndFinish(test, realtime);
       }
     };
     var onPublish = function() {
@@ -318,8 +283,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
       var cbCount = 5;
       var checkFinish = function() {
         if(count <= 0 && cbCount <= 0) {
-          test.done();
-          realtime.close();
+          closeAndFinish(test, realtime);
         }
       };
       var onPublish = function() {
@@ -344,8 +308,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
       var cbCount = 5;
       var checkFinish = function() {
         if(count <= 0 && cbCount <= 0) {
-          test.done();
-          realtime.close();
+          closeAndFinish(test, realtime);
         }
       };
       var onPublish = function() {
@@ -370,8 +333,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
       var cbCount = 5;
       var checkFinish = function() {
         if(count <= 0 && cbCount <= 0) {
-          test.done();
-          realtime.close();
+          closeAndFinish(test, realtime);
         }
       };
       var onPublish = function() {

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -1073,16 +1073,18 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           monitorConnection(test, clientRealtime2);
         }
       ], function() {
-        clientChannel2.presence.get(function(err, members) {
-          if(err) {
-            test.ok(false, 'Presence.get() failed with error: ' + err);
+        setTimeout(function(){
+          clientChannel2.presence.get(function(err, members) {
+            if(err) {
+              test.ok(false, 'Presence.get() failed with error: ' + err);
+              done();
+              return;
+            }
+            test.equal(members.length, 2, 'Verify both members present');
+            test.notEqual(members[0].connectionId, members[1].connectionId, 'Verify members have distinct connectionIds');
             done();
-            return;
-          }
-          test.equal(members.length, 2, 'Verify both members present');
-          test.notEqual(members[0].connectionId, members[1].connectionId, 'Verify members have distinct connectionIds');
-          done();
-        });
+          });
+        }, 500);
       });
     } catch(e) {
       test.ok(false, 'presence.member0 failed with exception: ' + e.stack);

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -2,7 +2,9 @@
 
 define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
   var exports = {},
-      displayError = helper.displayError;
+    displayError = helper.displayError,
+    closeAndFinish = helper.closeAndFinish,
+    monitorConnection = helper.monitorConnection;
 
   var rest, realtime, authToken, authToken2;
   var testClientId = 'testclient', testClientId2 = 'testclient2';
@@ -79,15 +81,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
                 cb(err);
               });
             });
-            var exitOnState = function(state) {
-              realtime.connection.on(state, function () {
-                test.ok(false, transport + ' connection to server failed');
-                realtime.close();
-                cb(new Error('Connection to server failed'));
-              });
-            };
-            exitOnState('failed');
-            exitOnState('suspended');
+            monitorConnection(test, realtime);
           } catch(err) {
             test.ok(false, 'Test failed with exception: ' + err.stack);
             cb(err);
@@ -108,7 +102,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -147,14 +141,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.enter0 failed with exception: ' + e.stack);
       done();
@@ -170,7 +157,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -201,14 +188,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           test.ok(true, 'Presence event sent');
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.enter1 failed with exception: ' + e.stack);
       done();
@@ -224,7 +204,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -253,14 +233,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
         }
         test.ok(true, 'Presence event sent');
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.enter2 failed with exception: ' + e.stack);
       done();
@@ -277,7 +250,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -329,14 +302,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           /* done() is called in presence event handler */
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.enter3 failed with exception: ' + e.stack);
       done();
@@ -352,7 +318,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -391,14 +357,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.enter4 failed with exception: ' + e.stack);
       done();
@@ -414,7 +373,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -446,14 +405,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           clientChannel.presence.enter();
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.enter5 failed with exception: ' + e.stack);
       done();
@@ -469,7 +421,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -501,14 +453,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           clientChannel.presence.enter('Test client data (enter6)');
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.enter6 failed with exception: ' + e.stack);
       done();
@@ -524,7 +469,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -572,14 +517,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.leave0 failed with exception: ' + e.stack);
       done();
@@ -595,7 +533,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -645,14 +583,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.update0 failed with exception: ' + e.stack);
       done();
@@ -668,7 +599,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -716,14 +647,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.get0 failed with exception: ' + e.stack);
       done();
@@ -739,7 +663,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -801,14 +725,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.get1 failed with exception: ' + e.stack);
       done();
@@ -824,7 +741,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -886,14 +803,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       test.ok(false, 'presence.history0 failed with exception: ' + e.stack);
       done();
@@ -1016,7 +926,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime1.close(); clientRealtime2.close();
+          closeAndFinish(test, [clientRealtime1, clientRealtime2]);
         }, 3000);
       }
     };
@@ -1074,27 +984,12 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
                   });
                 });
               });
-              var exitOnState = function(state) {
-                clientRealtime2.connection.on(state, function () {
-                  test.ok(false, transport + ' connection to server failed');
-                  done();
-                });
-              };
-              exitOnState('failed');
-              exitOnState('suspended');
-
+              monitorConnection(test, clientRealtime2);
             });
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime1.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime1);
     } catch(e) {
       test.ok(false, 'presence.attach0 failed with exception: ' + e.stack);
       done();
@@ -1111,7 +1006,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime1.close(); clientRealtime2.close();
+          closeAndFinish(test, [clientRealtime1, clientRealtime2]);
         }, 3000);
       }
     };
@@ -1121,6 +1016,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       async.parallel([
         function(cb1) {
           var transport = 'web_socket';
+          var data = 'Test client data (member0-1)';
           clientRealtime1 = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
           clientRealtime1.connection.on('connected', function() {
             /* get channel, attach, and enter */
@@ -1131,28 +1027,25 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
                 cb1(err);
                 return;
               }
-              clientChannel1.presence.enter('Test client data (member0-1)', function(err) {
+              clientChannel1.presence.on('enter', function(presenceEvent){
+                if(presenceEvent.data == data)
+                  cb1();
+              });
+              clientChannel1.presence.enter(data, function(err) {
                 if(err) {
                   test.ok(false, 'Enter failed with error: ' + err);
                   cb1(err);
                   return;
                 }
                 test.ok(true, 'Presence event sent');
-                cb1(null);
               });
             });
           });
-          var exitOnState = function(state) {
-            clientRealtime1.connection.on(state, function (err) {
-              test.ok(false, transport + ' connection to server failed');
-              cb1(err);
-            });
-          };
-          exitOnState('failed');
-          exitOnState('suspended');
+          monitorConnection(test, clientRealtime1);
         },
         function(cb2) {
           var transport = 'web_socket';
+          var data = 'Test client data (member0-2)';
           clientRealtime2 = helper.AblyRealtime({ clientId: testClientId2, authToken: authToken2, transports: [transport] });
           clientRealtime2.connection.on('connected', function() {
             /* get channel, attach */
@@ -1163,31 +1056,27 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
                 cb2(err);
                 return;
               }
-              clientChannel2.presence.enter('Test client data (member0-2)', function(err) {
+              clientChannel2.presence.on('enter', function(presenceEvent){
+                if(presenceEvent.data == data)
+                  cb2();
+              });
+              clientChannel2.presence.enter(data, function(err) {
                 if(err) {
                   test.ok(false, 'Enter failed with error: ' + err);
                   cb2(err);
                   return;
                 }
                 test.ok(true, 'Presence event sent');
-                cb2(null);
               });
             });
           });
-          var exitOnState = function(state) {
-            clientRealtime2.connection.on(state, function (err) {
-              test.ok(false, transport + ' connection to server failed');
-              cb2(err);
-            });
-          };
-          exitOnState('failed');
-          exitOnState('suspended');
+          monitorConnection(test, clientRealtime2);
         }
       ], function() {
         clientChannel2.presence.get(function(err, members) {
           if(err) {
             test.ok(false, 'Presence.get() failed with error: ' + err);
-            test.done();
+            done();
             return;
           }
           test.equal(members.length, 2, 'Verify both members present');
@@ -1210,7 +1099,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
       if(!isDone) {
         isDone = true;
         setTimeout(function() {
-          test.done(); clientRealtime.close();
+          closeAndFinish(test, clientRealtime);
         }, 3000);
       }
     };
@@ -1255,14 +1144,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
           });
         });
       });
-      var exitOnState = function(state) {
-        clientRealtime.connection.on(state, function () {
-          test.ok(false, transport + ' connection to server failed');
-          done();
-        });
-      };
-      exitOnState('failed');
-      exitOnState('suspended');
+      monitorConnection(test, clientRealtime);
     } catch(e) {
       console.log('presence.leave0 failed with exception: ' + e.stack);
       test.ok(false, 'presence.leave0 failed with exception: ' + e.stack);
@@ -1273,10 +1155,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
   exports.clear99 = function(test) {
     /* delay before closing, to allow final tests to see events on connections */
     setTimeout(function() {
-      realtime.close();
-      test.expect(1);
-      test.ok(true, 'Closed listener connection');
-      test.done();
+      closeAndFinish(test, realtime);
     }, 3000);
   };
 

--- a/spec/realtime/resume.test.js
+++ b/spec/realtime/resume.test.js
@@ -1,7 +1,9 @@
 "use strict";
 
 define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
-  var exports = {};
+  var exports = {},
+		closeAndFinish = helper.closeAndFinish,
+		monitorConnection = helper.monitorConnection;
 
   exports.setupResume = function(test) {
     test.expect(1);
@@ -141,9 +143,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
                 test.ok(false, 'Phase 4 failed with err: ' + err);
                 return;
               }
-              rxRealtime.close();
-              txRealtime.close();
-              test.done();
+              closeAndFinish(test, [rxRealtime, txRealtime]);
             });
           });
         });
@@ -265,30 +265,28 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
     phase0(function(err) {
       if(err) {
         test.ok(false, 'Phase 1 failed with err: ' + err);
-        test.done();
+        closeAndFinish(test, [rxRealtime, txRealtime]);
         return;
       }
       phase1(function(err) {
         if(err) {
           test.ok(false, 'Phase 1 failed with err: ' + err);
-          test.done();
+          closeAndFinish(test, [rxRealtime, txRealtime]);
           return;
         }
         phase2(function(err) {
           if(err) {
             test.ok(false, 'Phase 2 failed with err: ' + err);
-            test.done();
+            closeAndFinish(test, [rxRealtime, txRealtime]);
             return;
           }
           phase3(function(err) {
             if(err) {
               test.ok(false, 'Phase 3 failed with err: ' + err);
-              test.done();
+              closeAndFinish(test, [rxRealtime, txRealtime]);
               return;
             }
-            rxRealtime.close();
-            txRealtime.close();
-            test.done();
+            closeAndFinish(test, [rxRealtime, txRealtime]);
           });
         });
       });


### PR DESCRIPTION
So this does *not* make the saucelabs integration test pass in IE11. What it does do it make it consistently pass locally, in a VM. It makes sure that tests close their connections at the end of each test to avoid running into IE's limit of six simultaneous websocket connections.

The saucelabs test still fails - several tests time out. This then causes other failures, since when a test times out, its websocket connections stay open (as the `withTimeout` helper doesn't close them). So after six timeouts, all slots are used and any test which requires a websocket transport will fail (with a `SecurityError`, which are what IE throws if you try exceed the six-websocket limit).  I tried a quick fix for this of putting something in the `AblyRealtime` helper that registered the connection (on the test app object), and then had the timeout close all open connections -- or just overrid test.done() to force all connections to close at the end of every test -- which worked well but broke all the tests which set up a connection in one test and then went on to use it in others.

To demonstrate: increasing the timeout to 120s reduces the number of saucelabs timeouts to just two, see https://ci.ably.io/job/ably-js-browsers-min/113/consoleText . (Obv not included in the PR).

Also tried the obvious fix of [removing web_socket requirements](https://github.com/ably/ably-js/commit/cd844df) - but that broke everything that was forcing websockets to get around issue https://github.com/ably/ably-js/issues/27. (Had a quick go at fixing that issue but didn't get very far).

So, something is causing IE11 on saucelabs to just be incredibly slow, and combined with the six connections limit make it very annoying to get working on saucelabs. A temporary solution could be to remove ie11 from ably-js-browsers-min and just test it manually in virtualbox (or use one of the karma virtualbox IE runners), which with this pr seems to work ok; I've included that commit here.

Most of this is just test code so should be uncontroversial; the exception is https://github.com/ably/ably-js/commit/077b8679791efc8c094feed71264ce763e8fa5a0 (adding a transport `disconnect` event to comettransport no matter how the connection was closed). [The websocket transport does something similar already](https://github.com/ably/ably-js/blob/master/common/lib/transport/websockettransport.js#L107) so I figured it could make sense, but my understanding of the details of the different transport lifecycles is shaky, so wanted to flag it up to @paddybyers . (The normal connection `closed` event would work for comet, but for websockets it comes too early - it's emitted before the websocket object is actually disposed of, and on IE that seems to sometimes take a while).

cc @mattheworiordan @paddybyers 