### PR TITLE
Allow iframe transport to work with local (file://) pages

### DIFF
--- a/browser/lib/transport/iframetransport.js
+++ b/browser/lib/transport/iframetransport.js
@@ -1,6 +1,11 @@
 var IframeTransport = (function() {
 	var origin = location.origin || location.protocol + "//" + location.hostname + (location.port ? ':' + location.port: '');
 
+	/* Allows iframe to work from local (file://) files - firefox sets to origin
+	* to 'null', chrome to 'file://', neither of which are valid security
+	* restrictions. */
+	if (origin === 'null' || origin === 'file://') origin = '*';
+
 	/* public constructor */
 	function IframeTransport(connectionManager, auth, params) {
 		params.binary = false;


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/55. (Turns out was only broken because I was testing from a local file).

But -- **possibly introduces security hole**? In theory should only happen with local files, which means only for people testing / playing about with ably. But I don't know enough about what's going on to know if this could be an security hole when not a local file, eg through some malicious script manipulating `window.location`.

There doesn't seem to be any way around it at the moment (MDN says "posting a message to a page at a file: URL currently requires that the targetOrigin argument be `*`. file:// cannot be used as a security restriction; this restriction may be modified in the future"), so if it is a security hole, then I'll do an another PR that just makes `IframeTransport.isAvailable` return false when using local files.