### PR TITLE
Logging tweaks

### DIFF
--- a/common/lib/client/connection.js
+++ b/common/lib/client/connection.js
@@ -27,7 +27,7 @@ var Connection = (function() {
 	}
 
 	Connection.prototype.connect = function() {
-		Logger.logAction(Logger.LOG_MAJOR, 'Connection.connect()', '');
+		Logger.logAction(Logger.LOG_MINOR, 'Connection.connect()', '');
 		this.connectionManager.requestState({state: 'connecting'});
 	};
 
@@ -38,7 +38,7 @@ var Connection = (function() {
 	};
 
 	Connection.prototype.close = function() {
-		Logger.logAction(Logger.LOG_MAJOR, 'Connection.close()', 'connectionKey = ' + this.key);
+		Logger.logAction(Logger.LOG_MINOR, 'Connection.close()', 'connectionKey = ' + this.key);
 		this.connectionManager.requestState({state: 'closing'});
 	};
 

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -428,6 +428,8 @@ var RealtimeChannel = (function() {
 		if(err) {
 			this.errorReason = err;
 		}
+		var logLevel = state === 'failed' ? Logger.LOG_ERROR : Logger.LOG_MAJOR;
+		Logger.logAction(logLevel, 'Channel state for channel "' + this.name + '"', state + (err ? ('; reason: ' + err.message + ', code: ' + err.code) : ''));
 		this.emit(state, err);
 	};
 

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -153,7 +153,7 @@ var ConnectionManager = (function() {
 
 	ConnectionManager.prototype.chooseTransport = function(callback) {
 		var self = this;
-		Logger.logAction(Logger.LOG_MAJOR, 'ConnectionManager.chooseTransport()', '');
+		Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.chooseTransport()', '');
 		/* if there's already a transport, we're done */
 		if(this.activeProtocol) {
 			Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.chooseTransport()', 'Transport already established');
@@ -192,7 +192,7 @@ var ConnectionManager = (function() {
 		/* first attempt the main host; no need to check for general connectivity first. */
 		decideMode(function(mode) {
 			var transportParams = new TransportParams(self.options, null, mode, self.connectionKey, self.connectionSerial);
-			Logger.logAction(Logger.LOG_MAJOR, 'ConnectionManager.chooseTransport()', 'Transport recovery mode = ' + mode + (mode == 'clean' ? '' : '; connectionKey = ' + self.connectionKey + '; connectionSerial = ' + self.connectionSerial));
+			Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.chooseTransport()', 'Transport recovery mode = ' + mode + (mode == 'clean' ? '' : '; connectionKey = ' + self.connectionKey + '; connectionSerial = ' + self.connectionSerial));
 
 			/* if there are no http transports, just choose from the available transports,
 			 * falling back to the first host only;
@@ -224,7 +224,7 @@ var ConnectionManager = (function() {
 					httpTransport.once('connected', function(error, connectionKey) {
 						/* we allow other event handlers, including activating the transport, to run first */
 						Utils.nextTick(function() {
-							Logger.logAction(Logger.LOG_MAJOR, 'ConnectionManager.chooseTransport()', 'upgrading ... connectionKey = ' + connectionKey);
+							Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.chooseTransport()', 'upgrading ... connectionKey = ' + connectionKey);
 							transportParams = new TransportParams(self.options, transportParams.host, 'upgrade', connectionKey);
 							self.chooseTransportForHost(transportParams, self.upgradeTransports.slice(), noop);
 						});
@@ -647,6 +647,8 @@ var ConnectionManager = (function() {
 	};
 
 	ConnectionManager.prototype.enactStateChange = function(stateChange) {
+		var logLevel = stateChange.current === 'failed' ? Logger.LOG_ERROR : Logger.LOG_MAJOR;
+		Logger.logAction(logLevel, 'Connection state', stateChange.current + (stateChange.reason ? ('; reason: ' + stateChange.reason.message + ', code: ' + stateChange.reason.code) : ''));
 		Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.enactStateChange', 'setting new state: ' + stateChange.current + '; reason = ' + (stateChange.reason && stateChange.reason.message));
 		var newState = this.state = this.states[stateChange.current];
 		if(stateChange.reason) {

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -96,7 +96,7 @@ var Transport = (function() {
 			break;
 		case actions.ERROR:
 			var msgErr = message.error;
-			Logger.logAction(Logger.LOG_ERROR, 'Transport.onProtocolMessage()', 'error; connectionKey = ' + this.connectionManager.connectionKey + '; err = ' + JSON.stringify(msgErr) + (message.channel ? (', channel: ' +  message.channel) : ''));
+			Logger.logAction(Logger.LOG_MINOR, 'Transport.onProtocolMessage()', 'received error action; connectionKey = ' + this.connectionManager.connectionKey + '; err = ' + JSON.stringify(msgErr) + (message.channel ? (', channel: ' +  message.channel) : ''));
 			if(message.channel === undefined) {
 				/* a transport error */
 				var err = ErrorInfo.fromValues(msgErr);


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/273. See https://github.com/ably/ably-js/issues/273#issuecomment-219710992 for explanation and justification of changes. Basic idea is to keep LOG_MAJOR for high-level, user-friendly state information. If the user wants to peek into the inner workings of the lib (eg see connection upgrading, individual transports, potentially see raw protocol messages, etc), they need LOG_MINOR or higher.

Console log with LOG_MAJOR for connecting, channel attach, and one token renewal cycle, before changes:
```
Ably: ConnectionManager.chooseTransport(): Transport recovery mode = recover; connectionKey = undefined; connectionSerial = undefined 
Ably: ConnectionManager.chooseTransport(): upgrading ... connectionKey = 1082b!cdOMLOUkZzqbyBtS-4bad1082b 
Ably: Transport.onProtocolMessage(): error; connectionKey = 1082b!cdOMLOUkZzqbyBtS-4bae1082b; err = {"message":"Key/token status changed (expire)","code":40142,"statusCode":401} 
Ably: ConnectionManager.chooseTransport():  
Ably: ConnectionManager.chooseTransport(): Transport recovery mode = resume; connectionKey = 1082b!cdOMLOUkZzqbyBtS-4bae1082b; connectionSerial = -1 
Ably: ConnectionManager.chooseTransport(): upgrading ... connectionKey = 1082b!cdOMLOUkZzqbyBtS-4baf1082b
```
After changes:
```
Ably: Connection state: connecting 
Ably: Connection state: connected 
Ably: Channel state for channel "channel": attaching 
Ably: Channel state for channel "channel": attached 
Ably: Connection state: disconnected; reason: Key/token status changed (expire), code: 40142 
Ably: Connection state: connecting 
Ably: Connection state: connected
```