### PR TITLE
Pass along CONNECTED errors

### DIFF
--- a/common/lib/client/connection.js
+++ b/common/lib/client/connection.js
@@ -19,6 +19,11 @@ var Connection = (function() {
 				self.emit(state, stateChange);
 			});
 		});
+		this.connectionManager.on('error', function(error) {
+			Utils.nextTick(function() {
+				self.emit('error', error);
+			});
+		});
 	}
 	Utils.inherits(Connection, EventEmitter);
 

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -292,7 +292,7 @@ var ConnectionManager = (function() {
 					self.scheduleTransportActivation(transport, connectionKey);
 				}
 			} else {
-				self.activateTransport(transport, connectionKey, connectionSerial, connectionId, clientId);
+				self.activateTransport(error, transport, connectionKey, connectionSerial, connectionId, clientId);
 
 				/* allow connectImpl to start the upgrade process if needed, but allow
 				 * other event handlers, including activating the transport, to run first */
@@ -358,7 +358,7 @@ var ConnectionManager = (function() {
 			/* make this the active transport */
 			Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.scheduleTransportActivation()', 'Activating transport; transport = ' + transport);
 			/* if activateTransport returns that it has not done anything (eg because the connection is closing), don't bother syncing */
-			if(self.activateTransport(transport, connectionKey, self.connectionSerial, self.connectionId)) {
+			if(self.activateTransport(null, transport, connectionKey, self.connectionSerial, self.connectionId)) {
 				Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.scheduleTransportActivation()', 'Syncing transport; transport = ' + transport);
 				self.sync(transport, function(err, connectionSerial, connectionId) {
 					if(err) {
@@ -393,8 +393,11 @@ var ConnectionManager = (function() {
 	 * @param connectionSerial the current connectionSerial
 	 * @param connectionId the id of the new active connection
 	 */
-	ConnectionManager.prototype.activateTransport = function(transport, connectionKey, connectionSerial, connectionId, clientId) {
+	ConnectionManager.prototype.activateTransport = function(error, transport, connectionKey, connectionSerial, connectionId, clientId) {
 		Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.activateTransport()', 'transport = ' + transport);
+		if(error) {
+			Logger.logAction(Logger.LOG_ERROR, 'ConnectionManager.activateTransport()', 'error = ' + error);
+		}
 		if(connectionKey)
 			Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.activateTransport()', 'connectionKey =  ' + connectionKey);
 		if(connectionSerial !== undefined)
@@ -443,11 +446,18 @@ var ConnectionManager = (function() {
 
 		this.emit('transport.active', transport, connectionKey, transport.params);
 
-		/* notify the state change if previously not connected */
-		if(existingState !== this.states.connected) {
-			this.notifyState({state: 'connected'});
-			this.errorReason = null;
-			this.realtime.connection.errorReason = null;
+		/* If previously not connected, notify the state change (including any
+		 * error).  If previously connected (ie upgrading), no state change, so
+		* emit any error as a standalone event */
+		if(existingState.state === this.states.connected.state) {
+			if(error) {
+				this.emit('error', error);
+				/* if upgrading without error, leave any existing errorReason alone */
+				this.errorReason = this.realtime.connection.errorReason = error;
+			}
+		} else {
+			this.notifyState({state: 'connected', error: error});
+			this.errorReason = this.realtime.connection.errorReason = error || null;
 		}
 
 		/* Gracefully terminate existing protocol */

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -72,7 +72,7 @@ var Transport = (function() {
 			break;
 		case actions.CONNECTED:
 			this.onConnect(message);
-			this.emit('connected', null, (message.connectionDetails ? message.connectionDetails.connectionKey : message.connectionKey), message.connectionSerial, message.connectionId, (message.connectionDetails ? message.connectionDetails.clientId : null));
+			this.emit('connected', message.error, (message.connectionDetails ? message.connectionDetails.connectionKey : message.connectionKey), message.connectionSerial, message.connectionId, (message.connectionDetails ? message.connectionDetails.clientId : null));
 			break;
 		case actions.CLOSED:
 			this.onClose(message);

--- a/spec/realtime/connection.test.js
+++ b/spec/realtime/connection.test.js
@@ -104,5 +104,25 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		}
 	};
 
+	exports.unrecoverableConnection = function(test) {
+		test.expect(4);
+		var realtime,
+			fakeRecoveryKey = '_____!ablyjs_test_fake-key____:5';
+		try {
+			realtime = helper.AblyRealtime({recover: fakeRecoveryKey});
+			realtime.connection.on('connected', function(stateChange) {
+				console.log(JSON.stringify(stateChange));
+				test.equal(stateChange.reason.code, 80008, "verify unrecoverable-connection error set in stateChange.reason");
+				test.equal(realtime.connection.errorReason.code, 80008, "verify unrecoverable-connection error set in connection.errorReason");
+				test.equal(realtime.connection.serial, -1, "verify serial is -1 (new connection), not 5");
+				test.equal(realtime.connection.key.indexOf('ablyjs_test_fake'), -1, "verify connection using a new connectionkey");
+				closeAndFinish(test, realtime);
+			});
+		} catch(e) {
+			test.ok(false, 'test failed with exception: ' + e.stack);
+			closeAndFinish(test, realtime);
+		}
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
Was putting this off until the untilAttach, but pulled forward due to https://github.com/ably/realtime/issues/589

For connected errors in upgrades, I did the workaround described in https://github.com/ably/realtime/issues/587#issuecomment-227158648 - ie syncing with the new (-1) connectionSerial after a failed upgrade. This is a bit hacky, but fixes the problem from that issue for now. If we decide to change realtime behaviour (eg to not require a sync in the case of a failed upgrade), then we can change it then.