### PR TITLE
Ie8 10 test suite fixes

### DIFF
--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -23,7 +23,7 @@ Defaults.apiVersion       = '0.8';
 
 Defaults.getHost = function(options, host, ws) {
 	if(ws)
-		host = host == options.restHost ? options.realtimeHost : host || options.realtimeHost;
+		host = (host == options.restHost ? options.realtimeHost : host) || options.realtimeHost;
 	else
 		host = host || options.restHost;
 

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -23,7 +23,7 @@ Defaults.apiVersion       = '0.8';
 
 Defaults.getHost = function(options, host, ws) {
 	if(ws)
-		host = ((host == options.restHost) && options.realtimeHost) || host || options.realtimeHost;
+		host = host == options.restHost ? options.realtimeHost : host || options.realtimeHost;
 	else
 		host = host || options.restHost;
 
@@ -65,15 +65,13 @@ Defaults.normaliseOptions = function(options) {
 	if(!('queueMessages' in options))
 		options.queueMessages = true;
 
-	if(options.restHost) {
-		options.realtimeHost = options.realtimeHost || options.restHost;
-	} else {
-		var environment = (options.environment && String(options.environment).toLowerCase()) || Defaults.ENVIRONMENT,
-		production = !environment || (environment === 'production');
+	var environment = (options.environment && String(options.environment).toLowerCase()) || Defaults.ENVIRONMENT,
+	production = !environment || (environment === 'production');
+	options.fallbackHosts = production && !(options.restHost || options.realtimeHost) ? Defaults.FALLBACK_HOSTS : options.fallbackHosts;
+	if (!options.restHost)
 		options.restHost = production ? Defaults.REST_HOST : environment + '-' + Defaults.REST_HOST;
+	if (!options.realtimeHost)
 		options.realtimeHost = production ? Defaults.REALTIME_HOST : environment + '-' + Defaults.REALTIME_HOST;
-		options.fallbackHosts = production ? Defaults.FALLBACK_HOSTS : options.fallbackHosts;
-	}
 	options.port = options.port || Defaults.PORT;
 	options.tlsPort = options.tlsPort || Defaults.TLS_PORT;
 	if(!('tls' in options)) options.tls = true;

--- a/spec/common/globals/environment.js
+++ b/spec/common/globals/environment.js
@@ -21,13 +21,13 @@ define(function(require) {
 			query[keyValue[0]] = keyValue[1];
 		}
 
-		if(query['env'])          ablyEnvironment = query['env'];
+		if(query['env'])           ablyEnvironment = query['env'];
 		if(query['realtime_host']) realtimeHost = query['realtime_host'];
-		if(query['host'])         host = query['host'];
-		if(query['port'])         port = query['port'];
-		if(query['tls_port'])     tlsPort = query['tls_port'];
-		if(query['tls'])          tls = query['tls'].toLowerCase() !== 'false';
-		if(query['log_level'])    logLevel = Number(query['log_level']) || defaultLogLevel;
+		if(query['host'])          host = query['host'];
+		if(query['port'])          port = query['port'];
+		if(query['tls_port'])      tlsPort = query['tls_port'];
+		if(query['tls'])           tls = query['tls'].toLowerCase() !== 'false';
+		if(query['log_level'])     logLevel = Number(query['log_level']) || defaultLogLevel;
 	}
 
 	return module.exports = {

--- a/spec/common/modules/client_module.js
+++ b/spec/common/modules/client_module.js
@@ -34,7 +34,7 @@ define(['ably', 'globals', 'spec/common/modules/testapp_module'], function(Ably,
 		if (!options.restHost && ablyGlobals.environment) {
 			/* Use a new host name for each REST request to avoid old browser issues
 			   where HTTP connections are no longer available */
-			clientOptions.restHost = hostPrefixes[hostPrefixIndex] + "-" + ablyGlobals.environment + "-rest.ably.io";
+			clientOptions.restHost = hostPrefixes[hostPrefixIndex] + '-' + ablyGlobals.environment + '-rest.ably.io';
 			hostPrefixIndex = (hostPrefixIndex + 1) % hostPrefixes.length;
 		}
 

--- a/spec/common/modules/client_module.js
+++ b/spec/common/modules/client_module.js
@@ -3,7 +3,10 @@
 /* Shared test helper used for creating Rest and Real-time clients */
 
 define(['ably', 'globals', 'spec/common/modules/testapp_module'], function(Ably, ablyGlobals, testAppHelper) {
-	var utils = Ably.Realtime.Utils;
+	var utils = Ably.Realtime.Utils,
+			hostPrefixIndex = 0,
+			hostPrefixes = 'abcdefghikklmnopqrstuvwxyz';
+
 	function mixinOptions(dest, src) {
 		for (var key in src) {
 			if (src.hasOwnProperty(key)) {
@@ -26,6 +29,13 @@ define(['ably', 'globals', 'spec/common/modules/testapp_module'], function(Ably,
 			})) {
 				clientOptions.key = testAppHelper.getTestApp().keys[0].keyStr;
 			}
+		}
+
+		if (!options.restHost && ablyGlobals.environment) {
+			/* Use a new host name for each REST request to avoid old browser issues
+			   where HTTP connections are no longer available */
+			clientOptions.restHost = hostPrefixes[hostPrefixIndex] + "-" + ablyGlobals.environment + "-rest.ably.io";
+			hostPrefixIndex = (hostPrefixIndex + 1) % hostPrefixes.length;
 		}
 
 		return clientOptions;

--- a/spec/common/modules/testapp_manager.js
+++ b/spec/common/modules/testapp_manager.js
@@ -23,7 +23,7 @@ define(['globals', 'browser-base64', 'ably'], function(ablyGlobals, base64, ably
 		var result = new XMLHttpRequest();
 		if ('withCredentials' in result)
 			return result;
-		if(typeof XDomainRequest !== "undefined") {
+		if(typeof XDomainRequest !== 'undefined') {
 			var xdr = new XDomainRequest();        /* Use IE-specific "CORS" code with XDR */
 			xdr.isXDR = true;
 			return xdr;
@@ -129,7 +129,7 @@ define(['globals', 'browser-base64', 'ably'], function(ablyGlobals, base64, ably
 				retryCallback = function(err) {
 					if (err && (retries < maxRetries)) {
 						retries++;
-						console.log("TestApp:", description, "failed on attempt", retries, "; err = ", err);
+						console.log('TestApp:', description, 'failed on attempt', retries, '; err = ', err);
 						func(retryCallback);
 					} else {
 						callback.apply(this, arguments);
@@ -261,7 +261,7 @@ define(['globals', 'browser-base64', 'ably'], function(ablyGlobals, base64, ably
 
 	return module.exports = {
 		setup: function(callback) {
-			withRetry(3, "createNewApp", createNewApp, callback);
+			withRetry(3, 'createNewApp', createNewApp, callback);
 		},
 		tearDown: deleteApp,
 		createStatsFixtureData: createStatsFixtureData,

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -183,7 +183,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		try {
 			var realtime = helper.AblyRealtime({ key: 'not_a.real:key' });
 			var defaultHost = realtime.connection.connectionManager.httpHosts[0];
-			var hostWithoutEnv = defaultHost.replace(/^\w+\-rest/, 'rest');
+			var hostWithoutEnv = defaultHost.replace(/^[\w-]+\-rest/, 'rest');
 			test.equal(hostWithoutEnv, 'rest.ably.io', 'Verify correct default rest host chosen');
 			realtime.connection.on('failed', function (state) {
 				test.done();

--- a/spec/rest/defaults.test.js
+++ b/spec/rest/defaults.test.js
@@ -84,13 +84,13 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.done();
 	};
 
-	/* init with given host */
-	exports.defaults_given_host = function(test) {
+	/* init with given rest host */
+	exports.defaults_given_rest_host = function(test) {
 		test.expect(10);
 		var normalisedOptions = Defaults.normaliseOptions({restHost: 'test.org'});
 
 		test.equal(normalisedOptions.restHost, 'test.org');
-		test.equal(normalisedOptions.realtimeHost, 'test.org');
+		test.equal(normalisedOptions.realtimeHost, 'realtime.ably.io');
 		test.equal(normalisedOptions.port, 80);
 		test.equal(normalisedOptions.tlsPort, 443);
 		test.equal(normalisedOptions.fallbackHosts, undefined);
@@ -98,7 +98,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 		test.deepEqual(Defaults.getHosts(normalisedOptions), [normalisedOptions.restHost]);
 		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', false), 'test.org');
-		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', true), 'test.org');
+		test.deepEqual(Defaults.getHost(normalisedOptions, 'test.org', true), 'realtime.ably.io');
 
 		test.equal(Defaults.getPort(normalisedOptions), 443);
 		test.done();


### PR DESCRIPTION
This PR in response to discussion with @SimonWoolf on failing parts of the test suite cross-browser.

>  Had a look at some runs of browsers-all. Failures can be divided into:
> - Random http timeouts. Saucelabs internet connection seems to be occasionally flakey, and any of the VMs (inc firefox and chrome) sometimes get random timeouts with comet requests.

Ok, not sure we can do much about this.

> - Systematic saucelabs-only internet failures. Eg:
> - for IE9 and 9, the first attempt to set up an app (which happens to be the realtime auth tests) pretty much always times out, resulting in those tests all failing. Subsequent attempts succeed.

I hope I have fixed this by adding a retry into the app setup, 7a627c4

> - IE10 is almost the opposite: after 50 or so successful tests, starting usually somewhere the early channel tests the VM seems to stop being able to connect to ably in any way. All subsequent tests timeout.
>   (I've fired up local IE 9 and 10 virtual machines and double-checked that the test suite passes in both).

I've tried this in Saucelabs now with db56a1e and this appears to not be an issue now.  This also covers some of https://github.com/ably/ably-js/issues/211 although my commits are only aimed at fixing the tests.

> I spent some time trying to debug the IE10 one back when I did IE10, without success.
> Not really sure what to suggest tbh. Reliable cross-browser testing is something we're going to have to have eventually.(edited)
> OK -- I should stop darkly hinting that this is because saucelabs sucks, because I've just tried with testingbot, and got the same results, for both IE10 and IE8/9.
> - The IE10 problem (`network error 0x2ee4`) appears to be a bug in IE10 triggered by saucelabs/testingbot's use of a network proxy, which is why I'm not seeing it locally. Was reported to MS, closed as "fixed in latest version" (ie IE11) , which is unhelpful. (https://connect.microsoft.com/IE/feedback/details/852785/ie10-network-error-0x2ee4-https-proxy-ajax).

Ok, this may now be fixed in this PR

> The IE8/9 problem seems to only happen the first time the page is loaded after the VM is created. On subsequent page refeshes (even if cache cleared, 'always refresh from server' ticked etc.) it works fine; which is why I couldn't recreate it in my local VM.

As above, may now be fixed.

cc @SimonWoolf @paddybyers 
