### PR TITLE
Issue205 auth token expires fails

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -146,7 +146,19 @@ var Auth = (function() {
 			authOptions = null;
 		}
 
-		var token = this.tokenDetails;
+		var self = this,
+			token = this.tokenDetails;
+
+		var requestToken = function() {
+			self.requestToken(tokenParams, authOptions, function(err, tokenResponse) {
+				if(err) {
+					callback(err);
+					return;
+				}
+				callback(null, (self.tokenDetails = tokenResponse));
+			});
+		}
+
 		if(token) {
 			if(this._tokenClientIdMismatch(token.clientId)) {
 				callback(new ErrorInfo('ClientId in token was ' + token.clientId + ', but library was instantiated with clientId ' + this.clientId, 40102, 401));
@@ -167,16 +179,11 @@ var Auth = (function() {
 					Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'deleting expired token');
 					self.tokenDetails = null;
 				}
+				requestToken();
 			});
+		} else {
+			requestToken();
 		}
-		var self = this;
-		this.requestToken(tokenParams, authOptions, function(err, tokenResponse) {
-			if(err) {
-				callback(err);
-				return;
-			}
-			callback(null, (self.tokenDetails = tokenResponse));
-		});
 	};
 
 	/**

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -165,7 +165,7 @@ var Auth = (function() {
 				} else {
 					/* expired, so remove */
 					Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'deleting expired token');
