### PR TITLE
Allow connection to inherit clientId from connectionDetails

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -131,6 +131,10 @@ var Auth = (function() {
 	Auth.prototype.authorise = function(authOptions, tokenParams, callback) {
 		var token = this.tokenDetails;
 		if(token) {
+			if(this.rest.clientId && token.clientId && this.rest.clientId !== token.clientId) {
+				callback(new ErrorInfo('ClientId in token was ' + token.clientId + ', but library was instantiated with clientId ' + this.rest.clientId, 40102, 401));
+				return;
+			}
 			if(token.expires === undefined || (token.expires > this.getTimestamp())) {
 				if(!(authOptions && authOptions.force)) {
 					Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'using cached token; expires = ' + token.expires);

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -414,7 +414,11 @@ var ConnectionManager = (function() {
 			if(this.realtime.clientId && this.realtime.clientId != clientId) {
 				/* Should never happen in normal circumstances as realtime should
 				 * recognise mismatch and return an error */
-				Logger.logAction(Logger.LOG_ERROR, 'ConnectionManager.activateTransport()', 'Unexpected mismatch between expected and received clientId');
+				var msg = 'Unexpected mismatch between expected and received clientId'
+				var err = new ErrorInfo(msg, 40102, 401);
+				Logger.logAction(Logger.LOG_ERROR, 'ConnectionManager.activateTransport()', msg);
+				transport.abort(err);
+				return;
 			}
 			this.realtime.clientId = clientId;
 		}

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -61,7 +61,7 @@ var Transport = (function() {
 			break;
 		case actions.CONNECTED:
 			this.onConnect(message);
-			this.emit('connected', null, message.connectionKey, message.connectionSerial, message.connectionId);
+			this.emit('connected', null, message.connectionKey, message.connectionSerial, message.connectionId, (message.connectionDetails ? message.connectionDetails.clientId : null));
 			break;
 		case actions.CLOSED:
 			this.isConnected = false;

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -198,5 +198,42 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		monitorConnection(test, realtime);
 	};
 
+	/*
+	 * Request a token using clientId, then initialize a connection without one,
+	 * and check that the connection inherits the clientId of the token
+	 */
+	exports.auth_clientid_inheritance = function(test) {
+		test.expect(1);
+
+		var rest = helper.AblyRest(),
+		testClientId = 'testClientId';
+		var authCallback = function(tokenParams, callback) {
+			rest.auth.requestToken({clientId: testClientId}, function(err, tokenDetails) {
+				if(err) {
+					test.ok(false, helper.displayError(err));
+					test.done();
+					return;
+				}
+				callback(null, tokenDetails);
+			});
+		};
+
+		var realtime = helper.AblyRealtime({ authCallback: authCallback });
+
+		realtime.connection.on('connected', function() {
+			test.equal(realtime.clientId, testClientId);
+			realtime.connection.close();
+			test.done();
+			return;
+		});
+
+		realtime.connection.on('failed', function(err) {
+			realtime.close();
+			test.ok(false, "Failed: " + err);
+			test.done();
+			return;
+		});
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -235,5 +235,38 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		});
 	};
 
+	/*
+	 * Rest token generation with clientId, then connecting with a
+	 * different clientId, should fail with a library-generated message
+	 */
+	exports.auth_clientid_inheritance2 = function(test) {
+		test.expect(2);
+		var clientRealtime,
+			testClientId = 'test client id';
+		var rest = helper.AblyRest();
+		rest.auth.requestToken({clientId:testClientId}, function(err, tokenDetails) {
+			if(err) {
+				test.ok(false, displayError(err));
+				test.done();
+				return;
+			}
+			clientRealtime = helper.AblyRealtime({token: tokenDetails, clientId: 'WRONG'});
+			clientRealtime.connection.once('failed', function(stateChange){
+				test.ok(true, 'Verify connection failed');
+				test.deepEqual(stateChange.reason, {statusCode: 401, code: 40102, message: 'ClientId in token was ' + testClientId + ', but library was instantiated with clientId WRONG' })
+				clientRealtime.close();
+				test.done();
+			})
+			// Workaround for ably-js issue 101 (comet transport goes into disconnected
+			// rather than failed). TODO remove next 5 lines when that's fixed
+			clientRealtime.connection.once('disconnected', function(stateChange){
+				test.ok(true, 'Verify connection failed');
+				test.deepEqual(stateChange.reason, {statusCode: 401, code: 40102, message: 'ClientId in token was ' + testClientId + ', but library was instantiated with clientId WRONG' })
+				clientRealtime.close();
+				test.done();
+			})
+		});
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
Changes needed for https://github.com/ably/realtime/pulls/274.

Test currently fails just because sandbox isn't running a branch that supports connectionDetails. Run with local realtime on the connection-details-tentative branch.

Re-raised against new-upgrade.