### PR TITLE
Fixing issue #205 - Failing test auth_token_expires

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -432,7 +432,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			}
-			if(authOptions.queryTime || (typeof(authOptions.queryTime) === 'undefined' && Rest.prototype.serverTimeOffset === null )) {
+			if(authOptions.queryTime) {
 				rest.time(function(err, time) {
 					if(err) {callback(err); return;}
 					request.timestamp = time;

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -432,7 +432,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			}
-			if(authOptions.queryTime) {
+			if(authOptions.queryTime || (typeof queryTime == 'undefined' && Rest.prototype.serverTimeOffset === null )) {
 				rest.time(function(err, time) {
 					if(err) {callback(err); return;}
 					request.timestamp = time;
@@ -507,7 +507,7 @@ var Auth = (function() {
 	};
 
 	Auth.prototype.getTimestamp = function() {
-		return Date.now() + (this.rest.serverTimeOffset || 0);
+		return Date.now() + (Rest.prototype.serverTimeOffset || 0);
 	};
 
 	Auth.prototype._tokenClientIdMismatch = function(tokenClientId) {

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -432,7 +432,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			}
-			if(authOptions.queryTime || (typeof authOptions.queryTime == 'undefined' && Rest.prototype.serverTimeOffset === null )) {
+			if(authOptions.queryTime || (typeof(authOptions.queryTime) === 'undefined' && Rest.prototype.serverTimeOffset === null )) {
 				rest.time(function(err, time) {
 					if(err) {callback(err); return;}
 					request.timestamp = time;

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -432,7 +432,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			}
-			if(authOptions.queryTime || (typeof queryTime == 'undefined' && Rest.prototype.serverTimeOffset === null )) {
+			if(authOptions.queryTime || (typeof authOptions.queryTime == 'undefined' && Rest.prototype.serverTimeOffset === null )) {
 				rest.time(function(err, time) {
 					if(err) {callback(err); return;}
 					request.timestamp = time;

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -40,7 +40,6 @@ var Rest = (function() {
 			Logger.setLog(options.log.level, options.log.handler);
 		Logger.logAction(Logger.LOG_MINOR, 'Rest()', 'started');
 
-		this.serverTimeOffset = null;
 		this.baseUri = this.authority = function(host) { return Defaults.getHttpScheme(options) + host + ':' + Defaults.getPort(options, false); };
 
 		this.auth = new Auth(this, options);
@@ -70,6 +69,8 @@ var Rest = (function() {
 		})).get(params, callback);
 	};
 
+	Rest.prototype.serverTimeOffset = null;
+
 	Rest.prototype.time = function(params, callback) {
 		/* params and callback are optional; see if params contains the callback */
 		if(callback === undefined) {
@@ -98,7 +99,7 @@ var Rest = (function() {
 				callback(err);
 				return;
 			}
-			self.serverTimeOffset = (time - Date.now());
+			Rest.prototype.serverTimeOffset = (time - Date.now());
 			callback(null, time);
 		});
 	};

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -40,6 +40,7 @@ var Rest = (function() {
 			Logger.setLog(options.log.level, options.log.handler);
 		Logger.logAction(Logger.LOG_MINOR, 'Rest()', 'started');
 
+		this.serverTimeOffset = null;
 		this.baseUri = this.authority = function(host) { return Defaults.getHttpScheme(options) + host + ':' + Defaults.getPort(options, false); };
 
 		this.auth = new Auth(this, options);
@@ -69,8 +70,6 @@ var Rest = (function() {
 		})).get(params, callback);
 	};
 
-	Rest.prototype.serverTimeOffset = null;
-
 	Rest.prototype.time = function(params, callback) {
 		/* params and callback are optional; see if params contains the callback */
 		if(callback === undefined) {
@@ -99,7 +98,7 @@ var Rest = (function() {
 				callback(err);
 				return;
 			}
-			Rest.prototype.serverTimeOffset = (time - Date.now());
+			self.serverTimeOffset = (time - Date.now());
 			callback(null, time);
 		});
 	};


### PR DESCRIPTION
The Rest client would fail to connect if the client's clock is ahead of
the server's clock by more than the auth token's TTL. The serverTimeOffset
was calculated only when the queryTime auth param was set, thus any connections
initiated without queryTime=true would not benefit from the serverTimeOffset
mechanism, and the following test from Auth.prototype.authorise would fail:

    if(token.expires === undefined || (token.expires > this.getTimestamp())) {

The proposed solution memoizes the time offset on the Rest object's prototype,
making sure that the offset is calculated once per library load, as opposed to
once per request.

Memoization behaviour can be overriden with the queryTime bool parameter, if set.
Thus the offset is calculated in the following cases:

                                     queryTime
                        |  truthy  |   falsy   |   not set
                 -------|----------|-----------|-----------
    offset===null  true |   yes    |    no     |    yes
                  false |   yes    |    no     |    no

When reviewing, please verify that this is the desired behaviour.