### PR TITLE
Presence map: normalise enter/update actions to present in #put

### DIFF
--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -175,7 +175,6 @@ var RealtimePresence = (function() {
 					break;
 				case presenceAction.UPDATE:
 				case presenceAction.ENTER:
-					presence.action = presenceAction.PRESENT;
 				case presenceAction.PRESENT:
 					if(members.put(presence)) {
 						broadcastMessages.push(presence);
@@ -259,6 +258,10 @@ var RealtimePresence = (function() {
 	};
 
 	PresenceMap.prototype.put = function(item) {
+		if(item.action === presenceAction.ENTER || item.action === presenceAction.UPDATE) {
+			item = PresenceMessage.fromValues(item);
+			item.action = presenceAction.PRESENT;
+		}
 		var map = this.map, key = memberKey(item);
 		/* we've seen this member, so do not remove it at the end of sync */
 		if(this.residualMembers)


### PR DESCRIPTION
ITSM should be the presence map's responsibility to normalise its actions - neater than juggling different broadcast and map-member presence messages in #setPresence

Fixes presence tests broken by 9c4f8d7