### PR TITLE
Configurable timeouts and suspended fixes

### DIFF
--- a/browser/lib/transport/jsonptransport.js
+++ b/browser/lib/transport/jsonptransport.js
@@ -52,10 +52,10 @@ var JSONPTransport = (function() {
 	};
 
 	var createRequest = JSONPTransport.prototype.createRequest = function(uri, headers, params, body, requestMode) {
-		return new Request(undefined, uri, headers, params, body, requestMode);
+		return new Request(undefined, uri, headers, params, body, requestMode, this.timeouts);
 	};
 
-	function Request(id, uri, headers, params, body, requestMode) {
+	function Request(id, uri, headers, params, body, requestMode, timeouts) {
 		EventEmitter.call(this);
 		if(id === undefined) id = idCounter++;
 		this.id = id;
@@ -63,6 +63,7 @@ var JSONPTransport = (function() {
 		this.params = params || {};
 		this.body = body;
 		this.requestMode = requestMode;
+		this.timeouts = timeouts;
 		this.requestComplete = false;
 	}
 	Utils.inherits(Request, EventEmitter);
@@ -109,7 +110,7 @@ var JSONPTransport = (function() {
 			self.complete(err);
 		};
 
-		var timeout = (this.requestMode == CometTransport.REQ_SEND) ? Defaults.httpRequestTimeout : Defaults.recvTimeout;
+		var timeout = (this.requestMode == CometTransport.REQ_SEND) ? this.timeouts.httpRequestTimeout : this.timeouts.recvTimeout;
 		this.timer = setTimeout(function() { self.abort(); }, timeout);
 		head.insertBefore(script, head.firstChild);
 	};

--- a/browser/lib/transport/jsonptransport.js
+++ b/browser/lib/transport/jsonptransport.js
@@ -109,7 +109,7 @@ var JSONPTransport = (function() {
 			self.complete(err);
 		};
 
-		var timeout = (this.requestMode == CometTransport.REQ_SEND) ? Defaults.sendTimeout : Defaults.recvTimeout;
+		var timeout = (this.requestMode == CometTransport.REQ_SEND) ? Defaults.httpRequestTimeout : Defaults.recvTimeout;
 		this.timer = setTimeout(function() { self.abort(); }, timeout);
 		head.insertBefore(script, head.firstChild);
 	};

--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -82,7 +82,7 @@ var XHRRequest = (function() {
 	};
 
 	XHRRequest.prototype.exec = function() {
-		var timeout = (this.requestMode == REQ_SEND) ? Defaults.sendTimeout : Defaults.recvTimeout,
+		var timeout = (this.requestMode == REQ_SEND) ? Defaults.httpRequestTimeout : Defaults.recvTimeout,
 			timer = this.timer = setTimeout(function() { xhr.abort(); }, timeout),
 			body = this.body,
 			method = body ? 'POST' : 'GET',
@@ -276,7 +276,7 @@ var XHRRequest = (function() {
 	* http://msdn.microsoft.com/en-us/library/cc288060(v=VS.85).aspx
 	*/
 	XDRRequest.prototype.exec = function() {
-		var timeout = (this.requestMode == REQ_SEND) ? Defaults.sendTimeout : Defaults.recvTimeout,
+		var timeout = (this.requestMode == REQ_SEND) ? Defaults.httpRequestTimeout : Defaults.recvTimeout,
 			timer = this.timer = setTimeout(function() { xhr.abort(); }, timeout),
 			body = this.body,
 			method = body ? 'POST' : 'GET',

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -439,7 +439,7 @@ var RealtimeChannel = (function() {
 			self.stateTimer = null;
 			/* retry */
 			self.checkPendingState();
-		}, Defaults.httpRequestTimeout);
+		}, this.options.timeouts.httpRequestTimeout);
 	};
 
 	RealtimeChannel.prototype.checkPendingState = function() {

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -439,7 +439,7 @@ var RealtimeChannel = (function() {
 			self.stateTimer = null;
 			/* retry */
 			self.checkPendingState();
-		}, Defaults.sendTimeout);
+		}, Defaults.httpRequestTimeout);
 	};
 
 	RealtimeChannel.prototype.checkPendingState = function() {

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -439,7 +439,7 @@ var RealtimeChannel = (function() {
 			self.stateTimer = null;
 			/* retry */
 			self.checkPendingState();
-		}, this.options.timeouts.httpRequestTimeout);
+		}, this.options.timeouts.realtimeRequestTimeout);
 	};
 
 	RealtimeChannel.prototype.checkPendingState = function() {

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -80,12 +80,12 @@ var ConnectionManager = (function() {
 		this.options = options;
 		this.states = {
 			initialized:   {state: 'initialized',   terminal: false, queueEvents: true,  sendEvents: false},
-			connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.connectTimeout, failState: 'disconnected'},
+			connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.realtimeOpenTimeout, failState: 'disconnected'},
 			connected:     {state: 'connected',     terminal: false, queueEvents: false, sendEvents: true,  failState: 'disconnected'},
 			synchronizing: {state: 'connected',     terminal: false, queueEvents: true,  sendEvents: false},
-			disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.disconnectTimeout},
-			suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.suspendedTimeout},
-			closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.connectTimeout, failState: 'closed'},
+			disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.disconnectedRetryFrequency},
+			suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.suspendedRetryFrequency},
+			closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.realtimeCloseTimeout, failState: 'closed'},
 			closed:        {state: 'closed',        terminal: true,  queueEvents: false, sendEvents: false},
 			failed:        {state: 'failed',        terminal: true,  queueEvents: false, sendEvents: false}
 		};
