### PR TITLE
Tests no force ws; fix failure to callback on presence event causing implicit attach

### DIFF
--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -56,7 +56,14 @@ var RealtimePresence = (function() {
 				break;
 			case 'initialized':
 			case 'detached':
-				channel.attach();
+				var self = this;
+				channel.attach(function(err) {
+					// If error in attaching, callback immediately
+					if(err) {
+						self.pendingPresence = null;
+						callback(err);
+					}
+				});
 			case 'attaching':
 				this.pendingPresence = {
 					presence : presence,

--- a/common/lib/transport/protocol.js
+++ b/common/lib/transport/protocol.js
@@ -7,7 +7,7 @@ var Protocol = (function() {
 		this.messageQueue = new MessageQueue();
 		var self = this;
 		transport.on('ack', function(serial, count) { self.onAck(serial, count); });
-		transport.on('nack', function(serial, count, err) { self.onNck(serial, count, err); });
+		transport.on('nack', function(serial, count, err) { self.onNack(serial, count, err); });
 	}
 	Utils.inherits(Protocol, EventEmitter);
 

--- a/spec/realtime/channel.test.js
+++ b/spec/realtime/channel.test.js
@@ -192,6 +192,57 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	/*
+	 * Implicit attach with an invalid channel name by publishing
+	 */
+	exports.channelattach_publish = function(test) {
+		test.expect(1);
+		try {
+			var realtime = helper.AblyRealtime();
+			realtime.connection.once('connected', function() {
+				realtime.channels.get('channelattach_publish').publish(function(err) {
+					if(err) {
+						test.ok(false, 'Unexpected attach failure');
+						closeAndFinish(test, realtime);
+						return;
+					}
+					test.ok(true, 'publishfailed as expected');
+					closeAndFinish(test, realtime);
+				});
+			});
+			monitorConnection(test, realtime);
+		} catch(e) {
+			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
+	/*
+	 * Implicit attach with an invalid channel name by publishing
+	 */
+	exports.channelattach_publish_invalid = function(test) {
+		test.expect(2);
+		try {
+			var realtime = helper.AblyRealtime();
+			realtime.connection.once('connected', function() {
+				realtime.channels.get(':hell').publish(function(err) {
+					if(err) {
+						test.ok(true, 'publishfailed as expected');
+						test.equal(err.code, 40010, "correct error code")
+						closeAndFinish(test, realtime);
+						return;
+					}
+					test.ok(false, 'Unexpected attach success');
+					closeAndFinish(test, realtime);
+				});
+			});
+			monitorConnection(test, realtime);
+		} catch(e) {
+			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
+	/*
 	 * Attach with an invalid channel name and expect a channel error
 	 * and the connection to remain open
 	 */

--- a/spec/realtime/crypto.test.js
+++ b/spec/realtime/crypto.test.js
@@ -48,7 +48,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				test.ok(false, 'Unable to get test assets; err = ' + err);
 				return;
 			}
-			var realtime = helper.AblyRealtime({ transports: ['web_socket'] });
+			var realtime = helper.AblyRealtime();
 			var channel = realtime.channels.get('encrypt_message_128');
 			var key = BufferUtils.base64Decode(testData.key);
 			var iv = BufferUtils.base64Decode(testData.iv);
@@ -95,7 +95,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				test.ok(false, 'Unable to get test assets; err = ' + err);
 				return;
 			}
-			var realtime = helper.AblyRealtime({ transports: ['web_socket'] });
+			var realtime = helper.AblyRealtime();
 			var channel = realtime.channels.get('encrypt_message_256');
 			var key = BufferUtils.base64Decode(testData.key);
 			var iv = BufferUtils.base64Decode(testData.iv);
@@ -142,7 +142,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				test.ok(false, 'Unable to get test assets; err = ' + err);
 				return;
 			}
-			var realtime = helper.AblyRealtime({ transports: ['web_socket'] });
+			var realtime = helper.AblyRealtime();
 			var channel = realtime.channels.get('decrypt_message_128');
 			var key = BufferUtils.base64Decode(testData.key);
 
@@ -186,7 +186,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				test.ok(false, 'Unable to get test assets; err = ' + err);
 				return;
 			}
-			var realtime = helper.AblyRealtime({ transports: ['web_socket'] });
+			var realtime = helper.AblyRealtime();
 			var channel = realtime.channels.get('decrypt_message_256');
 			var key = BufferUtils.base64Decode(testData.key);
 
@@ -228,7 +228,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var realtime = helper.AblyRealtime({ transports: ['web_socket'] });
+		var realtime = helper.AblyRealtime();
 		test.expect(3);
 		var channel = realtime.channels.get('single_send_binary'),
 			messageText = 'Test message (single_send_binary)';
@@ -261,7 +261,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var realtime = helper.AblyRealtime({ transports: ['web_socket'], useBinaryProtocol: false });
+		var realtime = helper.AblyRealtime({ useBinaryProtocol: false });
 		test.expect(3);
 		var channel = realtime.channels.get('single_send_text'),
 			messageText = 'Test message (single_send_text)';
@@ -293,7 +293,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var realtime = helper.AblyRealtime({ transports: ['web_socket'] });
+		var realtime = helper.AblyRealtime();
 		test.expect(3);
 		var channel = realtime.channels.get('single_send_binary_256'),
 			messageText = 'Test message (single_send_binary_256)';
@@ -327,7 +327,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var realtime = helper.AblyRealtime({ transports: ['web_socket'], useBinaryProtocol: false });
+		var realtime = helper.AblyRealtime({ useBinaryProtocol: false });
 		test.expect(3);
 		var channel = realtime.channels.get('single_send_text_256'),
 			messageText = 'Test message (single_send_text_256)';
@@ -358,7 +358,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var realtime = helper.AblyRealtime({ transports: ['web_socket'], useBinaryProtocol: !text});
+		var realtime = helper.AblyRealtime({ useBinaryProtocol: !text});
 		test.expect(iterations + 3);
 		var channelName = 'multiple_send_' + (text ? 'text_' : 'binary_') + iterations + '_' + delay,
 			channel = realtime.channels.get(channelName),
@@ -422,8 +422,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var txRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
-		var rxRealtime = helper.AblyRealtime({ transports: ['web_socket'], useBinaryProtocol: false });
+		var txRealtime = helper.AblyRealtime();
+		var rxRealtime = helper.AblyRealtime({ useBinaryProtocol: false });
 		test.expect(3);
 		var channelName = 'single_send_binary_text',
 			messageText = 'Test message (' + channelName + ')',
@@ -466,8 +466,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var txRealtime = helper.AblyRealtime({ transports: ['web_socket'], useBinaryProtocol: false });
-		var rxRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
+		var txRealtime = helper.AblyRealtime({ useBinaryProtocol: false });
+		var rxRealtime = helper.AblyRealtime();
 		test.expect(3);
 		var channelName = 'single_send_text_binary',
 			messageText = 'Test message (' + channelName + ')',
@@ -511,8 +511,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var txRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
-		var rxRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
+		var txRealtime = helper.AblyRealtime();
+		var rxRealtime = helper.AblyRealtime();
 		test.expect(1);
 		var channelName = 'single_send_key_mismatch',
 			txChannel = txRealtime.channels.get(channelName),
@@ -554,8 +554,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var txRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
-		var rxRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
+		var txRealtime = helper.AblyRealtime();
+		var rxRealtime = helper.AblyRealtime();
 		test.expect(1);
 		var channelName = 'single_send_unencrypted',
 			txChannel = txRealtime.channels.get(channelName),
@@ -596,8 +596,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var txRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
-		var rxRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
+		var txRealtime = helper.AblyRealtime();
+		var rxRealtime = helper.AblyRealtime();
 		test.expect(1);
 		var channelName = 'single_send_encrypted_unhandled',
 			txChannel = txRealtime.channels.get(channelName),
@@ -639,8 +639,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			return;
 		}
 
-		var txRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
-		var rxRealtime = helper.AblyRealtime({ transports: ['web_socket'] });
+		var txRealtime = helper.AblyRealtime();
+		var rxRealtime = helper.AblyRealtime();
 		test.expect(3);
 		var channelName = 'set_cipher_params',
 			txChannel = txRealtime.channels.get(channelName),

--- a/spec/realtime/failure.test.js
+++ b/spec/realtime/failure.test.js
@@ -4,7 +4,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	var exports = {},
 		closeAndFinish = helper.closeAndFinish,
 		monitorConnection = helper.monitorConnection,
-		availableTransports = Object.keys(Ably.Realtime.ConnectionManager.transports);
+		// Ably.Realtime.ConnectionManager not defined in node
+		availableTransports = typeof Ably.Realtime.ConnectionManager === 'undefined' ? Ably.Realtime.Defaults.transports : Object.keys(Ably.Realtime.ConnectionManager.transports);
 
 
 	exports.setupFailure = function(test) {

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -67,10 +67,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					}
 				},
 				function(cb) {
-					var transport = 'web_socket';
 					test.expect(++expects);
 					try {
-						realtime = helper.AblyRealtime({ transports: [transport] });
+						realtime = helper.AblyRealtime();
 						realtime.connection.on('connected', function() {
 							presenceChannel = realtime.channels.get('presence0');
 							presenceChannel.attach(function(err) {
@@ -107,8 +106,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			}
 		};
 		try {
-			var transport = 'web_socket';
-
 			test.expect(2);
 			/* listen for the enter event, test is complete when received */
 			var presenceHandler = function() {
@@ -121,7 +118,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -174,8 +171,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -221,8 +217,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			/* get channel, attach, and enter */
 			var clientChannel = clientRealtime.channels.get('presence0');
 			clientChannel.presence.enter('Test client data (enter2)', function(err) {
@@ -267,8 +262,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -323,8 +317,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			}
 		};
 		try {
-			var transport = 'web_socket';
-
 			test.expect(2);
 			/* listen for the enter event, test is complete when received */
 			var presenceHandler = function() {
@@ -337,7 +329,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -378,8 +370,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			}
 		};
 		try {
-			var transport = 'web_socket';
-
 			test.expect(1);
 			/* listen for the enter event, test is complete when received */
 			var presenceHandler = function() {
@@ -392,7 +382,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -426,8 +416,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			}
 		};
 		try {
-			var transport = 'web_socket';
-
 			test.expect(1);
 			/* listen for the enter event, test is complete when received */
 			var presenceHandler = function() {
@@ -440,7 +428,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -467,8 +455,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		var clientRealtime;
 		try {
 			test.expect(2);
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			var clientChannel = clientRealtime.channels.get('presenceEnter7');
 			/* listen for the enter event, test is complete when received */
 			var presenceHandler = function(presenceMsg) {
@@ -536,8 +523,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			};
 			presenceChannel.presence.on(presenceHandler);
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -590,8 +576,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			test.expect(5);
 
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				var clientChannel = clientRealtime.channels.get('presenceUpdate0');
 
@@ -674,8 +659,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -744,8 +728,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -816,8 +799,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			};
 
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presenceHistory0');
@@ -859,8 +841,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	};
 
 	exports.history_until_attach = function(test) {
-		var transport = 'web_socket';
-		var clientRealtime = helper.AblyRealtime({clientId: testClientId, transports: [transport]});
+		var clientRealtime = helper.AblyRealtime({clientId: testClientId});
 		var clientChannel = clientRealtime.channels.get('presenceHistoryUntilAttach');
 		var testClientData = 'Test client data (history0)';
 		var done = function() {
@@ -981,8 +962,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		try {
 			test.expect(3);
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime1 = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime1 = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime1.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel1 = clientRealtime1.channels.get('presence1');
@@ -1008,7 +988,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 							test.equal(presenceMembers1.length, 1, 'Member present');
 							/* now set up second connection and attach */
 							/* set up authenticated connection */
-							clientRealtime2 = helper.AblyRealtime({ clientId: testClientId2, authToken: authToken2, transports: [transport] });
+							clientRealtime2 = helper.AblyRealtime({ clientId: testClientId2, authToken: authToken2 });
 							clientRealtime2.connection.on('connected', function() {
 								/* get channel, attach */
 								var clientChannel2 = clientRealtime2.channels.get('presence1');
@@ -1063,9 +1043,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			/* set up authenticated connections */
 			async.parallel([
 				function(cb1) {
-					var transport = 'web_socket';
 					var data = 'Test client data (member0-1)';
-					clientRealtime1 = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+					clientRealtime1 = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 					clientRealtime1.connection.on('connected', function() {
 						/* get channel, attach, and enter */
 						clientChannel1 = clientRealtime1.channels.get('presence2');
@@ -1092,9 +1071,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					monitorConnection(test, clientRealtime1);
 				},
 				function(cb2) {
-					var transport = 'web_socket';
 					var data = 'Test client data (member0-2)';
-					clientRealtime2 = helper.AblyRealtime({ clientId: testClientId2, authToken: authToken2, transports: [transport] });
+					clientRealtime2 = helper.AblyRealtime({ clientId: testClientId2, authToken: authToken2 });
 					clientRealtime2.connection.on('connected', function() {
 						/* get channel, attach */
 						clientChannel2 = clientRealtime2.channels.get('presence2');
@@ -1166,8 +1144,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			presenceChannel.presence.on(presenceHandler);
 
 			/* set up authenticated connection */
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			clientRealtime.connection.on('connected', function() {
 				/* get channel, attach, and enter */
 				var clientChannel = clientRealtime.channels.get('presence0');
@@ -1208,8 +1185,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		var clientRealtime;
 		try {
 			test.expect(2);
-			var transport = 'web_socket';
-			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken, transports: [transport] });
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
 			var clientChannel = clientRealtime.channels.get('presenceConnection1');
 			var presenceHandler = function(presenceMsg) {
 				if(this.event == 'enter' && presenceMsg.data == 'second') {

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -491,7 +491,35 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			});
 			monitorConnection(test, clientRealtime);
 		} catch(e) {
-			test.ok(false, 'presence.enter3 failed with exception: ' + e.stack);
+			test.ok(false, 'presence.enter7 failed with exception: ' + e.stack);
+			closeAndFinish(test, clientRealtime);
+		}
+	};
+
+	/*
+	 * Enter invalid presence channel (without attaching), check callback was called with error
+	 */
+	exports.enter8 = function(test) {
+		var clientRealtime;
+		try {
+			test.expect(2);
+			clientRealtime = helper.AblyRealtime({ clientId: testClientId, authToken: authToken });
+			var clientChannel = clientRealtime.channels.get('');
+			clientRealtime.connection.once('connected', function() {
+				clientChannel.presence.enter('clientId', function(err) {
+					if(err) {
+						test.ok(true, 'Enter correctly failed with error: ' + err);
+						test.equal(err.code, 40010, 'Correct error code')
+						closeAndFinish(test, clientRealtime);
+						return;
+					}
+					test.ok(false, 'should have failed');
+					closeAndFinish(test, clientRealtime);
+				});
+			});
+			monitorConnection(test, clientRealtime);
+		} catch(e) {
+			test.ok(false, 'presence.enter8 failed with exception: ' + e.stack);
 			closeAndFinish(test, clientRealtime);
 		}
 	};


### PR DESCRIPTION
Started out as a PR to just stop forcing web_sockets when not necessary (fixes https://github.com/ably/ably-js/pull/127), ended up also fixing a couple bugs that that exposed:

- If there's an error in an implicit attach caused by sending a presence message, callback with that err. (was only a problem with presence not with normal messages since normal messages get their callback called in `RealtimeChannel#failPendingMessages`). + test (and another test for normal messages, though that one was already passing)

- Fixed an onNack callback typo in protocol.js. (indicator that codepath for NACKs is not well-tested?)