### PR TITLE
Explicitly disallow empty string clientIds

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -363,6 +363,11 @@ var Auth = (function() {
 			return;
 		}
 
+		if(tokenParams.clientId === '') {
+			callback(new ErrorInfo('clientId can’t be an empty string', 40012, 400));
+			return;
+		}
+
 		tokenParams.capability = c14n(tokenParams.capability);
 
 		var request = Utils.mixin({ keyName: keyName }, tokenParams),

--- a/spec/rest/auth.test.js
+++ b/spec/rest/auth.test.js
@@ -209,6 +209,22 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	/*
+	 * Token generation with empty string clientId should error
+	 */
+	exports.authemptyclientid = function(test) {
+		test.expect(1);
+		rest.auth.requestToken({clientId: ''}, function(err, tokenDetails) {
+			if(err) {
+				test.equal(err.code, 40012);
+				test.done();
+				return;
+			}
+			test.ok(false);
+			test.done();
+		});
+	};
+
+	/*
 	 * Token generation with capability that subsets key capability
 	 */
 	exports.authcapability0 = function(test) {


### PR DESCRIPTION
Since realtime treats that as equivalent to no clientid