### PR TITLE
Emit any pre-connnect auth errors in a way the onConnect listeners will handle

### DIFF
--- a/browser/lib/transport/jsonptransport.js
+++ b/browser/lib/transport/jsonptransport.js
@@ -54,10 +54,10 @@ var JSONPTransport = (function() {
 	JSONPTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new JSONPTransport(connectionManager, auth, params);
 		var errorCb = function(err) { callback(err); };
-		transport.on('error', errorCb);
+		transport.on('failed', errorCb);
 		transport.on('preconnect', function() {
 			Logger.logAction(Logger.LOG_MINOR, 'JSONPTransport.tryConnect()', 'viable transport ' + transport);
-			transport.off('error', errorCb);
+			transport.off('failed', errorCb);
 			callback(null, transport);
 		});
 		transport.connect();
@@ -126,7 +126,7 @@ var JSONPTransport = (function() {
 				}
 			} else {
 				/* Handle as non-enveloped -- as will be eg from a customer's authUrl server */
-				self.complete(null, message)
+				self.complete(null, message);
 			}
 		};
 
@@ -172,7 +172,7 @@ var JSONPTransport = (function() {
 		req.once('complete', callback);
 		Utils.nextTick(function() {
 			req.exec();
-		})
+		});
 		return req;
 	};
 

--- a/browser/lib/transport/xhrpollingtransport.js
+++ b/browser/lib/transport/xhrpollingtransport.js
@@ -14,10 +14,10 @@ var XHRPollingTransport = (function() {
 	XHRPollingTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new XHRPollingTransport(connectionManager, auth, params);
 		var errorCb = function(err) { callback(err); };
-		transport.on('error', errorCb);
+		transport.on('failed', errorCb);
 		transport.on('preconnect', function() {
 			Logger.logAction(Logger.LOG_MINOR, 'XHRPollingTransport.tryConnect()', 'viable transport ' + transport);
-			transport.off('error', errorCb);
+			transport.off('failed', errorCb);
 			callback(null, transport);
 		});
 		transport.connect();

--- a/browser/lib/transport/xhrstreamingtransport.js
+++ b/browser/lib/transport/xhrstreamingtransport.js
@@ -23,10 +23,10 @@ var XHRStreamingTransport = (function() {
 	XHRStreamingTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new XHRStreamingTransport(connectionManager, auth, params);
 		var errorCb = function(err) { callback(err); };
-		transport.on('error', errorCb);
+		transport.on('failed', errorCb);
 		transport.on('preconnect', function() {
 			Logger.logAction(Logger.LOG_MINOR, 'XHRStreamingTransport.tryConnect()', 'viable transport ' + transport);
-			transport.off('error', errorCb);
+			transport.off('failed', errorCb);
 			callback(null, transport);
 		});
 		transport.connect();

--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -73,7 +73,7 @@ var CometTransport = (function() {
 				if(err) {
 					/* If connect errors before the preconnect, connectionManager is
 					 * never given the transport, so need to dispose of it ourselves */
-					self.finish('error', err);
+					self.abort(err);
 					return;
 				}
 				Utils.nextTick(function() {

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -22,10 +22,10 @@ var WebSocketTransport = (function() {
 	WebSocketTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new WebSocketTransport(connectionManager, auth, params);
 		var errorCb = function(err) { callback(err); };
-		transport.on('wserror', errorCb);
+		transport.on('failed', errorCb);
 		transport.on('wsopen', function() {
 			Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.tryConnect()', 'viable transport ' + transport);
-			transport.off('wserror', errorCb);
+			transport.off('failed', errorCb);
 			callback(null, transport);
 		});
 		transport.connect();
@@ -54,7 +54,7 @@ var WebSocketTransport = (function() {
 		Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.connect()', 'uri: ' + wsUri);
 		this.auth.getAuthParams(function(err, authParams) {
 			var paramStr = ''; for(var param in authParams) paramStr += ' ' + param + ': ' + authParams[param] + ';';
-			Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.connect()', 'authParams:' + paramStr);
+			Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.connect()', 'authParams:' + paramStr + ' err: ' + err);
 			if(err) {
 				self.abort(err);
 				return;
@@ -118,9 +118,7 @@ var WebSocketTransport = (function() {
 
 	WebSocketTransport.prototype.onWsError = function(err) {
 		Logger.logAction(Logger.LOG_ERROR, 'WebSocketTransport.onError()', 'Unexpected error from WebSocket: ' + err.message);
-		this.emit('wserror', err);
-		/* FIXME: this should not be fatal */
-		this.abort();
+		this.abort(err);
 	};
 
 	WebSocketTransport.prototype.dispose = function() {

--- a/nodejs/lib/transport/nodecomettransport.js
+++ b/nodejs/lib/transport/nodecomettransport.js
@@ -35,10 +35,10 @@ var NodeCometTransport = (function() {
 	NodeCometTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new NodeCometTransport(connectionManager, auth, params);
 		var errorCb = function(err) { callback(err); };
-		transport.on('error', errorCb);
+		transport.on('failed', errorCb);
 		transport.on('preconnect', function() {
 			Logger.logAction(Logger.LOG_MINOR, 'NodeCometTransport.tryConnect()', 'viable transport ' + transport);
-			transport.off('error', errorCb);
+			transport.off('failed', errorCb);
 			callback(null, transport);
 		});
 		transport.connect();


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/311

@paddybyers would you mind explaining a couple things when you have a sec?

- What's the semantic difference between finishing a transport with `failed` (which is what aborting does) and finishing it with `error`? Any reason not to merge the two events, and avoid bugs like this where something's listening for one but not the other?

- You have a `/* FIXME: this should not be fatal */` in the websocket `onerror` handler. Why not? Is it possible it'll ever be called with a nonfatal error? (the w3 spec is [very vague](https://www.w3.org/TR/websockets/#handler-websocket-onerror), and the websocket spec isn't much help either - it defines a lot of codes for the close frame, but doesn't mention any nonfatal errors that I can find). And if nonfatal errors are possible, why have the abort there at all -- why not just log them and rely on the `onclose` being called immediately after if the error was fatal?