### PR TITLE
Rework upgrade mechanism

### DIFF
--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -229,7 +229,7 @@ var RealtimePresence = (function() {
 		/* if this is the last message in a sequence of sync updates, end the sync */
 		if(!syncCursor) {
 			members.endSync();
-			this.channel.setInProgress(false);
+			this.channel.setInProgress(RealtimeChannel.progressOps.sync, false);
 		}
 
 		/* broadcast to listeners */

--- a/common/lib/transport/messagequeue.js
+++ b/common/lib/transport/messagequeue.js
@@ -52,5 +52,11 @@ var MessageQueue = (function() {
 		}
 	};
 
+	MessageQueue.prototype.clear = function() {
+		Logger.logAction(Logger.LOG_MICRO, 'MessageQueue.clear()', 'clearing ' + this.messages.length + ' messages');
+		this.messages = [];
+		this.emit('idle');
+	};
+
 	return MessageQueue;
 })();

--- a/common/lib/transport/protocol.js
+++ b/common/lib/transport/protocol.js
@@ -19,10 +19,7 @@ var Protocol = (function() {
 	Protocol.prototype.onNack = function(serial, count, err) {
 		Logger.logAction(Logger.LOG_ERROR, 'Protocol.onNack()', 'serial = ' + serial + '; count = ' + count + '; err = ' + Utils.inspectError(err));
 		if(!err) {
-			err = new Error('Unknown error');
-			err.statusCode = 500;
-			err.code = 50001;
-			err.message = 'Unable to send message; channel not responding';
+			err = new ErrorInfo('Unable to send message; channel not responding', 50001, 500);
 		}
 		this.messageQueue.completeMessages(serial, count, err);
 	};
@@ -52,6 +49,10 @@ var Protocol = (function() {
 
 	Protocol.prototype.getPendingMessages = function() {
 		return this.messageQueue.copyAll();
+	};
+
+	Protocol.prototype.clearPendingMessages = function() {
+		return this.messageQueue.clear();
 	};
 
 	Protocol.prototype.finish = function() {

--- a/common/lib/util/utils.js
+++ b/common/lib/util/utils.js
@@ -225,7 +225,7 @@ var Utils = (function() {
 			if(ownOnly && !ob.hasOwnProperty(prop)) continue;
 			result.push(ob[prop]);
 		}
-		return result.length ? result : undefined;
+		return result;
 	};
 
 	Utils.arrForEach = Array.prototype.forEach ?

--- a/spec/browser/connection.test.js
+++ b/spec/browser/connection.test.js
@@ -226,8 +226,6 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 
 	exports.persist_preferred_transport = function(test) {
 		test.expect(1);
-		/* ensure we start with a blank slate */
-		helper.clearTransportPreference();
 
 		var realtime = helper.AblyRealtime();
 

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -100,6 +100,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 		}
 
 		/* Wraps all tests with a timeout so that they don't run indefinitely */
+		/* Also clears transport preferences, so each test starts fresh */
 		function withTimeout(exports, defaultTimeout) {
 			var timeout = defaultTimeout || 60 * 1000;
 
@@ -116,6 +117,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 								test.ok(false, "Test timed out after " + (timeout / 1000) + "s");
 								test.done();
 							}, timeout);
+							clearTransportPreference();
 							originalFn(test);
 						};
 					})(exports[needle]);

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -7,7 +7,9 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 	function(testAppModule, clientModule, testAppManager, async) {
 		var utils = clientModule.Ably.Realtime.Utils;
 		var availableTransports = utils.keysArray(clientModule.Ably.Realtime.ConnectionManager.supportedTransports),
-			bestTransport = availableTransports[0];
+			bestTransport = availableTransports[0],
+			/* IANA reserved; requests to it will hang forever */
+			unroutableAddress = 'http://10.255.255.1/';
 
 		function displayError(err) {
 			if(typeof(err) == 'string')
@@ -133,6 +135,14 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			}
 		}
 
+		function isComet(transport) {
+			return transport.toString().indexOf('/comet/') > -1;
+		}
+
+		function isWebsocket(transport) {
+			return !!transport.toString().match(/wss?\:/);
+		}
+
 		return module.exports = {
 			setupApp:     testAppModule.setup,
 			tearDownApp:  testAppModule.tearDown,
@@ -156,5 +166,8 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			availableTransports:       availableTransports,
 			bestTransport:             bestTransport,
 			clearTransportPreference:  clearTransportPreference,
+			isComet:                   isComet,
+			isWebsocket:               isWebsocket,
+			unroutableAddress:         unroutableAddress
 		};
 	});

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -220,7 +220,6 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	exports.init_fallbacks = function(test) {
 		test.expect(5);
 		try {
-			helper.clearTransportPreference();
 			var realtime = helper.AblyRealtime({
 				key: 'not_a.real:key',
 				restHost: 'a',

--- a/spec/realtime/upgrade.test.js
+++ b/spec/realtime/upgrade.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-define(['ably', 'shared_helper'], function(Ably, helper) {
+define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	var exports = {},
 		_exports = {},
 		rest,
@@ -175,7 +175,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			var restChannel = rest.channels.get('publishpostupgrade1');
 			var connectionManager = realtime.connection.connectionManager;
 			connectionManager.on('transport.active', function(transport) {
-				if(transport.toString().indexOf('/comet/') > -1) {
+				if(helper.isComet(transport)) {
 					/* override the processing of incoming messages on this channel
 					 * so we can see if a message arrived.
 					 * NOTE: this relies on knowledge of the internal implementation
@@ -190,7 +190,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 				}
 			});
 			connectionManager.on('transport.active', function(transport) {
-				if(transport.toString().match(/wss?\:/)) {
+				if(helper.isWebsocket(transport)) {
 					if(rtChannel.state == 'attached') {
 						//console.log('*** publishing (channel attached on transport active) ...');
 						restChannel.publish('event0', testMsg);
@@ -522,6 +522,73 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			test.ok(false, 'test failed with exception: ' + e.stack);
 			closeAndFinish(test, realtime);
 		}
+	};
+
+	/*
+	 * Check that an attach that times out on the base transport does not prevent an upgrade
+	 */
+	exports.attach_timeout_on_base_transport = function(test) {
+		var realtime = helper.AblyRealtime({realtimeRequestTimeout: 3000}),
+			channel = realtime.channels.get('timeout0'),
+			connectionManager = realtime.connection.connectionManager;
+
+		connectionManager.once('transport.active', function(transport) {
+			test.ok(helper.isComet(transport), 'Check first transport to become active is comet');
+			transport.sendUri = helper.unroutableAddress;
+		});
+
+		realtime.connection.once('connected', function() {
+			channel.attach(function(err){
+				test.ok(err.code, 90000, 'Check error code for channel attach timing out');
+				test.ok(channel.state, 'detached', 'Check channel reverts to detach');
+				test.ok(realtime.connection.state, 'connected', 'Check connection state is still connected');
+				channel.attach(function(err){
+					test.ok(!err, 'Check a second attach works fine');
+					closeAndFinish(test, realtime)
+				});
+			});
+		});
+	};
+
+	/*
+	 * Check that a message that fails to publish on a comet transport can be
+	 * seamlessly transferred to the websocket transport and published there
+	 */
+	exports.message_timeout_stalling_upgrade = function(test) {
+		var realtime = helper.AblyRealtime({httpRequestTimeout: 3000}),
+			channel = realtime.channels.get('timeout1'),
+			connectionManager = realtime.connection.connectionManager;
+
+		realtime.connection.once('connected', function() {
+			channel.attach(function(err) {
+				if(err) {
+					test.ok(false, 'Attach failed with error: ' + helper.displayError(err));
+					closeAndFinish(test, realtime);
+					return;
+				}
+				/* Sabotage comet sending */
+				var transport = connectionManager.activeProtocol.getTransport();
+				test.ok(helper.isComet(transport), 'Check active transport is still comet');
+				transport.sendUri = helper.unroutableAddress;
+
+				async.parallel([
+					function(cb) {
+						channel.subscribe('event', function() {
+							test.ok(true, 'Received message');
+							cb();
+						});
+					},
+					function(cb) {
+						channel.publish('event', null, function(err) {
+							test.ok(!err, 'Successfully published message');
+							cb();
+						});
+					}
+				], function() {
+					closeAndFinish(test, realtime);
+				});
+			});
+		});
 	};
 
 	return module.exports = (bestTransport === 'web_socket') ? helper.withTimeout(exports) : {};

--- a/spec/realtime/upgrade.test.js
+++ b/spec/realtime/upgrade.test.js
@@ -40,15 +40,6 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.done();
 	};
 
-	if(isBrowser && window.localStorage) {
-		/* run before each test to ensure starting from a fresh state */
-		exports.setUp = function(callback) {
-			console.log('Clearing transport preference from localstorage');
-			helper.clearTransportPreference();
-			callback();
-		};
-	}
-
 	/*
 	 * Publish once with REST, before upgrade, verify message received
 	 */


### PR DESCRIPTION
Implements option 3 from https://github.com/ably/realtime/issues/522#issuecomment-226157187 , per @paddybyers .

Fixes https://github.com/ably/realtime/issues/522 and https://github.com/ably/ably-js/issues/286 (from the client-side end)
Fixes https://github.com/ably/ably-js/issues/285

This PR stalls messages from the moment the sync is sent until the old transport is idle. Once/if the realtime changes in https://github.com/ably/realtime/issues/522 are done, we'll be able to do a further change to only stall once the sync is done.

The change to separate the upgrade sync and the activation of the upgrade transport (delaying the latter until the old transport is idle) required some other changes in the library. Eg previously a message that arrived on a transport that was not the active transport could be safely discarded; this is no longer true as messages will arrive on the upgrade transport as soon as the sync is done.

The channel operation inprogress mechanism needed enough surgery to accommodate the change that I put it in a separate commit:
- It onlys sets the lock once have it's actually sent an attaching or detaching  message. The purpose of the mechanism is for connectionManager to decide when it's safe to upgrade. Before, channel might be inProgress and in the attaching state without any pending operations, eg if attached while the connection state is connecting. Since the upgrade transport now waits for nopending before activating, this caused a deadlock if an attach request timed out: checkPendingState is waiting for transport.active, which is waiting for nopending. Now, setting inProgress is only done once the a message has been sent.
- It now starts the statetimer when the message is sent (if it's not already running) - before, if an attach was queued due to not being connected, the timer would never be set, even on connected.
- The on('transport.active') checkpendingstate now happens a tick after transport.active, to give connectionManager time to finish activating the transport and setting the connection state.
- It also now treats channelstate operations (attach/detach) and sync separately, which solves the bug where a sync ending would incorrectly remove the lock of a pending detach (#285).