### PR TITLE
Fix iframe connections not starting a recv after the connect req closes

### DIFF
--- a/browser/lib/transport/iframeagent.js
+++ b/browser/lib/transport/iframeagent.js
@@ -78,6 +78,9 @@
 				self.postErrorEvent(err);
 				return;
 			}
+			Utils.nextTick(function() {
+				self.recv();
+			});
 		});
 		connectRequest.exec();
 	};
@@ -110,11 +113,6 @@
 		Logger.logAction(Logger.LOG_MICRO, 'IframeAgent.onConnect()', 'baseUri = ' + baseConnectionUri);
 		this.sendUri = baseConnectionUri + '/send';
 		this.recvUri = baseConnectionUri + '/recv';
-
-		var self = this;
-		Utils.nextTick(function() {
-			self.recv();
-		})
 	};
 
 	IframeAgent.prototype.onMessageEvent = function(data) {


### PR DESCRIPTION
Exactly the same as https://github.com/ably/ably-js/pull/181, except for iframes (I didn't notice that iframetransport doesn't use the shared comettransport#connect)