### PR TITLE
Presence action string

### DIFF
--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -264,7 +264,7 @@ var RealtimeChannel = (function() {
 		var msg = ProtocolMessage.fromValues({
 			action: actions.PRESENCE,
 			channel: this.name,
-			presence: [PresenceMessage.fromValuesWithNumericAction(presence)]
+			presence: [PresenceMessage.fromValues(presence)]
 		});
 		this.sendMessage(msg, callback);
 	};

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -264,7 +264,7 @@ var RealtimeChannel = (function() {
 		var msg = ProtocolMessage.fromValues({
 			action: actions.PRESENCE,
 			channel: this.name,
-			presence: [PresenceMessage.fromValues(presence)]
+			presence: [PresenceMessage.fromValuesWithNumericAction(presence)]
 		});
 		this.sendMessage(msg, callback);
 	};

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -1,6 +1,4 @@
 var RealtimePresence = (function() {
-	var presenceAction = PresenceMessage.Action;
-
 	var noop = function() {};
 
 	function memberKey(item) {
@@ -71,7 +69,7 @@ var RealtimePresence = (function() {
 		  action + 'ing; channel = ' + this.channel.name + ', client = ' + clientId || '(implicit) ' + getClientId(this));
 
 		var presence = PresenceMessage.fromValues({
-			action : presenceAction[action.toUpperCase()],
+			action : action,
 			data   : data
 		});
 		if (clientId) { presence.clientId = clientId; }
@@ -124,7 +122,7 @@ var RealtimePresence = (function() {
 
 		Logger.logAction(Logger.LOG_MICRO, 'RealtimePresence.leaveClient()', 'leaving; channel = ' + this.channel.name + ', client = ' + clientId);
 		var presence = PresenceMessage.fromValues({
-			action : presenceAction.LEAVE,
+			action : 'leave',
 			data   : data
 		});
 		if (clientId) { presence.clientId = clientId; }
@@ -326,7 +324,7 @@ var RealtimePresence = (function() {
 
 		for(var key in map) {
 			var item = map[key];
-			if(item.action === presenceAction.ABSENT) continue;
+			if(item.action === 'absent') continue;
 			if(clientId && clientId != item.clientId) continue;
 			if(connectionId && connectionId != item.connectionId) continue;
 			result.push(item);

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -1,6 +1,6 @@
 var RealtimePresence = (function() {
 	var presenceAction = PresenceMessage.Action;
-	var presenceActionToEvent = ['absent', 'present', 'enter', 'leave', 'update'];
+
 	var noop = function() {};
 
 	function memberKey(item) {
@@ -205,14 +205,14 @@ var RealtimePresence = (function() {
 		for(var i = 0; i < presenceSet.length; i++) {
 			var presence = PresenceMessage.fromValues(presenceSet[i]);
 			switch(presence.action) {
-				case presenceAction.LEAVE:
+				case 'leave':
 					if(members.remove(presence)) {
 						broadcastMessages.push(presence);
 					}
 					break;
-				case presenceAction.UPDATE:
-				case presenceAction.ENTER:
-				case presenceAction.PRESENT:
+				case 'update':
+				case 'enter':
+				case 'present':
 					if(members.put(presence)) {
 						broadcastMessages.push(presence);
 					}
@@ -228,7 +228,7 @@ var RealtimePresence = (function() {
 		/* broadcast to listeners */
 		for(var i = 0; i < broadcastMessages.length; i++) {
 			var presence = broadcastMessages[i];
-			this.subscriptions.emit(presenceActionToEvent[presence.action], presence);
+			this.subscriptions.emit(presence.action, presence);
 		}
 	};
 
@@ -312,7 +312,7 @@ var RealtimePresence = (function() {
 		var map = this.map, result = [];
 		for(var key in map) {
 			var item = map[key];
-			if(item.clientId == clientId && item.action != presenceAction.ABSENT)
+			if(item.clientId == clientId && item.action != 'absent')
 				result.push(item);
 		}
 		return result;
@@ -326,7 +326,7 @@ var RealtimePresence = (function() {
 
 		for(var key in map) {
 			var item = map[key];
-			if(item.action == presenceAction.ABSENT) continue;
+			if(item.action === presenceAction.ABSENT) continue;
 			if(clientId && clientId != item.clientId) continue;
 			if(connectionId && connectionId != item.connectionId) continue;
 			result.push(item);
@@ -335,9 +335,9 @@ var RealtimePresence = (function() {
 	};
 
 	PresenceMap.prototype.put = function(item) {
-		if(item.action === presenceAction.ENTER || item.action === presenceAction.UPDATE) {
+		if(item.action === 'enter' || item.action === 'update') {
 			item = PresenceMessage.fromValues(item);
-			item.action = presenceAction.PRESENT;
+			item.action = 'present';
 		}
 		var map = this.map, key = memberKey(item);
 		/* we've seen this member, so do not remove it at the end of sync */
@@ -361,7 +361,7 @@ var RealtimePresence = (function() {
 		var map = this.map, result = [];
 		for(var key in map) {
 			var item = map[key];
-			if(item.action != presenceAction.ABSENT)
+			if(item.action != 'absent')
 				result.push(item);
 		}
 		return result;
@@ -372,7 +372,7 @@ var RealtimePresence = (function() {
 		var existingItem = map[key];
 		if(existingItem) {
 			delete map[key];
-			if(existingItem.action == PresenceMessage.Action.ABSENT)
+			if(existingItem.action === 'absent')
 				return false;
 		}
 		return true;
@@ -396,7 +396,7 @@ var RealtimePresence = (function() {
 			 * received all of the out-of-order sync messages */
 			for(var memberKey in map) {
 				var entry = map[memberKey];
-				if(entry.action == presenceAction.ABSENT) {
+				if(entry.action === 'absent') {
 					delete map[memberKey];
 				}
 			}

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -99,14 +99,6 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			}
 		}
 
-		function mixin(target, src) {
-			for(var prop in src) {
-				if(src.hasOwnProperty(prop))
-					target[prop] = src[prop];
-			}
-			return target;
-		}
-
 		/* Wraps all tests with a timeout so that they don't run indefinitely */
 		function withTimeout(exports, defaultTimeout) {
 			var timeout = defaultTimeout || 60 * 1000;
@@ -155,6 +147,5 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			testOnAllTransports:       testOnAllTransports,
 			availableTransports:       availableTransports,
 			bestTransport:             bestTransport,
-			mixin:                     mixin
 		};
 	});

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -9,7 +9,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 		var availableTransports = utils.keysArray(clientModule.Ably.Realtime.ConnectionManager.transports),
 			bestTransport = availableTransports[0];
 
-		var displayError = function(err) {
+		function displayError(err) {
 			if(typeof(err) == 'string')
 				return err;
 
@@ -22,9 +22,9 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 				result += JSON.stringify(err.message);
 
 			return result;
-		};
+		}
 
-		var monitorConnection = function(test, realtime) {
+		function monitorConnection(test, realtime) {
 			utils.arrForEach(['failed', 'suspended'], function(state) {
 				realtime.connection.on(state, function () {
 					test.ok(false, 'Connection monitoring: state changed to ' + state + ', aborting test');
@@ -32,9 +32,9 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 					realtime.close();
 				});
 			});
-		};
+		}
 
-		var closeAndFinish = function(test, realtime) {
+		function closeAndFinish(test, realtime) {
 			if(typeof realtime === 'undefined') {
 				// Likely called in a catch block for an exception
 				// that occured before realtime was initialised
@@ -46,9 +46,9 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 				return;
 			}
 			callbackOnClose(realtime, function(){ test.done(); })
-		};
+		}
 
-		var simulateDroppedConnection = function(realtime) {
+		function simulateDroppedConnection(realtime) {
 			// Go into the 'disconnected' state before actually disconnecting the transports
 			// to avoid the instantaneous reconnect attempt that would be triggered in
 			// notifyState by the active transport getting disconnected from a connected state
@@ -84,7 +84,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 				});
 			}
 		 )
-		};
+		}
 
 		/* testFn is assumed to be a function of realtimeOptions that returns a nodeunit test */
 		function testOnAllTransports(exports, name, testFn, excludeUpgrade) {
@@ -108,7 +108,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 		}
 
 		/* Wraps all tests with a timeout so that they don't run indefinitely */
-		var withTimeout = function(exports, defaultTimeout) {
+		function withTimeout(exports, defaultTimeout) {
 			var timeout = defaultTimeout || 60 * 1000;
 
 			for (var needle in exports) {
@@ -131,7 +131,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			}
 
 			return exports;
-		};
+		}
 
 		return module.exports = {
 			setupApp:     testAppModule.setup,

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -99,6 +99,14 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			}
 		}
 
+		function mixin(target, src) {
+			for(var prop in src) {
+				if(src.hasOwnProperty(prop))
+					target[prop] = src[prop];
+			}
+			return target;
+		}
+
 		/* Wraps all tests with a timeout so that they don't run indefinitely */
 		var withTimeout = function(exports, defaultTimeout) {
 			var timeout = defaultTimeout || 60 * 1000;
@@ -146,6 +154,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			withTimeout:               withTimeout,
 			testOnAllTransports:       testOnAllTransports,
 			availableTransports:       availableTransports,
-			bestTransport:             bestTransport
+			bestTransport:             bestTransport,
+			mixin:                     mixin
 		};
 	});

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -1225,8 +1225,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		    encodedData = JSON.stringify(data),
 		    options = { clientId: testClientId, tokenDetails: authToken, autoConnect: false }
 
-		var realtimeBin = helper.AblyRealtime(helper.mixin(options, { useBinaryProtocol: true }));
-		var realtimeJson = helper.AblyRealtime(helper.mixin(options, { useBinaryProtocol: false }));
+		var realtimeBin = helper.AblyRealtime(utils.mixin(options, { useBinaryProtocol: true }));
+		var realtimeJson = helper.AblyRealtime(utils.mixin(options, { useBinaryProtocol: false }));
 
 		var runTest = function(realtime, callback) {
 			realtime.connection.once('connected', function() {
@@ -1235,7 +1235,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 				transport.send = function(message) {
 					if(message.action === 14) {
-						var presence = message.presence[0];
+						/* Message is formatted for Ably by the toJSON method, so need to
+						* stringify and parse to see what actually gets sent */
+						var presence = JSON.parse(JSON.stringify(message.presence[0]));
 						test.equal(presence.action, 2, 'Enter action');
 						test.equal(presence.data, encodedData, 'Correctly encoded data');
 						test.equal(presence.encoding, 'json', 'Correct encoding');

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -351,6 +351,25 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	};
 
 	/*
+	 * Attach to channel, enter presence channel and ensure PresenceMessage
+	 * has valid action string
+	 */
+	exports.presenceMessageAction = function(test) {
+		test.expect(1);
+
+		var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
+		var channelName = 'presenceMessageAction';
+		var clientChannel = clientRealtime.channels.get(channelName);
+		var presence = clientChannel.presence;
+		presence.subscribe(function(presenceMessage) {
+			test.equals(presenceMessage.action, 'enter', 'Action should contain string "enter"');
+			closeAndFinish(test, clientRealtime);
+		});
+		clientChannel.presence.enter();
+		monitorConnection(test, clientRealtime);
+	};
+
+	/*
 	 * Enter presence channel (without attaching), detach, then enter again to reattach
 	 */
 	exports.presenceEnterDetachEnter = function(test) {
@@ -690,7 +709,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				var presenceMessages = resultPage.items;
 				test.equal(presenceMessages.length, 2, 'Verify correct number of presence messages found');
 				var actions = utils.arrMap(presenceMessages, function(msg){return msg.action;}).sort();
-				test.deepEqual(actions, [2,3], 'Verify presenceMessages have correct actions');
+				test.deepEqual(actions, ['enter','leave'], 'Verify presenceMessages have correct actions');
 				test.equal(presenceMessages[0].data, testClientData, 'Verify first presenceMessages has correct data');
 				test.equal(presenceMessages[1].data, testClientData, 'Verify second presenceMessages has correct data');
 				closeAndFinish(test, clientRealtime);
@@ -780,7 +799,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				clientChannel.presence.history({untilAttach: false}, function(err, resultPage) {
 					if(err) { callback(err); }
 					test.equal(resultPage.items.length, 4, 'Verify both sets of presence messages returned when untilAttached is false');
-					test.deepEqual(sortedActions(resultPage.items), [2,2,3,3], 'Verify presenceMessages have correct actions');
+					test.deepEqual(sortedActions(resultPage.items), ['enter','enter','leave','leave'], 'Verify presenceMessages have correct actions');
 					callback();
 				});
 			},
@@ -788,7 +807,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				clientChannel.presence.history({untilAttach: true}, function(err, resultPage) {
 					if(err) { callback(err); }
 					test.equal(resultPage.items.length, 2, 'Verify only the first set of presence messages returned when untilAttached is true');
-					test.deepEqual(sortedActions(resultPage.items), [2,3], 'Verify presenceMessages have correct actions');
+					test.deepEqual(sortedActions(resultPage.items), ['enter','leave'], 'Verify presenceMessages have correct actions');
 					callback();
 				});
 			},
@@ -796,7 +815,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				clientChannel.presence.history(function(err, resultPage) {
 					if(err) { callback(err); }
 					test.equal(resultPage.items.length, 4, 'Verify both sets of presence messages returned when untilAttached is not present');
-					test.deepEqual(sortedActions(resultPage.items), [2,2,3,3], 'Verify presenceMessages have correct actions');
+					test.deepEqual(sortedActions(resultPage.items), ['enter','enter','leave','leave'], 'Verify presenceMessages have correct actions');
 					callback();
 				});
 			}
@@ -892,6 +911,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 												closeAndFinish(test, [clientRealtime1, clientRealtime2]);
 												return;
 											}
+											console.log(presenceMembers1, presenceMembers2);
 											test.deepEqual(presenceMembers1, presenceMembers2, 'Verify member presence is indicated after attach');
 											closeAndFinish(test, [clientRealtime1, clientRealtime2]);
 										});
@@ -1197,33 +1217,44 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	};
 
 	/*
-	 * Check that JSON-encodable presence messages are encoded correctly
+	 * Check that encodable presence messages are encoded correctly
 	 */
-	exports.presenceJsonEncoding = function(test) {
-		test.expect(3);
+	exports.presenceEncoding = function(test) {
+		test.expect(6);
 		var data = {'foo': 'bar'},
-			encodedData = JSON.stringify(data);
+		    encodedData = JSON.stringify(data),
+		    options = { clientId: testClientId, tokenDetails: authToken, autoConnect: false }
 
-		var realtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
+		var realtimeBin = helper.AblyRealtime(helper.mixin(options, { useBinaryProtocol: true }));
+		var realtimeJson = helper.AblyRealtime(helper.mixin(options, { useBinaryProtocol: false }));
 
-		realtime.connection.once('connected', function() {
-			var transport = realtime.connection.connectionManager.activeProtocol.transport,
-					originalSend = transport.send;
+		var runTest = function(realtime, callback) {
+			realtime.connection.once('connected', function() {
+				var transport = realtime.connection.connectionManager.activeProtocol.transport,
+						originalSend = transport.send;
 
-			transport.send = function(message) {
-				if(message.action === 14) {
-					var presence = message.presence[0];
-					console.log(JSON.stringify(presence))
-					test.equal(presence.action, 2, 'Enter action');
-					test.equal(presence.data, encodedData, 'Correctly encoded data');
-					test.equal(presence.encoding, 'json', 'Correct encoding');
-					closeAndFinish(test, realtime);
-				}
-				originalSend.apply(transport, arguments);
-			};
+				transport.send = function(message) {
+					if(message.action === 14) {
+						var presence = message.presence[0];
+						test.equal(presence.action, 2, 'Enter action');
+						test.equal(presence.data, encodedData, 'Correctly encoded data');
+						test.equal(presence.encoding, 'json', 'Correct encoding');
+						callback();
+					}
+					originalSend.apply(transport, arguments);
+				};
 
-			var channel = realtime.channels.get('presence-json-encoding');
-			channel.presence.enter(data);
+				var channel = realtime.channels.get('presence-json-encoding');
+				channel.presence.enter(data);
+			});
+			realtime.connect();
+		}
+
+		async.series([
+			function(callback) { runTest(realtimeBin, callback); },
+			function(callback) { console.log('test two'); runTest(realtimeJson, callback); },
+		], function() {
+			closeAndFinish(test, realtimeBin, realtimeJson);
 		});
 	}
 


### PR DESCRIPTION
Whilst working on the Realtime Presence documentation today, I found that the demo I was writing was not very intuitive, see https://jsbin.ably.io/oxituz/3/edit

The problem is simply that the action field is an integer value for the [`PresenceMessage.Action` enum like object](https://github.com/ably/ably-js/blob/master/common/lib/types/presencemessage.js#L14-L20), yet that enum is not available to the developer consuming the API, unlike pretty much all other client libraries we have implemented which expose the Enum or some constant to access the meaningful part of the enum.

I believe that in order to make our client library API easier for developers to use, we should change the `action` attribute of a PresenceMessage from an integer into a string when received (via REST or Realtime), and then convert back to an integer when published to Ably. I am sure we could come up with a far more robust way of doing this than this implementation, but as far as I can see this works, and I'd be happy to add an issue to improve this design later.

@paddybyers @SimonWoolf WDYT?