### PR TITLE
Remove presence leaveOnDisconnect test

### DIFF
--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -1055,42 +1055,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	};
 
 	/*
-	 * Attach to channel, enter presence channel, disconnect and await leave event
-	 */
-	exports.presenceLeaveOnDisconnect = function(test) {
-		test.expect(3);
-
-		var channelName = 'leaveOnDisconnect';
-		var leaveOnDisconnect = function(cb) {
-			var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
-			clientRealtime.connection.on('connected', function() {
-				/* get channel, attach, and enter */
-				var clientChannel = clientRealtime.channels.get(channelName);
-				clientChannel.attach(function(err) {
-					if(err) {
-						cb(err, clientRealtime);
-						return;
-					}
-					clientChannel.presence.enter('Test client data (connection0)', function(err) {
-						if(err) {
-							cb(err, clientRealtime);
-							return;
-						}
-						test.ok(true, 'Presence event sent');
-						/* once enter event is confirmed as having been
-						 * delivered, close the connection */
-						clientRealtime.close();
-						cb(null, clientRealtime);
-					});
-				});
-			});
-			monitorConnection(test, clientRealtime);
-		};
-
-		runTestWithEventListener(test, channelName, listenerFor('leave', testClientId), leaveOnDisconnect);
-	};
-
-	/*
 	 * Enter presence channel (without attaching), close the connection,
 	 * reconnect, then enter again to reattach
 	 */


### PR DESCRIPTION
The thing this is testing is that realtime broadcasts a `leave` event when a connection closes. That's not an ably-js feature, and there's not much ably-js can do when it [starts failing](https://ci.ably.io/job/ably-js/486/console). So: I want to remove it from ably-js and [add it to realtime](https://github.com/ably/realtime/pull/415), where it'll be better at catching realtime regressions.