### PR TITLE
Node build without crypto and buffertools

### DIFF
--- a/nodejs/lib/transport/nodecomettransport.js
+++ b/nodejs/lib/transport/nodecomettransport.js
@@ -1,6 +1,5 @@
 "use strict";
 var NodeCometTransport = (function() {
-	var buffertools = require('buffertools');
 	var http = require('http');
 	var https = require('https');
 	var url = require('url');

--- a/nodejs/lib/util/bufferutils.js
+++ b/nodejs/lib/util/bufferutils.js
@@ -1,6 +1,4 @@
 this.BufferUtils = (function() {
-	var buffertools = require('buffertools');
-
 	function BufferUtils() {}
 
 	BufferUtils.supportsBinary = true;
@@ -24,7 +22,7 @@ this.BufferUtils = (function() {
 	BufferUtils.bufferCompare = function(buf1, buf2) {
 		if(!buf1) return -1;
 		if(!buf2) return 1;
-		return buffertools.compare(buf1, buf2);
+		return buf1.compare(buf2);
 	};
 
 	return BufferUtils;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./nodejs/index.js",
   "dependencies": {
     "async": "git://github.com/ably-forks/async#requirejs",
-    "crypto-js": "git://github.com/ably-forks/crypto-js#typedarray-webkit",
     "hexy": "~0.2",
     "msgpack-js": "git://github.com/paddybyers/msgpack-js.git",
     "request": "^2.74.0",
@@ -38,7 +37,8 @@
     "kexec": "^2.0.2",
     "nodeunit": "~0.9",
     "requirejs": "~2.1",
-    "shelljs": "~0.3"
+    "shelljs": "~0.3",
+    "crypto-js": "git://github.com/ably-forks/crypto-js#typedarray-webkit"
   },
   "engines": {
     "node": ">=0.10.x"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./nodejs/index.js",
   "dependencies": {
     "async": "git://github.com/ably-forks/async#requirejs",
-    "buffertools": "^2.1.3",
     "crypto-js": "git://github.com/ably-forks/crypto-js#typedarray-webkit",
     "hexy": "~0.2",
     "msgpack-js": "git://github.com/paddybyers/msgpack-js.git",


### PR DESCRIPTION
That was a lot easier than I was expecting. Turns out node wasn't actually using either buffertools or crypto-js at all at runtime. So could basically just move them both from dependencies to devDependencies