### PR TITLE
Stop shimming async for requirejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.8.13",
   "main": "./nodejs/index.js",
   "dependencies": {
-    "async": "~0.9",
+    "async": "git://github.com/ably-forks/async#requirejs",
     "buffertools": "^2.1.3",
     "crypto-js": "git://github.com/ably-forks/crypto-js#typedarray-webkit",
     "hexy": "~0.2",

--- a/spec/support/browser_setup.js
+++ b/spec/support/browser_setup.js
@@ -53,9 +53,6 @@ require([(baseUrl + '/spec/common/globals/named_dependencies.js').replace('//','
 			},
 			'browser-base64': {
 				exports: 'Base64'
-			},
-			'async': {
-				exports: 'async'
 			}
 		},
 


### PR DESCRIPTION
Most-frustrating-to-debug bug so far in IE8/9 project turns out not to have been an IE bug at all!

Was looking at a test that used async.parallel, where in IE8, async wasn't calling the result callback even though all the subtests were calling their callbacks. But `console.log` statements in the functions in async.js somehow weren't getting printed, even though the file was definitely getting loaded.

Turns out, when the tests were run in the browser, the `async` that was getting used is *not* the one pointed to by named_dependencies (node_modules/async/lib/async), but rather a rather old version that's copied-and-pasted inline into karma-nodeunit (!) -- https://github.com/karma-runner/karma-nodeunit/blob/master/lib/nodeunit.js#L500.

Why was it using that one? Because when setting up requirejs in the browser, [we apparently put a shim which tells requirejs to use the global `async` object, whatever that may be](https://github.com/ably/ably-js/blob/07e6e3b9ca88f34f6a1ac5e6c657ce068f16788b/spec/support/browser_setup.js#L57-L59) -- ie whichever async was loaded most recently, which was the nodeunit one.

So: this PR removes the shim, and points to a branch of async in ably-forks with the issue that was causing async's requirejs-loader not to work with ably-js fixed.