@@ -639,7 +639,7 @@ var ConnectionManager = (function() {
 				self.states.connecting.queueEvents = false;
 				self.notifyState({state: 'suspended'});
 			}
-		}, Defaults.suspendedTimeout);
+		}, Defaults.connectionStateTtl);
 	};
 
 	ConnectionManager.prototype.checkSuspendTimer = function(state) {
@@ -965,7 +965,7 @@ var ConnectionManager = (function() {
 				callback(null, responseTime);
 			};
 
-			var timer = setTimeout(onTimeout, Defaults.sendTimeout);
+			var timer = setTimeout(onTimeout, Defaults.httpRequestTimeout);
 
 			transport.once('heartbeat', onHeartbeat);
 			transport.ping();

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -616,7 +616,7 @@ var ConnectionManager = (function() {
 				Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager connect timer expired', 'requesting new state: ' + self.states.connecting.failState);
 				self.notifyState({state: transitionState.failState});
 			}
-		}, Defaults.connectTimeout);
+		}, transitionState.retryDelay);
 	};
 
 	ConnectionManager.prototype.cancelTransitionTimer = function() {

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -84,8 +84,8 @@ var ConnectionManager = (function() {
 			connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: timeouts.realtimeRequestTimeout, failState: 'disconnected'},
 			connected:     {state: 'connected',     terminal: false, queueEvents: false, sendEvents: true,  failState: 'disconnected'},
 			synchronizing: {state: 'connected',     terminal: false, queueEvents: true,  sendEvents: false},
-			disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: timeouts.disconnectedRetryFrequency},
-			suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: timeouts.suspendedRetryFrequency},
+			disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: timeouts.disconnectedRetryTimeout},
+			suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: timeouts.suspendedRetryTimeout},
 			closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: timeouts.realtimeRequestTimeout, failState: 'closed'},
 			closed:        {state: 'closed',        terminal: true,  queueEvents: false, sendEvents: false},
 			failed:        {state: 'failed',        terminal: true,  queueEvents: false, sendEvents: false}

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -78,14 +78,15 @@ var ConnectionManager = (function() {
 		EventEmitter.call(this);
 		this.realtime = realtime;
 		this.options = options;
+		var timeouts = options.timeouts;
 		this.states = {
 			initialized:   {state: 'initialized',   terminal: false, queueEvents: true,  sendEvents: false},
-			connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.realtimeOpenTimeout, failState: 'disconnected'},
+			connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: timeouts.realtimeOpenTimeout, failState: 'disconnected'},
 			connected:     {state: 'connected',     terminal: false, queueEvents: false, sendEvents: true,  failState: 'disconnected'},
 			synchronizing: {state: 'connected',     terminal: false, queueEvents: true,  sendEvents: false},
-			disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: Defaults.disconnectedRetryFrequency},
-			suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.suspendedRetryFrequency},
-			closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: Defaults.realtimeCloseTimeout, failState: 'closed'},
+			disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: timeouts.disconnectedRetryFrequency},
+			suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: timeouts.suspendedRetryFrequency},
+			closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: timeouts.realtimeCloseTimeout, failState: 'closed'},
 			closed:        {state: 'closed',        terminal: true,  queueEvents: false, sendEvents: false},
 			failed:        {state: 'failed',        terminal: true,  queueEvents: false, sendEvents: false}
 		};
