### PR TITLE
Connection state events 3

### DIFF
--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -800,6 +800,31 @@ var ConnectionManager = (function() {
 		this.notifyState({state: 'closed'});
 	};
 
+	ConnectionManager.prototype.disconnectAllTransports = function() {
+		Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.disconnectAllTransports()', 'disconnecting all transports');
+
+		function disconnectTransport(transport) {
+			if(transport) {
+				try {
+					Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.disconnectAllTransports()', 'disconnecting transport: ' + transport);
+					transport.disconnect();
+				} catch(e) {
+					var msg = 'Unexpected exception attempting to disconnect transport; e = ' + e;
+					Logger.logAction(Logger.LOG_ERROR, 'ConnectionManager.disconnectAllTransports()', msg);
+					var err = new ErrorInfo(msg, 50000, 500);
+					transport.abort(err);
+				}
+			}
+		}
+
+		for(var i = 0; i < this.pendingTransports.length; i++) {
+			disconnectTransport(this.pendingTransports[i]);
+		}
+		disconnectTransport(this.activeProtocol && this.activeProtocol.getTransport());
+		// No need to notify state disconnected; disconnecting the active transport
+		// will have that effect
+	};
+
 	/******************
 	 * event queueing
 	 ******************/

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -7,18 +7,7 @@ var ConnectionManager = (function() {
 	var actions = ProtocolMessage.Action;
 	var PendingMessage = Protocol.PendingMessage;
 	var noop = function() {};
-
-	var states = {
-		initialized:   {state: 'initialized',   terminal: false, queueEvents: true,  sendEvents: false},
-		connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.connectTimeout, failState: 'disconnected'},
-		connected:     {state: 'connected',     terminal: false, queueEvents: false, sendEvents: true,  failState: 'disconnected'},
-		synchronizing: {state: 'connected',     terminal: false, queueEvents: true,  sendEvents: false},
-		disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.disconnectTimeout},
-		suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.suspendedTimeout},
-		closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.connectTimeout, failState: 'closed'},
-		closed:        {state: 'closed',        terminal: true,  queueEvents: false, sendEvents: false},
-		failed:        {state: 'failed',        terminal: true,  queueEvents: false, sendEvents: false}
-	};
+	var states;
 
 	var isErrFatal = function(err) {
 		var RESOLVABLE_ERROR_CODES = [40140];
@@ -90,6 +79,17 @@ var ConnectionManager = (function() {
 		EventEmitter.call(this);
 		this.realtime = realtime;
 		this.options = options;
+		states = {
+			initialized:   {state: 'initialized',   terminal: false, queueEvents: true,  sendEvents: false},
+			connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.connectTimeout, failState: 'disconnected'},
+			connected:     {state: 'connected',     terminal: false, queueEvents: false, sendEvents: true,  failState: 'disconnected'},
+			synchronizing: {state: 'connected',     terminal: false, queueEvents: true,  sendEvents: false},
+			disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.disconnectTimeout},
+			suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.suspendedTimeout},
+			closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.connectTimeout, failState: 'closed'},
+			closed:        {state: 'closed',        terminal: true,  queueEvents: false, sendEvents: false},
+			failed:        {state: 'failed',        terminal: true,  queueEvents: false, sendEvents: false}
+		};
 		this.state = states.initialized;
 		this.error = null;
 

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -123,6 +123,26 @@ var ConnectionManager = (function() {
 		/* intercept close event in browser to persist connection id if requested */
 		if(createCookie && options.recover === true && window.addEventListener)
 			window.addEventListener('beforeunload', this.persistConnection.bind(this));
+
+		/* Listen for online and offline events */
+		if(typeof window === "object" && window.addEventListener) {
+			var self = this;
+			window.addEventListener('online', function() {
+				if(self.state == states.disconnected || self.state == states.suspended) {
+					Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager caught browser ‘online’ event', 'reattempting connection');
+					self.requestState({state: 'connecting'});
+				}
+			});
+			window.addEventListener('offline', function() {
+				if(self.state == states.connected) {
+					Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager caught browser ‘offline’ event', 'disconnecting active transport');
+					// Not sufficient to just go to the 'disconnected' state, want to
+					// force all transports to reattempt the connection. Will immediately
+					// retry.
+					self.disconnectAllTransports();
+				}
+			});
+		}
 	}
 	Utils.inherits(ConnectionManager, EventEmitter);
 

--- a/spec/browser/connection.test.js
+++ b/spec/browser/connection.test.js
@@ -1,0 +1,120 @@
+"use strict";
+
+define(['ably', 'shared_helper'], function(Ably, helper) {
+  var exports = {};
+
+  exports.setup_realtime_history = function(test) {
+    test.expect(1);
+    helper.setupApp(function(err) {
+      if(err) {
+        test.ok(false, helper.displayError(err));
+      } else {
+        test.ok(true, 'app set up');
+      }
+      test.done();
+    });
+  };
+
+  exports.device_going_offline_causes_disconnected_state = function(test) {
+    var realtime = helper.AblyRealtime(),
+        connection = realtime.connection,
+        offlineEvent = new Event('offline');
+
+    test.expect(2);
+
+    connection.once('connected', function() {
+      var connectedAt = new Date().getTime()
+
+      connection.once('disconnected', function() {
+        var disconnectedAt = new Date().getTime();
+
+        test.ok(connectedAt > disconnectedAt - 250, 'Offline event caused connection to move to the disconnected state immediately (under 250ms)');
+
+        connection.once('connecting', function() {
+          var reconnectingAt = new Date().getTime();
+
+          test.ok(disconnectedAt > reconnectingAt - 250, 'Client automatically reattempts connection even if the state is still offline');
+          connection.close();
+          test.done();
+        });
+      })
+
+      // simulate offline event, expect connection moves to disconnected state and waits to retry connection
+      document.dispatchEvent(offlineEvent);
+    });
+
+    setTimeout(function() {
+      connection.close();
+      test.done();
+    }, 10000)
+  };
+
+  exports.device_going_online_causes_disconnected_connection_to_reconnect_immediately = function(test) {
+    var realtime = helper.AblyRealtime(),
+        connection = realtime.connection,
+        onlineEvent = new Event('online');
+
+    test.expect(2);
+
+    connection.connectionManager.on('transport.active', function(transport) {
+      transport.disconnect(); // disconnect the transport before the connection is connected
+    });
+
+    connection.once('disconnected', function() {
+      var disconnectedAt = new Date();
+
+      setTimeout(function() {
+        test.ok(connection.state == 'disconnected', 'Connection should still be disconnected before we trigger it to connect');
+        connection.once('connecting', function() {
+          test.ok(disconnectedAt > new Date() - 250, 'Online event should have caused the connection to enter the connecting state immediately');
+          connection.close();
+          test.done();
+        });
+        document.dispatchEvent(onlineEvent);
+      }, 1000)
+    });
+
+    setTimeout(function() {
+      connection.close();
+      test.done();
+    }, 10000)
+  };
+
+  // TODO: Ensure that connection goes online from the suspended state
+  exports.device_going_online_causes_suspended_connection_to_reconnect_immediately = function(test) {
+    var realtime = helper.AblyRealtime(),
+        connection = realtime.connection,
+        onlineEvent = new Event('online');
+
+    test.expect(2);
+
+    // TODO: This will not work as Defaults is contained within an anonymous closure, also need to confirm if this will work once defaults can be changed
+    Defaults.disconnectTimeout = 100; // retry connection more frequently
+    Defaults.suspendedTimeout = 1000; // move to suspended state after 1s of being disconencted
+
+    connection.connectionManager.on('transport.active', function(transport) {
+      transport.disconnect(); // disconnect the transport before the connection is connected
+    });
+
+    connection.once('suspended', function() {
+      var suspendedAt = new Date();
+
+      setTimeout(function() {
+        test.ok(connection.state == 'suspended', 'Connection should still be suspended before we trigger it to connect');
+        connection.once('connecting', function() {
+          test.ok(suspendedAt > new Date() - 250, 'Online event should have caused the connection to enter the connecting state immediately');
+          connection.close();
+          test.done();
+        });
+        document.dispatchEvent(onlineEvent);
+      }, 1000)
+    });
+
+    setTimeout(function() {
+      connection.close();
+      test.done();
+    }, 10000)
+  };
+
+  return module.exports = helper.withTimeout(exports);
+});


### PR DESCRIPTION
Reraising https://github.com/ably/ably-js/pull/126 against master as new-upgrade has merged.

Added additional commit https://github.com/ably/ably-js/commit/482d277d589182f8b27807cb181c88a6ad46431a per discussion in old PR, and redid the second test to stub out `chooseTransport` rather than calling `disconnectAllTransports` on('connected') to fix the immediate reconnection making that test fail.