### PR TITLE
Fix presence messages ending an in-progress sync

### DIFF
--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -266,7 +266,7 @@ var RealtimeChannel = (function() {
 	};
 
 	RealtimeChannel.prototype.onMessage = function(message) {
-		var syncChannelSerial;
+		var syncChannelSerial, isSync = false;
 		switch(message.action) {
 		case actions.ATTACHED:
 			this.setAttached(message);
@@ -277,6 +277,8 @@ var RealtimeChannel = (function() {
 			break;
 
 		case actions.SYNC:
+			/* syncs can have channelSerials, but might not if the sync is one page long */
+			isSync = true;
 			syncChannelSerial = this.syncChannelSerial = message.channelSerial;
 			/* syncs can happen on channels with no presence data as part of connection
 			 * resuming, in which case protocol message has no presence property */
@@ -300,7 +302,7 @@ var RealtimeChannel = (function() {
 				if(!presenceMsg.timestamp) presenceMsg.timestamp = timestamp;
 				if(!presenceMsg.id) presenceMsg.id = id + ':' + i;
 			}
-			this.presence.setPresence(presence, true, syncChannelSerial);
+			this.presence.setPresence(presence, isSync, syncChannelSerial);
 			break;
 
 		case actions.MESSAGE:

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -1426,5 +1426,67 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
+	/*
+	 * Do a 110-member sync, so split into two sync messages. Inject a normal
+	 * presence enter between the syncs. Check everything was entered correctly
+	 */
+	exports.presence_sync_interruptus = function(test) {
+		test.expect(1);
+		var channelName = "presence_sync_interruptus";
+		var interrupterClientId = "dark_horse";
+		var enterer = helper.AblyRealtime();
+		var syncer = helper.AblyRealtime();
+		var entererChannel = enterer.channels.get(channelName);
+		var syncerChannel = syncer.channels.get(channelName);
+
+		function waitForBothConnect(cb) {
+			async.parallel([
+				function(connectCb) { enterer.connection.on('connected', connectCb); },
+				function(connectCb) { syncer.connection.on('connected', connectCb); }
+			], function() { cb(); });
+		}
+
+		async.series([
+			waitForBothConnect,
+			function(cb) { entererChannel.attach(cb); },
+			function(cb) {
+				async.times(110, function(i, presCb) {
+					entererChannel.presence.enterClient(i.toString(), null, presCb);
+				}, cb);
+			},
+			function(cb) {
+				var originalOnMessage = syncerChannel.onMessage;
+				syncerChannel.onMessage = function(message) {
+					originalOnMessage.apply(this, arguments);
+					/* Inject an additional presence message after the first sync */
+					if(message.action === 16) {
+						syncerChannel.onMessage = originalOnMessage;
+						syncerChannel.onMessage({
+							"action": 14,
+							"id": "messageid-0",
+							"connectionId": "connid",
+							"timestamp": 2000000000000,
+							"presence": [{
+								"clientId": interrupterClientId,
+								"action": 'enter'
+							}]});
+					}
+				};
+				syncerChannel.attach(cb);
+			},
+			function(cb) {
+				syncerChannel.presence.get(function(err, presenceSet) {
+					test.equal(presenceSet && presenceSet.length, 111, 'Check everyone’s in presence set');
+					cb(err);
+				});
+			}
+		], function(err) {
+			if(err) {
+				test.ok(false, helper.displayError(err));
+			}
+			closeAndFinish(test, [enterer, syncer]);
+		});
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
Issue reported by Larry where a large room would occasionally show far too few presence members (within a region - separate from inter-region sync issues). Turns out that a presence message arriving in the middle of a sync would interrupt the sync.

(I reused the `broadcast` parameter from `setPresence`, since it wasn't actually used anywhere in the function. I'm assuming it's leftover from some previous design for presence and is now defunct)