### PR TITLE
Add onPageRefresh option

### DIFF
--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -354,6 +354,11 @@ var ConnectionManager = (function() {
 			} else {
 				self.activateTransport(transport, connectionKey, connectionSerial, connectionId, clientId);
 			}
+			if(mode === 'recover' && self.options.onPageRefresh === 'persist') {
+				/* After a successful recovery, we remove the recover cookie we used to
+				* connect, so other browser tabs don't try to reuse the same connection params */
+				self.unpersistConnection();
+			}
 		});
 
 		var eventHandler = function(event) {
@@ -577,9 +582,6 @@ var ConnectionManager = (function() {
 		this.realtime.connection.serial = this.connectionSerial = (connectionSerial === undefined) ? -1 : connectionSerial;
 		this.realtime.connection.recoveryKey = connectionKey + ':' + this.connectionSerial;
 		this.msgSerial = 0;
-		if(this.options.recover === true)
-			this.persistConnection();
-
 	};
 
 	ConnectionManager.prototype.clearConnection = function() {
@@ -588,7 +590,6 @@ var ConnectionManager = (function() {
 		this.realtime.connection.serial = this.connectionSerial = undefined;
 		this.realtime.connection.recoveryKey = null;
 		this.msgSerial = 0;
-		this.unpersistConnection();
 	};
 
 	/**

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -62,6 +62,19 @@ Defaults.normaliseOptions = function(options) {
 		options.queueMessages = options.queueEvents;
 	}
 
+	if(options.recover === true) {
+		Logger.deprecated('{recover: true}', '{onPageRefresh: "persist"}');
+		options.recover = undefined;
+		options.onPageRefresh = 'persist';
+	} else if(!('onPageRefresh' in options)) {
+		options.onPageRefresh = 'none';
+	} else if(options.onPageRefresh !== 'none' &&
+	          options.onPageRefresh !== 'close' &&
+	          options.onPageRefresh !== 'persist') {
+		Logger.logAction(Logger.LOG_ERROR, 'Defaults.normaliseOptions()', options.onPageRefresh.toString() + ' is an invalid value for options.onPageRefresh. Valid values are: "none", "close", or "persist".');
+		options.onPageRefresh = 'none';
+	}
+
 	if(!('queueMessages' in options))
 		options.queueMessages = true;
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-curl": "~2.1",
     "grunt-shell": "~1.1",
     "grunt-zip": "~0.16",
-    "karma": "~0.13.11",
+    "karma": "git://github.com/ably-forks/karma.git#ably-js-custom",
     "karma-chrome-launcher": "~0.1",
     "karma-cli": "~0.0",
     "karma-env-preprocessor": "~0.1",

--- a/spec/browser/connection.test.js
+++ b/spec/browser/connection.test.js
@@ -24,6 +24,10 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		return true;
 	}
 
+	function eraseCookie(name) {
+		document.cookie = name + '=; expires=' + new Date().toGMTString() + '; path=/';
+	}
+
 	exports.setup_realtime = function(test) {
 		test.expect(1);
 		helper.setupApp(function(err) {
@@ -34,6 +38,10 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			}
 			test.done();
 		});
+
+		/* Ensure persistance cookies are clean for persist tests */
+		eraseCookie('ably-connection-key');
+		eraseCookie('ably-connection-serial');
 	};
 
 	exports.device_going_offline_causes_disconnected_state = function(test) {
@@ -147,6 +155,29 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				test.ok(sameConnection(connectionKey, newRealtime.connection.key), 'Check new realtime recovered the connection from the cookie');
 				closeAndFinish(test, [realtime, newRealtime]);
 			});
+		});
+	};
+
+	/* Client should not recover if you use a different clientId */
+	exports.page_refresh_persist_with_different_clientId = function(test) {
+		var realtime = helper.AblyRealtime({ onPageRefresh: 'persist', clientId: 'first' }),
+			refreshEvent = new Event('beforeunload', {'bubbles': true});
+
+		test.expect(2);
+		monitorConnection(test, realtime);
+
+		realtime.connection.once('connected', function() {
+			var connectionKey = realtime.connection.key;
+			document.dispatchEvent(refreshEvent);
+			test.equal(realtime.connection.state, 'connected', 'check connection state initially unaffected by page refresh');
+			simulateDroppedConnection(realtime);
+
+			var newRealtime = helper.AblyRealtime({ onPageRefresh: 'persist', clientId: 'second' });
+			newRealtime.connection.once('connected', function() {
+				test.ok(!sameConnection(connectionKey, newRealtime.connection.key), 'Check new realtime created a new connection');
+				closeAndFinish(test, [realtime, newRealtime]);
+			});
+			monitorConnection(test, newRealtime);
 		});
 	};
 


### PR DESCRIPTION
326e78d Fixes #259.

Currently this leaves `none` as the default, same behaviour as now.

Also includes  c62fc42 as a proposed solution to https://github.com/ably/realtime/issues/540: turn off persisting the connection onConnect, so that it's only persisted on page refresh; and unpersist after a successful recovery. Former change minimises the time the cookie is persisted to the duration of the refresh/reconnect cycle, rather than the whole time. Latter change prevents a recovery key from being used twice (unless there's a race condition between tabs, which is much less likely). The downside is we lose the fallback recover-from-key-only (no serial) functionality - but afaict that's really only useful if onPageRefresh isn't supported, which at this point is very few browsers (safari < 3 and that's about it), so I don't think we're losing much.