### PR TITLE
NodeCometTransport: clear request timeout on request error

### DIFF
--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -71,6 +71,9 @@ var CometTransport = (function() {
 				self.recvRequest = null;
 				if(err) {
 					self.emit('error', err);
+					/* If connect errors before the preconnect, connectionManager is
+					* never given the transport, so need to dispose of it ourselves */
+					self.dispose();
 					return;
 				}
 			});

--- a/nodejs/lib/transport/nodecomettransport.js
+++ b/nodejs/lib/transport/nodecomettransport.js
@@ -96,6 +96,8 @@ var NodeCometTransport = (function() {
 
 		req.on('error', this.onReqError = function(err) {
 			console.log('req error: ' + err.stack);
+			clearTimeout(timer);
+			self.timer = null;
 			self.complete(err);
 		});
 


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/commit/d5fc19a327bde198126238bbb824a9b019cae99a.

(The connectionmanager doesn't know about the transport till it calls the preconnect callback, which it never does if the initial connect fails - which is fine, it's just the transport wasn't clearing the timeout when it got a 404)

@paddybyers not sure if the transport should also dispose() itself if the connect request errors (ie put a `self.dispose()` in [here](https://github.com/ably/ably-js/blob/master/common/lib/transport/comettransport.js#L72-L75)), wdyt?