### PR TITLE
EventEmitter fixes

### DIFF
--- a/common/lib/client/connection.js
+++ b/common/lib/client/connection.js
@@ -21,14 +21,9 @@ var Connection = (function() {
 	}
 	Utils.inherits(Connection, EventEmitter);
 
-	/* public instance methods */
-	Connection.prototype.on = function(state, callback) {
-		EventEmitter.prototype.on.apply(this, arguments);
-		if(this.state == state && callback)
-			try {
-				callback(new ConnectionStateChange(undefined, state));
-			} catch(e) {}
-	};
+	Connection.prototype.onceOrIf = function(state, listener) {
+		EventEmitter.prototype.onceOrIfState.call(this, state, this.state, listener, new ConnectionStateChange(undefined, state));
+	}
 
 	Connection.prototype.connect = function() {
 		Logger.logAction(Logger.LOG_MAJOR, 'Connection.connect()', '');

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -522,5 +522,9 @@ var RealtimeChannel = (function() {
 		Channel.prototype._history.call(this, params, callback);
 	};
 
+	RealtimeChannel.prototype.onceOrIf = function(state, listener) {
+		EventEmitter.prototype.onceOrIfState.call(this, state, this.state, listener);
+	}
+
 	return RealtimeChannel;
 })();

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -265,6 +265,9 @@ var RealtimePresence = (function() {
 	}
 
 	RealtimePresence.prototype.unsubscribe = function() {
+		if(channel.state === 'failed') {
+			throw(ErrorInfo.fromValues(RealtimeChannel.invalidStateError));
+		}
 		_off.apply(this, arguments);
 	}
 

--- a/common/lib/util/eventemitter.js
+++ b/common/lib/util/eventemitter.js
@@ -8,6 +8,13 @@ var EventEmitter = (function() {
 		this.eventsOnce = {};
 	}
 
+	/* Call the listener, catch any exceptions and log, but continue operation*/
+	function callListener(eventThis, listener, args) {
+		try { listener.apply(eventThis, args); } catch(e) {
+			Logger.logAction(Logger.LOG_ERROR, 'EventEmitter.emit()', 'Unexpected listener exception: ' + e + '; stack = ' + e.stack);
+		}
+	}
+
 	/**
 	 * Add an event listener
 	 * @param event (optional) the name of the event to listen to
@@ -104,18 +111,11 @@ var EventEmitter = (function() {
 		var args = Array.prototype.slice.call(arguments, 1);
 		var eventThis = {event:event};
 
-		/* wrap the try/catch in a function improves performance by 30% */
-		function callListener(listener) {
-			try { listener.apply(eventThis, args); } catch(e) {
-				Logger.logAction(Logger.LOG_ERROR, 'EventEmitter.emit()', 'Unexpected listener exception: ' + e + '; stack = ' + e.stack);
-				throw e;
-			}
-		}
 		if(this.anyOnce.length) {
 			var listeners = this.anyOnce;
 			this.anyOnce = [];
 			for(var i = 0; i < listeners.length; i++)
-				callListener((listeners[i]));
+				callListener(eventThis, listeners[i], args);
 		}
 		for(var i = 0; i < this.any.length; i++)
 			this.any[i].apply(eventThis, args);
@@ -123,12 +123,12 @@ var EventEmitter = (function() {
 		if(listeners) {
 			delete this.eventsOnce[event];
 			for(var i = 0; i < listeners.length; i++)
-				callListener((listeners[i]));
+				callListener(eventThis, listeners[i], args);
 		}
 		var listeners = this.events[event];
 		if(listeners)
 			for(var i = 0; i < listeners.length; i++)
-				callListener((listeners[i]));
+				callListener(eventThis, listeners[i], args);
 	};
 
 	/**
@@ -146,6 +146,31 @@ var EventEmitter = (function() {
 			listeners.push(listener);
 		}
 	};
+
+	/**
+	 * Private API
+	 *
+	 * Listen for a single occurrence of a state event and fire immediately if currentState matches targetState
+	 * @param targetState the name of the state event to listen to
+	 * @param currentState the name of the current state of this object
+	 * @param listener the listener to be called
+	 */
+	EventEmitter.prototype.onceOrIfState = function(targetState, currentState, listener /* ...listenerArgs */) {
+		var eventThis = {event:targetState},
+				listenerArgs = Array.prototype.slice.call(arguments, 3);
+
+		if((typeof(targetState) !== 'string') || (typeof(currentState) !== 'string')) {
+			throw("onceOrIf requires a valid event String argument");
+		} else if (typeof(listener) !== 'function') {
+			throw("onceOrIf requires a valid listener argument");
+		} else {
+			if(targetState === currentState) {
+				callListener(eventThis, listener, listenerArgs);
+			} else {
+				this.once(targetState, listener);
+			}
+		}
+	}
 
 	return EventEmitter;
 })();

--- a/common/lib/util/eventemitter.js
+++ b/common/lib/util/eventemitter.js
@@ -159,16 +159,15 @@ var EventEmitter = (function() {
 		var eventThis = {event:targetState},
 				listenerArgs = Array.prototype.slice.call(arguments, 3);
 
-		if((typeof(targetState) !== 'string') || (typeof(currentState) !== 'string')) {
+		if((typeof(targetState) !== 'string') || (typeof(currentState) !== 'string'))
 			throw("onceOrIf requires a valid event String argument");
-		} else if (typeof(listener) !== 'function') {
+		if (typeof(listener) !== 'function')
 			throw("onceOrIf requires a valid listener argument");
+
+		if(targetState === currentState) {
+			callListener(eventThis, listener, listenerArgs);
 		} else {
-			if(targetState === currentState) {
-				callListener(eventThis, listener, listenerArgs);
-			} else {
-				this.once(targetState, listener);
-			}
+			this.once(targetState, listener);
 		}
 	}
 

--- a/spec/realtime/channel.test.js
+++ b/spec/realtime/channel.test.js
@@ -495,6 +495,54 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	}
 
 	/*
+	 * Attach then later call onceOrIf which fires immediately
+	 */
+	exports.channelattachOnceOrIfAfter = function(test) {
+		test.expect(1);
+		try {
+			var realtime = helper.AblyRealtime(),
+					channel = realtime.channels.get('channelattachOnceOrIf'),
+					firedImmediately = false;
+
+			channel.attach(function(err) {
+				channel.onceOrIf('attached', function() {
+					firedImmediately = true;
+				});
+				test.ok(firedImmediately, 'onceOrIf fired immediately as attached');
+				closeAndFinish(test, realtime);
+			});
+			monitorConnection(test, realtime);
+		} catch(e) {
+			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
+	/*
+	 * Attach and call onceOrIf before attach which fires later
+	 */
+	exports.channelattachOnceOrIfBefore = function(test) {
+		test.expect(2);
+		try {
+			var realtime = helper.AblyRealtime(),
+					channel = realtime.channels.get('channelattachOnceOrIf'),
+					firedImmediately = false;
+
+			channel.attach();
+			channel.onceOrIf('attached', function() {
+				firedImmediately = true;
+				test.ok(channel.state === 'attached', 'onceOrIf fired when attached');
+				closeAndFinish(test, realtime);
+			});
+			test.ok(!firedImmediately, 'onceOrIf should not fire immediately as not attached');
+			monitorConnection(test, realtime);
+		} catch(e) {
+			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
+	/*
 	 * Subscribe, then unsubscribe, binary transport
 	 */
 	exports.channelsubscribe0 = function(test) {

--- a/spec/realtime/event_emitter.test.js
+++ b/spec/realtime/event_emitter.test.js
@@ -84,5 +84,19 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		}
 	};
 
+	exports.emitCallsAllCallbacksIgnoringExceptions = function(test) {
+		var realtime = helper.AblyRealtime(),
+				callbackCalled = false,
+				eventEmitter = realtime.connection;
+
+		eventEmitter.on('custom', function() { throw('Expected failure 1'); });
+		eventEmitter.on('custom', function() { throw('Expected failure 2'); });
+		eventEmitter.on('custom', function() { callbackCalled = true; });
+
+		eventEmitter.emit('custom');
+		test.ok(callbackCalled, 'Last callback should have been called');
+		closeAndFinish(test, realtime);
+	}
+
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/realtime/history.test.js
+++ b/spec/realtime/history.test.js
@@ -58,7 +58,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			/* second, connect and attach to the channel */
 			try {
-				realtime.connection.on('connected', function() {
+				realtime.connection.onceOrIf('connected', function() {
 					var rtChannel = realtime.channels.get('persisted:history_until_attach');
 					rtChannel.attach(function(err) {
 						if(err) {


### PR DESCRIPTION
@SimonWoolf and @paddybyers please see my PR which fixes an inconsistency we had with the EventEmitter.  Firstly, it could fire twice when adding an `on` event handler with the Connection object, but this would not fire for `once` or for the Channel object.  I don't see the logic in this exception.

Also, I discovered that the EventEmitter did not correctly handle exceptions by continuing with other handlers when there was an exception, and it would also cause an exception to be thrown in the caller of the `emit`

I added a convenience (undocumented) method `onceOrIf` that is the equivalent of https://github.com/ably/ably-ruby/blob/master/lib/ably/modules/state_emitter.rb#L74