### PR TITLE
test: clientId takes precedence over defaultCliendId for auth operations

### DIFF
--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -380,6 +380,28 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	/*
+	 * When a clientId value is provided in both ClientOptions#clientId and ClientOptions#defaultTokenParams,
+	 * the ClientOptions#clientId takes precendence and is used for all Auth operations (RSA7a4)
+	 */
+	exports.auth_clientid_precedence = function(test) {
+		test.expect(2);
+		var testClientId = 'test client id',
+			testClientDefaultId = 'test client default id';
+
+		var rest = helper.AblyRest();
+		rest.auth.requestToken({clientId: testClientId, defaultTokenParams: { clientId: testClientDefaultId } }, function(err, tokenDetails) {
+			if(err) {
+				test.ok(false, displayError(err));
+				test.done();
+				return;
+			}
+			test.ok((tokenDetails.token), 'Verify token value');
+			test.equal(tokenDetails.clientId, testClientId, 'Authenticated with clientId that overrides default clientId');
+			test.done();
+		});
+	};
+
+	/*
 	 * Check state change reason is propogated during a disconnect
 	 * (when connecting with a token that expires while connected)
 	 */


### PR DESCRIPTION
Adding auth test for RSA7a4.