### PR TITLE
test(realtime): Testing echoMessages=true and echoMessages=false

### DIFF
--- a/spec/realtime/message.test.js
+++ b/spec/realtime/message.test.js
@@ -137,8 +137,15 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 						return;
 					}
 
+					/* wait to see that event is not echoed */
+					var timeoutHandler = setTimeout(function() {
+						test.ok(true, 'No event received within a reasonable time');
+						closeAndFinish(test, realtime);
+					}, 15000);
+
 					/* subscribe to event */
 					rtChannel.subscribe('event0', function(msg) {
+						clearTimeout(timeoutHandler);
 						test.ok(false, 'Received event0 when it should not be echoed back');
 						closeAndFinish(test, realtime);
 					});
@@ -146,11 +153,6 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 					/* publish event */
 					rtChannel.publish('event0', testMsg);
 
-					/* wait to see that event is not echoed */
-					setTimeout(function() {
-						test.ok(true, 'No event received within a reasonable time');
-						closeAndFinish(test, realtime);
-					}, 15000);
 				});
 			});
 			monitorConnection(test, realtime);

--- a/spec/realtime/message.test.js
+++ b/spec/realtime/message.test.js
@@ -90,11 +90,14 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			testMsg1 = 'Hello',
 			testMsg2 = 'World!';
 
+		monitorConnection(test, rt1);
+		monitorConnection(test, rt2);
+
 		// We expect to see testMsg2 on rt1 and testMsg1 on both rt1 and rt2
 		var expectedMessages = 3;
 
 		rt1Channel.subscribe('event0', function(msg) {
-			test.equal(msg.data, testMsg2, 'Received testMsg1 or testMsg2 via rt1 instance');
+			test.equal(msg.data, testMsg2, 'Received testMsg2 via rt1 instance');
 			if (!--expectedMessages)
 				closeAndFinish(test, [rt1, rt2]);
 		});

--- a/spec/realtime/message.test.js
+++ b/spec/realtime/message.test.js
@@ -81,36 +81,35 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.expect(3);
 
 		// set up two realtimes
-		var rt1 = helper.AblyRealtime({ echoMessages: false }),
-			rt2 = helper.AblyRealtime({ echoMessages: true }),
+		var realtimeNoEcho = helper.AblyRealtime({ echoMessages: false }),
+			realtimeEcho = helper.AblyRealtime({ echoMessages: true }),
 
-			rt1Channel = rt1.channels.get('publishecho'),
-			rt2Channel = rt2.channels.get('publishecho'),
+			realtimeNoEchoChannel = realtimeNoEcho.channels.get('publishecho'),
+			realtimeEchoChannel = realtimeEcho.channels.get('publishecho'),
 
 			testMsg1 = 'Hello',
 			testMsg2 = 'World!';
 
-		monitorConnection(test, rt1);
-		monitorConnection(test, rt2);
+		monitorConnection(test, realtimeNoEcho, realtimeEcho);
 
-		// We expect to see testMsg2 on rt1 and testMsg1 on both rt1 and rt2
+		// We expect to see testMsg2 on realtimeNoEcho and testMsg1 on both realtimeNoEcho and realtimeEcho
 		var expectedMessages = 3;
 
-		rt1Channel.subscribe('event0', function(msg) {
-			test.equal(msg.data, testMsg2, 'Received testMsg2 via rt1 instance');
+		realtimeNoEchoChannel.subscribe('event0', function(msg) {
+			test.equal(msg.data, testMsg2, 'Received testMsg2 via realtimeNoEcho instance');
 			if (!--expectedMessages)
-				closeAndFinish(test, [rt1, rt2]);
+				closeAndFinish(test, [realtimeNoEcho, realtimeEcho]);
 		});
 
-		rt2Channel.subscribe('event0', function(msg) {
-			test.ok( msg.data == testMsg1 || msg.data == testMsg2, 'Received testMsg1 or 2 via rt2 instance' );
+		realtimeEchoChannel.subscribe('event0', function(msg) {
+			test.ok( msg.data == testMsg1 || msg.data == testMsg2, 'Received testMsg1 or 2 via realtimeEcho instance' );
 			if (!--expectedMessages)
-				closeAndFinish(test, [rt1, rt2]);
+				closeAndFinish(test, [realtimeNoEcho, realtimeEcho]);
 		});
 
-		// publish testMsg1 on rt1 and testMsg2 on rt2
-		rt1Channel.publish('event0', testMsg1, function() {
-			rt2Channel.publish('event0', testMsg2);
+		// publish testMsg1 on realtimeNoEcho and testMsg2 on realtimeEcho
+		realtimeNoEchoChannel.publish('event0', testMsg1, function() {
+			realtimeEchoChannel.publish('event0', testMsg2);
 		});
 	};
 

--- a/spec/realtime/message.test.js
+++ b/spec/realtime/message.test.js
@@ -99,10 +99,14 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		var finishTest = function() {
 			if (receivedMessagesNoEcho.length + receivedMessagesEcho.length == 3) {
 				test.equal(receivedMessagesNoEcho.length, 1, 'Received exactly one message on realtimeNoEcho');
-				test.equal(receivedMessagesNoEcho[0].data, testMsg2, 'Received testMsg2 on realtimeNoEcho');
 				test.equal(receivedMessagesEcho.length, 2, 'Received exactly two messages on realtimeEcho');
-				test.equal(receivedMessagesEcho[0].data, testMsg1, 'Received testMsg1 on realtimeEcho first');
-				test.equal(receivedMessagesEcho[1].data, testMsg2, 'Received testMsg2 on realtimeEcho second');
+				try {
+					test.equal(receivedMessagesNoEcho[0].data, testMsg2, 'Received testMsg2 on realtimeNoEcho');
+					test.equal(receivedMessagesEcho[0].data, testMsg1, 'Received testMsg1 on realtimeEcho first');
+					test.equal(receivedMessagesEcho[1].data, testMsg2, 'Received testMsg2 on realtimeEcho second');
+				} catch(e) {
+					test.ok(false, 'Failed to find an expected message in the received messages');
+				}
 				closeAndFinish(test, [realtimeNoEcho, realtimeEcho]);
 			}
 		}


### PR DESCRIPTION
At first I was hoping that something could be done so I could somehow query the server and have it tell me that all pending messages up to now have been sent. I scanned the code and docs for the SYNC message and for the ping/HEARTBEAT mechanism. 

I thought I could send a message followed by a ping and then if I got the ping back but not the message, I could assume that the message was not echoed. Then I wouldn't have to stall the tests for an arbitrary amount of seconds.

When the above didn't work, I had a look at the implementations in other languages.
1. In .NET, there is a timer waiting for 10 seconds before asserting that the message was not returned.
2. In GO, there is a similar timer for 15 seconds.
3. In IOS, the wait is for 60 seconds, which sounds more correct given that other connection timeouts are also set to 60s, but slows down the tests.

I set my timeout to 15 seconds.