### PR TITLE
clientId specs

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -41,6 +41,7 @@ var Auth = (function() {
 	function Auth(rest, options) {
 		this.rest = rest;
 		this.tokenParams = {};
+		this.clientId = options.clientId;
 
 		/* decide default auth method */
 		var key = options.key;
@@ -133,8 +134,8 @@ var Auth = (function() {
 	Auth.prototype.authorise = function(tokenParams, authOptions, callback) {
 		var token = this.tokenDetails;
 		if(token) {
-			if(this.rest.clientId && token.clientId && this.rest.clientId !== token.clientId) {
-				callback(new ErrorInfo('ClientId in token was ' + token.clientId + ', but library was instantiated with clientId ' + this.rest.clientId, 40102, 401));
+			if(this.clientId && token.clientId && this.clientId !== token.clientId) {
+				callback(new ErrorInfo('ClientId in token was ' + token.clientId + ', but library was instantiated with clientId ' + this.clientId, 40102, 401));
 				return;
 			}
 			if(token.expires === undefined || (token.expires > this.getTimestamp())) {

--- a/common/lib/client/channel.js
+++ b/common/lib/client/channel.js
@@ -63,8 +63,7 @@ var Channel = (function() {
 	Channel.prototype.publish = function() {
 		var argCount = arguments.length,
 			messages = arguments[0],
-			callback = arguments[argCount - 1],
-			options = this.options;
+			callback = arguments[argCount - 1];
 
 		if(typeof(callback) !== 'function') {
 			callback = noop;
@@ -86,7 +85,11 @@ var Channel = (function() {
 		if(rest.options.headers)
 			Utils.mixin(headers, rest.options.headers);
 
-		Resource.post(rest, this.basePath + '/messages', requestBody, headers, null, false, callback);
+		this._publish(requestBody, headers, callback);
+	};
+
+	Channel.prototype._publish = function(requestBody, headers, callback) {
+		Resource.post(this.rest, this.basePath + '/messages', requestBody, headers, null, false, callback);
 	};
 
 	return Channel;

--- a/common/lib/client/connection.js
+++ b/common/lib/client/connection.js
@@ -8,6 +8,7 @@ var Connection = (function() {
 		this.state = this.connectionManager.state.state;
 		this.key = undefined;
 		this.id = undefined;
+		this.serial = undefined;
 
 		var self = this;
 		this.connectionManager.on('connectionstate', function(stateChange) {

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -18,22 +18,22 @@ var RealtimePresence = (function() {
 	RealtimePresence.prototype.enter = function(data, callback) {
 		if(!this.clientId)
 			throw new Error('clientId must be specified to enter a presence channel');
-		this._enterOrUpdateClient(this.clientId, data, callback, 'enter');
+		this._enterOrUpdateClient(undefined, data, callback, 'enter');
 	};
 
 	RealtimePresence.prototype.update = function(data, callback) {
 		if(!this.clientId) {
 			throw new Error('clientId must be specified to update presence data');
 		}
-		this._enterOrUpdateClient(this.clientId, data, callback, 'update');
+		this._enterOrUpdateClient(undefined, data, callback, 'update');
 	};
 
 	RealtimePresence.prototype.enterClient = function(clientId, data, callback) {
-		this._enterOrUpdateClient(clientId, data, callback, 'enter')
+		this._enterOrUpdateClient(clientId, data, callback, 'enter');
 	};
 
 	RealtimePresence.prototype.updateClient = function(clientId, data, callback) {
-		this._enterOrUpdateClient(clientId, data, callback, 'update')
+		this._enterOrUpdateClient(clientId, data, callback, 'update');
 	};
 
 	RealtimePresence.prototype._enterOrUpdateClient = function(clientId, data, callback, action) {
@@ -47,13 +47,13 @@ var RealtimePresence = (function() {
 		}
 
 		Logger.logAction(Logger.LOG_MICRO, 'RealtimePresence.' + action + 'Client()',
-		  action + 'ing; channel = ' + this.channel.name + ', client = ' + clientId)
+		  action + 'ing; channel = ' + this.channel.name + ', client = ' + clientId || '(implicit) ' + this.clientId);
 
 		var presence = PresenceMessage.fromValues({
 			action : presenceAction[action.toUpperCase()],
-			clientId : clientId,
-			data: data
+			data   : data
 		});
+		if (clientId) { presence.clientId = clientId; }
 		var channel = this.channel;
 		switch(channel.state) {
 			case 'attached':
@@ -89,16 +89,16 @@ var RealtimePresence = (function() {
 		}
 		if(!this.clientId)
 			throw new Error('clientId must have been specified to enter or leave a presence channel');
-		this.leaveClient(this.clientId, data, callback);
+		this.leaveClient(undefined, data, callback);
 	};
 
 	RealtimePresence.prototype.leaveClient = function(clientId, data, callback) {
 		Logger.logAction(Logger.LOG_MICRO, 'RealtimePresence.leaveClient()', 'leaving; channel = ' + this.channel.name + ', client = ' + clientId);
 		var presence = PresenceMessage.fromValues({
 			action : presenceAction.LEAVE,
-			clientId : clientId,
-			data: data
+			data   : data
 		});
+		if (clientId) { presence[clientId] = clientId; }
 		var channel = this.channel;
 		switch(channel.state) {
 			case 'attached':

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -31,7 +31,6 @@ var Rest = (function() {
 		if(options.log)
 			Logger.setLog(options.log.level, options.log.handler);
 		Logger.logAction(Logger.LOG_MINOR, 'Rest()', 'started');
-		this.clientId = options.clientId;
 
 		this.serverTimeOffset = null;
 		this.baseUri = this.authority = function(host) { return 'https://' + host + ':' + (options.tlsPort || Defaults.TLS_PORT); };

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -539,7 +539,7 @@ var ConnectionManager = (function() {
 	ConnectionManager.prototype.setConnection = function(connectionId, connectionKey, connectionSerial) {
 		this.realtime.connection.id = this.connectionId = connectionId;
 		this.realtime.connection.key = this.connectionKey = connectionKey;
-		this.connectionSerial = (connectionSerial === undefined) ? -1 : connectionSerial;
+		this.realtime.connection.serial = this.connectionSerial = (connectionSerial === undefined) ? -1 : connectionSerial;
 		this.msgSerial = 0;
 		if(this.options.recover === true)
 			this.persistConnection();
@@ -549,7 +549,7 @@ var ConnectionManager = (function() {
 	ConnectionManager.prototype.clearConnection = function() {
 		this.realtime.connection.id = this.connectionId = undefined;
 		this.realtime.connection.key = this.connectionKey = undefined;
-		this.connectionSerial = undefined;
+		this.realtime.connection.serial = this.connectionSerial = undefined;
 		this.msgSerial = 0;
 		this.unpersistConnection();
 	};
@@ -938,7 +938,7 @@ var ConnectionManager = (function() {
 				return;
 			}
 			if(connectionSerial !== undefined) {
-				this.connectionSerial = connectionSerial;
+				this.realtime.connection.serial = this.connectionSerial = connectionSerial;
 			}
 			this.realtime.channels.onChannelMessage(message);
 		} else {

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -442,8 +442,10 @@ var ConnectionManager = (function() {
 		if(connectionKey && this.connectionKey != connectionKey)  {
 			this.setConnection(connectionId, connectionKey, connectionSerial);
 		}
+
+		var auth = this.realtime.auth;
 		if(clientId) {
-			if(this.realtime.clientId && this.realtime.clientId != clientId) {
+			if(auth.clientId && auth.clientId != clientId) {
 				/* Should never happen in normal circumstances as realtime should
 				 * recognise mismatch and return an error */
 				var msg = 'Unexpected mismatch between expected and received clientId'
@@ -452,7 +454,7 @@ var ConnectionManager = (function() {
 				transport.abort(err);
 				return;
 			}
-			this.realtime.clientId = clientId;
+			auth.clientId = clientId;
 		}
 
 		this.emit('transport.active', transport, connectionKey, transport.params);

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -66,7 +66,7 @@ var Transport = (function() {
 			break;
 		case actions.CONNECTED:
 			this.onConnect(message);
-			this.emit('connected', null, message.connectionKey, message.connectionSerial, message.connectionId, (message.connectionDetails ? message.connectionDetails.clientId : null));
+			this.emit('connected', null, (message.connectionDetails ? message.connectionDetails.connectionKey : message.connectionKey), message.connectionSerial, message.connectionId, (message.connectionDetails ? message.connectionDetails.clientId : null));
 			break;
 		case actions.CLOSED:
 			this.isConnected = false;

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -226,7 +226,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var realtime = helper.AblyRealtime({ authCallback: authCallback });
 
 		realtime.connection.on('connected', function() {
-			test.equal(realtime.clientId, testClientId);
+			test.equal(realtime.auth.clientId, testClientId);
 			realtime.connection.close();
 			test.done();
 			return;

--- a/spec/realtime/failure.test.js
+++ b/spec/realtime/failure.test.js
@@ -124,7 +124,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						disconnectedRetryTimeout: 1000,
 						realtimeRequestTimeout: 50,
 						suspendedRetryTimeout: 1000,
-						connectionStateTtl: 2500
+						connectionStateTtl: 2900
 					});
 					realtime.connection.on(function() {
 						connectionEvents.push(this.event);
@@ -136,13 +136,13 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						'connecting','disconnected', // immediately
 						'connecting','disconnected', // at 1s
 						'connecting','disconnected', // at 2s
-						'suspended',                 // at 2.5s
-						'connecting', 'suspended'    // at 3.5s
+						'suspended',                 // at 2.9s
+						'connecting', 'suspended'    // at 3.9s
 					];
 					setTimeout(function() {
 						test.deepEqual(connectionEvents, expectedConnectionEvents, 'connection state for ' + transports + ' was ' + connectionEvents + ', expected ' + expectedConnectionEvents);
 						cb(null, realtime);
-					}, 4000);
+					}, 4800);
 				};
 			};
 			async.parallel(

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -83,16 +83,17 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 	/* init with key string and useTokenAuth: true */
 	exports.init_key_with_usetokenauth = function(test) {
-		test.expect(2);
+		test.expect(3);
 		var realtime;
 		try {
 			var keyStr = helper.getTestApp().keys[0].keyStr;
-			realtime = new helper.Ably.Realtime({key: keyStr, useTokenAuth: true});
+			realtime = helper.AblyRealtime({key: keyStr, useTokenAuth: true});
 			test.equal(realtime.options.key, keyStr);
 			test.equal(realtime.auth.method, 'token');
+			test.equal(realtime.auth.clientId, null);
 			closeAndFinish(test, realtime);
 		} catch(e) {
-			test.ok(false, 'Init with key failed with exception: ' + e.stack);
+			test.ok(false, 'Init with key and usetokenauth failed with exception: ' + e.stack);
 			closeAndFinish(test, realtime);
 		}
 	};

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -170,5 +170,37 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		}
 	}
 
+	/* Check that the connectionKey in ConnectionDetails takes precedence over connectionKey in ProtocolMessage,
+	   and clientId in ConnectionDetails updates the client clientId */
+	exports.init_and_connection_details = function(test) {
+		test.expect(4);
+		try {
+			var keyStr = helper.getTestApp().keys[0].keyStr;
+			var realtime = helper.AblyRealtime({ key: keyStr, useTokenAuth: true, transports: ['web_socket'] });
+			realtime.connection.connectionManager.once('transport.pending', function (state) {
+				var transport = realtime.connection.connectionManager.pendingTransports[0],
+						originalOnProtocolMessage = transport.onProtocolMessage;
+				realtime.connection.connectionManager.pendingTransports[0].onProtocolMessage = function(message) {
+					if(message.action === 4) {
+						test.ok(message.connectionDetails.connectionKey);
+						test.equal(message.connectionDetails.connectionKey, message.connectionKey, 'connection keys should match');
+						message.connectionDetails.connectionKey = 'importantConnectionKey';
+						message.connectionDetails.clientId = 'customClientId';
+					}
+					originalOnProtocolMessage.call(transport, message);
+				};
+			});
+			realtime.connection.once('connected', function() {
+				test.equal(realtime.auth.clientId, 'customClientId', 'clientId should be set on the Auth object from connectionDetails');
+				test.equal(realtime.connection.key, 'importantConnectionKey', 'connection key from connectionDetails should be used');
+				test.done();
+				realtime.close();
+			});
+		} catch(e) {
+			test.ok(false, 'Init with token failed with exception: ' + e.stack);
+			test.done();
+		}
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -854,9 +854,10 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	/*
 	 * Attach and enter channel on two connections, seeing
 	 * both members in presence set
+	 * Use get to filter by clientId and connectionId
 	 */
 	exports.presenceTwoMembers = function(test) {
-		test.expect(6);
+		test.expect(10);
 
 		var clientRealtime1, clientRealtime2, clientChannel1, clientChannel2;
 		var channelName = "twoMembers";
@@ -929,8 +930,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 								};
 							};
 							async.parallel([
-								waitForClient(testClientId, 'present'),
-								waitForClient(testClientId2, 'enter'),
+								waitForClient(testClientId),
+								waitForClient(testClientId2),
 								enterPresence
 							], function() {
 								cb2();
@@ -939,20 +940,58 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					});
 					monitorConnection(test, clientRealtime2);
 				}
-			], function() {
-				clientChannel2.presence.get(function(err, members) {
-					if(err) {
-						test.ok(false, 'Presence.get() failed with error: ' + displayError(err));
-						done();
-						return;
+			], function(err) {
+				if (err) {
+					test.ok(false, 'Setup failed: ' + displayError(err));
+					return done();
+				}
+				async.parallel([
+					/* First test: no filters */
+					function(cb) {
+						clientChannel2.presence.get(function(err, members) {
+							if(err) {
+								test.ok(false, 'Presence.get() failed with error: ' + displayError(err));
+								return cb(err);
+							}
+							test.equal(members.length, 2, 'Verify both members present');
+							test.notEqual(members[0].connectionId, members[1].connectionId, 'Verify members have distinct connectionIds');
+							cb();
+						});
+					},
+					/* Second test: filter by clientId */
+					function(cb) {
+						clientChannel2.presence.get({ clientId: testClientId }, function(err, members) {
+							if(err) {
+								test.ok(false, 'Presence.get() failed with error: ' + displayError(err));
+								return cb(err);
+							}
+							test.equal(members.length, 1, 'Verify only one member present when filtered by clientId');
+							test.equal(members[0].clientId, testClientId, 'Verify clientId filter works');
+							cb();
+						});
+					},
+					/* Third test: filter by connectionId */
+					function(cb) {
+						clientChannel2.presence.get({ connectionId: clientRealtime1.connection.id }, function(err, members) {
+							if(err) {
+								test.ok(false, 'Presence.get() failed with error: ' + displayError(err));
+								return cb(err);
+							}
+							test.equal(members.length, 1, 'Verify only one member present when filtered by connectionId');
+							test.equal(members[0].connectionId, clientRealtime1.connection.id, 'Verify connectionId filter works');
+							cb();
+						});
 					}
-					test.equal(members.length, 2, 'Verify both members present');
-					test.notEqual(members[0].connectionId, members[1].connectionId, 'Verify members have distinct connectionIds');
+				], function(err) {
+					if (err) {
+						test.ok(false, 'Setup failed: ' + displayError(err));
+					}
 					done();
 				});
+
 			});
 		} catch(e) {
-			test.ok(false, 'presence.member0 failed with exception: ' + e.stack);
+			test.ok(false, 'presence.presenceTwoMembers failed with exception: ' + e.stack);
 			done();
 		}
 	};

--- a/spec/rest/message.test.js
+++ b/spec/rest/message.test.js
@@ -1,0 +1,134 @@
+"use strict";
+
+define(['ably', 'shared_helper'], function(Ably, helper) {
+	var exports = {};
+
+	exports.setupInit = function(test) {
+		test.expect(1);
+		helper.setupApp(function(err) {
+			if(err) {
+				test.ok(false, helper.displayError(err));
+			} else {
+				test.ok(true, 'app set up');
+			}
+			test.done();
+		});
+	};
+
+
+	/* Authenticate with a clientId and ensure that the clientId is not sent in the Message
+		 and is implicitly added when published */
+	exports.rest_implicit_client_id_0 = function(test) {
+		var clientId = 'implicit_client_id_0',
+			rest = helper.AblyRest({ clientId: clientId }),
+			channel = rest.channels.get('rest_implicit_client_id_0');
+
+		test.expect(3);
+
+		var originalPublish = channel._publish;
+		channel._publish = function(requestBody) {
+			var message = JSON.parse(requestBody)[0];
+			test.ok(message.name === 'event0', 'Outgoing message interecepted');
+			test.ok(!message.clientId, 'client ID is not added by the client library as it is implicit');
+			originalPublish.apply(channel, arguments);
+		};
+
+		channel.publish('event0', null, function(err) {
+			if (err) {
+				test.ok(err, 'Publish failed with implicit clientId');
+				return test.done();
+			}
+
+			channel.history(function(err, page) {
+				if (err) {
+					test.ok(err, 'History failed with implicit clientId');
+					return test.done();
+				}
+
+				var message = page.items[0];
+				test.ok(message.clientId == clientId, 'Client ID was added implicitly');
+				test.done();
+			});
+		});
+	};
+
+	/* Authenticate with a clientId and explicitly provide the same clientId in the Message
+		 and ensure it is published */
+	exports.rest_explicit_client_id_0 = function(test) {
+		var clientId = 'explicit_client_id_0',
+			rest = helper.AblyRest({ clientId: clientId }),
+			channel = rest.channels.get('rest_explicit_client_id_0');
+
+		test.expect(3);
+
+		var originalPublish = channel._publish;
+		channel._publish = function(requestBody) {
+			var message = JSON.parse(requestBody)[0];
+			test.ok(message.name === 'event0', 'Outgoing message interecepted');
+			test.ok(message.clientId == clientId, 'client ID is added by the client library as it is explicit in the publish');
+			originalPublish.apply(channel, arguments);
+		};
+
+		channel.publish({ name: 'event0', clientId: clientId}, function(err) {
+			if (err) {
+				test.ok(err, 'Publish failed with explicit clientId');
+				return test.done();
+			}
+
+			channel.history(function(err, page) {
+				if (err) {
+					test.ok(err, 'History failed with explicit clientId');
+					return test.done();
+				}
+
+				var message = page.items[0];
+				test.ok(message.clientId == clientId, 'Client ID was retained');
+				test.done();
+			});
+		});
+	};
+
+	/* Authenticate with a clientId and explicitly provide a different invalid clientId in the Message
+		 and expect it to not be published and be rejected */
+	exports.rest_explicit_client_id_1 = function(test) {
+		var clientId = 'explicit_client_id_0',
+			invalidClientId = 'invalid';
+
+		test.expect(4);
+
+		helper.AblyRest().auth.requestToken({ clientId: clientId }, function(err, token) {
+			test.ok(token.clientId === clientId, 'client ID is present in the Token');
+
+			// REST client uses a token string so is unaware of the clientId so cannot reject before communicating with Ably
+			var rest = helper.AblyRest({ token: token.token }),
+				channel = rest.channels.get('rest_explicit_client_id_1');
+
+			var originalPublish = channel._publish;
+			channel._publish = function(requestBody) {
+				var message = JSON.parse(requestBody)[0];
+				test.ok(message.name === 'event0', 'Outgoing message interecepted');
+				test.ok(message.clientId == invalidClientId, 'invalid client ID is added by the client library as it is explicit in the publish');
+				originalPublish.apply(channel, arguments);
+			};
+
+			channel.publish({ name: 'event0', clientId: invalidClientId}, function(err) {
+				if (!err) {
+					test.ok(false, 'Publish should have failed with invalid clientId');
+					return test.done();
+				}
+
+				channel.history(function(err, page) {
+					if (err) {
+						test.ok(err, 'History failed with explicit clientId');
+						return test.done();
+					}
+
+					test.equal(page.items.length, 0, 'Message should not have been published');
+					test.done();
+				});
+			});
+		});
+	};
+
+	return module.exports = helper.withTimeout(exports);
+});


### PR DESCRIPTION
This covers off some of the requirements described in the [recent updates to the spec in regards to clientId](https://github.com/ably/docs/commit/e5d66bdeb50994c82b21cae4a1a6aecfac26adbb)

@paddybyers most of these tests don't pass because of the known implicit and explicit `clientId` issues.  Specifically the following is failing:

* implicit clientId not added via REST publish
* invalid clientId not rejected when publishing over Realtime or REST