### PR TITLE
Upgrade when closing

### DIFF
--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -1256,7 +1256,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			function(callback) { runTest(realtimeBin, callback); },
 			function(callback) { console.log('test two'); runTest(realtimeJson, callback); },
 		], function() {
-			closeAndFinish(test, realtimeBin, realtimeJson);
+			closeAndFinish(test, [realtimeBin, realtimeJson]);
 		});
 	}
 


### PR DESCRIPTION
Fix to minor race condition: if connection was closing/closed when an upgrade happens, `activateTransport` would return without doing anything, but `scheduleTransportActivation` assumed there was a new active transport and tries to sync it, set the state, etc, leading to the occasional `Unexpected exception in transport.send()` exception happening right after a test `closeAndFinish`'s.

Also syntax fix to a closeAndFinish call that was leaving a realtime connection open.