### PR TITLE
Basic http test for version headers (rsc7a)

### DIFF
--- a/common/lib/client/presence.js
+++ b/common/lib/client/presence.js
@@ -1,9 +1,9 @@
 var Presence = (function() {
+	function noop() {}
 	function Presence(channel) {
 		this.channel = channel;
 		this.basePath = channel.basePath + '/presence';
 	}
-
 	Utils.inherits(Presence, EventEmitter);
 
 	Presence.prototype.get = function(params, callback) {

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+define(['ably', 'shared_helper'], function(Ably, helper) {
+	var rest, exports = {},
+		Defaults = Ably.Rest.Defaults;
+
+	exports.setupHttp = function(test) {
+		test.expect(1);
+		helper.setupApp(function() {
+			rest = helper.AblyRest();
+			test.ok(true, 'App created');
+			test.done();
+		});
+	}
+
+	exports.apiVersionHeader = function(test) {
+
+		//Intercept get&post methods with test
+		Ably.Rest.Http.get_inner = Ably.Rest.Http.get;
+		Ably.Rest.Http.get = function (rest, path, headers, params, callback) {
+			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
+			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
+			return this.get_inner(rest, path, headers, params, callback);
+		};
+
+		Ably.Rest.Http.post_inner = Ably.Rest.Http.post;
+		Ably.Rest.Http.post = function (rest, path, headers, body, params, callback) {
+			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
+			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify for current version number');
+			return this.post_inner(rest, path, headers, body, params, callback);
+		};
+
+		//Call all methods that use rest http calls
+		test.expect(8);
+
+		rest.auth.requestToken();
+		rest.time();
+		rest.stats();
+		rest.channels.get().publish();
+
+		test.done();
+
+	};
+
+	return module.exports = helper.withTimeout(exports);
+});

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -43,7 +43,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 		var channel = rest.channels.get('persisted:presence_fixtures');
 		channel.publish();
-		channel.presence.get(function(){});
+		channel.presence.get();
 
 		test.done();
 	};

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -13,6 +13,10 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		});
 	}
 
+	/**
+	 * Check presence of X-Ably-Version headers in get&post requests
+	 * @spec : (RSC7a)
+	 */
 	exports.apiVersionHeader = function(test) {
 
 		//Intercept get&post methods with test
@@ -26,7 +30,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		Ably.Rest.Http.post_inner = Ably.Rest.Http.post;
 		Ably.Rest.Http.post = function (rest, path, headers, body, params, callback) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
-			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify for current version number');
+			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
 			return this.post_inner(rest, path, headers, body, params, callback);
 		};
 
@@ -39,7 +43,6 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		rest.channels.get().publish();
 
 		test.done();
-
 	};
 
 	return module.exports = helper.withTimeout(exports);

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -24,14 +24,12 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		Ably.Rest.Http.get = function (rest, path, headers, params, callback) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
 			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
-			return get_inner(rest, path, headers, params, callback);
 		};
 
 		var post_inner = Ably.Rest.Http.post;
 		Ably.Rest.Http.post = function (rest, path, headers, body, params, callback) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
 			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
-			return post_inner(rest, path, headers, body, params, callback);
 		};
 
 		//Call all methods that use rest http calls

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -20,18 +20,18 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	exports.apiVersionHeader = function(test) {
 
 		//Intercept get&post methods with test
-		Ably.Rest.Http.get_inner = Ably.Rest.Http.get;
+		var get_inner = Ably.Rest.Http.get;
 		Ably.Rest.Http.get = function (rest, path, headers, params, callback) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
 			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
-			return this.get_inner(rest, path, headers, params, callback);
+			return get_inner(rest, path, headers, params, callback);
 		};
 
-		Ably.Rest.Http.post_inner = Ably.Rest.Http.post;
+		var post_inner = Ably.Rest.Http.post;
 		Ably.Rest.Http.post = function (rest, path, headers, body, params, callback) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
 			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
-			return this.post_inner(rest, path, headers, body, params, callback);
+			return post_inner(rest, path, headers, body, params, callback);
 		};
 
 		//Call all methods that use rest http calls
@@ -46,8 +46,8 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		channel.presence.get();
 
 		//Clean interceptors from get&post methods
-		Ably.Rest.Http.get = Ably.Rest.Http.get_inner;
-		Ably.Rest.Http.post = Ably.Rest.Http.post_inner;
+		Ably.Rest.Http.get = get_inner;
+		Ably.Rest.Http.post = post_inner;
 
 		test.done();
 	};

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -41,8 +41,8 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		rest.time();
 		rest.stats();
 
-		var channel = rest.channels.get('persisted:presence_fixtures');
-		channel.publish();
+		var channel = rest.channels.get('http_test_channel');
+		channel.publish('test', 'Testing http headers');
 		channel.presence.get();
 
 		test.done();

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -35,12 +35,15 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		};
 
 		//Call all methods that use rest http calls
-		test.expect(8);
+		test.expect(10);
 
 		rest.auth.requestToken();
 		rest.time();
 		rest.stats();
-		rest.channels.get().publish();
+
+		var channel = rest.channels.get('persisted:presence_fixtures');
+		channel.publish();
+		channel.presence.get(function(){});
 
 		test.done();
 	};

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -45,6 +45,10 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		channel.publish('test', 'Testing http headers');
 		channel.presence.get();
 
+		//Clean interceptors from get&post methods
+		Ably.Rest.Http.get = Ably.Rest.Http.get_inner;
+		Ably.Rest.Http.post = Ably.Rest.Http.post_inner;
+
 		test.done();
 	};
 


### PR DESCRIPTION
First try for this test - I created a new test file for it, I figure any additional tests regarding http requests could go here. 
Simple stuff, I replace the get&post functions with interceptors and test the headers there.
I call the minimal versions of the functions using the requests to test their responses.

If I call the presence function without arguments I get an error - noop() is not defined in presence.js.
I'll go through it again tomorrow, just creating the pull to get the ball rolling.