@@ -558,8 +559,8 @@ var ConnectionManager = (function() {
 	ConnectionManager.prototype.persistConnection = function() {
 		if(createCookie) {
 			if(this.connectionKey && this.connectionSerial !== undefined) {
-				createCookie(connectionKeyCookie, this.connectionKey, Defaults.connectionPersistTimeout);
-				createCookie(connectionSerialCookie, this.connectionSerial, Defaults.connectionPersistTimeout);
+				createCookie(connectionKeyCookie, this.connectionKey, this.options.timeouts.connectionPersistTimeout);
+				createCookie(connectionSerialCookie, this.connectionSerial, this.options.timeouts.connectionPersistTimeout);
 			}
 		}
 	};
@@ -639,7 +640,7 @@ var ConnectionManager = (function() {
 				self.states.connecting.queueEvents = false;
 				self.notifyState({state: 'suspended'});
 			}
-		}, Defaults.connectionStateTtl);
+		}, this.options.timeouts.connectionStateTtl);
 	};
 
 	ConnectionManager.prototype.checkSuspendTimer = function(state) {
@@ -968,7 +969,7 @@ var ConnectionManager = (function() {
 				callback(null, responseTime);
 			};
 
-			var timer = setTimeout(onTimeout, Defaults.httpRequestTimeout);
+			var timer = setTimeout(onTimeout, this.options.timeouts.httpRequestTimeout);
 
 			transport.once('heartbeat', onHeartbeat);
 			transport.ping();

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -643,7 +643,7 @@ var ConnectionManager = (function() {
 	};
 
 	ConnectionManager.prototype.checkSuspendTimer = function(state) {
-		if(state !== 'disconnected' && state !== 'suspended')
+		if(state !== 'disconnected' && state !== 'suspended' && state !== 'connecting')
 			this.cancelSuspendTimer();
 	};
 
@@ -680,10 +680,11 @@ var ConnectionManager = (function() {
 		if(state == this.state.state)
 			return;
 
-		/* kill timers (possibly excepting suspend timer, as these are superseded by this notification */
+		/* kill timers (possibly excepting suspend timer depending on the notified
+		* state), as these are superseded by this notification */
 		this.cancelTransitionTimer();
 		this.cancelRetryTimer();
-		this.checkSuspendTimer();
+		this.checkSuspendTimer(indicated.state);
 
 		/* do nothing if we're unable to move from the current state */
 		if(this.state.terminal)
@@ -719,7 +720,9 @@ var ConnectionManager = (function() {
 		/* kill running timers, as this request supersedes them */
 		this.cancelTransitionTimer();
 		this.cancelRetryTimer();
-		this.cancelSuspendTimer();
+		/* for suspend timer check rather than cancel -- eg requesting a connecting
+		* state should not reset the suspend timer */
+		this.checkSuspendTimer(state);
 
 		if(state == 'connecting') {
 			if(this.state.state == 'connected')

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -81,12 +81,12 @@ var ConnectionManager = (function() {
 		var timeouts = options.timeouts;
 		this.states = {
 			initialized:   {state: 'initialized',   terminal: false, queueEvents: true,  sendEvents: false},
-			connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: timeouts.realtimeOpenTimeout, failState: 'disconnected'},
+			connecting:    {state: 'connecting',    terminal: false, queueEvents: true,  sendEvents: false, retryDelay: timeouts.realtimeRequestTimeout, failState: 'disconnected'},
 			connected:     {state: 'connected',     terminal: false, queueEvents: false, sendEvents: true,  failState: 'disconnected'},
 			synchronizing: {state: 'connected',     terminal: false, queueEvents: true,  sendEvents: false},
 			disconnected:  {state: 'disconnected',  terminal: false, queueEvents: true,  sendEvents: false, retryDelay: timeouts.disconnectedRetryFrequency},
 			suspended:     {state: 'suspended',     terminal: false, queueEvents: false, sendEvents: false, retryDelay: timeouts.suspendedRetryFrequency},
-			closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: timeouts.realtimeCloseTimeout, failState: 'closed'},
+			closing:       {state: 'closing',       terminal: false, queueEvents: false, sendEvents: false, retryDelay: timeouts.realtimeRequestTimeout, failState: 'closed'},
 			closed:        {state: 'closed',        terminal: true,  queueEvents: false, sendEvents: false},
 			failed:        {state: 'failed',        terminal: true,  queueEvents: false, sendEvents: false}
 		};
@@ -969,7 +969,7 @@ var ConnectionManager = (function() {
 				callback(null, responseTime);
 			};
 
-			var timer = setTimeout(onTimeout, this.options.timeouts.httpRequestTimeout);
+			var timer = setTimeout(onTimeout, this.options.timeouts.realtimeRequestTimeout);
 
 			transport.once('heartbeat', onHeartbeat);
 			transport.ping();

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -20,6 +20,7 @@ var Transport = (function() {
 		this.connectionManager = connectionManager;
 		this.auth = auth;
 		this.params = params;
+		this.timeouts = params.options.timeouts;
 		this.format = params.format;
 		this.isConnected = false;
 	}

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -143,7 +143,7 @@ var WebSocketTransport = (function() {
 			Logger.logAction(Logger.LOG_MICRO, 'WebSocketTransport.startConnectTimeout()',
 				'Websocket failed to open after connectTimeout expired; disposing');
 			self.dispose();
-		}, Defaults.connectTimeout);
+		}, Defaults.realtimeOpenTimeout);
 	};
 
 	WebSocketTransport.prototype.cancelConnectTimeout = function() {

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -143,7 +143,7 @@ var WebSocketTransport = (function() {
 			Logger.logAction(Logger.LOG_MICRO, 'WebSocketTransport.startConnectTimeout()',
 				'Websocket failed to open after connectTimeout expired; disposing');
 			self.dispose();
-		}, this.timeouts.realtimeOpenTimeout);
+		}, this.timeouts.realtimeRequestTimeout);
 	};
 
 	WebSocketTransport.prototype.cancelConnectTimeout = function() {

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -143,7 +143,7 @@ var WebSocketTransport = (function() {
 			Logger.logAction(Logger.LOG_MICRO, 'WebSocketTransport.startConnectTimeout()',
 				'Websocket failed to open after connectTimeout expired; disposing');
 			self.dispose();
-		}, Defaults.realtimeOpenTimeout);
+		}, this.timeouts.realtimeOpenTimeout);
 	};
 
 	WebSocketTransport.prototype.cancelConnectTimeout = function() {

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -5,15 +5,18 @@ Defaults.WS_HOST                  = 'realtime.ably.io';
 Defaults.FALLBACK_HOSTS           = ['A.ably-realtime.com', 'B.ably-realtime.com', 'C.ably-realtime.com', 'D.ably-realtime.com', 'E.ably-realtime.com'];
 Defaults.PORT                     = 80;
 Defaults.TLS_PORT                 = 443;
-
-Defaults.realtimeOpenTimeout        = 15000;
-Defaults.realtimeCloseTimeout       = 10000;
-Defaults.disconnectedRetryFrequency = 15000;
-Defaults.suspendedRetryFrequency    = 30000;
-Defaults.connectionStateTtl         = 60000;
-Defaults.recvTimeout                = 90000;
-Defaults.httpRequestTimeout         = 15000;
-Defaults.connectionPersistTimeout   = 15000;
+Defaults.TIMEOUTS = {
+	/* Documented as options params: */
+	disconnectedRetryFrequency : 15000,
+	suspendedRetryFrequency    : 30000,
+	httpRequestTimeout         : 15000,
+	/* Not documented: */
+	connectionStateTtl         : 60000,
+	realtimeOpenTimeout        : 15000,
+	realtimeCloseTimeout       : 10000,
+	recvTimeout                : 90000,
+	connectionPersistTimeout   : 15000
+};
 
 Defaults.version                  = '0.8.6';
 
@@ -51,6 +54,12 @@ Defaults.normaliseOptions = function(options) {
 	options.port = options.port || Defaults.PORT;
 	options.tlsPort = options.tlsPort || Defaults.TLS_PORT;
 	if(!('tls' in options)) options.tls = true;
+
+	/* Allow values passed in options to override default timeouts */
+	options.timeouts = {};
+	for(var prop in Defaults.TIMEOUTS) {
+		options.timeouts[prop] = options[prop] || Defaults.TIMEOUTS[prop];
+	};
 
 	return options;
 };

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -7,8 +7,8 @@ Defaults.PORT                     = 80;
 Defaults.TLS_PORT                 = 443;
 Defaults.TIMEOUTS = {
 	/* Documented as options params: */
-	disconnectedRetryFrequency : 15000,
-	suspendedRetryFrequency    : 30000,
+	disconnectedRetryTimeout : 15000,
+	suspendedRetryTimeout    : 30000,
 	httpRequestTimeout         : 15000,
 	/* Not documented: */
 	connectionStateTtl         : 60000,

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -12,8 +12,7 @@ Defaults.TIMEOUTS = {
 	httpRequestTimeout         : 15000,
 	/* Not documented: */
 	connectionStateTtl         : 60000,
-	realtimeOpenTimeout        : 15000,
-	realtimeCloseTimeout       : 10000,
+	realtimeRequestTimeout     : 15000,
 	recvTimeout                : 90000,
 	connectionPersistTimeout   : 15000
 };

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -5,12 +5,16 @@ Defaults.WS_HOST                  = 'realtime.ably.io';
 Defaults.FALLBACK_HOSTS           = ['A.ably-realtime.com', 'B.ably-realtime.com', 'C.ably-realtime.com', 'D.ably-realtime.com', 'E.ably-realtime.com'];
 Defaults.PORT                     = 80;
 Defaults.TLS_PORT                 = 443;
-Defaults.connectTimeout           = 15000;
-Defaults.disconnectTimeout        = 30000;
-Defaults.suspendedTimeout         = 120000;
-Defaults.recvTimeout              = 90000;
-Defaults.sendTimeout              = 10000;
-Defaults.connectionPersistTimeout = 15000;
+
+Defaults.realtimeOpenTimeout        = 15000;
+Defaults.realtimeCloseTimeout       = 10000;
+Defaults.disconnectedRetryFrequency = 15000;
+Defaults.suspendedRetryFrequency    = 30000;
+Defaults.connectionStateTtl         = 60000;
+Defaults.recvTimeout                = 90000;
+Defaults.httpRequestTimeout         = 15000;
+Defaults.connectionPersistTimeout   = 15000;
+
 Defaults.version                  = '0.8.6';
 
 Defaults.getHost = function(options, host, ws) {

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -17,6 +17,7 @@ Defaults.TIMEOUTS = {
 	recvTimeout                : 90000,
 	connectionPersistTimeout   : 15000
 };
+Defaults.httpMaxRetryCount = 3;
 
 Defaults.version                  = '0.8.6';
 
@@ -35,9 +36,10 @@ Defaults.getPort = function(options, tls) {
 
 Defaults.getHosts = function(options) {
 	var hosts = [options.host],
-		fallbackHosts = options.fallbackHosts;
+		fallbackHosts = options.fallbackHosts,
+		httpMaxRetryCount = typeof(options.httpMaxRetryCount) !== 'undefined' ? options.httpMaxRetryCount : Defaults.httpMaxRetryCount;
 
-	if(fallbackHosts) hosts = hosts.concat(fallbackHosts);
+	if(fallbackHosts) hosts = hosts.concat(fallbackHosts.slice(0, httpMaxRetryCount));
 	return hosts;
 };
 

--- a/nodejs/lib/transport/nodecomettransport.js
+++ b/nodejs/lib/transport/nodecomettransport.js
@@ -88,7 +88,7 @@ var NodeCometTransport = (function() {
 	Utils.inherits(Request, EventEmitter);
 
 	Request.prototype.exec = function() {
-		var timeout = (this.requestMode == CometTransport.REQ_SEND) ? Defaults.sendTimeout : Defaults.recvTimeout,
+		var timeout = (this.requestMode == CometTransport.REQ_SEND) ? Defaults.httpRequestTimeout : Defaults.recvTimeout,
 			self = this;
 
 		var timer = this.timer = setTimeout(function() { self.abort(); }, timeout),

--- a/nodejs/lib/transport/nodecomettransport.js
+++ b/nodejs/lib/transport/nodecomettransport.js
@@ -50,14 +50,15 @@ var NodeCometTransport = (function() {
 	};
 
 	NodeCometTransport.prototype.createRequest = function(uri, headers, params, body, requestMode) {
-		return new Request(uri, headers, params, body, requestMode, this.format);
+		return new Request(uri, headers, params, body, requestMode, this.format, this.timeouts);
 	};
 
-	function Request(uri, headers, params, body, requestMode, format) {
+	function Request(uri, headers, params, body, requestMode, format, timeouts) {
 		EventEmitter.call(this);
 		if(typeof(uri) == 'string') uri = url.parse(uri);
 		this.client = (uri.protocol == 'http:') ? http : https;
 		this.requestMode = requestMode;
+		this.timeouts = timeouts;
 		this.requestComplete = false;
 		this.req = this.res = null;
 
@@ -88,7 +89,7 @@ var NodeCometTransport = (function() {
 	Utils.inherits(Request, EventEmitter);
 
 	Request.prototype.exec = function() {
-		var timeout = (this.requestMode == CometTransport.REQ_SEND) ? Defaults.httpRequestTimeout : Defaults.recvTimeout,
+		var timeout = (this.requestMode == CometTransport.REQ_SEND) ? this.timeouts.httpRequestTimeout : this.timeouts.recvTimeout,
 			self = this;
 
 		var timer = this.timer = setTimeout(function() { self.abort(); }, timeout),

--- a/spec/browser/connection.test.js
+++ b/spec/browser/connection.test.js
@@ -2,13 +2,10 @@
 
 define(['ably', 'shared_helper'], function(Ably, helper) {
 	var exports = {},
+	_exports = {},
 		closeAndFinish = helper.closeAndFinish,
 		monitorConnection = helper.monitorConnection,
-		simulateDroppedConnection = helper.simulateDroppedConnection,
-		Defaults = Ably.Realtime.Defaults,
-		oldDisconnectTimeout = Defaults.disconnectTimeout,
-		oldSuspendedTimeout = Defaults.suspendedTimeout,
-		oldConnectTimeout = Defaults.connectTimeout;
+		simulateDroppedConnection = helper.simulateDroppedConnection;
 
 	function supportedBrowser(test) {
 		if(document.body.ononline === undefined) {
@@ -68,12 +65,12 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	exports.device_going_online_causes_disconnected_connection_to_reconnect_immediately = function(test) {
-		var realtime = helper.AblyRealtime(),
+ 		/* Give up trying to connect fairly quickly */
+		var realtime = helper.AblyRealtime({realtimeOpenTimeout: 1000}),
 		connection = realtime.connection,
 		onlineEvent = new Event('online', {'bubbles': true});
 
 		test.expect(3);
-		Defaults.connectTimeout = 1000; // Give up trying to connect fairly quickly
 		monitorConnection(test, realtime);
 
 		// simulate the internet being failed by stubbing out chooseTransport to foil
@@ -89,7 +86,6 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				test.ok(new Date() - disconnectedAt < 1500, 'Online event should have caused the connection to enter the connecting state without waiting for disconnect timeout');
 				connection.once('connected', function() {
 					test.ok(true, 'Successfully reconnected');
-					Defaults.connectTimeout = oldConnectTimeout;
 					closeAndFinish(test, realtime);
 				})
 			});
@@ -100,10 +96,8 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	exports.device_going_online_causes_suspended_connection_to_reconnect_immediately = function(test) {
-		Defaults.disconnectTimeout = 200; // retry connection more frequently
-		Defaults.suspendedTimeout = 2000; // move to suspended state after 2s of being disconnected
-
-		var realtime = helper.AblyRealtime(),
+		/* move to suspended state after 2s of being disconnected */
+		var realtime = helper.AblyRealtime({ disconnectedRetryFrequency: 500, realtimeOpenTimeout: 500, connectionStateTtl: 2000 }),
 		connection = realtime.connection,
 		onlineEvent = new Event('online', {'bubbles': true});
 
@@ -115,28 +109,19 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			test.ok(false, 'connection to server failed');
 			closeAndFinish(test, realtime);
 		});
+		connection.on(function(){console.log(this.event)})
 
 		connection.once('suspended', function() {
 			var suspendedAt = new Date();
 			test.ok(connection.state == 'suspended', 'Connection should still be suspended before we trigger it to connect');
 			connection.once('connecting', function() {
 				test.ok(new Date() - suspendedAt < 1500, 'Online event should have caused the connection to enter the connecting state without waiting for suspended timeout');
-				Defaults.disconnectTimeout = oldDisconnectTimeout;
-				Defaults.suspendedTimeout = oldSuspendedTimeout;
 				closeAndFinish(test, realtime);
 			});
 			// simulate online event
 			document.dispatchEvent(onlineEvent);
 		});
 	};
-
-	exports.clean99 = function(test) {
-		// Ensure defaults are reset
-		Defaults.connectTimeout = oldConnectTimeout;
-		Defaults.disconnectTimeout = oldDisconnectTimeout;
-		Defaults.suspendedTimeout = oldSuspendedTimeout;
-		test.done();
-	}
 
 	return module.exports = supportedBrowser() ? helper.withTimeout(exports) : {};
 

--- a/spec/browser/connection.test.js
+++ b/spec/browser/connection.test.js
@@ -66,7 +66,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 	exports.device_going_online_causes_disconnected_connection_to_reconnect_immediately = function(test) {
  		/* Give up trying to connect fairly quickly */
-		var realtime = helper.AblyRealtime({realtimeOpenTimeout: 1000}),
+		var realtime = helper.AblyRealtime({realtimeRequestTimeout: 1000}),
 		connection = realtime.connection,
 		onlineEvent = new Event('online', {'bubbles': true});
 
@@ -97,7 +97,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 	exports.device_going_online_causes_suspended_connection_to_reconnect_immediately = function(test) {
 		/* move to suspended state after 2s of being disconnected */
-		var realtime = helper.AblyRealtime({ disconnectedRetryFrequency: 500, realtimeOpenTimeout: 500, connectionStateTtl: 2000 }),
+		var realtime = helper.AblyRealtime({ disconnectedRetryFrequency: 500, realtimeRequestTimeout: 500, connectionStateTtl: 2000 }),
 		connection = realtime.connection,
 		onlineEvent = new Event('online', {'bubbles': true});
 

--- a/spec/browser/connection.test.js
+++ b/spec/browser/connection.test.js
@@ -97,7 +97,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 	exports.device_going_online_causes_suspended_connection_to_reconnect_immediately = function(test) {
 		/* move to suspended state after 2s of being disconnected */
-		var realtime = helper.AblyRealtime({ disconnectedRetryFrequency: 500, realtimeRequestTimeout: 500, connectionStateTtl: 2000 }),
+		var realtime = helper.AblyRealtime({ disconnectedRetryTimeout: 500, realtimeRequestTimeout: 500, connectionStateTtl: 2000 }),
 		connection = realtime.connection,
 		onlineEvent = new Event('online', {'bubbles': true});
 

--- a/spec/realtime/failure.test.js
+++ b/spec/realtime/failure.test.js
@@ -91,5 +91,62 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		}
 	};
 
+	/*
+	 * Connect with various transports with a bad host, check that
+	 * the connecting/disconnecting/suspended cycle works as expected
+	 */
+	exports.no_connection_lifecycle = function(test) {
+		test.expect(availableTransports.length + 1);
+
+		try {
+			var lifecycleTest = function(transports) {
+				return function(cb) {
+					var connectionEvents = [];
+					var realtime = helper.AblyRealtime({
+						transports: transports,
+						wsHost: 'example.com',
+						host: 'example.com',
+						/* Timings note: some transports fail immediately with an invalid
+						* host, others take longer; so set the realtimeOpenTimeout to be
+						* small enough that the max difference is never large enough that
+						* the suspended timeout trips before three connection cycles */
+						disconnectedRetryFrequency: 1000,
+						realtimeOpenTimeout: 50,
+						suspendedRetryFrequency: 1000,
+						connectionStateTtl: 2500
+					});
+					realtime.connection.on(function() {
+						connectionEvents.push(this.event);
+					});
+
+					/* After 4s, has been through three connecting/disconnected cycles
+					* and one connecting/suspended cycles */
+					var expectedConnectionEvents = [
+						'connecting','disconnected', // immediately
+						'connecting','disconnected', // at 1s
+						'connecting','disconnected', // at 2s
+						'suspended',                 // at 2.5s
+						'connecting', 'suspended'    // at 3.5s
+					];
+					setTimeout(function() {
+						test.deepEqual(connectionEvents, expectedConnectionEvents, 'connection state for ' + transports + ' was ' + connectionEvents + ', expected ' + expectedConnectionEvents);
+						cb(null, realtime);
+					}, 4000);
+				};
+			};
+			async.parallel(
+				availableTransports.map(function(transport) {
+					return lifecycleTest([transport]);
+				}).concat(lifecycleTest(null)), // to test not specifying a transport (so will use upgrade mechanism)
+				function(err, realtimes) {
+					closeAndFinish(test, realtimes);
+				}
+			);
+		} catch(e) {
+			test.ok(false, 'connection failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/realtime/failure.test.js
+++ b/spec/realtime/failure.test.js
@@ -110,9 +110,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						* host, others take longer; so set the realtimeRequestTimeout to be
 						* small enough that the max difference is never large enough that
 						* the suspended timeout trips before three connection cycles */
-						disconnectedRetryFrequency: 1000,
+						disconnectedRetryTimeout: 1000,
 						realtimeRequestTimeout: 50,
-						suspendedRetryFrequency: 1000,
+						suspendedRetryTimeout: 1000,
 						connectionStateTtl: 2500
 					});
 					realtime.connection.on(function() {

--- a/spec/realtime/failure.test.js
+++ b/spec/realtime/failure.test.js
@@ -107,11 +107,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						wsHost: 'example.com',
 						host: 'example.com',
 						/* Timings note: some transports fail immediately with an invalid
-						* host, others take longer; so set the realtimeOpenTimeout to be
+						* host, others take longer; so set the realtimeRequestTimeout to be
 						* small enough that the max difference is never large enough that
 						* the suspended timeout trips before three connection cycles */
 						disconnectedRetryFrequency: 1000,
-						realtimeOpenTimeout: 50,
+						realtimeRequestTimeout: 50,
 						suspendedRetryFrequency: 1000,
 						connectionStateTtl: 2500
 					});

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -136,8 +136,8 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		try {
 			var realtime = helper.AblyRealtime({
 				key: 'not_a.real:key',
-				disconnectedRetryFrequency: 123,
-				suspendedRetryFrequency: 456,
+				disconnectedRetryTimeout: 123,
+				suspendedRetryTimeout: 456,
 				httpRequestTimeout: 789,
 			});
 			/* Note: uses internal knowledge of connectionManager */

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -151,5 +151,24 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		}
 	};
 
+	/* check changing the default fallback hosts and changing httpMaxRetryCount */
+	exports.init_fallbacks = function(test) {
+		test.expect(1);
+		try {
+			var realtime = helper.AblyRealtime({
+				key: 'not_a.real:key',
+				host: 'a',
+				httpMaxRetryCount: 2,
+				fallbackHosts: ['b', 'c', 'd', 'e']
+			});
+			/* Note: uses internal knowledge of connectionManager */
+			test.deepEqual(realtime.connection.connectionManager.httpHosts, ['a', 'b', 'c'], 'Verify hosts list is as expected');
+			closeAndFinish(test, realtime);
+		} catch(e) {
+			test.ok(false, 'init_defaulthost failed with exception: ' + e.stack);
+			test.done();
+		}
+	}
+
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -130,5 +130,26 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		}
 	};
 
+	/* check changing the default timeouts */
+	exports.init_timeouts = function(test) {
+		test.expect(3);
+		try {
+			var realtime = helper.AblyRealtime({
+				key: 'not_a.real:key',
+				disconnectedRetryFrequency: 123,
+				suspendedRetryFrequency: 456,
+				httpRequestTimeout: 789,
+			});
+			/* Note: uses internal knowledge of connectionManager */
+			test.equal(realtime.connection.connectionManager.states.disconnected.retryDelay, 123, 'Verify disconnected retry frequency is settable');
+			test.equal(realtime.connection.connectionManager.states.suspended.retryDelay, 456, 'Verify suspended retry frequency is settable');
+			test.equal(realtime.connection.connectionManager.options.timeouts.httpRequestTimeout, 789, 'Verify suspended retry frequency is settable');
+			closeAndFinish(test, realtime);
+		} catch(e) {
+			test.ok(false, 'init_defaulthost failed with exception: ' + e.stack);
+			test.done();
+		}
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/rest/defaults.test.js
+++ b/spec/rest/defaults.test.js
@@ -16,7 +16,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.deepEqual(normalisedOptions.fallbackHosts, Defaults.FALLBACK_HOSTS);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host].concat(Defaults.FALLBACK_HOSTS));
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host].concat(Defaults.FALLBACK_HOSTS.slice(0,3)));
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'rest.ably.io', false), 'rest.ably.io');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'rest.ably.io', true), 'realtime.ably.io');
 
@@ -36,7 +36,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.deepEqual(normalisedOptions.fallbackHosts, Defaults.FALLBACK_HOSTS);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host].concat(Defaults.FALLBACK_HOSTS));
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host].concat(Defaults.FALLBACK_HOSTS.slice(0,3)));
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'rest.ably.io', false), 'rest.ably.io');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'rest.ably.io', true), 'realtime.ably.io');
 


### PR DESCRIPTION
Implementation of https://github.com/ably/docs/pull/51, as well as some fixes to make the `suspended` state work. (Not implemented yet pending discussion: `httpMaxRetryDuration`).

Not for merging until https://github.com/ably/docs/pull/51 is finalised and merged.

Closes https://github.com/ably/ably-js/issues/99