### PR TITLE
Invalid encodings

### DIFF
--- a/browser/lib/util/bufferutils.js
+++ b/browser/lib/util/bufferutils.js
@@ -90,19 +90,19 @@ var BufferUtils = (function() {
 	BufferUtils.base64Decode = function(str) {
 		if(ArrayBuffer)
 			return base64ToArrayBuffer(str);
-
-		if(CryptoJS)
-			return CryptoJS.enc.Base64.parse(str);
+		return CryptoJS.enc.Base64.parse(str);
 	};
 
 	BufferUtils.utf8Encode = function(string) {
-		if(CryptoJS)
-			return CryptoJS.enc.Utf8.parse(string);
+		return CryptoJS.enc.Utf8.parse(string);
 	};
 
 	BufferUtils.utf8Decode = function(buf) {
-		if(CryptoJS)
+		if(isArrayBuffer(buf))
+			buf = BufferUtils.toWordArray(buf) // CryptoJS only works with WordArrays
+		if(isWordArray(buf))
 			return CryptoJS.enc.Utf8.stringify(buf);
+		throw new Error("Expected input of utf8Decode to be a buffer or CryptoJS WordArray");
 	};
 
 	BufferUtils.bufferCompare = function(buf1, buf2) {

--- a/common/lib/client/channel.js
+++ b/common/lib/client/channel.js
@@ -49,13 +49,14 @@ var Channel = (function() {
 			format = rest.options.useBinaryProtocol ? 'msgpack' : 'json',
 			envelope = Http.supportsLinkHeaders ? undefined : format,
 			headers = Utils.copy(Utils.defaultGetHeaders(format)),
-			options = this.options;
+			options = this.options,
+			channel = this;
 
 		if(rest.options.headers)
 			Utils.mixin(headers, rest.options.headers);
 
 		(new PaginatedResource(rest, this.basePath + '/messages', headers, envelope, function(body, headers, unpacked) {
-			return Message.fromResponseBody(body, options, !unpacked && format);
+			return Message.fromResponseBody(body, options, !unpacked && format, channel);
 		})).get(params, callback);
 	};
 

--- a/common/lib/client/presence.js
+++ b/common/lib/client/presence.js
@@ -50,13 +50,14 @@ var Presence = (function() {
 			format = rest.options.useBinaryProtocol ? 'msgpack' : 'json',
 			envelope = Http.supportsLinkHeaders ? undefined : format,
 			headers = Utils.copy(Utils.defaultGetHeaders(format)),
-			options = this.channel.options;
+			options = this.channel.options,
+			channel = this.channel;
 
 		if(rest.options.headers)
 			Utils.mixin(headers, rest.options.headers);
 
 		(new PaginatedResource(rest, this.basePath + '/history', headers, envelope, function(body, headers, unpacked) {
-			return PresenceMessage.fromResponseBody(body, options, !unpacked && format);
+			return PresenceMessage.fromResponseBody(body, options, !unpacked && format, channel);
 		})).get(params, callback);
 	};
 

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -274,11 +274,8 @@ var RealtimeChannel = (function() {
 					var presenceMsg = presence[i];
 					PresenceMessage.decode(presenceMsg, options);
 				} catch (e) {
-					/* decrypt failed .. the most likely cause is that we have the wrong key */
-					var errmsg = 'Unexpected error decoding message; err = ' + e;
-					Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.onMessage()', errmsg);
-					var err = new Error(errmsg);
-					this.emit('error', err);
+					Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.onMessage()', e.toString());
+					this.emit('error', e);
 				}
 				if(!presenceMsg.connectionId) presenceMsg.connectionId = connectionId;
 				if(!presenceMsg.timestamp) presenceMsg.timestamp = timestamp;
@@ -300,10 +297,8 @@ var RealtimeChannel = (function() {
 					Message.decode(msg, options);
 				} catch (e) {
 					/* decrypt failed .. the most likely cause is that we have the wrong key */
-					var errmsg = 'Unexpected error decoding message; err = ' + e;
-					Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.onMessage()', errmsg);
-					var err = new Error(errmsg);
-					this.emit('error', err);
+					Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.onMessage()', e.toString());
+					this.emit('error', e);
 				}
 				if(!msg.connectionId) msg.connectionId = connectionId;
 				if(!msg.timestamp) msg.timestamp = timestamp;

--- a/common/lib/types/presencemessage.js
+++ b/common/lib/types/presencemessage.js
@@ -70,13 +70,18 @@ var PresenceMessage = (function() {
 	PresenceMessage.encode = Message.encode;
 	PresenceMessage.decode = Message.decode;
 
-	PresenceMessage.fromResponseBody = function(body, options, format) {
+	PresenceMessage.fromResponseBody = function(body, options, format, channel) {
 		if(format)
 			body = (format == 'msgpack') ? msgpack.decode(body) : JSON.parse(String(body));
 
 		for(var i = 0; i < body.length; i++) {
 			var msg = body[i] = PresenceMessage.fromDecoded(body[i]);
-			PresenceMessage.decode(msg, options);
+			try {
+				PresenceMessage.decode(msg, options);
+			} catch (e) {
+				Logger.logAction(Logger.LOG_ERROR, 'PresenceMessage.fromResponseBody()', e.toString());
+				channel.emit('error', e);
+			}
 		}
 		return body;
 	};

--- a/nodejs/lib/util/bufferutils.js
+++ b/nodejs/lib/util/bufferutils.js
@@ -13,7 +13,11 @@ this.BufferUtils = (function() {
 
 	BufferUtils.utf8Encode = function(string) { return new Buffer(string, 'utf8'); };
 
-	BufferUtils.utf8Decode = function(buf) { return buf.toString('utf8'); };
+	BufferUtils.utf8Decode = function(buf) {
+		if(BufferUtils.isBuffer(buf))
+			return buf.toString('utf8');
+		throw new Error("Expected input of utf8Decode to be a buffer or CryptoJS WordArray");
+	};
 
 	BufferUtils.bufferCompare = function(buf1, buf2) {
 		if(!buf1) return -1;

--- a/spec/rest/history.test.js
+++ b/spec/rest/history.test.js
@@ -382,5 +382,51 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		}
 	};
 
+	exports.history_encoding_errors = function(test) {
+		var testchannel = rest.channels.get('persisted:history_encoding_errors');
+		var badMessage = {name: 'jsonUtf8string', encoding: 'json/utf-8', data: '{\"foo\":\"bar\"}'};
+		test.expect(4);
+		try {
+			testchannel.publish(badMessage, function(err) {
+				if(err) {
+					test.ok(false, displayError(err));
+					test.done();
+					return;
+				}
+				setTimeout(function(){
+					async.parallel(
+						[
+							function(cb) {
+								/* Add channel error event listeners */
+								testchannel.on('error', function(err) {
+									test.equal(err.code, 40013, "Error emitted has correct error code");
+									test.ok(err.message.indexOf("utf-8") > -1, "Error emitted contains correct encoding component");
+									cb();
+								});
+							},
+							function(cb) {
+								testchannel.history(function(err, resultPage) {
+									if(err) {
+										test.ok(false, displayError(err));
+										test.done();
+										return;
+									}
+									/* verify all messages are received */
+									var message = resultPage.items[0];
+									test.equal(message.data, badMessage.data, 'Verify data preserved');
+									test.equal(message.encoding, badMessage.encoding, 'Verify encoding preserved');
+									cb();
+								});
+							}
+						],
+						function() { test.done(); }
+					)
+				}, 1000)
+			});
+		} catch(e) {
+			console.log(e.stack);
+		}
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/121

Throw errors if input to utf8Decode is not a wordArray or an arrayBuffer, and properly handle when it's an arrayBuffer.

Also remove unnecessary if(CryptoJS) calls. if CryptoJS is undefined (though it shouldn't be, we bundle it in), we want it to throw an error (which it will do when it tries to call a method on undefined) to be caught by the Message.decode try/catch block, not silently return null. (Though it'll error because of [this](https://github.com/ably/ably-js/blob/master/browser/lib/util/bufferutils.js#L2) anyway)

Also add tests for the changed behaviour.

The first commit (86b86ef) is a separate PR: https://github.com/ably/ably-js/pull/122. included here as it's needed to make the test work; so that one should be merged first.