### PR TITLE
If client lib initialised with clientid, use that for auth if no new tokenParams object is supplied

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -76,6 +76,7 @@ var Auth = (function() {
 			options.tokenDetails = (typeof(options.token) === 'string') ? {token: options.token} : options.token;
 		}
 		this.tokenDetails = options.tokenDetails;
+		this.tokenParams.clientId = options.clientId;
 
 		if(options.authCallback) {
 			Logger.logAction(Logger.LOG_MINOR, 'Auth()', 'using token auth with authCallback');

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -137,12 +137,15 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	/*
-	 * Use authCallback for authentication with tokenDetails response
+	 * Use authCallback for authentication with tokenDetails response,
+	 * also check that clientId lib is initialised with is passed through
+	 * to the auth callback
 	 */
 	exports.auth_useAuthCallback_tokenDetailsResponse = function(test) {
-		test.expect(3);
+		test.expect(4);
 
 		var realtime, rest = helper.AblyRest();
+		var clientId = "test clientid";
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.requestToken(null, tokenParams, function(err, tokenDetails) {
 				if(err) {
@@ -151,11 +154,12 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					return;
 				}
 				test.ok("token" in tokenDetails);
+				test.equal(tokenDetails.clientId, clientId);
 				callback(null, tokenDetails);
 			});
 		};
 
-		realtime = helper.AblyRealtime({ authCallback: authCallback });
+		realtime = helper.AblyRealtime({ authCallback: authCallback, clientId: clientId });
 
 		realtime.connection.on('connected', function() {
 			test.equal(realtime.auth.method, 'token');


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/108