### PR TITLE
Don’t include timestamp/connectionid in string/json representations of messages

### DIFF
--- a/common/lib/types/message.js
+++ b/common/lib/types/message.js
@@ -20,7 +20,6 @@ var Message = (function() {
 			name: this.name,
 			clientId: this.clientId,
 			connectionId: this.connectionId,
-			timestamp: this.timestamp,
 			encoding: this.encoding
 		};
 

--- a/common/lib/types/presencemessage.js
+++ b/common/lib/types/presencemessage.js
@@ -26,8 +26,6 @@ var PresenceMessage = (function() {
 	PresenceMessage.prototype.toJSON = function() {
 		var result = {
 			clientId: this.clientId,
-			connectionId: this.connectionId,
-			timestamp: this.timestamp,
 			action: this.action,
 			encoding: this.encoding
 		};


### PR DESCRIPTION
And only include clientId in json rep if present

Fixes https://github.com/ably/ably-js/issues/44