### PR TITLE
Force token rerequest if realtime indicates token problems

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -290,7 +290,10 @@ var Auth = (function() {
 			Logger.logAction(Logger.LOG_MINOR, 'Auth.requestToken()', 'using token auth with client-side signing');
 			tokenRequestCallback = function(params, cb) { self.createTokenRequest(params, authOptions, cb); };
 		} else {
-			throw new Error('Auth.requestToken(): authOptions must include valid authentication parameters');
+			var msg = "Need a new token, but authOptions does not include any way to request one";
+			Logger.logAction(Logger.LOG_ERROR, 'Auth.requestToken()', msg);
+			callback(new ErrorInfo(msg, 40101, 401));
+			return;
 		}
 
 		/* normalise token params */

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -514,5 +514,9 @@ var Auth = (function() {
 			(this.clientId !== tokenClientId);
 	};
 
+	Auth.isTokenErr = function(error) {
+		return error.code && (error.code >= 40140) && (error.code < 40150);
+	};
+
 	return Auth;
 })();

--- a/common/lib/client/connection.js
+++ b/common/lib/client/connection.js
@@ -10,6 +10,7 @@ var Connection = (function() {
 		this.id = undefined;
 		this.serial = undefined;
 		this.recoveryKey = undefined;
+		this.errorReason = null;
 
 		var self = this;
 		this.connectionManager.on('connectionstate', function(stateChange) {

--- a/common/lib/client/resource.js
+++ b/common/lib/client/resource.js
@@ -1,5 +1,8 @@
 var Resource = (function() {
 	var msgpack = (typeof(window) == 'object') ? window.Ably.msgpack : require('msgpack-js');
+	var isErrATokenProblem = function(error) {
+		return error.code && (error.code >= 40140) && (error.code < 40150);
+	};
 
 	function Resource() {}
 
@@ -104,7 +107,7 @@ var Resource = (function() {
 			}
 
 			Http.get(rest, path, headers, params, function(err, res, headers, unpacked) {
-				if(err && err.code == 40140) {
+				if(err && isErrATokenProblem(err)) {
 					/* token has expired, so get a new one */
 					rest.auth.authorise(null, {force:true}, function(err) {
 						if(err) {
@@ -146,7 +149,7 @@ var Resource = (function() {
 			}
 
 			Http.post(rest, path, headers, body, params, function(err, res, headers, unpacked) {
-				if(err && err.code == 40140) {
+				if(err && isErrATokenProblem(err)) {
 					/* token has expired, so get a new one */
 					rest.auth.authorise(null, {force:true}, function(err) {
 						if(err) {

--- a/common/lib/client/resource.js
+++ b/common/lib/client/resource.js
@@ -107,7 +107,7 @@ var Resource = (function() {
 			}
 
 			Http.get(rest, path, headers, params, function(err, res, headers, unpacked) {
-				if(err && isErrATokenProblem(err)) {
+				if(err && Auth.isTokenErr(err)) {
 					/* token has expired, so get a new one */
 					rest.auth.authorise(null, {force:true}, function(err) {
 						if(err) {
@@ -149,7 +149,7 @@ var Resource = (function() {
 			}
 
 			Http.post(rest, path, headers, body, params, function(err, res, headers, unpacked) {
-				if(err && isErrATokenProblem(err)) {
+				if(err && Auth.isTokenErr(err)) {
 					/* token has expired, so get a new one */
 					rest.auth.authorise(null, {force:true}, function(err) {
 						if(err) {

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -456,6 +456,7 @@ var ConnectionManager = (function() {
 		if(existingState !== this.states.connected) {
 			this.notifyState({state: 'connected'});
 			this.errorReason = null;
+			this.realtime.connection.errorReason = null;
 		}
 
 		/* Gracefully terminate existing protocol */
@@ -591,6 +592,7 @@ var ConnectionManager = (function() {
 		var newState = this.state = this.states[stateChange.current];
 		if(stateChange.reason) {
 			this.errorReason = stateChange.reason;
+			this.realtime.connection.errorReason = stateChange.reason;
 		}
 		if(newState.terminal) {
 			this.clearConnection();

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -8,21 +8,17 @@ var ConnectionManager = (function() {
 	var PendingMessage = Protocol.PendingMessage;
 	var noop = function() {};
 
-	var isTokenErr = function(error) {
-		return error.code && (error.code >= 40140) && (error.code < 40150);
-	};
-
-	var isErrFatal = function(err) {
+	function isFatalErr(err) {
 		var UNRESOLVABLE_ERROR_CODES = [80015, 80017, 80030];
 
 		if(err.code) {
-			if(isTokenErr(err)) return false;
+			if(Auth.isTokenErr(err)) return false;
 			if(Utils.arrIn(UNRESOLVABLE_ERROR_CODES, err.code)) return true;
 			return (err.code >= 40000 && err.code < 50000)
 		}
-		// If no statusCode either, assume false
+		/* If no statusCode either, assume false */
 		return err.statusCode < 500;
-	};
+	}
 
 	function TransportParams(options, host, mode, connectionKey, connectionSerial) {
 		this.options = options;
@@ -244,7 +240,7 @@ var ConnectionManager = (function() {
 			}
 			if(err) {
 				/* a 4XX error, such as 401, signifies that there is an error that will not be resolved by another transport */
-				if(isErrFatal(err)) {
+				if(isFatalErr(err)) {
 					callback(err);
 					return;
 				}
@@ -301,7 +297,7 @@ var ConnectionManager = (function() {
 				transportParams.host = Utils.arrRandomElement(candidateHosts);
 				self.chooseTransportForHost(transportParams, self.httpTransports.slice(), function(err, httpTransport) {
 					if(err) {
-						if(isErrFatal(err)) {
+						if(isFatalErr(err)) {
 							callback(err);
 							return;
 						}
@@ -316,7 +312,7 @@ var ConnectionManager = (function() {
 
 		this.chooseTransportForHost(transportParams, this.httpTransports.slice(), function(err, httpTransport) {
 			if(err) {
-				if(isErrFatal(err)) {
+				if(isFatalErr(err)) {
 					callback(err);
 					return;
 				}
@@ -499,7 +495,7 @@ var ConnectionManager = (function() {
 		if(wasActive || (this.activeProtocol === null && wasPending && this.pendingTransports.length === 0)) {
 			/* Transport failures only imply a connection failure
 			 * if the reason for the failure is fatal */
-			if((state === 'failed') && error && !isErrFatal(error)) {
+			if((state === 'failed') && error && !isFatalErr(error)) {
 				state = 'disconnected';
 			}
 			this.notifyState({state: state, error: error});
@@ -763,7 +759,7 @@ var ConnectionManager = (function() {
 				/* do nothing */
 				return;
 			}
-			if(isTokenErr(err)) {
+			if(Auth.isTokenErr(err)) {
 				/* re-get a token */
 				auth.authorise(null, {force: true}, function(err) {
 					if(err) {
@@ -778,7 +774,7 @@ var ConnectionManager = (function() {
 			/* Only allow connection to be 'failed' if err has a definite unrecoverable
 			 * code from realtime; otherwise err on the side of 'disconnected' so will
 			 * retry. (Note: token problems case is dealt with above) */
-			if(err.code && isErrFatal(err))
+			if(err.code && isFatalErr(err))
 				self.notifyState({state: 'failed', error: err});
 			else
 				self.notifyState({state: self.states.connecting.failState, error: err});
@@ -798,7 +794,7 @@ var ConnectionManager = (function() {
 		if(auth.method == 'basic') {
 			tryConnect();
 		} else {
-			var authOptions = (this.errorReason && isTokenErr(this.errorReason)) ? {force: true} : null;
+			var authOptions = (this.errorReason && Auth.isTokenErr(this.errorReason)) ? {force: true} : null;
 			auth.authorise(null, authOptions, function(err) {
 				if(err)
 					connectErr(err);


### PR DESCRIPTION
Including adding a new ConnectionManager#disconnectReason so can remember whether the reason for the last disconnect was a token issue.

Also add isErrATokenProblem helper in anticipation of upcoming token code changes (uses `40140 <= err.code < 40150` so works with both old and new errors).

Fixes https://github.com/ably/ably-js/issues/203