### PR TITLE
ably-js-browsers-all

### DIFF
--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -32,6 +32,10 @@ var XHRRequest = (function() {
 		return xhr.getResponseHeader && xhr.getResponseHeader('content-type');
 	}
 
+	function isEncodingChunked(xhr) {
+		return xhr.getResponseHeader && xhr.getResponseHeader('transfer-encoding') === 'chunked';
+	}
+
 	function XHRRequest(uri, headers, params, body, requestMode) {
 		EventEmitter.call(this);
 		params = params || {};
@@ -127,7 +131,7 @@ var XHRRequest = (function() {
 				self.complete();
 				return;
 			}
-			streaming = (self.requestMode == REQ_RECV_STREAM && successResponse);
+			streaming = (self.requestMode == REQ_RECV_STREAM && successResponse && isEncodingChunked(xhr));
 		}
 
 		function onEnd() {

--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -28,6 +28,17 @@ var XHRRequest = (function() {
 		return false;
 	};
 
+	function ieVersion() {
+		var match = navigator.userAgent.toString().match(/MSIE\s([\d.]+)/);
+		return match && Number(match[1]);
+	}
+
+	function needJsonEnvelope() {
+		/* IE 10 xhr bug: http://stackoverflow.com/a/16320339 */
+		var version;
+		return isIE && (version = ieVersion()) && version === 10;
+	}
+
 	function getContentType(xhr) {
 		return xhr.getResponseHeader && xhr.getResponseHeader('content-type');
 	}
@@ -40,6 +51,8 @@ var XHRRequest = (function() {
 		EventEmitter.call(this);
 		params = params || {};
 		params.rnd = String(Math.random()).substr(2);
+		if(needJsonEnvelope() && !params.envelope)
+			params.envelope = 'json';
 		this.uri = uri + Utils.toQueryString(params);
 		this.headers = headers || {};
 		this.body = body;
@@ -137,6 +150,7 @@ var XHRRequest = (function() {
 		function onEnd() {
 			try {
 				var contentType = getContentType(xhr),
+					headers = null,
 					json = contentType ? (contentType == 'application/json') : (xhr.responseType == 'text');
 
 				responseBody = json ? xhr.responseText : xhr.response;
@@ -153,6 +167,14 @@ var XHRRequest = (function() {
 					responseBody = JSON.parse(String(responseBody));
 					unpacked = true;
 				}
+
+				if(responseBody.response !== undefined) {
+					/* unwrap JSON envelope */
+					statusCode = responseBody.statusCode;
+					successResponse = (statusCode < 400);
+					headers = responseBody.headers;
+					responseBody = responseBody.response;
+				}
 			} catch(e) {
 				var err = new Error('Malformed response body from server: ' + e.message);
 				err.statusCode = 400;
@@ -161,7 +183,7 @@ var XHRRequest = (function() {
 			}
 
 			if(successResponse) {
-				self.complete(null, responseBody, (contentType && {'content-type': contentType}), unpacked);
+				self.complete(null, responseBody, headers || (contentType && {'content-type': contentType}), unpacked);
 				return;
 			}
 

--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -44,7 +44,9 @@ var XHRRequest = (function() {
 	}
 
 	function isEncodingChunked(xhr) {
-		return xhr.getResponseHeader && xhr.getResponseHeader('transfer-encoding') === 'chunked';
+		// TODO below line is wrong, remove it and uncomment the other when realtime supports it
+		return true;
+		//return xhr.getResponseHeader && xhr.getResponseHeader('transfer-encoding') === 'chunked';
 	}
 
 	function XHRRequest(uri, headers, params, body, requestMode) {

--- a/common/lib/client/resource.js
+++ b/common/lib/client/resource.js
@@ -37,6 +37,12 @@ var Resource = (function() {
 				}
 			}
 
+			if(body.statusCode === undefined) {
+				/* Envelope already unwrapped by the transport */
+				callback(err, body, headers, true);
+				return;
+			}
+
 			var statusCode = body.statusCode,
 				response = body.response,
 				headers = body.headers;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -157,7 +157,8 @@ module.exports = function(config) {
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: Object.keys(customLaunchers),
     captureTimeout: 360000,
-    browserNoActivityTimeout: 3600000,
+    browserDisconnectTimeout : 10000,
+    browserNoActivityTimeout: 360000,
     customLaunchers: customLaunchers,
 
     // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,30 +36,30 @@ module.exports = function(config) {
       platform: 'Windows 10',
       version: '11'
     },
-    sl_ie_10: {
+    sl_ie_10_win7: {
       base: 'SauceLabs',
       browserName: 'internet explorer',
-      platform: 'Windows 8',
+      platform: 'Windows 7',
       version: '10'
     },
-    sl_ios_safari_8_2: {
+    sl_ios_safari_8_4: {
       base: 'SauceLabs',
       browserName: 'iphone',
       platform: 'OS X 10.10',
-      version: '8.2'
+      version: '8.4'
     },
-    sl_ios_safari_7_1: {
+    sl_ios_safari_9_1: {
       base: 'SauceLabs',
       browserName: 'iphone',
-      platform: 'OS X 10.9',
-      version: '7.1'
+      platform: 'OS X 10.10',
+      version: '9.1'
     },
-    sl_android_5_1: {
+    sl_android_5_0: {
       base: 'SauceLabs',
       browserName: 'android',
       deviceName: 'Android Emulator',
       platform: 'Linux',
-      version: '5.1'
+      version: '5.0'
     }
   };
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -155,7 +155,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: Object.keys(customLaunchers),
+    browsers: Object.keys(customLaunchers).concat('IE10 - Win7'),
     captureTimeout: 360000,
     browserDisconnectTimeout : 10000,
     browserNoActivityTimeout: 360000,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "karma-cli": "~0.0",
     "karma-env-preprocessor": "~0.1",
     "karma-firefox-launcher": "~0.1",
+    "karma-ievms": "^0.1.0",
     "karma-nodeunit": "~0.2",
     "karma-phantomjs-launcher": "~0.1",
     "karma-requirejs": "~0.2",
@@ -37,7 +38,7 @@
     "karma-story-reporter": "~0.3",
     "kexec": "~1.2",
     "nodeunit": "~0.9",
-	"requirejs": "~2.1",
+    "requirejs": "~2.1",
     "shelljs": "~0.3"
   },
   "engines": {

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -2,6 +2,7 @@
 
 define(['ably', 'shared_helper'], function(Ably, helper) {
 	var currentTime, exports = {},
+		displayError = helper.displayError,
 		closeAndFinish = helper.closeAndFinish,
 		monitorConnection = helper.monitorConnection;
 
@@ -35,7 +36,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var realtime = helper.AblyRealtime();
 		realtime.auth.requestToken(function(err, tokenDetails) {
 			if(err) {
-				test.ok(false, helper.displayError(err));
+				test.ok(false, displayError(err));
 				closeAndFinish(test, realtime);
 				return;
 			}
@@ -58,7 +59,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var realtime, rest = helper.AblyRest();
 		rest.auth.requestToken(null, null, function(err, tokenDetails) {
 			if(err) {
-				test.ok(false, helper.displayError(err));
+				test.ok(false, displayError(err));
 				closeAndFinish(test, realtime);
 				return;
 			}
@@ -86,7 +87,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var realtime, rest = helper.AblyRest();
 		rest.auth.requestToken(null, null, function(err, tokenDetails) {
 			if(err) {
-				test.ok(false, helper.displayError(err));
+				test.ok(false, displayError(err));
 				closeAndFinish(test, realtime);
 				return;
 			}
@@ -115,7 +116,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.createTokenRequest(tokenParams, null, function(err, tokenRequest) {
 				if(err) {
-					test.ok(false, helper.displayError(err));
+					test.ok(false, displayError(err));
 					closeAndFinish(test, realtime);
 					return;
 				}
@@ -149,7 +150,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.requestToken(tokenParams, null, function(err, tokenDetails) {
 				if(err) {
-					test.ok(false, helper.displayError(err));
+					test.ok(false, displayError(err));
 					closeAndFinish(test, realtime);
 					return;
 				}
@@ -181,7 +182,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.requestToken(null, tokenParams, function(err, tokenDetails) {
 				if(err) {
-					test.ok(false, helper.displayError(err));
+					test.ok(false, displayError(err));
 					closeAndFinish(test, realtime);
 					return;
 				}
@@ -214,7 +215,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.requestToken({clientId: testClientId}, function(err, tokenDetails) {
 				if(err) {
-					test.ok(false, helper.displayError(err));
+					test.ok(false, displayError(err));
 					test.done();
 					return;
 				}
@@ -233,7 +234,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 		realtime.connection.on('failed', function(err) {
 			realtime.close();
-			test.ok(false, "Failed: " + err);
+			test.ok(false, "Failed: " + displayError(err));
 			test.done();
 			return;
 		});

--- a/spec/realtime/channel.test.js
+++ b/spec/realtime/channel.test.js
@@ -29,7 +29,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				var channel0 = realtime.channels.get('channelattach0');
 				channel0.attach(function(err) {
 					if(err)
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 					else
 						test.ok(true, 'Attach to channel 0 with no options');
 					closeAndFinish(test, realtime);
@@ -53,7 +53,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				var channel1 = realtime.channels.get('channelattach1');
 				channel1.attach(function(err) {
 					if(err)
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 					else
 						test.ok(true, 'Attach to channel1 with no options');
 					closeAndFinish(test, realtime);
@@ -76,7 +76,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			var channel2 = realtime.channels.get('channelattach2');
 			channel2.attach(function(err) {
 				if(err)
-					test.ok(false, 'Attach failed with error: ' + err);
+					test.ok(false, 'Attach failed with error: ' + displayError(err));
 				else
 					test.ok(true, 'Attach to channel 0 with no options');
 				closeAndFinish(test, realtime);
@@ -99,12 +99,12 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				var channel0 = realtime.channels.get('channelattach3');
 				channel0.attach(function(err) {
 					if(err) {
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 						closeAndFinish(test, realtime);
 					}
 					channel0.detach(function(err) {
 						if(err) {
-							test.ok(false, 'Detach failed with error: ' + err);
+							test.ok(false, 'Detach failed with error: ' + displayError(err));
 							closeAndFinish(test, realtime);
 						}
 						if(channel0.state == 'detached')
@@ -288,7 +288,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					var channel3 = realtime.channels.get('channel3');
 					channel3.attach(function(err) {
 						if(err)
-							test.ok(false, 'Attach failed with error: ' + err);
+							test.ok(false, 'Attach failed with error: ' + displayError(err));
 						else
 							test.ok(true, 'Attach to channel 3 with no options');
 						closeAndFinish(test, realtime);
@@ -314,13 +314,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					var channel5 = realtime.channels.get('channelattachjson2');
 					channel5.attach(function(err) {
 						if(err) {
-							test.ok(false, 'Attach failed with error: ' + err);
+							test.ok(false, 'Attach failed with error: ' + displayError(err));
 							closeAndFinish(test, realtime);
 						}
 						/* we can't get a callback on a detach, so set a timeout */
 						channel5.detach(function(err) {
 							if(err) {
-								test.ok(false, 'Attach failed with error: ' + err);
+								test.ok(false, 'Attach failed with error: ' + displayError(err));
 								closeAndFinish(test, realtime);
 							}
 							if(channel5.state == 'detached')
@@ -351,7 +351,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					var channel3 = realtime.channels.get('channelattachxhr1');
 					channel3.attach(function(err) {
 						if(err)
-							test.ok(false, 'Attach failed with error: ' + err);
+							test.ok(false, 'Attach failed with error: ' + displayError(err));
 						else
 							test.ok(true, 'Attach to channel 3 with no options');
 						closeAndFinish(test, realtime);
@@ -377,13 +377,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					var channel5 = realtime.channels.get('channelattachxhr2');
 					channel5.attach(function(err) {
 						if(err) {
-							test.ok(false, 'Attach failed with error: ' + err);
+							test.ok(false, 'Attach failed with error: ' + displayError(err));
 							closeAndFinish(test, realtime);
 						}
 						/* we can't get a callback on a detach, so set a timeout */
 						channel5.detach(function(err) {
 							if(err) {
-								test.ok(false, 'Attach failed with error: ' + err);
+								test.ok(false, 'Attach failed with error: ' + displayError(err));
 								closeAndFinish(test, realtime);
 							}
 							if(channel5.state == 'detached')
@@ -414,7 +414,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					var channel3 = realtime.channels.get('channelattachcomet1');
 					channel3.attach(function(err) {
 						if(err)
-							test.ok(false, 'Attach failed with error: ' + err);
+							test.ok(false, 'Attach failed with error: ' + displayError(err));
 						else
 							test.ok(true, 'Attach to channel 3 with no options');
 						closeAndFinish(test, realtime);
@@ -440,13 +440,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					var channel5 = realtime.channels.get('channelattachcomet2');
 					channel5.attach(function(err) {
 						if(err) {
-							test.ok(false, 'Attach failed with error: ' + err);
+							test.ok(false, 'Attach failed with error: ' + displayError(err));
 							closeAndFinish(test, realtime);
 						}
 						/* we can't get a callback on a detach, so set a timeout */
 						channel5.detach(function(err) {
 							if(err) {
-								test.ok(false, 'Attach failed with error: ' + err);
+								test.ok(false, 'Attach failed with error: ' + displayError(err));
 								closeAndFinish(test, realtime);
 							}
 							if(channel5.state == 'detached')
@@ -476,7 +476,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				var channel6 = realtime.channels.get('channelsubscribe0');
 				channel6.attach(function(err) {
 					if(err) {
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 						closeAndFinish(test, realtime);
 					}
 					try {

--- a/spec/realtime/crypto.test.js
+++ b/spec/realtime/crypto.test.js
@@ -6,6 +6,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		BufferUtils = Ably.Realtime.BufferUtils,
 		Crypto = Ably.Realtime.Crypto,
 		Message = Ably.Realtime.Message,
+		displayError = helper.displayError,
 		testResourcesPath = helper.testResourcesPath,
 		msgpack = (typeof(window) == 'object') ? Ably.msgpack : require('msgpack-js'),
 		closeAndFinish = helper.closeAndFinish,
@@ -36,7 +37,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		loadTestData(testResourcesPath + filename, function(err, testData) {
 			if(err) {
-				test.ok(false, 'Unable to get test assets; err = ' + err);
+				test.ok(false, 'Unable to get test assets; err = ' + displayError(err));
 				return;
 			}
 			var realtime = helper.AblyRealtime();
@@ -46,7 +47,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			Crypto.getDefaultParams(key, function(err, params) {
 				if(err) {
-					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 					closeAndFinish(test, realtime);
 					return;
 				}
@@ -183,7 +184,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		Crypto.getDefaultParams(function(err, params) {
 			if(err) {
-				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 				closeAndFinish(test, realtime);
 				return;
 			}
@@ -218,7 +219,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			test.equal(params.algorithm, 'aes');
 			test.equal(params.keyLength, 128);
 			if(err) {
-				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 				closeAndFinish(test, realtime);
 				return;
 			}
@@ -251,7 +252,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				test.equal(params.algorithm, 'aes');
 				test.equal(params.keyLength, 256);
 				if(err) {
-					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 					closeAndFinish(test, realtime);
 					return;
 				}
@@ -285,7 +286,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				test.equal(params.algorithm, 'aes');
 				test.equal(params.keyLength, 256);
 				if(err) {
-					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 					closeAndFinish(test, realtime);
 					return;
 				}
@@ -317,7 +318,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				test.equal(params.algorithm, 'aes');
 				test.equal(params.keyLength, 128);
 				if(err) {
-					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 					closeAndFinish(test, realtime);
 					return;
 				}
@@ -344,7 +345,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				}
 				async.parallel([sendAll, recvAll], function(err) {
 					if(err) {
-						test.ok(false, 'Error sending messages; err = ' + err);
+						test.ok(false, 'Error sending messages; err = ' + displayError(err));
 					}
 					test.ok('Verify all messages received');
 					closeAndFinish(test, realtime);
@@ -383,7 +384,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			function(cb) { attachChannels([txChannel, rxChannel], cb); }
 		], function(err, res) {
 			if (err) {
-				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
@@ -427,7 +428,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			function(cb) { attachChannels([txChannel, rxChannel], cb); }
 		], function(err, res) {
 			if (err) {
-				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
@@ -473,7 +474,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			function(cb) { attachChannels([txChannel, rxChannel], cb); }
 		], function(err, res) {
 			if(err) {
-				test.ok(false, 'Unable to get cipher params; err = ' + err);
+				test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
@@ -512,13 +513,13 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		attachChannels([txChannel, rxChannel], function(err) {
 			if(err) {
-				test.ok(false, 'Unable to get attach channels; err = ' + err);
+				test.ok(false, 'Unable to get attach channels; err = ' + displayError(err));
 				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
 			Crypto.getDefaultParams(function(err, rxParams) {
 				if(err) {
-					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 					closeAndFinish(test, [txRealtime, rxRealtime]);
 					return;
 				}
@@ -554,13 +555,13 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		attachChannels([txChannel, rxChannel], function(err) {
 			if(err) {
-				test.ok(false, 'Unable to get attach channels; err = ' + err);
+				test.ok(false, 'Unable to get attach channels; err = ' + displayError(err));
 				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}
 			Crypto.getDefaultParams(function(err, txParams) {
 				if(err) {
-					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 					closeAndFinish(test, [txRealtime, rxRealtime]);
 					return;
 				}
@@ -600,7 +601,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		var setInitialOptions = function(cb) {
 			Crypto.getDefaultParams(function(err, params) {
 				if(err) {
-					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 					closeAndFinish(test, [txRealtime, rxRealtime]);
 					return;
 				}
@@ -624,7 +625,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		var createSecondKey = function(cb) {
 			Crypto.getDefaultParams(function(err, params) {
 				if(err) {
-					test.ok(false, 'Unable to get cipher params; err = ' + err);
+					test.ok(false, 'Unable to get cipher params; err = ' + displayError(err));
 					closeAndFinish(test, [txRealtime, rxRealtime]);
 					return;
 				}
@@ -670,7 +671,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			sendThirdMessage
 		], function(err) {
 			if(err) {
-				test.ok(false, 'Unexpected error running test; err = ' + err);
+				test.ok(false, 'Unexpected error running test; err = ' + displayError(err));
 				closeAndFinish(test, [txRealtime, rxRealtime]);
 				return;
 			}

--- a/spec/realtime/event_emitter.test.js
+++ b/spec/realtime/event_emitter.test.js
@@ -72,7 +72,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				});
 				channel.attach(function(err) {
 					if(err) {
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 						closeAndFinish(test, realtime);
 					}
 				});

--- a/spec/realtime/history.test.js
+++ b/spec/realtime/history.test.js
@@ -62,7 +62,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					var rtChannel = realtime.channels.get('persisted:history_until_attach');
 					rtChannel.attach(function(err) {
 						if(err) {
-							test.ok(false, 'Attach failed with error: ' + err);
+							test.ok(false, 'Attach failed with error: ' + displayError(err));
 							closeAndFinish(test, realtime);
 							return;
 						}

--- a/spec/realtime/message.test.js
+++ b/spec/realtime/message.test.js
@@ -46,7 +46,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				var rtChannel = realtime.channels.get('publishonce');
 				rtChannel.attach(function(err) {
 					if(err) {
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 						closeAndFinish(test, realtime);
 						return;
 					}
@@ -74,7 +74,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var testData = 'Some data';
 		var errorCallback = function(err){
 			if(err) {
-				test.ok(false, 'Error received by publish callback ' + err);
+				test.ok(false, 'Error received by publish callback ' + displayError(err));
 				closeAndFinish(test, realtime);
 				return;
 			}
@@ -112,7 +112,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				var rtChannel = realtime.channels.get('publishVariations');
 				rtChannel.attach(function(err) {
 					if(err) {
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 						closeAndFinish(test, realtime);
 						return;
 					}
@@ -199,7 +199,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				var rtChannel = realtime.channels.get('publishDisallowed');
 				rtChannel.attach(function(err) {
 					if(err) {
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 						closeAndFinish(test, realtime);
 						return;
 					}
@@ -249,7 +249,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				var rtChannel = realtime.channels.get('publishEncodings');
 				rtChannel.attach(function(err) {
 					if(err) {
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 						closeAndFinish(test, realtime);
 						return;
 					}
@@ -312,7 +312,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 				rtChannel.attach(function(err) {
 					if(err) {
-						test.ok(false, 'Attach failed with error: ' + err);
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
 						closeAndFinish(test, realtime);
 						return;
 					}

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -516,12 +516,12 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Attach to channel, enter presence channel and get presence
 	 */
 	exports.presenceEnterGet = function(test) {
-		test.expect(5);
+		test.expect(4);
 		var channelName = 'enterGet';
 		var testData = 'some data for presenceEnterGet';
 		var eventListener = function(test, channel, callback) {
 			var presenceHandler = function() {
-				test.equal(this.event, 'enter', 'Expect the only presence event to be enter');
+				/* Should be ENTER, but may be PRESENT in a race */
 				channel.presence.get(function(err, presenceMembers) {
 					if(err) {
 						callback(err);

--- a/spec/realtime/resume.test.js
+++ b/spec/realtime/resume.test.js
@@ -3,6 +3,7 @@
 define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	var exports = {},
 		closeAndFinish = helper.closeAndFinish,
+		displayError = helper.displayError,
 		monitorConnection = helper.monitorConnection,
 		simulateDroppedConnection = helper.simulateDroppedConnection;
 
@@ -108,31 +109,31 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		phase0(function(err) {
 			if(err) {
-				test.ok(false, 'Phase 1 failed with err: ' + err);
+				test.ok(false, 'Phase 1 failed with err: ' + displayError(err));
 				test.done();
 				return;
 			}
 			phase1(function(err) {
 				if(err) {
-					test.ok(false, 'Phase 1 failed with err: ' + err);
+					test.ok(false, 'Phase 1 failed with err: ' + displayError(err));
 					test.done();
 					return;
 				}
 				phase2(function(err) {
 					if(err) {
-						test.ok(false, 'Phase 2 failed with err: ' + err);
+						test.ok(false, 'Phase 2 failed with err: ' + displayError(err));
 						test.done();
 						return;
 					}
 					phase3(function(err) {
 						if(err) {
-							test.ok(false, 'Phase 3 failed with err: ' + err);
+							test.ok(false, 'Phase 3 failed with err: ' + displayError(err));
 							test.done();
 							return;
 						}
 						phase4(function(err) {
 							if(err) {
-								test.ok(false, 'Phase 4 failed with err: ' + err);
+								test.ok(false, 'Phase 4 failed with err: ' + displayError(err));
 								return;
 							}
 							closeAndFinish(test, [rxRealtime, txRealtime]);
@@ -251,25 +252,25 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		phase0(function(err) {
 			if(err) {
-				test.ok(false, 'Phase 1 failed with err: ' + err);
+				test.ok(false, 'Phase 1 failed with err: ' + displayError(err));
 				closeAndFinish(test, [rxRealtime, txRealtime]);
 				return;
 			}
 			phase1(function(err) {
 				if(err) {
-					test.ok(false, 'Phase 1 failed with err: ' + err);
+					test.ok(false, 'Phase 1 failed with err: ' + displayError(err));
 					closeAndFinish(test, [rxRealtime, txRealtime]);
 					return;
 				}
 				phase2(function(err) {
 					if(err) {
-						test.ok(false, 'Phase 2 failed with err: ' + err);
+						test.ok(false, 'Phase 2 failed with err: ' + displayError(err));
 						closeAndFinish(test, [rxRealtime, txRealtime]);
 						return;
 					}
 					phase3(function(err) {
 						if(err) {
-							test.ok(false, 'Phase 3 failed with err: ' + err);
+							test.ok(false, 'Phase 3 failed with err: ' + displayError(err));
 							closeAndFinish(test, [rxRealtime, txRealtime]);
 							return;
 						}

--- a/spec/realtime/upgrade.test.js
+++ b/spec/realtime/upgrade.test.js
@@ -15,6 +15,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				setTimeout(helper(i), 20*i);
 			}
 		},
+		displayError = helper.displayError,
 		closeAndFinish = helper.closeAndFinish,
 		monitorConnection = helper.monitorConnection;
 
@@ -116,9 +117,9 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					if(rtChannel.state == 'attached') {
 						//console.log('*** publishpostupgrade0: publishing (channel attached on transport active) ...');
 						restChannel.publish('event0', testMsg, function(err) {
-							//console.log('publishpostupgrade0: publish returned err = ' + err);
+							//console.log('publishpostupgrade0: publish returned err = ' + displayError(err));
 							if(err) {
-								test.ok(false, 'Publish failed with error: ' + err);
+								test.ok(false, 'Publish failed with error: ' + displayError(err));
 								closeAndFinish(test, realtime);
 							}
 						});
@@ -126,9 +127,9 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 						rtChannel.on('attached', function() {
 							//console.log('*** publishpostupgrade0: publishing (channel attached after wait) ...');
 							restChannel.publish('event0', testMsg, function(err) {
-								//console.log('publishpostupgrade0: publish returned err = ' + err);
+								//console.log('publishpostupgrade0: publish returned err = ' + displayError(err));
 								if(err) {
-									test.ok(false, 'Publish failed with error: ' + err);
+									test.ok(false, 'Publish failed with error: ' + displayError(err));
 									closeAndFinish(test, realtime);
 								}
 							});

--- a/test/bin/ci-saucelabs-all.sh
+++ b/test/bin/ci-saucelabs-all.sh
@@ -10,20 +10,15 @@ echo "\n$GREEN -> Installing all dependencies $NO_COLOUR"
 npm install
 npm install grunt-cli
 
-echo "\n$GREEN -> Running Karma test suite (Sauce Labs - part 1/3) $NO_COLOUR"
-$(npm bin)/grunt test:karma --browsers sl_chrome_42,sl_chrome_35,sl_firefox_37
+echo "\n$GREEN -> Running Karma test suite (Sauce Labs - part 1/2) $NO_COLOUR"
+$(npm bin)/grunt test:karma --browsers sl_chrome_42,sl_chrome_35,sl_firefox_37,sl_firefox_31
 karma_exitstatus1=$?
 
-echo "\n$GREEN -> Running Karma test suite (Sauce Labs - part 2/3) $NO_COLOUR"
-$(npm bin)/grunt test:karma --browsers sl_firefox_31,sl_ie_11
+echo "\n$GREEN -> Running Karma test suite (Sauce Labs - part 2/2) $NO_COLOUR"
+$(npm bin)/grunt test:karma --browsers sl_ios_safari_9_1,sl_ios_safari_8_4,sl_android_5_0,sl_ie_11
 karma_exitstatus2=$?
-
-echo "\n$GREEN -> Running Karma test suite (Sauce Labs - part 3/3) $NO_COLOUR"
-$(npm bin)/grunt test:karma --browsers sl_ios_safari_9_1,sl_ios_safari_8_4,sl_android_5_0
-karma_exitstatus3=$?
 
 if [[ $karma_exitstatus1 -ne 0 ]]; then exit $karma_exitstatus1; fi
 if [[ $karma_exitstatus2 -ne 0 ]]; then exit $karma_exitstatus2; fi
-if [[ $karma_exitstatus3 -ne 0 ]]; then exit $karma_exitstatus3; fi
 
 exit 0

--- a/test/bin/ci-saucelabs-all.sh
+++ b/test/bin/ci-saucelabs-all.sh
@@ -15,11 +15,11 @@ $(npm bin)/grunt test:karma --browsers sl_chrome_42,sl_chrome_35,sl_firefox_37
 karma_exitstatus1=$?
 
 echo "\n$GREEN -> Running Karma test suite (Sauce Labs - part 2/3) $NO_COLOUR"
-$(npm bin)/grunt test:karma --browsers sl_firefox_31,sl_ie_11,sl_ie_10
+$(npm bin)/grunt test:karma --browsers sl_firefox_31,sl_ie_11
 karma_exitstatus2=$?
 
 echo "\n$GREEN -> Running Karma test suite (Sauce Labs - part 3/3) $NO_COLOUR"
-$(npm bin)/grunt test:karma --browsers sl_ios_safari_8_2,sl_ios_safari_7_1,sl_android_5_1
+$(npm bin)/grunt test:karma --browsers sl_ios_safari_9_1,sl_ios_safari_8_4,sl_android_5_0
 karma_exitstatus3=$?
 
 if [[ $karma_exitstatus1 -ne 0 ]]; then exit $karma_exitstatus1; fi


### PR DESCRIPTION
https://ci.ably.io/job/ably-js-browsers-all/100/ passing ably-js-browsers-all test run! \o/

Fixes an xhr issue on IE10 by using an envelope, to get around [this bug](http://stackoverflow.com/a/16320339).

I only did it for true XHR (which IE10 can use), not XDR, because I don't understand the current xdr code -- it [seems to be assuming](https://github.com/ably/ably-js/blob/master/browser/lib/transport/xhrrequest.js#L292-L295) that all responses from realtime are chunked, even when streaming is off, which they aren't -- I didn't want to assume it was completely broken and rewrite from scratch if I might be missing something. (XDR's only used by IE9 and below anyway, which I explicitly wasn't targeting with this piece of work (it's not in ably-js-browsers-all), so can be sorted later when we do IE9).

This makes IE10 pass. But -- not on saucelabs. I've completely failed at getting the IE10 saucelabs VM to work properly. (It just seems to lose all external connectivity (xhr, jsonp, whatever) about 30s after the test starts, after which every test fails). Having banged by head against that for a few days, I gave up and added a VM karma test. Run with `grunt test:karma --browsers "IE10\ -\ Win7"` after installing the IE10 vm with `curl -s https://raw.githubusercontent.com/xdissent/ievms/master/ievms.sh | env IEVMS_VERSIONS="10" bash`. Will talk to Lewis about getting it working in ci. For now can be run manually.

The way envelopes are used at the moment is a bit messy: they're sometimes added at the restclient level, and sometimes at the transport level (eg jsonp, and now xhr on IE10), but the restclient assumes that if it added one it can remove it (which it can't if the transport already has). 6ab1c31 is a quick fix to stop the resource trying to unwrap an already-unwrapped envelope, but still, a bit inelegant.

Also a few more test fixes and an update to browser selection used in browsers-all.

9624f6f is a temp fix to stop everything failing due to CORS issues, just until https://github.com/ably/realtime/pull/337 is deployed to sandbox. Remove before merging if that's deployed.