-					this.tokenDetails = null;
+					self.tokenDetails = null;
 				}
 			});
 		}

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -152,11 +152,11 @@ var Auth = (function() {
 				callback(new ErrorInfo('ClientId in token was ' + token.clientId + ', but library was instantiated with clientId ' + this.clientId, 40102, 401));
 				return;
 			}
-			this.getTimestamp(!!authOptions.queryTime, function(err, time) {
+			this.getTimestamp(self.authOptions && self.authOptions.queryTime, function(err, time) {
 				if(err)
 					callback(err);
 
-				if(token.expires === undefined || (token.expires > time)) {
+				if(token.expires === undefined || (token.expires >= time)) {
 					if(!(authOptions && authOptions.force)) {
 						Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'using cached token; expires = ' + token.expires);
 						callback(null, token);
@@ -437,7 +437,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			};
-			self.getTimestamp(authOptions.queryTime, function(err, time) {
+			self.getTimestamp(authOptions && authOptions.queryTime, function(err, time) {
 				if(err) {callback(err); return;}
 				request.timestamp = time;
 				authoriseCb();
@@ -507,7 +507,7 @@ var Auth = (function() {
 	};
 
 	Auth.prototype.getTimestamp = function(queryTime, callback) {
-		if (queryTime) {
+		if (queryTime || this.rest.options.queryTime) {
 			this.rest.time(function(err, time) {
 				if(err) {
 					callback(err);

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -513,8 +513,15 @@ var Auth = (function() {
 		}
 	};
 
+	/**
+	 * Get the current time based on the local clock,
+	 * or if the option queryTime is true, return the server time.
+	 * The server time offset from the local time is stored so that
+	 * only one request to the server to get the time is ever needed
+	 */
 	Auth.prototype.getTimestamp = function(queryTime, callback) {
-		if (queryTime || this.client.options.queryTime) {
+		var offsetSet = !isNaN(parseInt(this.client.serverTimeOffset));
+		if (!offsetSet && (queryTime || this.client.options.queryTime)) {
 			this.client.time(function(err, time) {
 				if(err) {
 					callback(err);

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -432,7 +432,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			}
-			if(authOptions.queryTime || (typeof(authOptions.queryTime) === 'undefined' && Rest.prototype.serverTimeOffset === null )) {
+			if(authOptions.queryTime) {
 				rest.time(function(err, time) {
 					if(err) {callback(err); return;}
 					request.timestamp = time;

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -432,7 +432,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			}
-			if(authOptions.queryTime) {
+			if(authOptions.queryTime || (typeof queryTime == 'undefined' && Rest.prototype.serverTimeOffset === null )) {
 				rest.time(function(err, time) {
 					if(err) {callback(err); return;}
 					request.timestamp = time;

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -432,7 +432,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			}
-			if(authOptions.queryTime || (typeof authOptions.queryTime == 'undefined' && Rest.prototype.serverTimeOffset === null )) {
+			if(authOptions.queryTime || (typeof(authOptions.queryTime) === 'undefined' && Rest.prototype.serverTimeOffset === null )) {
 				rest.time(function(err, time) {
 					if(err) {callback(err); return;}
 					request.timestamp = time;

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -432,7 +432,7 @@ var Auth = (function() {
 				authoriseCb();
 				return;
 			}
-			if(authOptions.queryTime || (typeof queryTime == 'undefined' && Rest.prototype.serverTimeOffset === null )) {
+			if(authOptions.queryTime || (typeof authOptions.queryTime == 'undefined' && Rest.prototype.serverTimeOffset === null )) {
 				rest.time(function(err, time) {
 					if(err) {callback(err); return;}
 					request.timestamp = time;

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -152,17 +152,22 @@ var Auth = (function() {
 				callback(new ErrorInfo('ClientId in token was ' + token.clientId + ', but library was instantiated with clientId ' + this.clientId, 40102, 401));
 				return;
 			}
-			if(token.expires === undefined || (token.expires > this.getTimestamp())) {
-				if(!(authOptions && authOptions.force)) {
-					Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'using cached token; expires = ' + token.expires);
-					callback(null, token);
-					return;
+			this.getTimestamp(!!authOptions.queryTime, function(err, time) {
+				if(err)
+					callback(err);
+
+				if(token.expires === undefined || (token.expires > time)) {
+					if(!(authOptions && authOptions.force)) {
+						Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'using cached token; expires = ' + token.expires);
+						callback(null, token);
+						return;
+					}
+				} else {
+					/* expired, so remove */
+					Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'deleting expired token');
+					this.tokenDetails = null;
 				}
-			} else {
-				/* expired, so remove */
-				Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'deleting expired token');
-				this.tokenDetails = null;
-			}
+			});
 		}
 		var self = this;
 		this.requestToken(tokenParams, authOptions, function(err, tokenResponse) {
@@ -431,17 +436,12 @@ var Auth = (function() {
 			if(request.timestamp) {
 				authoriseCb();
 				return;
-			}
-			if(authOptions.queryTime) {
-				rest.time(function(err, time) {
-					if(err) {callback(err); return;}
-					request.timestamp = time;
-					authoriseCb();
-				});
-				return;
-			}
-			request.timestamp = self.getTimestamp();
-			authoriseCb();
+			};
+			self.getTimestamp(authOptions.queryTime, function(err, time) {
+				if(err) {callback(err); return;}
+				request.timestamp = time;
+				authoriseCb();
+			});
 		})(function() {
 			/* nonce */
 			/* NOTE: there is no expectation that the client
@@ -506,8 +506,18 @@ var Auth = (function() {
 		}
 	};
 
-	Auth.prototype.getTimestamp = function() {
-		return Utils.now() + (this.rest.serverTimeOffset || 0);
+	Auth.prototype.getTimestamp = function(queryTime, callback) {
+		if (queryTime) {
+			this.rest.time(function(err, time) {
+				if(err) {
+					callback(err);
+					return;
+				}
+				callback(null, time);
+			});
+		} else {
+			callback(null, Utils.now() + (this.rest.serverTimeOffset || 0));
+		}
 	};
 
 	Auth.prototype._tokenClientIdMismatch = function(tokenClientId) {

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -69,6 +69,9 @@ var Rest = (function() {
 		})).get(params, callback);
 	};
 
+	/* Explicitly set serverTimeOffset to null ensuring any request
+	   requiring knowledge of the server time knows to query the server
+	   as this value is null */
 	Rest.prototype.serverTimeOffset = null;
 
 	Rest.prototype.time = function(params, callback) {
@@ -100,7 +103,7 @@ var Rest = (function() {
 				return;
 			}
 			/* calculate time offset only once for this device by adding to the prototype */
-			Rest.prototype.serverTimeOffset = (time - Date.now());
+			Rest.prototype.serverTimeOffset = (time - Utils.now());
 			callback(null, time);
 		});
 	};

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -40,7 +40,6 @@ var Rest = (function() {
 			Logger.setLog(options.log.level, options.log.handler);
 		Logger.logAction(Logger.LOG_MINOR, 'Rest()', 'started');
 
-		this.serverTimeOffset = null;
 		this.baseUri = this.authority = function(host) { return Defaults.getHttpScheme(options) + host + ':' + Defaults.getPort(options, false); };
 
 		this.auth = new Auth(this, options);
@@ -70,6 +69,8 @@ var Rest = (function() {
 		})).get(params, callback);
 	};
 
+	Rest.prototype.serverTimeOffset = null;
+
 	Rest.prototype.time = function(params, callback) {
 		/* params and callback are optional; see if params contains the callback */
 		if(callback === undefined) {
@@ -98,7 +99,8 @@ var Rest = (function() {
 				callback(err);
 				return;
 			}
-			self.serverTimeOffset = (time - Utils.now());
+			/* calculate time offset only once for this device by adding to the prototype */
+			Rest.prototype.serverTimeOffset = (time - Date.now());
 			callback(null, time);
 		});
 	};

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -42,6 +42,7 @@ var Rest = (function() {
 
 		this.baseUri = this.authority = function(host) { return Defaults.getHttpScheme(options) + host + ':' + Defaults.getPort(options, false); };
 
+		this.serverTimeOffset = null;
 		this.auth = new Auth(this, options);
 		this.channels = new Channels(this);
 	}
@@ -68,11 +69,6 @@ var Rest = (function() {
 			return statsValues;
 		})).get(params, callback);
 	};
-
-	/* Explicitly set serverTimeOffset to null ensuring any request
-	   requiring knowledge of the server time knows to query the server
-	   as this value is null */
-	Rest.prototype.serverTimeOffset = null;
 
 	Rest.prototype.time = function(params, callback) {
 		/* params and callback are optional; see if params contains the callback */
@@ -103,7 +99,7 @@ var Rest = (function() {
 				return;
 			}
 			/* calculate time offset only once for this device by adding to the prototype */
-			Rest.prototype.serverTimeOffset = (time - Utils.now());
+			self.serverTimeOffset = (time - Utils.now());
 			callback(null, time);
 		});
 	};

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -27,7 +27,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 		var monitorConnection = function(test, realtime) {
 			utils.arrForEach(['failed', 'suspended'], function(state) {
 				realtime.connection.on(state, function () {
-					test.ok(false, 'connection to server ' + state);
+					test.ok(false, 'Connection monitoring: state changed to ' + state + ', aborting test');
 					test.done();
 					realtime.close();
 				});

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -388,14 +388,15 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var clientRealtime,
 			rest = helper.AblyRest();
 
-		rest.auth.requestToken({ ttl: 5000 }, null, function(err, tokenDetails) {
+		rest.auth.requestToken({ ttl: 5000 }, { queryTime: true }, function(err, tokenDetails) {
 			if(err) {
 				test.ok(false, displayError(err));
 				test.done();
 				return;
 			}
-			clientRealtime = helper.AblyRealtime({ tokenDetails: tokenDetails });
+			clientRealtime = helper.AblyRealtime({ tokenDetails: tokenDetails, queryTime: true });
 			monitorConnection(test, clientRealtime);
+
 			clientRealtime.connection.once('connected', function(){
 				test.ok(true, 'Verify connection connected');
 				clientRealtime.connection.once('disconnected', function(stateChange){


### PR DESCRIPTION
@alex-georgiou this builds on your PR https://github.com/ably/ably-js/pull/213

As you will see, there were in fact quite a few issues that was causing it to fail including:

* Token request in authorise was not run asynchronously once time was retrierved
* You were not getting the server time for both instances of the library so the Realtime library still had the wrong time
* Few bugs relating to expectations around objects existing such as authOptions
* Not using the client library configured queryTime option

cc @SimonWoolf @paddybyers 