### PR TITLE
Use foreverAgent for node http requests

### DIFF
--- a/nodejs/lib/util/http.js
+++ b/nodejs/lib/util/http.js
@@ -89,7 +89,10 @@ this.Http = (function() {
 	 * @param callback (err, response)
 	 */
 	Http.getUri = function(rest, uri, headers, params, callback) {
-		var getOptions = {headers:headers, encoding:null};
+		/* Will generally be making requests to one or two servers exclusively
+		* (Ably and perhaps an auth server), so for efficiency, use the
+		* foreverAgent to keep the TCP stream alive between requests where possible */
+		var getOptions = {headers:headers, encoding:null, forever: true};
 		if(params)
 			getOptions.qs = params;
 
@@ -139,7 +142,7 @@ this.Http = (function() {
 	 * @param callback (err, response)
 	 */
 	Http.postUri = function(rest, uri, headers, body, params, callback) {
-		var postOptions = {headers:headers, body:body, encoding:null};
+		var postOptions = {headers:headers, body:body, encoding:null, forever: true};
 		if(params)
 			postOptions.qs = params;
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "crypto-js": "git://github.com/ably-forks/crypto-js#typedarray-webkit",
     "hexy": "~0.2",
     "msgpack-js": "git://github.com/paddybyers/msgpack-js.git",
-    "request": "~2.53",
+    "request": "^2.74.0",
     "ws": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The lib will generally be making requests repeatedly to one or two servers only (usually just Ably), so for efficiency, can use the foreverAgent to keep the TCP stream alive between requests.

Fixes https://github.com/ably/ably-js/issues/330

(hard to test, but I've checked in wireshark and the option seems to do what it should be doing)