### PR TITLE
Fix comet connections not starting a recv after the connect req closes

### DIFF
--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -75,6 +75,9 @@ var CometTransport = (function() {
 					self.finish('error', err);
 					return;
 				}
+				Utils.nextTick(function() {
+					self.recv();
+				});
 			});
 			connectRequest.exec();
 		});
@@ -134,11 +137,6 @@ var CometTransport = (function() {
 		this.sendUri = baseConnectionUri + '/send';
 		this.recvUri = baseConnectionUri + '/recv';
 		this.closeUri = function(closing) { return baseConnectionUri + (closing ? '/close' : '/disconnect'); };
-
-		var self = this;
-		Utils.nextTick(function() {
-			self.recv();
-		})
 	};
 
 	CometTransport.prototype.send = function(message, callback) {


### PR DESCRIPTION
Fixes #180. Cause was just that there was no `self.recv()` in `connectRequest.on('complete')`. I did find one lurking in `onConnect`, though, which AFAICS doesn't make sense -- when `onConnect` fires, the `/connect` stream is still good for another 59 or so seconds. So I'm guessing it just got put in the wrong place.

(a bit ashamed that I'd never noticed before that comet connections had never worked for more than a minute. possible future enhancement: a longrunning.test.js suite that tests that everything works as it should after a few /recv cycles, that websocket connections don't die after a few minutes, etc. perhaps run in a separate ci job, or maybe by ci-browsers-all in parallel with the saucelabs tests)