### PR TITLE
Spec updates and miscellania

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.8.9](https://github.com/ably/ably-js/tree/0.8.9) (2015-12-07)
+
+[Changes since 0.8.2](https://github.com/ably/ably-js/compare/0.8.2...0.8.9)
+
 ## [0.8.2](https://github.com/ably/ably-js/tree/0.8.2) (2015-07-01)
 
 [Full Changelog](https://github.com/ably/ably-js/compare/0.8.1...0.8.2)

--- a/README.md
+++ b/README.md
@@ -10,24 +10,11 @@ For complete API documentation, see the [ably documentation](https://ably.io/doc
 
 # For node.js
 
-## Installation
+### Installation from npm
 
-### From npm
+    npm install ably
 
-    npm install ably-js
-
-### From a git url
-
-    npm install <git url>
-
-### From a local clone of this repo
-
-    cd </path/to/this/repo>
-    npm install
-
-## Usage
-
-### With Node.js
+### Usage
 
 For the realtime library:
 
@@ -41,7 +28,7 @@ For the rest-only library:
 var rest = require('ably-js').Rest;
 ```
 
-### With the Browser library
+### For browsers
 
 Include the Ably library in your HTML:
 
@@ -49,7 +36,7 @@ Include the Ably library in your HTML:
 <script src="https://cdn.ably.io/lib/ably.min.js"></script>
 ```
 
-The Ably client library follows [Semantic Versioning](http://semver.org/).  To lock into a major or minor verison of the client library, you can specify a specific version number such as http://cdn.ably.io/lib/ably.min-0.8.2.js or http://cdn.ably.io/lib/ably-0.8.2.js for the non-minified version.  See https://github.com/ably/ably-js/tags for a list of tagged releases.
+The Ably client library follows [Semantic Versioning](http://semver.org/).  To lock into a major or minor verison of the client library, you can specify a specific version number such as http://cdn.ably.io/lib/ably.min-0.8.9.js or http://cdn.ably.io/lib/ably-0.8.9.js for the non-minified version.  See https://github.com/ably/ably-js/tags for a list of tagged releases.
 
 For the real-time library:
 
@@ -347,7 +334,7 @@ Please visit http://support.ably.io/ for access to our knowledgebase and to ask 
 
 You can also view the [community reported Github issues](https://github.com/ably/ably-js/issues).
 
-To see what has changed in recent versions of Bundler, see the [CHANGELOG](CHANGELOG.md).
+To see what has changed in recent versions, see the [CHANGELOG](CHANGELOG.md).
 
 ## Contributing
 
@@ -357,6 +344,12 @@ To see what has changed in recent versions of Bundler, see the [CHANGELOG](CHANG
 4. Ensure you have added suitable tests and the test suite is passing(`grunt test`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+## Releasing
+
+- `grunt release:patch` (or: "major", "minor", "patch", "prepatch")
+- `git push --follow-tags`
+- `npm publish .`
 
 ## License
 

--- a/browser/compat/pubnub.js
+++ b/browser/compat/pubnub.js
@@ -387,8 +387,8 @@
 						occupancy : ablyChannel.presence.get().length
 					});
 				} 
-				ablyChannel.presence.on('enter', function(data) { data.action = 'enter'; presenceEventCb(data); });
-				ablyChannel.presence.on('leave', function(data) { data.action = 'leave'; presenceEventCb(data); });
+				ablyChannel.presence.subscribe('enter', function(data) { data.action = 'enter'; presenceEventCb(data); });
+				ablyChannel.presence.subscribe('leave', function(data) { data.action = 'leave'; presenceEventCb(data); });
 			}
 			ablyChannel.subscribe(cb);
 

--- a/browser/compat/pubnub.js
+++ b/browser/compat/pubnub.js
@@ -128,7 +128,7 @@
 			opts.clientId = uuid;
 		if (origin && (origin.length != 0)) {
 			var p = origin.split(':');
-			opts.host = opts.wsHost = p[0];
+			opts.restHost = opts.realtimeHost = p[0];
 			if (p.length > 1)
 				opts.port = p[1];
 		}

--- a/browser/compat/pusher.js
+++ b/browser/compat/pusher.js
@@ -81,7 +81,7 @@
 		if (options.auth && options.auth.headers) opts.authHeaders = options.auth.headers;
 		if (origin && (origin.length != 0)) {
 			var p = origin.split(':');
-			opts.host = opts.wsHost = p[0];
+			opts.realtimeHost = opts.restHost = p[0];
 			if (p.length > 1)
 				opts.port = p[1];
 		}

--- a/browser/compat/pusher.js
+++ b/browser/compat/pusher.js
@@ -239,13 +239,13 @@
 		if (this.isPresence) {
 			var presence = this.channel.presence;
 			this.entered = false;
-			presence.on('enter', function(id) {
+			presence.subscribe('enter', function(id) {
 				if (!self.entered) return;
 				if (id.clientId === self.members.myID) return;
 				var member = self.members.addMember(id.clientId, id.clientInfo);
 				if (member) self.channel.emit('pusher:member_added', member);
 			});
-			presence.on('leave', function(id) {
+			presence.subscribe('leave', function(id) {
 				if (!self.entered) return;
 				var member = self.members.removeMember(id.clientId);
 				if (member) self.channel.emit('pusher:member_removed', member);

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -40,8 +40,14 @@ var Auth = (function() {
 
 	function Auth(rest, options) {
 		this.rest = rest;
-		this.tokenParams = {};
-		this.clientId = options.clientId;
+		this.tokenParams = options.defaultTokenParams || {};
+
+		/* RSA7a4: if options.clientId is provided and is not
+		 * null, it overrides defaultTokenParams.clientId */
+		if(options.clientId) {
+			this.tokenParams.clientId = options.clientId;
+			this.clientId = options.clientId
+		}
 
 		/* decide default auth method */
 		var key = options.key;
@@ -77,7 +83,6 @@ var Auth = (function() {
 			options.tokenDetails = (typeof(options.token) === 'string') ? {token: options.token} : options.token;
 		}
 		this.tokenDetails = options.tokenDetails;
-		this.tokenParams.clientId = options.clientId;
 
 		if(options.authCallback) {
 			Logger.logAction(Logger.LOG_MINOR, 'Auth()', 'using token auth with authCallback');

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -137,6 +137,15 @@ var Auth = (function() {
 	 * @param callback (err, tokenDetails)
 	 */
 	Auth.prototype.authorise = function(tokenParams, authOptions, callback) {
+		/* shuffle and normalise arguments as necessary */
+		if(typeof(tokenParams) == 'function' && !callback) {
+			callback = tokenParams;
+			authOptions = tokenParams = null;
+		} else if(typeof(authOptions) == 'function' && !callback) {
+			callback = authOptions;
+			authOptions = null;
+		}
+
 		var token = this.tokenDetails;
 		if(token) {
 			if(this.clientId && token.clientId && this.clientId !== token.clientId) {
@@ -375,6 +384,15 @@ var Auth = (function() {
 	 *
 	 */
 	Auth.prototype.createTokenRequest = function(tokenParams, authOptions, callback) {
+		/* shuffle and normalise arguments as necessary */
+		if(typeof(tokenParams) == 'function' && !callback) {
+			callback = tokenParams;
+			authOptions = tokenParams = null;
+		} else if(typeof(authOptions) == 'function' && !callback) {
+			callback = authOptions;
+			authOptions = null;
+		}
+
 		authOptions = Utils.mixin(Utils.copy(this.rest.options), authOptions);
 		tokenParams = tokenParams || Utils.copy(this.tokenParams);
 

--- a/common/lib/client/channel.js
+++ b/common/lib/client/channel.js
@@ -68,9 +68,12 @@ var Channel = (function() {
 			++argCount;
 		}
 		if(argCount == 2) {
-			if(!Utils.isArray(messages))
-				messages = [messages];
-			messages = Message.fromValuesArray(messages);
+			if(Utils.isObject(messages))
+				messages = [Message.fromValues(messages)];
+			else if(Utils.isArray(messages))
+				messages = Message.fromValuesArray(messages);
+			else
+				throw new ErrorInfo('The single-argument form of publish() expects a message object or an array of message objects', 40013, 400);
 		} else {
 			messages = [Message.fromValues({name: arguments[0], data: arguments[1]})];
 		}

--- a/common/lib/client/channel.js
+++ b/common/lib/client/channel.js
@@ -1,23 +1,21 @@
 var Channel = (function() {
 	function noop() {}
 
-	var defaultOptions = {};
-
 	/* public constructor */
-	function Channel(rest, name, options) {
+	function Channel(rest, name, channelOptions) {
 		Logger.logAction(Logger.LOG_MINOR, 'Channel()', 'started; name = ' + name);
 		EventEmitter.call(this);
 		this.rest = rest;
 		this.name = name;
 		this.basePath = '/channels/' + encodeURIComponent(name);
 		this.presence = new Presence(this);
-		this.setOptions(options);
+		this.setOptions(channelOptions);
 	}
 	Utils.inherits(Channel, EventEmitter);
 
 	Channel.prototype.setOptions = function(options, callback) {
 		callback = callback || noop;
-		options = this.options = Utils.prototypicalClone(defaultOptions, options);
+		this.channelOptions = options = options || {};
 		if(options.encrypted) {
 			if(!Crypto) throw new Error('Encryption not enabled; use ably.encryption.js instead');
 			Crypto.getCipher(options, function(err, cipher) {
@@ -49,7 +47,7 @@ var Channel = (function() {
 			format = rest.options.useBinaryProtocol ? 'msgpack' : 'json',
 			envelope = Http.supportsLinkHeaders ? undefined : format,
 			headers = Utils.copy(Utils.defaultGetHeaders(format)),
-			options = this.options,
+			options = this.channelOptions,
 			channel = this;
 
 		if(rest.options.headers)
@@ -79,7 +77,7 @@ var Channel = (function() {
 
 		var rest = this.rest,
 			format = rest.options.useBinaryProtocol ? 'msgpack' : 'json',
-			requestBody = Message.toRequestBody(messages, this.options, format),
+			requestBody = Message.toRequestBody(messages, this.channelOptions, format),
 			headers = Utils.copy(Utils.defaultPostHeaders(format));
 
 		if(rest.options.headers)

--- a/common/lib/client/connection.js
+++ b/common/lib/client/connection.js
@@ -9,6 +9,7 @@ var Connection = (function() {
 		this.key = undefined;
 		this.id = undefined;
 		this.serial = undefined;
+		this.recoveryKey = undefined;
 
 		var self = this;
 		this.connectionManager.on('connectionstate', function(stateChange) {

--- a/common/lib/client/paginatedresource.js
+++ b/common/lib/client/paginatedresource.js
@@ -66,8 +66,15 @@ var PaginatedResource = (function() {
 			this.first = function(cb) { self.get(relParams.first, cb); };
 		if('current' in relParams)
 			this.current = function(cb) { self.get(relParams.current, cb); };
-		if('next' in relParams)
-			this.next = function(cb) { self.get(relParams.next, cb); };
+		this.next = function(cb) {
+			if('next' in relParams)
+				self.get(relParams.next, cb);
+			else
+				cb(null, null);
+		};
+
+		this.hasNext = function() { return ('next' in relParams) };
+		this.isLast = function() { return !this.hasNext(); }
 	}
 
 	PaginatedResult.prototype.get = function(params, callback) {

--- a/common/lib/client/presence.js
+++ b/common/lib/client/presence.js
@@ -21,7 +21,7 @@ var Presence = (function() {
 			format = rest.options.useBinaryProtocol ? 'msgpack' : 'json',
 			envelope = Http.supportsLinkHeaders ? undefined : format,
 			headers = Utils.copy(Utils.defaultGetHeaders(format)),
-			options = this.channel.options;
+			options = this.channel.channelOptions;
 
 		if(rest.options.headers)
 			Utils.mixin(headers, rest.options.headers);
@@ -50,7 +50,7 @@ var Presence = (function() {
 			format = rest.options.useBinaryProtocol ? 'msgpack' : 'json',
 			envelope = Http.supportsLinkHeaders ? undefined : format,
 			headers = Utils.copy(Utils.defaultGetHeaders(format)),
-			options = this.channel.options,
+			options = this.channel.channelOptions,
 			channel = this.channel;
 
 		if(rest.options.headers)

--- a/common/lib/client/realtime.js
+++ b/common/lib/client/realtime.js
@@ -58,11 +58,13 @@ var Realtime = (function() {
 		}
 	};
 
-	Channels.prototype.get = function(name) {
+	Channels.prototype.get = function(name, channelOptions) {
 		name = String(name);
 		var channel = this.all[name];
 		if(!channel) {
-			channel = this.all[name] = new RealtimeChannel(this.realtime, name, this.realtime.options);
+			channel = this.all[name] = new RealtimeChannel(this.realtime, name, channelOptions);
+		} else if(channelOptions) {
+			channel.setOptions(channelOptions);
 		}
 		return channel;
 	};

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -4,7 +4,7 @@ var RealtimeChannel = (function() {
 	var noop = function() {};
 
 	var defaultOptions = {
-		queueEvents: true
+		queueMessages: true
 	};
 
 	/* public constructor */
@@ -234,7 +234,7 @@ var RealtimeChannel = (function() {
 	};
 
 	RealtimeChannel.prototype.sendMessage = function(msg, callback) {
-		this.connectionManager.send(msg, this.options.queueEvents, callback);
+		this.connectionManager.send(msg, this.options.queueMessages, callback);
 	};
 
 	RealtimeChannel.prototype.sendPresence = function(presence, callback) {

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -31,6 +31,14 @@ var RealtimeChannel = (function() {
 		message: 'Channel is detached'
 	};
 
+	RealtimeChannel.processListenerArgs = function(args) {
+		/* [event], listener, [callback] */
+		if(typeof(args[0]) == 'function')
+			return [null, args[0], args[1] || noop];
+		else
+			return [args[0], args[1], (args[2] || noop)];
+	}
+
 	RealtimeChannel.prototype.setOptions = function(options, callback) {
 		callback = callback || noop;
 		this.channelOptions = options = options || {};
@@ -183,19 +191,14 @@ var RealtimeChannel = (function() {
 	};
 
 	RealtimeChannel.prototype.subscribe = function(/* [event], listener, [callback] */) {
-		var args = Array.prototype.slice.call(arguments);
-		if(args.length == 1 && typeof(args[0]) == 'function')
-			args.unshift(null);
-
+		var args = RealtimeChannel.processListenerArgs(arguments);
 		var event = args[0];
 		var listener = args[1];
 		var callback = args[2];
 		var subscriptions = this.subscriptions;
 
 		if(this.state === 'failed') {
-			var err = ErrorInfo.fromValues(RealtimeChannel.invalidStateError);
-			if(callback) callback(err);
-			else throw(err);
+			callback(ErrorInfo.fromValues(RealtimeChannel.invalidStateError));
 			return;
 		}
 
@@ -209,19 +212,14 @@ var RealtimeChannel = (function() {
 	};
 
 	RealtimeChannel.prototype.unsubscribe = function(/* [event], listener, [callback] */) {
-		var args = Array.prototype.slice.call(arguments);
-		if(args.length == 1 && typeof(args[0]) == 'function')
-			args.unshift(null);
-
+		var args = RealtimeChannel.processListenerArgs(arguments);
 		var event = args[0];
 		var listener = args[1];
 		var callback = args[2];
 		var subscriptions = this.subscriptions;
 
 		if(this.state === 'failed') {
-			var err = ErrorInfo.fromValues(RealtimeChannel.invalidStateError);
-			if(callback) callback(err);
-			else throw(err);
+			callback(ErrorInfo.fromValues(RealtimeChannel.invalidStateError));
 			return;
 		}
 
@@ -520,7 +518,7 @@ var RealtimeChannel = (function() {
 				delete params.untilAttach;
 				params.from_serial = this.attachSerial;
 			} else {
-				throw new ErrorInfo("option untilAttach requires the channel to be attached", 40000, 400);
+				callback(new ErrorInfo("option untilAttach requires the channel to be attached", 40000, 400));
 			}
 		}
 

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -405,23 +405,25 @@ var RealtimeChannel = (function() {
 		if(msgErr) {
 			/* this is an error message */
 			var err = {statusCode: msgErr.statusCode, code: msgErr.code, message: msgErr.message};
-			this.failPendingMessages(err);
 			this.setState('failed', err);
+			this.failPendingMessages(err);
 		} else {
-			this.failPendingMessages({statusCode: 404, code: 90001, message: 'Channel detached'});
 			if(this.state !== 'detached') {
 				this.setState('detached');
 			}
+			this.failPendingMessages({statusCode: 404, code: 90001, message: 'Channel detached'});
 		}
 	};
 
 	RealtimeChannel.prototype.setSuspended = function(err, suppressEvent) {
-		Logger.logAction(Logger.LOG_MINOR, 'RealtimeChannel.setSuspended', 'deactivating channel; name = ' + this.name + ', err ' + (err ? err.message : 'none'));
-		this.clearStateTimer();
-		this.failPendingMessages(err);
-		this.presence.setSuspended(err);
-		if(!suppressEvent && this.state !== 'detached') {
-			this.setState('detached');
+		if(this.state !== 'detached' && this.state !== 'failed') {
+			Logger.logAction(Logger.LOG_MINOR, 'RealtimeChannel.setSuspended', 'deactivating channel; name = ' + this.name + ', err ' + (err ? err.message : 'none'));
+			this.clearStateTimer();
+			this.presence.setSuspended(err);
+			if(!suppressEvent) {
+				this.setState('detached');
+			}
+			this.failPendingMessages(err);
 		}
 	};
 

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -61,9 +61,12 @@ var RealtimeChannel = (function() {
 			return;
 		}
 		if(argCount == 2) {
-			if(!Utils.isArray(messages))
-				messages = [messages];
-			messages = Message.fromValuesArray(messages);
+			if(Utils.isObject(messages))
+				messages = [Message.fromValues(messages)];
+			else if(Utils.isArray(messages))
+				messages = Message.fromValuesArray(messages);
+			else
+				throw new ErrorInfo('The single-argument form of publish() expects a message object or an array of message objects', 40013, 400);
 		} else {
 			messages = [Message.fromValues({name: arguments[0], data: arguments[1]})];
 		}

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -102,16 +102,21 @@ var RealtimePresence = (function() {
 	};
 
 	RealtimePresence.prototype.leave = function(data, callback) {
-		if (!callback && (typeof(data)==='function')) {
-			callback = data;
-			data = '';
-		}
 		if(!this.clientId)
 			throw new Error('clientId must have been specified to enter or leave a presence channel');
 		this.leaveClient(undefined, data, callback);
 	};
 
 	RealtimePresence.prototype.leaveClient = function(clientId, data, callback) {
+		if (!callback) {
+			if (typeof(data)==='function') {
+				callback = data;
+				data = null;
+			} else {
+				callback = noop;
+			}
+		}
+
 		Logger.logAction(Logger.LOG_MICRO, 'RealtimePresence.leaveClient()', 'leaving; channel = ' + this.channel.name + ', client = ' + clientId);
 		var presence = PresenceMessage.fromValues({
 			action : presenceAction.LEAVE,

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -151,11 +151,14 @@ var RealtimePresence = (function() {
 			args.unshift(null);
 
 		var params = args[0],
-			callback = args[1] || noop,
-			members = this.members;
+			callback = args[1] || noop;
 
-		members.waitSync(function() {
-			callback(null, params ? members.list(params) : members.values());
+		var self = this;
+		waitAttached(this.channel, callback, function() {
+			var members = self.members;
+			members.waitSync(function() {
+				callback(null, params ? members.list(params) : members.values());
+			});
 		});
 	};
 
@@ -267,6 +270,10 @@ var RealtimePresence = (function() {
 	RealtimePresence.prototype.off = function() {
 		Logger.deprecated('presence.off', 'presence.unsubscribe');
 		_off.apply(this, arguments);
+	}
+
+	RealtimePresence.prototype.syncComplete = function() {
+		return !this.members.syncInProgress;
 	}
 
 	function PresenceMap(presence) {

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -223,6 +223,27 @@ var RealtimePresence = (function() {
 		this.members.startSync();
 	};
 
+	var _on = RealtimePresence.prototype.on;
+	var _off = RealtimePresence.prototype.off;
+
+	RealtimePresence.prototype.subscribe = function() {
+		_on.apply(this, arguments);
+	}
+
+	RealtimePresence.prototype.unsubscribe = function() {
+		_off.apply(this, arguments);
+	}
+
+	RealtimePresence.prototype.on = function() {
+		Logger.deprecated('presence.on', 'presence.subscribe');
+		_on.apply(this, arguments);
+	}
+
+	RealtimePresence.prototype.off = function() {
+		Logger.deprecated('presence.off', 'presence.unsubscribe');
+		_off.apply(this, arguments);
+	}
+
 	function PresenceMap(presence) {
 		EventEmitter.call(this);
 		this.presence = presence;

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -135,6 +135,7 @@ var RealtimePresence = (function() {
 				};
 				break;
 			case 'initialized':
+			case 'failed':
 				/* we're not attached; therefore we let any entered status
 				 * timeout by itself instead of attaching just in order to leave */
 				this.pendingPresence = null;
@@ -264,6 +265,8 @@ var RealtimePresence = (function() {
 	}
 
 	RealtimePresence.prototype.unsubscribe = function() {
+		if(this.channel.state === 'failed')
+			throw new ErrorInfo.fromValues(RealtimeChannel.invalidStateError);
 		_off.apply(this, arguments);
 	}
 

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -28,6 +28,14 @@ var Rest = (function() {
 			options.keyName = keyMatch[1];
 			options.keySecret = keyMatch[2];
 		}
+
+		if('clientId' in options) {
+			if(!(typeof(options.clientId) === 'string' || options.clientId === null))
+				throw new ErrorInfo('clientId must be either a string or null', 40012, 400);
+			else if(options.clientId === '*')
+				throw new ErrorInfo('Can’t use "*" as a clientId as that string is reserved. (To change the default token request behaviour to use a wildcard clientId, use {defaultTokenParams: {clientId: "*"}})', 40012, 400);
+		}
+
 		if(options.log)
 			Logger.setLog(options.log.level, options.log.handler);
 		Logger.logAction(Logger.LOG_MINOR, 'Rest()', 'started');

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -100,12 +100,15 @@ var Rest = (function() {
 		this.attached = {};
 	}
 
-	Channels.prototype.get = function(name) {
+	Channels.prototype.get = function(name, channelOptions) {
 		name = String(name);
 		var channel = this.attached[name];
 		if(!channel) {
-			this.attached[name] = channel = new Channel(this.rest, name);
+			this.attached[name] = channel = new Channel(this.rest, name, channelOptions);
+		} else if(channelOptions) {
+			channel.setOptions(channelOptions);
 		}
+
 		return channel;
 	};
 

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -431,7 +431,7 @@ var ConnectionManager = (function() {
 		}
 
 		var auth = this.realtime.auth;
-		if(clientId) {
+		if(clientId && !(clientId === '*')) {
 			if(auth.clientId && auth.clientId != clientId) {
 				/* Should never happen in normal circumstances as realtime should
 				 * recognise mismatch and return an error */

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -527,6 +527,7 @@ var ConnectionManager = (function() {
 		this.realtime.connection.id = this.connectionId = connectionId;
 		this.realtime.connection.key = this.connectionKey = connectionKey;
 		this.realtime.connection.serial = this.connectionSerial = (connectionSerial === undefined) ? -1 : connectionSerial;
+		this.realtime.connection.recoveryKey = connectionKey + ':' + this.connectionSerial;
 		this.msgSerial = 0;
 		if(this.options.recover === true)
 			this.persistConnection();
@@ -537,6 +538,7 @@ var ConnectionManager = (function() {
 		this.realtime.connection.id = this.connectionId = undefined;
 		this.realtime.connection.key = this.connectionKey = undefined;
 		this.realtime.connection.serial = this.connectionSerial = undefined;
+		this.realtime.connection.recoveryKey = null;
 		this.msgSerial = 0;
 		this.unpersistConnection();
 	};
@@ -924,6 +926,7 @@ var ConnectionManager = (function() {
 			}
 			if(connectionSerial !== undefined) {
 				this.realtime.connection.serial = this.connectionSerial = connectionSerial;
+				this.realtime.connection.recoveryKey = this.connectionKey + ':' + connectionSerial;
 			}
 			this.realtime.channels.onChannelMessage(message);
 		} else {

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -70,7 +70,7 @@ var ConnectionManager = (function() {
 			params.format = this.format;
 		if(this.stream !== undefined)
 			params.stream = this.stream;
-		params.v = Defaults.ablyVersion;
+		params.v = Defaults.apiVersion;
 		return params;
 	};
 

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -70,6 +70,7 @@ var ConnectionManager = (function() {
 			params.format = this.format;
 		if(this.stream !== undefined)
 			params.stream = this.stream;
+		params.v = Defaults.ablyVersion;
 		return params;
 	};
 

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -19,14 +19,21 @@ var WebSocketTransport = (function() {
 	WebSocketTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new WebSocketTransport(connectionManager, auth, params);
 		var errorCb = function(err) { callback(err); };
+		var closeHandler;
 		transport.on('wserror', errorCb);
 		transport.on('wsopen', function() {
 			Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.tryConnect()', 'viable transport ' + transport);
 			transport.off('wserror', errorCb);
 			transport.cancelConnectTimeout();
+			connectionManager.off(closeHandler);
 			callback(null, transport);
 		});
+		/* At this point connectionManager has no reference to websocketTransport.
+		* So need to handle a connect timeout and listen for close events here temporarily */
 		transport.startConnectTimeout();
+		closeHandler = connectionManager.on('connectionstate', function(stateChange) {
+			if(stateChange.current === 'closing') transport.close();
+		});
 		transport.connect();
 	};
 

--- a/common/lib/types/protocolmessage.js
+++ b/common/lib/types/protocolmessage.js
@@ -81,7 +81,7 @@ var ProtocolMessage = (function() {
 		return '[ ' + result.join(', ') + ' ]';
 	}
 
-	var simpleAttributes = 'id channel channelSerial connectionId connectionKey connectionSerial count flags messageSerial timestamp'.split(' ');
+	var simpleAttributes = 'id channel channelSerial connectionId connectionKey connectionSerial count flags msgSerial timestamp'.split(' ');
 
 	ProtocolMessage.stringify = function(msg) {
 		var result = '[ProtocolMessage';

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -1,7 +1,7 @@
 Defaults.protocolVersion          = 1;
 Defaults.ENVIRONMENT              = '';
-Defaults.HOST                     = 'rest.ably.io';
-Defaults.WS_HOST                  = 'realtime.ably.io';
+Defaults.REST_HOST                     = 'rest.ably.io';
+Defaults.REALTIME_HOST                  = 'realtime.ably.io';
 Defaults.FALLBACK_HOSTS           = ['A.ably-realtime.com', 'B.ably-realtime.com', 'C.ably-realtime.com', 'D.ably-realtime.com', 'E.ably-realtime.com'];
 Defaults.PORT                     = 80;
 Defaults.TLS_PORT                 = 443;
@@ -22,9 +22,9 @@ Defaults.version                  = '0.8.9';
 
 Defaults.getHost = function(options, host, ws) {
 	if(ws)
-		host = ((host == options.host) && options.wsHost) || host || options.wsHost;
+		host = ((host == options.restHost) && options.realtimeHost) || host || options.realtimeHost;
 	else
-		host = host || options.host;
+		host = host || options.restHost;
 
 	return host;
 };
@@ -38,7 +38,7 @@ Defaults.getHttpScheme = function(options) {
 };
 
 Defaults.getHosts = function(options) {
-	var hosts = [options.host],
+	var hosts = [options.restHost],
 		fallbackHosts = options.fallbackHosts,
 		httpMaxRetryCount = typeof(options.httpMaxRetryCount) !== 'undefined' ? options.httpMaxRetryCount : Defaults.httpMaxRetryCount;
 
@@ -47,13 +47,23 @@ Defaults.getHosts = function(options) {
 };
 
 Defaults.normaliseOptions = function(options) {
+	/* Deprecated options */
 	if(options.host) {
-		options.wsHost = options.wsHost || options.host;
+		Logger.deprecated('host', 'restHost');
+		options.restHost = options.host;
+	}
+	if(options.wsHost) {
+		Logger.deprecated('wsHost', 'realtimeHost');
+		options.realtimeHost = options.wsHost;
+	}
+
+	if(options.restHost) {
+		options.realtimeHost = options.realtimeHost || options.restHost;
 	} else {
 		var environment = (options.environment && String(options.environment).toLowerCase()) || Defaults.ENVIRONMENT,
-			production = !environment || (environment === 'production');
-		options.host = production ? Defaults.HOST : environment + '-' + Defaults.HOST;
-		options.wsHost = production ? Defaults.WS_HOST : environment + '-' + Defaults.WS_HOST;
+		production = !environment || (environment === 'production');
+		options.restHost = production ? Defaults.REST_HOST : environment + '-' + Defaults.REST_HOST;
+		options.realtimeHost = production ? Defaults.REALTIME_HOST : environment + '-' + Defaults.REALTIME_HOST;
 		options.fallbackHosts = production ? Defaults.FALLBACK_HOSTS : options.fallbackHosts;
 	}
 	options.port = options.port || Defaults.PORT;

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -19,7 +19,7 @@ Defaults.TIMEOUTS = {
 Defaults.httpMaxRetryCount = 3;
 
 Defaults.version           = '0.8.9';
-Defaults.ablyVersion       = '0.8';
+Defaults.apiVersion       = '0.8';
 
 Defaults.getHost = function(options, host, ws) {
 	if(ws)

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -1,7 +1,7 @@
 Defaults.protocolVersion          = 1;
 Defaults.ENVIRONMENT              = '';
-Defaults.REST_HOST                     = 'rest.ably.io';
-Defaults.REALTIME_HOST                  = 'realtime.ably.io';
+Defaults.REST_HOST                = 'rest.ably.io';
+Defaults.REALTIME_HOST            = 'realtime.ably.io';
 Defaults.FALLBACK_HOSTS           = ['A.ably-realtime.com', 'B.ably-realtime.com', 'C.ably-realtime.com', 'D.ably-realtime.com', 'E.ably-realtime.com'];
 Defaults.PORT                     = 80;
 Defaults.TLS_PORT                 = 443;
@@ -18,7 +18,8 @@ Defaults.TIMEOUTS = {
 };
 Defaults.httpMaxRetryCount = 3;
 
-Defaults.version                  = '0.8.9';
+Defaults.version           = '0.8.9';
+Defaults.ablyVersion       = '0.8';
 
 Defaults.getHost = function(options, host, ws) {
 	if(ws)

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -61,6 +61,9 @@ Defaults.normaliseOptions = function(options) {
 		options.queueMessages = options.queueEvents;
 	}
 
+	if(!('queueMessages' in options))
+		options.queueMessages = true;
+
 	if(options.restHost) {
 		options.realtimeHost = options.realtimeHost || options.restHost;
 	} else {

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -56,6 +56,10 @@ Defaults.normaliseOptions = function(options) {
 		Logger.deprecated('wsHost', 'realtimeHost');
 		options.realtimeHost = options.wsHost;
 	}
+	if(options.queueEvents) {
+		Logger.deprecated('queueEvents', 'queueMessages');
+		options.queueMessages = options.queueEvents;
+	}
 
 	if(options.restHost) {
 		options.realtimeHost = options.realtimeHost || options.restHost;

--- a/common/lib/util/logger.js
+++ b/common/lib/util/logger.js
@@ -33,6 +33,12 @@ var Logger = (function() {
 		}
 	};
 
+	Logger.deprecated = function(original, replacement) {
+		if (Logger.shouldLog(LOG_ERROR)) {
+			logHandler("Ably: Deprecation warning - '" + original + "' is deprecated and will be removed from a future version. Please use '" + replacement + "' instead.");
+		}
+	}
+
 	/* Where a logging operation is expensive, such as serialisation of data, use shouldLog will prevent
 	   the object being serialised if the log level will not output the message */
 	Logger.shouldLog = function(level) {

--- a/common/lib/util/utils.js
+++ b/common/lib/util/utils.js
@@ -215,7 +215,7 @@ var Utils = (function() {
 		var accept = (format === 'json') ? contentTypes.json : contentTypes[format] + ',' + contentTypes.json;
 		return {
 			accept: accept,
-			'X-Ably-Version': Defaults.ablyVersion
+			'X-Ably-Version': Defaults.apiVersion
 		};
 	};
 
@@ -227,7 +227,7 @@ var Utils = (function() {
 		return {
 			accept: accept,
 			'content-type': contentType,
-			'X-Ably-Version': Defaults.ablyVersion
+			'X-Ably-Version': Defaults.apiVersion
 		};
 	};
 

--- a/common/lib/util/utils.js
+++ b/common/lib/util/utils.js
@@ -213,7 +213,10 @@ var Utils = (function() {
 	Utils.defaultGetHeaders = function(format) {
 		format = format || 'json';
 		var accept = (format === 'json') ? contentTypes.json : contentTypes[format] + ',' + contentTypes.json;
-		return { accept: accept };
+		return {
+			accept: accept,
+			'X-Ably-Version': Defaults.ablyVersion
+		};
 	};
 
 	Utils.defaultPostHeaders = function(format) {
@@ -223,7 +226,8 @@ var Utils = (function() {
 
 		return {
 			accept: accept,
-			'content-type': contentType
+			'content-type': contentType,
+			'X-Ably-Version': Defaults.ablyVersion
 		};
 	};
 

--- a/spec/common/globals/environment.js
+++ b/spec/common/globals/environment.js
@@ -4,8 +4,8 @@ define(function(require) {
 	var defaultLogLevel = 2,
 		environment = isBrowser ? (window.__env__ || {}) : process.env,
 		ablyEnvironment = environment.ABLY_ENV || 'sandbox',
-		wsHost = environment.ABLY_REALTIME_HOST,
-		host = environment.ABLY_REST_HOST,
+		realtimeHost = environment.ABLY_REALTIME_HOST,
+		restHost = environment.ABLY_REST_HOST,
 		port = environment.ABLY_PORT || 80,
 		tlsPort = environment.ABLY_TLS_PORT || 443,
 		tls = ('ABLY_USE_TLS' in environment) ? (environment.ABLY_USE_TLS.toLowerCase() !== 'false') : true,
@@ -22,7 +22,7 @@ define(function(require) {
 		}
 
 		if(query['env'])          ablyEnvironment = query['env'];
-		if(query['reltime_host']) wsHost = query['realtime_host'];
+		if(query['realtime_host']) realtimeHost = query['realtime_host'];
 		if(query['host'])         host = query['host'];
 		if(query['port'])         port = query['port'];
 		if(query['tls_port'])     tlsPort = query['tls_port'];
@@ -32,8 +32,8 @@ define(function(require) {
 
 	return module.exports = {
 		environment: ablyEnvironment,
-		wsHost:      wsHost,
-		restHost:    host,
+		realtimeHost:realtimeHost,
+		restHost:    restHost,
 		port:        port,
 		tlsPort:     tlsPort,
 		tls:         tls,

--- a/spec/realtime/channel.test.js
+++ b/spec/realtime/channel.test.js
@@ -19,6 +19,35 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	/*
+	 * Channel init with options
+	 */
+	exports.channelinit0 = function(test) {
+		test.expect(4);
+		try {
+			var realtime = helper.AblyRealtime();
+			realtime.connection.on('connected', function() {
+				/* set options on init */
+				var channel0 = realtime.channels.get('channelinit0', {encrypted: true});
+				test.equal(channel0.channelOptions.encrypted, true);
+
+				/* set options on fetch */
+				var channel1 = realtime.channels.get('channelinit0', {encrypted: false});
+				test.equal(channel0.channelOptions.encrypted, false);
+				test.equal(channel1.channelOptions.encrypted, false);
+
+				/* set options with setOptions */
+				channel1.setOptions({encrypted: true});
+				test.equal(channel1.channelOptions.encrypted, true);
+				closeAndFinish(test, realtime);
+			});
+			monitorConnection(test, realtime);
+		} catch(e) {
+			test.ok(false, 'Channel attach failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
+	/*
 	 * Base attach case, binary transport
 	 */
 	exports.channelattach0 = function(test) {

--- a/spec/realtime/connection.test.js
+++ b/spec/realtime/connection.test.js
@@ -80,14 +80,18 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 							closeAndFinish(test, realtime);
 							return;
 						}
-						test.equal(realtime.connection.serial, 0, "verify serial is 0 after ack received")
-						test.equal(realtime.connection.recoveryKey, realtime.connection.key + ':' + realtime.connection.serial, 'verify recovery key still correct');
+						/* Timeout needed because connectionSerial is not necessarily set
+						 * by the time the publish callback is called */
+						setTimeout(function() {
+							test.equal(realtime.connection.serial, 0, "verify serial is 0 after ack received")
+							test.equal(realtime.connection.recoveryKey, realtime.connection.key + ':' + realtime.connection.serial, 'verify recovery key still correct');
 
-						realtime.connection.close();
-						realtime.connection.once('closed', function() {
-							test.equal(realtime.connection.recoveryKey, null, 'verify recovery key null after close');
-							closeAndFinish(test, realtime);
-						});
+							realtime.connection.close();
+							realtime.connection.once('closed', function() {
+								test.equal(realtime.connection.recoveryKey, null, 'verify recovery key null after close');
+								closeAndFinish(test, realtime);
+							});
+						}, 50);
 					});
 					test.equal(realtime.connection.serial, -1, "verify serial is -1 after publish but before ack")
 				});

--- a/spec/realtime/connection.test.js
+++ b/spec/realtime/connection.test.js
@@ -58,6 +58,46 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		}
 	};
 
+	exports.connectionAttributes = function(test) {
+		test.expect(6);
+		var realtime;
+		try {
+			realtime = helper.AblyRealtime();
+			realtime.connection.on('connected', function() {
+				test.equal(realtime.connection.serial, -1, "verify serial is -1 on connect");
+				test.equal(realtime.connection.recoveryKey, realtime.connection.key + ':' + realtime.connection.serial, 'verify correct recovery key');
+
+				var channel = realtime.channels.get('connectionattributes');
+				channel.attach(function(err) {
+					if(err) {
+						test.ok(false, 'Attach failed with error: ' + displayError(err));
+						closeAndFinish(test, realtime);
+						return;
+					}
+					channel.publish("name", "data", function(err) {
+						if(err) {
+							test.ok(false, 'Publish failed with error: ' + displayError(err));
+							closeAndFinish(test, realtime);
+							return;
+						}
+						test.equal(realtime.connection.serial, 0, "verify serial is 0 after ack received")
+						test.equal(realtime.connection.recoveryKey, realtime.connection.key + ':' + realtime.connection.serial, 'verify recovery key still correct');
+
+						realtime.connection.close();
+						realtime.connection.on('closed', function() {
+							test.equal(realtime.connection.recoveryKey, null, 'verify recovery key null after close');
+							test.done();
+						});
+					});
+					test.equal(realtime.connection.serial, -1, "verify serial is -1 after publish but before ack")
+				});
+			});
+			monitorConnection(test, realtime);
+		} catch(e) {
+			test.ok(false, 'test failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
 
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/realtime/connection.test.js
+++ b/spec/realtime/connection.test.js
@@ -84,9 +84,9 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 						test.equal(realtime.connection.recoveryKey, realtime.connection.key + ':' + realtime.connection.serial, 'verify recovery key still correct');
 
 						realtime.connection.close();
-						realtime.connection.on('closed', function() {
+						realtime.connection.once('closed', function() {
 							test.equal(realtime.connection.recoveryKey, null, 'verify recovery key null after close');
-							test.done();
+							closeAndFinish(test, realtime);
 						});
 					});
 					test.equal(realtime.connection.serial, -1, "verify serial is -1 after publish but before ack")

--- a/spec/realtime/crypto.test.js
+++ b/spec/realtime/crypto.test.js
@@ -67,7 +67,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					/* reset channel cipher, to ensure it uses the given iv */
 					channel.setOptions({encrypted:true, cipherParams: params});
 
-					fixtureTest(channel.options, testMessage, encryptedMessage, item.msgpack);
+					fixtureTest(channel.channelOptions, testMessage, encryptedMessage, item.msgpack);
 				}
 				closeAndFinish(test, realtime);
 			});

--- a/spec/realtime/failure.test.js
+++ b/spec/realtime/failure.test.js
@@ -115,8 +115,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					var connectionEvents = [];
 					var realtime = helper.AblyRealtime({
 						transports: transports,
-						wsHost: 'example.com',
-						host: 'example.com',
+						realtimeHost: 'example.com',
+						restHost: 'example.com',
 						/* Timings note: some transports fail immediately with an invalid
 						* host, others take longer; so set the realtimeRequestTimeout to be
 						* small enough that the max difference is never large enough that

--- a/spec/realtime/failure.test.js
+++ b/spec/realtime/failure.test.js
@@ -177,8 +177,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					callback();
 				});
 			},
-			/* subscribe can in theory be called with a callback in addition to the message listener */
-			/* in that case, callback with the error instead of throwing */
 			function(callback) {
 				failChan.subscribe('event', noop, function(err) {
 					test.ok(err, "subscribe failed");
@@ -187,19 +185,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				});
 			},
 			function(callback) {
-				test.throws(failChan.subscribe, "check subscribe threw an exception");
-				callback();
-			},
-			function(callback) {
 				failChan.unsubscribe('event', noop, function(err) {
 					test.ok(err, "unsubscribe failed");
 					test.equal(err.code, channelFailedCode, "unsubscribe failure code");
 					callback();
 				});
-			},
-			function(callback) {
-				test.throws(failChan.unsubscribe, "check subscribe threw an exception");
-				callback();
 			},
 			function(callback) {
 				failChan.presence.enterClient('clientId', function(err) {
@@ -216,12 +206,18 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				});
 			},
 			function(callback) {
-				test.throws(failChan.presence.subscribe, "check presence subscribe threw an exception");
-				callback();
+				failChan.presence.subscribe('event', noop, function(err) {
+					test.ok(err, "presence subscribe failed");
+					test.equal(err.code, channelFailedCode, "subscribe failure code");
+					callback();
+				});
 			},
 			function(callback) {
-				test.throws(failChan.presence.unsubscribe, "check presence unsubscribe threw an exception");
-				callback();
+				failChan.presence.subscribe('event', noop, function(err) {
+					test.ok(err, "presence unsubscribe failed");
+					test.equal(err.code, channelFailedCode, "subscribe failure code");
+					callback();
+				});
 			},
 			function(callback) {
 				failChan.presence.get(function(err) {

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -83,7 +83,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 	/* init with key string and useTokenAuth: true */
 	exports.init_key_with_usetokenauth = function(test) {
-		test.expect(3);
+		test.expect(4);
 		var realtime;
 		try {
 			var keyStr = helper.getTestApp().keys[0].keyStr;
@@ -91,9 +91,73 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			test.equal(realtime.options.key, keyStr);
 			test.equal(realtime.auth.method, 'token');
 			test.equal(realtime.auth.clientId, null);
-			closeAndFinish(test, realtime);
+			/* Check that useTokenAuth by default results in an anonymous (and not wildcard) token */
+			realtime.connection.on('connected', function() {
+				test.equal(realtime.auth.tokenDetails.clientId, null);
+				closeAndFinish(test, realtime);
+			});
 		} catch(e) {
 			test.ok(false, 'Init with key and usetokenauth failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
+	/* init with key string, useTokenAuth: true, and some defaultTokenParams to
+	* request a wildcard clientId */
+	exports.init_usetokenauth_defaulttokenparams_wildcard = function(test) {
+		test.expect(4);
+		var realtime;
+		try {
+			var keyStr = helper.getTestApp().keys[0].keyStr;
+			realtime = helper.AblyRealtime({key: keyStr, useTokenAuth: true, defaultTokenParams: {clientId: '*', ttl: 12345}});
+			test.equal(realtime.auth.clientId, null);
+			realtime.connection.on('connected', function() {
+				test.equal(realtime.auth.tokenDetails.clientId, '*');
+				/* auth.clientId does not inherit the value '*'; it remains null as
+				* client is not identified */
+				test.equal(realtime.auth.clientId, null);
+				test.equal(realtime.auth.tokenDetails.expires - realtime.auth.tokenDetails.issued, 12345);
+				closeAndFinish(test, realtime);
+			});
+		} catch(e) {
+			test.ok(false, 'init_usetokenauth_defaulttokenparams_wildcard failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
+	/* init with using defaultTokenParams to set a non-wildcard clientId should set auth.clientId */
+	exports.init_defaulttokenparams_nonwildcard = function(test) {
+		test.expect(3);
+		var realtime;
+		try {
+			var keyStr = helper.getTestApp().keys[0].keyStr;
+			realtime = helper.AblyRealtime({key: keyStr, useTokenAuth: true, defaultTokenParams: {clientId: 'test'}});
+			test.equal(realtime.auth.clientId, null);
+			realtime.connection.on('connected', function() {
+				test.equal(realtime.auth.tokenDetails.clientId, 'test');
+				test.equal(realtime.auth.clientId, 'test');
+				closeAndFinish(test, realtime);
+			});
+		} catch(e) {
+			test.ok(false, 'init_defaulttokenparams_nonwildcard failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
+	/* init when specifying clientId both in defaultTokenParams and in clientOptions: the latter takes precedence */
+	exports.init_conflicting_clientids = function(test) {
+		test.expect(2);
+		var realtime;
+		try {
+			var keyStr = helper.getTestApp().keys[0].keyStr;
+			realtime = helper.AblyRealtime({key: keyStr, useTokenAuth: true, clientId: 'yes', defaultTokenParams: {clientId: 'no'}});
+			realtime.connection.on('connected', function() {
+				test.equal(realtime.auth.tokenDetails.clientId, 'yes');
+				test.equal(realtime.auth.clientId, 'yes');
+				closeAndFinish(test, realtime);
+			});
+		} catch(e) {
+			test.ok(false, 'init_conflicting_clientids failed with exception: ' + e.stack);
 			closeAndFinish(test, realtime);
 		}
 	};

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -158,7 +158,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		try {
 			var realtime = helper.AblyRealtime({
 				key: 'not_a.real:key',
-				host: 'a',
+				restHost: 'a',
 				httpMaxRetryCount: 2,
 				fallbackHosts: ['b', 'c', 'd', 'e']
 			});

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -1095,7 +1095,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * reconnect, then enter again to reattach
 	 */
 	exports.presenceEnterAfterClose = function(test) {
-		test.expect(3);
+		test.expect(5);
 
 		var channelName = "enterAfterClose";
 		var secondEnterListener = function(test, channel, callback) {
@@ -1121,7 +1121,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					test.ok(true, 'Entered presence first time');
 					clientRealtime.close();
 					clientRealtime.connection.once('closed', function() {
+						test.ok(true, 'Connection successfully closed');
 						clientRealtime.connection.once('connected', function() {
+							test.ok(true, 'Successfully reconnected');
 							//Should automatically reattach
 							clientChannel.presence.enter('second', function(err) {
 								if(!err)

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -207,7 +207,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		// will not run its callback
 		var channelName = 'enterDetachRace';
 		try {
-			test.expect(4);
+			test.expect(3);
 			/* listen for the enter event, test is complete when received */
 
 			createListenerChannel(channelName, function(err, listenerRealtime, presenceChannel){
@@ -219,7 +219,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 				var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
 
-				listenerFor('enter')(test, presenceChannel, function() {
+				listenerFor('enter', testClientId)(test, presenceChannel, function() {
 					closeAndFinish(test, [listenerRealtime, clientRealtime]);
 				});
 
@@ -239,7 +239,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 								closeAndFinish(test, [listenerRealtime, clientRealtime]);
 								return;
 							}
-							test.ok(true, 'Detached');
 						});
 					});
 					clientChannel.presence.enter('Test client data (enter3)', function(err) {
@@ -253,8 +252,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 							closeAndFinish(test, [listenerRealtime, clientRealtime]);
 							return;
 						}
-						test.ok(true, 'Presence event sent');
-						/* if presence event gets sent, 5th assertion happens and test
+						/* if presence event gets sent successfully, second and third assertions happen and test
 						* finishes in the presence event handler */
 					});
 				});

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -34,11 +34,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					if(expectedClientId !== undefined) {
 						test.equal(presmsg.clientId, expectedClientId, 'Verify correct clientId');
 					}
-					channel.presence.off(presenceHandler);
+					channel.presence.unsubscribe(presenceHandler);
 					callback();
 				}
 			};
-			channel.presence.on(presenceHandler);
+			channel.presence.subscribe(presenceHandler);
 		};
 	};
 
@@ -362,11 +362,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			var presenceHandler = function(presenceMsg) {
 				if(presenceMsg.data == 'second') {
 					test.ok(true, 'Second presence event received');
-					channel.presence.off(presenceHandler);
+					channel.presence.unsubscribe(presenceHandler);
 					callback();
 				}
 			};
-			channel.presence.on(presenceHandler);
+			channel.presence.subscribe(presenceHandler);
 		};
 		var enterDetachEnter = function(cb) {
 			var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -477,11 +477,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					test.ok(true, 'Update event received');
 					test.equal(presenceMsg.clientId, testClientId, 'Check presence event has correct clientId');
 					test.equal(presenceMsg.data, newData, 'Check presence event has correct data');
-					channel.presence.off(presenceHandler);
+					channel.presence.unsubscribe(presenceHandler);
 					callback();
 				}
 			};
-			channel.presence.on(presenceHandler);
+			channel.presence.subscribe(presenceHandler);
 		};
 		var enterUpdate = function(cb) {
 			var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -530,11 +530,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					test.equal(presenceMembers.length, 1, 'Expect test client to be the only member present');
 					test.equal(presenceMembers[0].clientId, testClientId, 'Expected test clientId to be correct');
 					test.equal(presenceMembers[0].data, testData, 'Expected data to be correct');
-					channel.presence.off(presenceHandler);
+					channel.presence.unsubscribe(presenceHandler);
 					callback();
 				});
 			};
-			channel.presence.on(presenceHandler);
+			channel.presence.subscribe(presenceHandler);
 		};
 		var enterGet = function(cb) {
 			var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -575,12 +575,12 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 							return;
 						}
 						test.equal(presenceMembers.length, 0, 'Expect presence set to be empty');
-						channel.presence.off(presenceHandler);
+						channel.presence.unsubscribe(presenceHandler);
 						callback();
 					});
 				}
 			};
-			channel.presence.on(presenceHandler);
+			channel.presence.subscribe(presenceHandler);
 		};
 		var enterLeaveGet = function(cb) {
 			var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -805,7 +805,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						}
 						test.ok(true, 'Presence event sent');
 					});
-					clientChannel1.presence.on('enter', function() {
+					clientChannel1.presence.subscribe('enter', function() {
 						clientChannel1.presence.get(function(err, presenceMembers1) {
 							if(err) {
 								test.ok(false, 'Presence get() failed with error: ' + displayError(err));
@@ -825,7 +825,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 										closeAndFinish(test, [clientRealtime1, clientRealtime2]);
 										return;
 									}
-									clientChannel2.presence.on('present', function() {
+									clientChannel2.presence.subscribe('present', function() {
 										/* get the channel members and verify testclient is there */
 										clientChannel2.presence.get(function(err, presenceMembers2) {
 											if(err) {
@@ -922,11 +922,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 										/* PrenceEvent from first connection might come through as an enter or a present */
 										if(presenceEvent.clientId == clientId && (this.event === 'enter' || this.event === 'present')) {
 											test.ok(true, 'Presence event for ' + clientId + ' received');
-											clientChannel2.presence.off(presenceHandler);
+											clientChannel2.presence.unsubscribe(presenceHandler);
 											onEnterCb();
 										}
 									};
-									clientChannel2.presence.on(presenceHandler);
+									clientChannel2.presence.subscribe(presenceHandler);
 								};
 							};
 							async.parallel([
@@ -1044,11 +1044,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			var presenceHandler = function(presenceMsg) {
 				if(this.event == 'enter' && presenceMsg.data == 'second') {
 					test.ok(true, 'Second presence event received');
-					channel.presence.off(presenceHandler);
+					channel.presence.unsubscribe(presenceHandler);
 					callback();
 				}
 			};
-			channel.presence.on(presenceHandler);
+			channel.presence.subscribe(presenceHandler);
 		};
 		var enterAfterClose = function(cb) {
 			var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });

--- a/spec/realtime/resume.test.js
+++ b/spec/realtime/resume.test.js
@@ -200,7 +200,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			var txCount = 0;
 			function ph1TxOnce() {
 				console.log('sending (phase 1): ' + txCount);
-				txChannel.publish('event0', 'Hello world at: ' + new Date());
+				txChannel.publish('event0', 'phase 1 message ' + txCount + ' at ' + new Date());
 				if(++txCount == count) {
 					/* sent all messages */
 					setTimeout(function() {
@@ -224,7 +224,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 			function ph2TxOnce() {
 				console.log('sending (phase 2): ' + txCount);
-				txChannel.publish('event0', 'Hello world at: ' + new Date());
+				txChannel.publish('event0', 'phase 2 message ' + txCount + ' at ' + new Date());
 				if(++txCount == count) {
 					/* sent all messages */
 					setTimeout(function() { callback(null); }, 1000);

--- a/spec/rest/auth.test.js
+++ b/spec/rest/auth.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-define(['ably', 'shared_helper'], function(Ably, helper) {
+define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	var currentTime, rest, exports = {};
 
 	var getServerTime = function(callback) {
@@ -370,6 +370,36 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	/*
+	 * Authorise with different args
+	 */
+	exports.authauthorise = function(test) {
+		test.expect(3);
+		async.parallel([
+			function(cb) {
+				rest.auth.authorise(null, null, function(err, tokenDetails) {
+					test.ok(tokenDetails.token, 'Check token obtained');
+					cb(err);
+				});
+			},
+			function(cb) {
+				rest.auth.authorise(null, function(err, tokenDetails) {
+					test.ok(tokenDetails.token, 'Check token obtained');
+					cb(err);
+				});
+			},
+			function(cb) {
+				rest.auth.authorise(function(err, tokenDetails) {
+					test.ok(tokenDetails.token, 'Check token obtained');
+					cb(err);
+				});
+			},
+		], function(err) {
+			if(err) test.ok(false, "Authorise returned an error: " + helper.displayError(err));
+			test.done();
+		});
+	};
+
+	/*
 	 * Specify non-default ttl
 	 */
 	exports.authttl0 = function(test) {
@@ -439,6 +469,38 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	exports.auth_createTokenRequest_given_key = function(test) {
 		test.expect(1);
 		rest.auth.createTokenRequest(null, null, function(err, tokenRequest) {
+			if(err) {
+				test.ok(false, helper.displayError(err));
+				test.done();
+				return;
+			}
+			test.equal(tokenRequest.keyName, helper.getTestApp().keys[0].keyName);
+			test.done();
+		});
+	};
+
+	/*
+	 * createTokenRequest: no authoptions, callback as 2nd param
+	 */
+	exports.auth_createTokenRequest_params0 = function(test) {
+		test.expect(1);
+		rest.auth.createTokenRequest(null, function(err, tokenRequest) {
+			if(err) {
+				test.ok(false, helper.displayError(err));
+				test.done();
+				return;
+			}
+			test.equal(tokenRequest.keyName, helper.getTestApp().keys[0].keyName);
+			test.done();
+		});
+	};
+
+	/*
+	 * createTokenRequest: no authoptions or tokenparams, callback as 1st param
+	 */
+	exports.auth_createTokenRequest_params1 = function(test) {
+		test.expect(1);
+		rest.auth.createTokenRequest(function(err, tokenRequest) {
 			if(err) {
 				test.ok(false, helper.displayError(err));
 				test.done();

--- a/spec/rest/auth.test.js
+++ b/spec/rest/auth.test.js
@@ -332,6 +332,44 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	/*
+	 * Token generation with defaultTokenParams set and no tokenParams passed in
+	 */
+	exports.authdefaulttokenparams0 = function(test) {
+		test.expect(1);
+		var rest1 = helper.AblyRest({defaultTokenParams: {ttl: 123, clientId: "foo"}});
+		rest1.auth.requestToken(function(err, tokenDetails) {
+			if(err) {
+				test.ok(false, helper.displayError(err));
+				test.done();
+				return;
+			}
+			test.expect(3);
+			test.ok((tokenDetails.token), 'Verify token value');
+			test.equal(tokenDetails.clientId, 'foo', 'Verify client id from defaultTokenParams used');
+			test.equal(tokenDetails.expires - tokenDetails.issued, 123, 'Verify ttl from defaultTokenParams used');
+			test.done();
+		});
+	};
+
+	/*
+	 * Token generation: if tokenParams passed in, defaultTokenParams should be ignored altogether, not merged
+	 */
+	exports.authdefaulttokenparams1 = function(test) {
+		test.expect(2);
+		var rest1 = helper.AblyRest({defaultTokenParams: {ttl: 123, clientId: "foo"}});
+		rest1.auth.requestToken({clientId: 'bar'}, null, function(err, tokenDetails) {
+			if(err) {
+				test.ok(false, helper.displayError(err));
+				test.done();
+				return;
+			}
+			test.equal(tokenDetails.clientId, 'bar', 'Verify client id passed in is used, not the one from defaultTokenParams');
+			test.equal(tokenDetails.expires - tokenDetails.issued, 60 * 60 * 1000, 'Verify ttl from defaultTokenParams ignored completely, even though not overridden');
+			test.done();
+		});
+	};
+
+	/*
 	 * Specify non-default ttl
 	 */
 	exports.authttl0 = function(test) {

--- a/spec/rest/defaults.test.js
+++ b/spec/rest/defaults.test.js
@@ -9,14 +9,14 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.expect(10);
 		var normalisedOptions = Defaults.normaliseOptions({});
 
-		test.equal(normalisedOptions.host, 'rest.ably.io');
-		test.equal(normalisedOptions.wsHost, 'realtime.ably.io');
+		test.equal(normalisedOptions.restHost, 'rest.ably.io');
+		test.equal(normalisedOptions.realtimeHost, 'realtime.ably.io');
 		test.equal(normalisedOptions.port, 80);
 		test.equal(normalisedOptions.tlsPort, 443);
 		test.deepEqual(normalisedOptions.fallbackHosts, Defaults.FALLBACK_HOSTS);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host].concat(Defaults.FALLBACK_HOSTS.slice(0,3)));
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost].concat(Defaults.FALLBACK_HOSTS.slice(0,3)));
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'rest.ably.io', false), 'rest.ably.io');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'rest.ably.io', true), 'realtime.ably.io');
 
@@ -29,14 +29,14 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.expect(10);
 		var normalisedOptions = Defaults.normaliseOptions({environment: 'production'});
 
-		test.equal(normalisedOptions.host, 'rest.ably.io');
-		test.equal(normalisedOptions.wsHost, 'realtime.ably.io');
+		test.equal(normalisedOptions.restHost, 'rest.ably.io');
+		test.equal(normalisedOptions.realtimeHost, 'realtime.ably.io');
 		test.equal(normalisedOptions.port, 80);
 		test.equal(normalisedOptions.tlsPort, 443);
 		test.deepEqual(normalisedOptions.fallbackHosts, Defaults.FALLBACK_HOSTS);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host].concat(Defaults.FALLBACK_HOSTS.slice(0,3)));
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost].concat(Defaults.FALLBACK_HOSTS.slice(0,3)));
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'rest.ably.io', false), 'rest.ably.io');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'rest.ably.io', true), 'realtime.ably.io');
 
@@ -49,14 +49,14 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.expect(10);
 		var normalisedOptions = Defaults.normaliseOptions({environment: 'sandbox'});
 
-		test.equal(normalisedOptions.host, 'sandbox-rest.ably.io');
-		test.equal(normalisedOptions.wsHost, 'sandbox-realtime.ably.io');
+		test.equal(normalisedOptions.restHost, 'sandbox-rest.ably.io');
+		test.equal(normalisedOptions.realtimeHost, 'sandbox-realtime.ably.io');
 		test.equal(normalisedOptions.port, 80);
 		test.equal(normalisedOptions.tlsPort, 443);
 		test.equal(normalisedOptions.fallbackHosts, undefined);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host]);
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost]);
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', false), 'sandbox-rest.ably.io');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', true), 'sandbox-realtime.ably.io');
 
@@ -69,14 +69,14 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.expect(10);
 		var normalisedOptions = Defaults.normaliseOptions({environment: 'local', port: 8080, tlsPort: 8081});
 
-		test.equal(normalisedOptions.host, 'local-rest.ably.io');
-		test.equal(normalisedOptions.wsHost, 'local-realtime.ably.io');
+		test.equal(normalisedOptions.restHost, 'local-rest.ably.io');
+		test.equal(normalisedOptions.realtimeHost, 'local-realtime.ably.io');
 		test.equal(normalisedOptions.port, 8080);
 		test.equal(normalisedOptions.tlsPort, 8081);
 		test.equal(normalisedOptions.fallbackHosts, undefined);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host]);
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost]);
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'local-rest.ably.io', false), 'local-rest.ably.io');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'local-rest.ably.io', true), 'local-realtime.ably.io');
 
@@ -87,16 +87,16 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	/* init with given host */
 	exports.defaults_given_host = function(test) {
 		test.expect(10);
-		var normalisedOptions = Defaults.normaliseOptions({host: 'test.org'});
+		var normalisedOptions = Defaults.normaliseOptions({restHost: 'test.org'});
 
-		test.equal(normalisedOptions.host, 'test.org');
-		test.equal(normalisedOptions.wsHost, 'test.org');
+		test.equal(normalisedOptions.restHost, 'test.org');
+		test.equal(normalisedOptions.realtimeHost, 'test.org');
 		test.equal(normalisedOptions.port, 80);
 		test.equal(normalisedOptions.tlsPort, 443);
 		test.equal(normalisedOptions.fallbackHosts, undefined);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host]);
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost]);
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', false), 'test.org');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', true), 'test.org');
 
@@ -104,19 +104,40 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.done();
 	};
 
-	/* init with given host and ws host */
-	exports.defaults_given_wshost = function(test) {
+	/* init with given restHost and realtimeHost */
+	exports.defaults_given_realtimehost = function(test) {
 		test.expect(10);
-		var normalisedOptions = Defaults.normaliseOptions({host: 'test.org', wsHost: 'ws.test.org'});
+		var normalisedOptions = Defaults.normaliseOptions({restHost: 'test.org', realtimeHost: 'ws.test.org'});
 
-		test.equal(normalisedOptions.host, 'test.org');
-		test.equal(normalisedOptions.wsHost, 'ws.test.org');
+		test.equal(normalisedOptions.restHost, 'test.org');
+		test.equal(normalisedOptions.realtimeHost, 'ws.test.org');
 		test.equal(normalisedOptions.port, 80);
 		test.equal(normalisedOptions.tlsPort, 443);
 		test.equal(normalisedOptions.fallbackHosts, undefined);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host]);
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost]);
+		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', false), 'test.org');
+		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', true), 'ws.test.org');
+
+		test.equal(Defaults.getPort(normalisedOptions), 443);
+		test.done();
+	};
+
+	/* init with deprecated host and wsHost options */
+	/* will emit a warning */
+	exports.defaults_given_deprecated_host = function(test) {
+		test.expect(10);
+		var normalisedOptions = Defaults.normaliseOptions({host: 'test.org', wsHost: 'ws.test.org'});
+
+		test.equal(normalisedOptions.restHost, 'test.org');
+		test.equal(normalisedOptions.realtimeHost, 'ws.test.org');
+		test.equal(normalisedOptions.port, 80);
+		test.equal(normalisedOptions.tlsPort, 443);
+		test.equal(normalisedOptions.fallbackHosts, undefined);
+		test.equal(normalisedOptions.tls, true);
+
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost]);
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', false), 'test.org');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', true), 'ws.test.org');
 
@@ -130,14 +151,14 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		Defaults.ENVIRONMENT = 'sandbox';
 		var normalisedOptions = Defaults.normaliseOptions({});
 
-		test.equal(normalisedOptions.host, 'sandbox-rest.ably.io');
-		test.equal(normalisedOptions.wsHost, 'sandbox-realtime.ably.io');
+		test.equal(normalisedOptions.restHost, 'sandbox-rest.ably.io');
+		test.equal(normalisedOptions.realtimeHost, 'sandbox-realtime.ably.io');
 		test.equal(normalisedOptions.port, 80);
 		test.equal(normalisedOptions.tlsPort, 443);
 		test.equal(normalisedOptions.fallbackHosts, undefined);
 		test.equal(normalisedOptions.tls, true);
 
-		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.host]);
+		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost]);
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', false), 'sandbox-rest.ably.io');
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', true), 'sandbox-realtime.ably.io');
 

--- a/spec/rest/history.test.js
+++ b/spec/rest/history.test.js
@@ -124,7 +124,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		var testchannel = rest.channels.get('persisted:history_simple_paginated_b');
 
 		/* first, send a number of events to this channel */
-		test.expect(4 * testMessages.length);
+		test.expect(5 * testMessages.length + 1);
 		var publishTasks = testMessages.map(function(event) {
 			return function(publishCb) {
 				testchannel.publish(event.name, event.data, publishCb);
@@ -166,8 +166,12 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						test.deepEqual(expectedMessage.data, resultMessage.data, 'Verify expected data value present');
 
 						if(--totalMessagesExpected > 0) {
+							test.ok(resultPage.hasNext(), 'Verify next link is present');
+							test.ok(!resultPage.isLast(), 'Verify not last page');
 							nextPage = resultPage.next;
-							test.ok(!!nextPage, 'Verify next link is present');
+						} else {
+							test.ok(!resultPage.hasNext(), 'Verify next link is present');
+							test.ok(resultPage.isLast(), 'Verify not last page');
 						}
 						cb();
 					});
@@ -232,8 +236,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						test.deepEqual(expectedMessage.data, resultMessage.data, 'Verify expected data value present');
 
 						if(--totalMessagesExpected > 0) {
+							test.ok(resultPage.hasNext(), 'Verify next link is present');
 							nextPage = resultPage.next;
-							test.ok(!!nextPage, 'Verify next link is present');
 						}
 						cb();
 					});
@@ -297,8 +301,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						test.deepEqual(expectedMessage.data, resultMessage.data, 'Verify expected data value present');
 
 						if(--totalMessagesExpected > 0) {
+							test.ok(resultPage.hasNext(), 'Verify next link is present');
 							nextPage = resultPage.next;
-							test.ok(!!nextPage, 'Verify next link is present');
 						}
 						cb();
 					});
@@ -361,8 +365,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						test.deepEqual(expectedMessage.data, resultMessage.data, 'Verify expected data value present');
 
 						if(--totalMessagesExpected > 0) {
+							test.ok(resultPage.hasNext(), 'Verify next link is present');
 							nextPage = resultPage.next;
-							test.ok(!!nextPage, 'Verify next link is present');
 						}
 						cb();
 					});

--- a/spec/rest/init.test.js
+++ b/spec/rest/init.test.js
@@ -81,5 +81,21 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.done();
 	};
 
+	/* init with a clientId set to '*', or anything other than a string or null,
+	* should raise an exception */
+	exports.init_wildcard_clientId = function(test) {
+		test.expect(3);
+		test.throws(function() {
+			var rest = helper.AblyRest({clientId: '*'});
+		}, 'Check can’t init library with a wildcard clientId');
+		test.throws(function() {
+			var rest = helper.AblyRest({clientId: 123});
+		}, 'Check can’t init library with a numerical clientId');
+		test.throws(function() {
+			var rest = helper.AblyRest({clientId: false});
+		}, 'Check can’t init library with a boolean clientId');
+		test.done();
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/rest/presence.test.js
+++ b/spec/rest/presence.test.js
@@ -43,9 +43,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	exports.presence_get_simple = function(test) {
 		test.expect(6);
 		try {
-			var channel = rest.channels.get('persisted:presence_fixtures');
 			var cipherParams = cipherParamsFromConfig(cipherConfig);
-			channel.setOptions({encrypted: true, cipherParams: cipherParams});
+			var channel = rest.channels.get('persisted:presence_fixtures',
+																			{encrypted: true, cipherParams: cipherParams});
 			channel.presence.get(function(err, resultPage) {
 				if(err) {
 					test.ok(false, displayError(err));

--- a/spec/rest/stats.test.js
+++ b/spec/rest/stats.test.js
@@ -322,7 +322,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			test.equal(totalData, 7000, 'Verify all published message data found');
 
 			/* get next page */
-			test.ok(page.next, 'Verify next page rel link present');
+			test.ok(page.hasNext(), 'Verify next page rel link present');
 			page.next(function(err, page) {
 				if(err) {
 					test.ok(false, displayError(err));
@@ -338,7 +338,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				test.equal(totalData, 6000, 'Verify all published message data found');
 
 				/* get next page */
-				test.ok(page.next, 'Verify next page rel link present');
+				test.ok(page.hasNext(), 'Verify next page rel link present');
 				page.next(function(err, page) {
 					if(err) {
 						test.ok(false, displayError(err));
@@ -354,7 +354,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					test.equal(totalData, 5000, 'Verify all published message data found');
 
 					/* verify no further pages */
-					test.ok(!page.next, 'Verify next page rel link not present');
+					test.ok(page.isLast(), 'Verify last page');
 
 					test.expect(10);
 
@@ -398,7 +398,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			test.equal(totalData, 5000, 'Verify all published message data found');
 
 			/* get next page */
-			test.ok(page.next, 'Verify next page rel link present');
+			test.ok(page.hasNext(), 'Verify next page rel link present');
 			page.next(function(err, page) {
 				if(err) {
 					test.ok(false, displayError(err));
@@ -414,7 +414,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				test.equal(totalData, 6000, 'Verify all published message data found');
 
 				/* get next page */
-				test.ok(page.next, 'Verify next page rel link present');
+				test.ok(page.hasNext(), 'Verify next page rel link present');
 				page.next(function(err, page) {
 					if(err) {
 						test.ok(false, displayError(err));
@@ -430,7 +430,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					test.equal(totalData, 7000, 'Verify all published message data found');
 
 					/* verify no further pages */
-					test.ok(!page.next, 'Verify next page rel link not present');
+					test.ok(page.isLast(), 'Verify last page');
 
 					test.expect(10);
 

--- a/test/browser/crypto_.js
+++ b/test/browser/crypto_.js
@@ -13,8 +13,8 @@ function mixin(target, source) {
 function createRealtime(opts) {
 	var options = {
 		//log: {level: 4},
-		host: testVars.restHost,
-		wsHost: testVars.realtimeHost,
+		restHost: testVars.restHost,
+		realtimeHost: testVars.realtimeHost,
 		port: testVars.realtimePort,
 		tlsPort: testVars.realtimeTlsPort,
 		key: testVars.key0Str,

--- a/test/compat/pusher/common/common.js
+++ b/test/compat/pusher/common/common.js
@@ -124,7 +124,7 @@ exports.setup = function() {
 		};
 		if (origin && (origin.length != 0)) {
 			var p = origin.split(':');
-			opts.host = opts.wsHost = p[0];
+			opts.restHost = opts.realtimeHost = p[0];
 			if (p.length > 1)
 				opts.port = p[1];
 		}
@@ -149,7 +149,7 @@ exports.setup = function() {
 		};
 		if (origin && (origin.length != 0)) {
 			var p = origin.split(':');
-			opts.host = opts.wsHost = p[0];
+			opts.restHost = opts.realtimeHost = p[0];
 			if (p.length > 1)
 				opts.port = p[1];
 		}


### PR DESCRIPTION
A chocolate box of a pull request, with 25 tasty, mostly-unrelated commits - should probably be a dozen separate PRs, but eh. Mix of spec updates and bug fixes. Closes https://github.com/ably/ably-js/issues/170, https://github.com/ably/ably-js/issues/175, https://github.com/ably/ably-js/issues/171.

Requires a realtime with https://github.com/ably/realtime/pull/405 (x-ably-version cors fix) when run in the browser -- not to be deployed until after realtime production has that. Passes locally except for the intermittent `resume` failures related to https://github.com/ably/realtime/issues/404, and occasional `leaveOnDisconnect` failures related to https://github.com/ably/realtime/issues/389 (arguably that test should be removed from ably-js as it's really testing a realtime feature, not an ably-js one).

enjoy!
![](http://chocolatatoi.org/wp-content/uploads/2012/03/Easter-Choc-Box1.jpg)