### PR TITLE
When retrying previously-attempted messages on a new transport, keep the same msgSerial

### DIFF
--- a/common/lib/transport/protocol.js
+++ b/common/lib/transport/protocol.js
@@ -40,6 +40,7 @@ var Protocol = (function() {
 		if (Logger.shouldLog(Logger.LOG_MICRO)) {
 			Logger.logAction(Logger.LOG_MICRO, 'Protocol.send()', 'sending msg; ' + ProtocolMessage.stringify(pendingMessage.message));
 		}
+		pendingMessage.sendAttempted = true;
 		this.transport.send(pendingMessage.message, callback);
 	};
 
@@ -67,6 +68,7 @@ var Protocol = (function() {
 		this.callback = callback;
 		this.merged = false;
 		var action = message.action;
+		this.sendAttempted = false;
 		this.ackRequired = (action == actions.MESSAGE || action == actions.PRESENCE);
 	}
 	Protocol.PendingMessage = PendingMessage;


### PR DESCRIPTION
Also stop newer messages from being merged into previously-attempted messages. (I originally just checked whether msg.msgSerial was defined to see if it'd previously been attempted, but having an explicit boolean field in the pendingMessage object is neater & more robust in case we change how msgSerials are done in the future)