### PR TITLE
Allow connection to inherit clientId from connectionDetails

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -131,6 +131,9 @@ var Auth = (function() {
 	Auth.prototype.authorise = function(authOptions, tokenParams, callback) {
 		var token = this.tokenDetails;
 		if(token) {
+			if(this.rest.clientId && token.clientId && this.rest.clientId !== token.clientId) {
+				callback(new ErrorInfo('ClientId in token was ' + token.clientId + ', but library was instantiated with clientId ' + this.rest.clientId, 40102, 401));
+			}
 			if(token.expires === undefined || (token.expires > this.getTimestamp())) {
 				if(!(authOptions && authOptions.force)) {
 					Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'using cached token; expires = ' + token.expires);

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -650,8 +650,9 @@ var ConnectionManager = (function() {
 				});
 				return;
 			}
-			/* FIXME: decide if fatal */
-			var fatal = false;
+			/* all codes in the 40-50k zone indicate a fault with the request, so
+			 * should not be retried unmodified */
+			var fatal = err.code >= 40000 && err.code <= 50000;
 			if(fatal)
 				self.notifyState({state: 'failed', error: err});
 			else

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -331,7 +331,7 @@ var ConnectionManager = (function() {
 
 		var self = this;
 		var handleTransportEvent = function(state) {
-			return function(error, connectionKey, connectionSerial, connectionId) {
+			return function(error, connectionKey, connectionSerial, connectionId, clientId) {
 				Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.setTransportPending', 'on state = ' + state);
 				if(error && error.message)
 					Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.setTransportPending', 'reason =  ' + error.message);
@@ -341,11 +341,14 @@ var ConnectionManager = (function() {
 					Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.setTransportPending', 'connectionSerial =  ' + connectionSerial);
 				if(connectionId)
 					Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.setTransportPending', 'connectionId =  ' + connectionId);
+				if(clientId)
+					Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.setTransportPending', 'clientId=  ' + clientId);
+
 
 				/* handle activity transition */
 				var notifyState;
 				if(state == 'connected') {
-					self.activateTransport(transport, connectionKey, connectionSerial, connectionId);
+					self.activateTransport(transport, connectionKey, connectionSerial, connectionId, clientId);
 					notifyState = true;
 				} else {
 					notifyState = self.deactivateTransport(transport);
@@ -374,8 +377,8 @@ var ConnectionManager = (function() {
 	 *   'recover': new connection with recoverable messages;
 	 *   'resume': uninterrupted resumption of connection without loss of messages
 	 */
-	ConnectionManager.prototype.activateTransport = function(transport, connectionKey, connectionSerial, connectionId) {
-		Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.activateTransport()', 'transport = ' + transport + '; connectionKey = ' + connectionKey + '; connectionSerial = ' + connectionSerial);
+	ConnectionManager.prototype.activateTransport = function(transport, connectionKey, connectionSerial, connectionId, clientId) {
+		Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.activateTransport()', 'transport = ' + transport + '; connectionKey = ' + connectionKey + '; connectionSerial = ' + connectionSerial + '; clientId = ' + clientId);
 		/* if the connectionmanager moved to the closing/closed state before this
 		 * connection event, then we won't activate this transport */
 		if(this.state == states.closing || this.state == states.closed)
@@ -405,6 +408,14 @@ var ConnectionManager = (function() {
 			if(createCookie && this.options.recover === true)
 				this.persistConnection();
 			this.msgSerial = 0;
+		}
+		if(clientId) {
+			if(this.realtime.clientId && this.realtime.clientId != clientId) {
+				/* Should never happen in normal circumstances as realtime should
+				 * return an error code in case of mismatch */
+				throw new Error('Unexpected mismatch between expected and received clientId');
+			}
+			this.realtime.clientId = clientId;
 		}
 
  		/* set up handler for events received on this transport */

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -59,7 +59,7 @@ var Transport = (function() {
 			break;
 		case actions.CONNECTED:
 			this.onConnect(message);
-			this.emit('connected', null, message.connectionKey, message.connectionSerial, message.connectionId);
+			this.emit('connected', null, message.connectionKey, message.connectionSerial, message.connectionId, (message.connectionDetails ? message.connectionDetails.clientId : null));
 			break;
 		case actions.CLOSED:
 			this.isConnected = false;


### PR DESCRIPTION
Changes needed for https://github.com/ably/realtime/pulls/274.

Test currently fails just because sandbox isn't running a branch that supports connectionDetails. Run with local realtime on the `connection-details-tentative` branch.