### PR TITLE
Safeguard Realtime Constructor

### DIFF
--- a/common/lib/client/realtime.js
+++ b/common/lib/client/realtime.js
@@ -1,6 +1,10 @@
 var Realtime = (function() {
 
 	function Realtime(options) {
+		if(!(this instanceof Realtime)){
+			return new Realtime(options);
+		}
+
 		Logger.logAction(Logger.LOG_MINOR, 'Realtime()', '');
 		Rest.call(this, options);
 		this.connection = new Connection(this, this.options);


### PR DESCRIPTION
Ably.Realtime is part of the public api to the whole library. I came across this because the presence docs have an example where the new keyword is not used to instantiate a client. Currently this throws an obscure error. `TypeError: this.connect is not a function(…)`

It seams that `new Ably.Realtime()` should never be called without the new keyword so this safeguard makes sense'