### PR TITLE
Some proposed fixes for "Poor connection never attaches and reports connection to be connected #195"

### DIFF
--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -172,6 +172,7 @@ var RealtimeChannel = (function() {
 							callback();
 							break;
 						case 'failed':
+						case 'attached':
 							callback(err || connectionManager.getStateError());
 							break;
 						default:
@@ -461,8 +462,7 @@ var RealtimeChannel = (function() {
 		this.stateTimer = setTimeout(function() {
 			Logger.logAction(Logger.LOG_MINOR, 'RealtimeChannel.setPendingState', 'timer expired');
 			self.stateTimer = null;
-			/* retry */
-			self.checkPendingState();
+			self.timeoutPendingState();
 		}, this.realtime.options.timeouts.realtimeRequestTimeout);
 	};
 
@@ -478,6 +478,23 @@ var RealtimeChannel = (function() {
 				/* resume any sync operation that was in progress */
 				this.sync();
 			default:
+				break;
+		}
+	};
+
+	RealtimeChannel.prototype.timeoutPendingState = function() {
+		switch(this.state) {
+			case 'attaching':
+				var err = new ErrorInfo('Channel attach timed out', 90000, 408);
+				this.setState('detached', err);
+				this.failPendingMessages(err);
+				break;
+			case 'detaching':
+				var err = new ErrorInfo('Channel detach timed out', 90000, 408);
+				this.setState('attached', err);
+				break;
+			default:
+				this.checkPendingState();
 				break;
 		}
 	};

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -467,15 +467,12 @@ var RealtimeChannel = (function() {
 	};
 
 	RealtimeChannel.prototype.checkPendingState = function() {
-		var result = false;
 		switch(this.state) {
 			case 'attaching':
 				this.attachImpl();
-				result = true;
 				break;
 			case 'detaching':
 				this.detachImpl();
-				result = true;
 				break;
 			case 'attached':
 				/* resume any sync operation that was in progress */
@@ -483,7 +480,6 @@ var RealtimeChannel = (function() {
 			default:
 				break;
 		}
-		return result;
 	};
 
 	RealtimeChannel.prototype.clearStateTimer = function() {

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -31,14 +31,15 @@ var Transport = (function() {
 	Transport.prototype.connect = function() {};
 
 	Transport.prototype.close = function() {
-		if(this.isConnected)
-			this.requestClose(true);
+		if(this.isConnected) {
+			this.requestClose();
+		}
 		this.finish('closed', ConnectionError.closed);
 	};
 
 	Transport.prototype.abort = function(error) {
 		if(this.isConnected) {
-			this.requestClose(false);
+			this.requestDisconnect();
 		}
 		this.finish('failed', error);
 	};
@@ -143,9 +144,14 @@ var Transport = (function() {
 		this.finish('closed', err);
 	};
 
-	Transport.prototype.requestClose = function(closing) {
+	Transport.prototype.requestClose = function() {
 		Logger.logAction(Logger.LOG_MINOR, 'Transport.requestClose()', '');
-		this.send((closing ? closeMessage :disconnectMessage), noop);
+		this.send(closeMessage, noop);
+	};
+
+	Transport.prototype.requestDisconnect = function() {
+		Logger.logAction(Logger.LOG_MINOR, 'Transport.requestDisconnect()', '');
+		this.send(disconnectMessage, noop);
 	};
 
 	Transport.prototype.ping = function(callback) {

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -38,7 +38,7 @@ var Transport = (function() {
 
 	Transport.prototype.abort = function(error) {
 		if(this.isConnected) {
-			this.requestClose(true);
+			this.requestClose(false);
 		}
 		this.finish('failed', error);
 	};

--- a/nodejs/lib/transport/nodecomettransport.js
+++ b/nodejs/lib/transport/nodecomettransport.js
@@ -305,7 +305,7 @@ var NodeCometTransport = (function() {
 			req.abort();
 			this.req = null;
 		}
-		this.complete({statusCode: 400, code: 40000, message: 'Cancelled'})
+		this.complete({statusCode: 400, code: 80000, message: 'Cancelled'})
 	};
 
 	return NodeCometTransport;


### PR DESCRIPTION
Addresses #195.

The questions from that issue, with discussion & questions:

> (1) we should change the Error to an ErrorInfo and verify we get a meaningful error message.

Already addressed by https://github.com/ably/ably-js/pull/197

> (2) does it correctly handle the timeout of the attach()? how come the channel remains in the attaching state?

Because previous strategy on timeout was just to retry. https://github.com/ably/ably-js/commit/96e65dee0f0d01bce8035683b7b429822fdbd17b changes that to fail channel ops (leaving the channel in the state it was in beforehand) if the request fails.

I'm not certain this is the correct thing to do (in particular, since realtimeRequestTimeout is 10s and httpRequestTimeout is 15s, this leaves a period of 5s after which the channel considers the request failed, but during which it could still succeed, which is kinda weird). Opinions?

> (3) what should be done about this ws transport that's orphaned, associated with an upgrade that's gone bad. Can we just arrange for this to become the active transport? Is the behaviour here actually ok, and the problem is that we keep going with the second xhr connection even though we're now connected?

https://github.com/ably/ably-js/commit/96f83a6921c1ed8f7fdf6055af8989368f20f625 changes the deactivateTransport logic such that if there is a pending transport which is connected and scheduled for activation -- just waiting for the active transport to finish what its
doing - then, if the current active transport fails, it just lets the pending one take over, avoiding going into the disconnected state. If that's not the case, we continue as we do at the moment.

(This technically leaves a period in which the state is `connected` but activeProtocol is null -- I think should be at most one cycle of the event loop -- not sure if this is a problem?)

> (4) why this error - is this reproducible?

Because transport#abort was calling `requestClose(true)`. I don't understand why that was like that -- AFAIK the only reason to do a /close (rather than a /disconnect) is if we want realtime to discard the connection state, which surely isn't something we should be doing unless the user requests a close. @paddybyers am I missing something?

https://github.com/ably/ably-js/commit/7a593e23236cc87f413b307ab438ac7b9243dbb6 changes it to `requestClose(false)`.

> (5) is it right that setSuspended() is called as a result of a non-fatal upgrade error?

In that case I think it was right -- realtime lost the connection state (due to the previous point), so Matt was no longer attached. 