### PR TITLE
Avoid ambiguity in received transport protocol message

### DIFF
--- a/browser/lib/transport/iframetransport.js
+++ b/browser/lib/transport/iframetransport.js
@@ -127,7 +127,7 @@ var IframeTransport = (function() {
 			var items = JSON.parse(String(data));
 			if(items && items.length)
 				for(var i = 0; i < items.length; i++)
-					this.onChannelMessage(items[i]);
+					this.onProtocolMessage(items[i]);
 		} catch (e) {
 			Logger.logAction(Logger.LOG_ERROR, 'IframeTransport.onData()', 'Unexpected exception handing channel event: ' + e);
 		}

--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -243,7 +243,7 @@ var CometTransport = (function() {
 			var items = this.decodeResponse(responseData);
 			if(items && items.length)
 				for(var i = 0; i < items.length; i++)
-					this.onChannelMessage(ProtocolMessage.fromDecoded(items[i]));
+					this.onProtocolMessage(ProtocolMessage.fromDecoded(items[i]));
 		} catch (e) {
 			Logger.logAction(Logger.LOG_ERROR, 'CometTransport.onData()', 'Unexpected exception handing channel event: ' + e.stack);
 		}

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -53,10 +53,10 @@ var Transport = (function() {
 		this.dispose();
 	};
 
-	Transport.prototype.onChannelMessage = function(message) {
+	Transport.prototype.onProtocolMessage = function(message) {
 		switch(message.action) {
 		case actions.HEARTBEAT:
-			Logger.logAction(Logger.LOG_MICRO, 'Transport.onChannelMessage()', 'heartbeat; connectionKey = ' + this.connectionManager.connectionKey);
+			Logger.logAction(Logger.LOG_MICRO, 'Transport.onProtocolMessage()', 'heartbeat; connectionKey = ' + this.connectionManager.connectionKey);
 			this.emit('heartbeat');
 			break;
 		case actions.CONNECTED:
@@ -88,7 +88,7 @@ var Transport = (function() {
 			break;
 		case actions.ERROR:
 			var msgErr = message.error;
-			Logger.logAction(Logger.LOG_ERROR, 'Transport.onChannelMessage()', 'error; connectionKey = ' + this.connectionManager.connectionKey + '; err = ' + JSON.stringify(msgErr));
+			Logger.logAction(Logger.LOG_ERROR, 'Transport.onProtocolMessage()', 'error; connectionKey = ' + this.connectionManager.connectionKey + '; err = ' + JSON.stringify(msgErr));
 			if(message.channel === undefined) {
 				/* a transport error */
 				var err = {

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -86,7 +86,7 @@ var WebSocketTransport = (function() {
 	WebSocketTransport.prototype.onWsData = function(data) {
 		Logger.logAction(Logger.LOG_MICRO, 'WebSocketTransport.onWsData()', 'data received; length = ' + data.length + '; type = ' + typeof(data));
 		try {
-			this.onChannelMessage(ProtocolMessage.decode(data, this.format));
+			this.onProtocolMessage(ProtocolMessage.decode(data, this.format));
 		} catch (e) {
 			Logger.logAction(Logger.LOG_ERROR, 'WebSocketTransport.onWsData()', 'Unexpected exception handing channel message: ' + e.stack);
 		}

--- a/spec/realtime/upgrade.test.js
+++ b/spec/realtime/upgrade.test.js
@@ -178,11 +178,11 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					 * NOTE: this relies on knowledge of the internal implementation
 					 * of the transport */
 
-					var originalOnChannelMessage = transport.onChannelMessage;
-					transport.onChannelMessage = function(message) {
+					var originalOnProtocolMessage = transport.onProtocolMessage;
+					transport.onProtocolMessage = function(message) {
 						if(message.messages)
 							test.ok(false, 'Message received on comet transport');
-						originalOnChannelMessage.apply(this, arguments);
+						originalOnProtocolMessage.apply(this, arguments);
 					};
 				}
 			});


### PR DESCRIPTION
@paddybyers @SimonWoolf 

Whilst looking through some code, I found the name `onChannelMessage` incredibly misleading, especially when `ChannelManager.onChannelMessage` expects a ChannelMessage, whereas `Transport.onChannelMessage` expects any type of ProtocolMessage.