### PR TITLE
Limit node http agent socket pool to 25

### DIFF
--- a/nodejs/lib/util/defaults.js
+++ b/nodejs/lib/util/defaults.js
@@ -5,5 +5,6 @@ this.Defaults = {
 	* intersection of this list and the transports clientOption that's supported */
 	transports: ['comet', 'web_socket'],
 	transportPreferenceOrder: ['comet', 'web_socket'],
-	upgradeTransports: ['web_socket']
+	upgradeTransports: ['web_socket'],
+	restAgentOptions: {maxSockets: 40}
 };

--- a/nodejs/lib/util/http.js
+++ b/nodejs/lib/util/http.js
@@ -94,7 +94,8 @@ this.Http = (function() {
 		/* Will generally be making requests to one or two servers exclusively
 		* (Ably and perhaps an auth server), so for efficiency, use the
 		* foreverAgent to keep the TCP stream alive between requests where possible */
-		var getOptions = {headers:headers, encoding:null, forever: true};
+		var agentOptions = (rest && rest.options.restAgentOptions) || Defaults.restAgentOptions;
+		var getOptions = {headers:headers, encoding:null, forever: true, agentOptions: agentOptions};
 		if(params)
 			getOptions.qs = params;
 
@@ -144,7 +145,8 @@ this.Http = (function() {
 	 * @param callback (err, response)
 	 */
 	Http.postUri = function(rest, uri, headers, body, params, callback) {
-		var postOptions = {headers:headers, body:body, encoding:null, forever: true};
+		var agentOptions = (rest && rest.options.restAgentOptions) || Defaults.restAgentOptions;
+		var postOptions = {headers:headers, body:body, encoding:null, forever: true, agentOptions: agentOptions};
 		if(params)
 			postOptions.qs = params;
 


### PR DESCRIPTION
Having a reasonable limit on the max number of parallel TCP connections for doing rest requests with (by default there's no limit) seems to eliminate the TCP errors and timeouts we were seeing when hundreds of rest requests are fired off in parallel.

I'm open to input on the exact value. With 50 I was still seeing a couple TCP spurious retransmissions with 500 parallel publishes; with 25, no TCP errors; and a socket pool of 25 is large enough for reasonable parallelism (500 simple publishes end up with starting times spread out over around around 2 seconds, which seems not unreasonable).