### PR TITLE
RSC18 client options tls

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -483,8 +483,15 @@ var Auth = (function() {
 	 * based on the current auth parameters
 	 */
 	Auth.prototype.getAuthParams = function(callback) {
-		if(this.method == 'basic')
+		if(this.method == 'basic') {
+			if (!this.rest.options.tls) {
+				var msg = 'invalid use of Basic auth over non-TLS transport';
+				Logger.logAction(Logger.LOG_ERROR, 'Rest.getAuthParams()', msg );
+				callback(new ErrorInfo(msg, 40103, 401));
+				return;
+			}
 			callback(null, {key: this.key});
+		}
 		else
 			this.authorise(null, null, function(err, tokenDetails) {
 				if(err) {
@@ -501,6 +508,12 @@ var Auth = (function() {
 	 */
 	Auth.prototype.getAuthHeaders = function(callback) {
 		if(this.method == 'basic') {
+			if (!this.rest.options.tls) {
+				var msg = 'invalid use of Basic auth over non-TLS transport';
+				Logger.logAction(Logger.LOG_ERROR, 'Rest.getAuthHeaders()', msg );
+				callback(new ErrorInfo(msg, 40103, 401));
+				return;
+			}
 			callback(null, {authorization: 'Basic ' + this.basicKey});
 		} else {
 			this.authorise(null, null, function(err, tokenDetails) {

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -484,15 +484,14 @@ var Auth = (function() {
 	 */
 	Auth.prototype.getAuthParams = function(callback) {
 		if(this.method == 'basic') {
-			if (!this.rest.options.tls) {
+			if (!this.client.options.tls) {
 				var msg = 'invalid use of Basic auth over non-TLS transport';
-				Logger.logAction(Logger.LOG_ERROR, 'Rest.getAuthParams()', msg );
+				Logger.logAction(Logger.LOG_ERROR, 'Rest.getAuthParams()', msg);
 				callback(new ErrorInfo(msg, 40103, 401));
 				return;
 			}
 			callback(null, {key: this.key});
-		}
-		else
+		} else
 			this.authorise(null, null, function(err, tokenDetails) {
 				if(err) {
 					callback(err);
@@ -508,9 +507,9 @@ var Auth = (function() {
 	 */
 	Auth.prototype.getAuthHeaders = function(callback) {
 		if(this.method == 'basic') {
-			if (!this.rest.options.tls) {
+			if (!this.client.options.tls) {
 				var msg = 'invalid use of Basic auth over non-TLS transport';
-				Logger.logAction(Logger.LOG_ERROR, 'Rest.getAuthHeaders()', msg );
+				Logger.logAction(Logger.LOG_ERROR, 'Rest.getAuthHeaders()', msg);
 				callback(new ErrorInfo(msg, 40103, 401));
 				return;
 			}

--- a/spec/rest/tls.test.js
+++ b/spec/rest/tls.test.js
@@ -51,7 +51,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 *  A stats request is a good example of this.
 	 */
 	exports.basic_auth_no_tls_error = function(test) {
-		test.expect(5);
+		test.expect(6);
 
 		var rest,
 			keyStr = helper.getTestApp().keys[0].keyStr;
@@ -69,8 +69,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			},
 			function(cb) {
 				rest.stats(function(err, stats) {
-					test.ok(err, 'A stats request causes error with basic auth over https because it would have to send the secret key');
+					test.ok(err, 'A stats request causes error with basic auth over a non-tls connection because it would have to send the secret key');
 					test.equals(err.code, 40103, 'The error thrown is 40103');
+					test.ok(typeof(err.serverId) === 'undefined', 'The error did not come from a server');
 					cb();
 				});
 			}

--- a/spec/rest/tls.test.js
+++ b/spec/rest/tls.test.js
@@ -1,0 +1,87 @@
+"use strict";
+
+define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
+	var exports = {};
+
+	/*
+	 * Set up.
+	 */
+	exports.setup = function(test) {
+		test.expect(1);
+		helper.setupApp(function() {
+			var rest = helper.AblyRest();
+			test.ok(rest, 'Instantiated rest client');
+			test.done();
+		});
+	};
+
+	/*
+	 * tls:true initiates an https connection (RSC18)
+	 */
+	exports.tls_connection = function(test) {
+		test.expect(3);
+
+		var keyStr = helper.getTestApp().keys[0].keyStr,
+			rest = helper.AblyRest({ tls: true, key: keyStr, useTokenAuth: false });
+
+		async.parallel([
+			function(cb) {
+				rest.auth.requestToken(function(err, tokenDetails) {
+					test.ok(!err, 'A token request does not cause error with basic auth over tls');
+					cb();
+				});
+			},
+			function(cb) {
+				rest.stats(function(err, stats) {
+					test.ok(!err, 'A stats request does not cause error with basic auth over tls');
+					cb();
+				});
+			}
+		], function() {
+			test.equal(rest.baseUri().substr(0,5), "https", 'Requested token and stats over a tls connection');
+			test.done();
+		});
+	};
+
+	/*
+	 *  The combination of tls:false and basic auth results in error (see RSC18, RSA1).
+	 *  The error MUST NOT occur at instantiation, because we might need the Rest client 
+	 *  for things that don't require sending a key such as a token request.
+	 *  The error MUST occur on any request that tries to send a secret key over HTTP.
+	 *  A stats request is a good example of this.
+	 */
+	exports.basic_auth_no_tls_error = function(test) {
+		test.expect(5);
+
+		var rest,
+			keyStr = helper.getTestApp().keys[0].keyStr;
+
+		test.doesNotThrow(function() {
+			rest = helper.AblyRest({ tls: false, key: keyStr, useTokenAuth: false });
+		}, Error, 'Rest client does not throw error on instantiation, even if a secret key is specified along with tls:false');
+
+		async.parallel([
+			function(cb) {
+				rest.auth.requestToken(function(err, tokenDetails) {
+					test.ok(!err, 'A token request does not cause an error over a non-tls connection, because the secret key is not sent with the request');
+					cb();
+				});
+			},
+			function(cb) {
+				rest.stats(function(err, stats) {
+					test.ok(err, 'A stats request causes error with basic auth over https because it would have to send the secret key');
+					test.equals(err.code, 40103, 'The error thrown is 40103');
+					cb();
+				});
+			}
+		], function() {
+			test.equal(rest.baseUri().substr(0,5), "http:", 'Requested token and stats over a non-tls connection');
+			test.done();
+		});
+	};
+
+	return module.exports = helper.withTimeout(exports);
+});
+
+
+


### PR DESCRIPTION
This is my attempt at RSC18.

First I verified that the requirement for not sending a secret key over HTTP was NOT implemented. I used the stats request for this.

Then I modified the `Auth` object so that the error is generated exactly at the two functions where the key is added to the headers. This should ensure that all requests using the basic authentication headers will check for TLS.

Notes:
1. I have put in some other TLS-related tests in, perhaps some overlap with other tests in `/spec/rest/defaults.test.js`. Please review and let me know if it's overkill.
2. I am returning an `ErrorInfo`. I see we do not have any mechanism that will pull error message strings from `errors.json` so I repeated the strings in the code.
3. I am printing the error to the logger as it occurs, even though it is also printed when sent higher up to `PaginatedResource.get()`. I don't know how verbose we want our error reporting to be, but in theory the `Auth` functions could be called elsewhere, hence I'm printing out the error as it occurs for safety.