### PR TITLE
'utf-8' encoding currently assumes a wordArray?

### DIFF
--- a/browser/lib/util/bufferutils.js
+++ b/browser/lib/util/bufferutils.js
@@ -101,8 +101,10 @@ var BufferUtils = (function() {
 	};
 
 	BufferUtils.utf8Decode = function(buf) {
-		if(CryptoJS)
+		if(isWordArray(buf) && CryptoJS)
 			return CryptoJS.enc.Utf8.stringify(buf);
+		else
+			return buf.toString();
 	};
 
 	BufferUtils.bufferCompare = function(buf1, buf2) {


### PR DESCRIPTION
So currently, if ably-js is fed a message like [this one](https://github.com/ably/ably-common/blob/master/test-resources/test-app-setup.json#L21) (not encrypted, but with a `utf-8` encoding), it feeds it to `BufferUtils.utf8Decode` because of the `utf-8` in the encoding, which in a browser, passes it to `CryptoJS.enc.Utf8.stringify`, which [expects](https://code.google.com/p/crypto-js/#Encoders) a wordArray so outputs an empty string. (in node it just calls `toString('utf-8')`, which works fine).

This PR fixes that immediate problem, but I'm not sure if there's a deeper issue here - not clear to me if there's a significant difference in how the different libs interpret `utf-8` (ably-js [treating it](https://github.com/ably/ably-js/blob/master/browser/lib/util/bufferutils.js) as meaning wordArray-encoded, ably-ruby [treating it](https://github.com/ably/ably-ruby/blob/master/lib/ably/models/message_encoders/utf8.rb) as meaning just a utf-8-encoded string), or if I'm misunderstanding the code

@mattheworiordan @paddybyers 