### PR TITLE
Remove nodecomet transport by default, various minor fixes & refactorings

### DIFF
--- a/browser/lib/transport/jsonptransport.js
+++ b/browser/lib/transport/jsonptransport.js
@@ -32,27 +32,6 @@ var JSONPTransport = (function() {
 	 * connectionmanager should ensure this doesn't happen anyway */
 	var checksInProgress = null;
 	window.JSONPTransport = JSONPTransport
-	JSONPTransport.checkConnectivity = function(callback) {
-		var upUrl = Defaults.jsonpInternetUpUrl;
-
-		if(checksInProgress) {
-			checksInProgress.push(callback);
-			return;
-		}
-		checksInProgress = [callback];
-		Logger.logAction(Logger.LOG_MICRO, 'JSONPTransport.checkConnectivity()', 'Sending; ' + upUrl);
-
-		var req = new Request('isTheInternetUp', upUrl, null, null, null, CometTransport.REQ_SEND, Defaults.TIMEOUTS);
-		req.once('complete', function(err, response) {
-			var result = !err && response;
-			Logger.logAction(Logger.LOG_MICRO, 'JSONPTransport.checkConnectivity()', 'Result: ' + result);
-			for(var i = 0; i < checksInProgress.length; i++) checksInProgress[i](null, result);
-			checksInProgress = null;
-		});
-		Utils.nextTick(function() {
-			req.exec();
-		});
-	};
 
 	JSONPTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new JSONPTransport(connectionManager, auth, params);
@@ -195,6 +174,28 @@ var JSONPTransport = (function() {
 				req.exec();
 			});
 			return req;
+		};
+
+		Http.checkConnectivity = function(callback) {
+			var upUrl = Defaults.jsonpInternetUpUrl;
+
+			if(checksInProgress) {
+				checksInProgress.push(callback);
+				return;
+			}
+			checksInProgress = [callback];
+			Logger.logAction(Logger.LOG_MICRO, '(JSONP)Http.checkConnectivity()', 'Sending; ' + upUrl);
+
+			var req = new Request('isTheInternetUp', upUrl, null, null, null, CometTransport.REQ_SEND, Defaults.TIMEOUTS);
+			req.once('complete', function(err, response) {
+				var result = !err && response;
+				Logger.logAction(Logger.LOG_MICRO, '(JSONP)Http.checkConnectivity()', 'Result: ' + result);
+				for(var i = 0; i < checksInProgress.length; i++) checksInProgress[i](null, result);
+				checksInProgress = null;
+			});
+			Utils.nextTick(function() {
+				req.exec();
+			});
 		};
 	}
 

--- a/browser/lib/transport/xhrpollingtransport.js
+++ b/browser/lib/transport/xhrpollingtransport.js
@@ -9,7 +9,6 @@ var XHRPollingTransport = (function() {
 	Utils.inherits(XHRPollingTransport, CometTransport);
 
 	XHRPollingTransport.isAvailable = XHRRequest.isAvailable;
-	XHRPollingTransport.checkConnectivity = XHRStreamingTransport.checkConnectivity;
 
 	XHRPollingTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new XHRPollingTransport(connectionManager, auth, params);

--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -293,6 +293,16 @@ var XHRRequest = (function() {
 				req.exec();
 				return req;
 			};
+
+			Http.checkConnectivity = function(callback) {
+				var upUrl = Defaults.internetUpUrl;
+				Logger.logAction(Logger.LOG_MICRO, '(XHRRequest)Http.checkConnectivity()', 'Sending; ' + upUrl);
+				Http.Request(null, upUrl, null, null, null, function(err, responseText) {
+					var result = (!err && responseText.replace(/\n/, '') == 'yes');
+					Logger.logAction(Logger.LOG_MICRO, '(XHRRequest)Http.checkConnectivity()', 'Result: ' + result);
+					callback(null, result);
+				});
+			};
 		}
 	}
 

--- a/browser/lib/transport/xhrstreamingtransport.js
+++ b/browser/lib/transport/xhrstreamingtransport.js
@@ -10,16 +10,6 @@ var XHRStreamingTransport = (function() {
 
 	XHRStreamingTransport.isAvailable = XHRRequest.isAvailable;
 
-	XHRStreamingTransport.checkConnectivity = function(callback) {
-		var upUrl = Defaults.internetUpUrl;
-		Logger.logAction(Logger.LOG_MICRO, 'XHRStreamingTransport.checkConnectivity()', 'Sending; ' + upUrl);
-		Http.Request(null, upUrl, null, null, null, function(err, responseText) {
-			var result = (!err && responseText.replace(/\n/, '') == 'yes');
-			Logger.logAction(Logger.LOG_MICRO, 'XHRStreamingTransport.checkConnectivity()', 'Result: ' + result);
-			callback(null, result);
-		});
-	};
-
 	XHRStreamingTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new XHRStreamingTransport(connectionManager, auth, params);
 		var errorCb = function(err) { callback({event: this.event, error: err}); };

--- a/browser/lib/util/defaults.js
+++ b/browser/lib/util/defaults.js
@@ -2,11 +2,12 @@ var Defaults = {
 	internetUpUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
 	jsonpInternetUpUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up-0-9.js',
 	/* Order matters here: the base transport is the leftmost one in the
-	 * intersection of this list and the transports clientOption that's
+	 * intersection of baseTransportOrder and the transports clientOption that's
 	 * supported.  This is not quite the same as the preference order -- e.g.
 	 * xhr_polling is preferred to jsonp, but for browsers that support it we want
 	 * the base transport to be xhr_polling, not jsonp */
-	transports: ['xhr_polling', 'xhr_streaming', 'jsonp', 'web_socket'],
+	defaultTransports: ['xhr_polling', 'xhr_streaming', 'jsonp', 'web_socket'],
+	baseTransportOrder: ['xhr_polling', 'xhr_streaming', 'jsonp', 'web_socket'],
 	transportPreferenceOrder: ['jsonp', 'xhr_polling', 'xhr_streaming', 'web_socket'],
 	upgradeTransports: ['xhr_streaming', 'web_socket'],
 	minified: !(function _(){}).name

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -583,12 +583,16 @@ var RealtimeChannel = (function() {
 		}
 
 		if(params && params.untilAttach) {
-			if(this.state === 'attached') {
-				delete params.untilAttach;
-				params.from_serial = this.attachSerial;
-			} else {
+			if(this.state !== 'attached') {
 				callback(new ErrorInfo("option untilAttach requires the channel to be attached", 40000, 400));
+				return;
 			}
+			if(!this.attachSerial) {
+				callback(new ErrorInfo("untilAttach was specified and channel is attached, but attachSerial is not defined", 40000, 400));
+				return;
+			}
+			delete params.untilAttach;
+			params.from_serial = this.attachSerial;
 		}
 
 		Channel.prototype._history.call(this, params, callback);

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -1075,8 +1075,7 @@ var ConnectionManager = (function() {
 			/* before trying any fallback (or any remaining fallback) we decide if
 			 * there is a problem with the ably host, or there is a general connectivity
 			 * problem */
-			var connectivityCheckTransport = self.baseTransport === 'web_socket' ? 'xhr_polling' : self.baseTransport;
-			ConnectionManager.supportedTransports[connectivityCheckTransport].checkConnectivity(function(err, connectivity) {
+			Http.checkConnectivity(function(err, connectivity) {
 				/* we know err won't happen but handle it here anyway */
 				if(err) {
 					giveUp(err);

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -1117,8 +1117,9 @@ var ConnectionManager = (function() {
 			return;
 		}
 
-		var upgradeTransportParams = new TransportParams(this.options, transportParams.host, 'upgrade', this.connectionKey);
 		Utils.arrForEach(upgradePossibilities, function(upgradeTransport) {
+			/* Note: the transport may mutate the params, so give each transport a fresh one */
+			var upgradeTransportParams = new TransportParams(self.options, transportParams.host, 'upgrade', self.connectionKey);
 			self.tryATransport(upgradeTransportParams, upgradeTransport, noop);
 		});
 	};

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -103,12 +103,12 @@ var ConnectionManager = (function() {
 		this.connectionKey = undefined;
 		this.connectionSerial = undefined;
 
-		this.transports = Utils.intersect((options.transports || Defaults.transports), ConnectionManager.supportedTransports);
-		/* baseTransports selects the leftmost transport in the Defaults.transports list
+		this.transports = Utils.intersect((options.transports || Defaults.defaultTransports), ConnectionManager.supportedTransports);
+		/* baseTransports selects the leftmost transport in the Defaults.baseTransportOrder list
 		* that's both requested and supported. Normally this will be xhr_polling;
 		* if xhr isn't supported it will be jsonp. If the user has forced a
 		* transport, it'll just be that one. */
-		this.baseTransport = Utils.intersect(Defaults.transports, this.transports)[0];
+		this.baseTransport = Utils.intersect(Defaults.baseTransportOrder, this.transports)[0];
 		this.upgradeTransports = Utils.intersect(this.transports, Defaults.upgradeTransports);
 		/* Map of hosts to an array of transports to not be tried for that host */
 		this.transportHostBlacklist = {};
@@ -122,7 +122,7 @@ var ConnectionManager = (function() {
 		this.lastAutoReconnectAttempt = null;
 
 		Logger.logAction(Logger.LOG_MINOR, 'Realtime.ConnectionManager()', 'started');
-		Logger.logAction(Logger.LOG_MICRO, 'Realtime.ConnectionManager()', 'requested transports = [' + (options.transports || Defaults.transports) + ']');
+		Logger.logAction(Logger.LOG_MICRO, 'Realtime.ConnectionManager()', 'requested transports = [' + (options.transports || Defaults.defaultTransports) + ']');
 		Logger.logAction(Logger.LOG_MICRO, 'Realtime.ConnectionManager()', 'available transports = [' + this.transports + ']');
 		Logger.logAction(Logger.LOG_MICRO, 'Realtime.ConnectionManager()', 'http hosts = [' + this.httpHosts + ']');
 

--- a/nodejs/lib/transport/nodecomettransport.js
+++ b/nodejs/lib/transport/nodecomettransport.js
@@ -23,14 +23,6 @@ var NodeCometTransport = (function() {
 	NodeCometTransport.isAvailable = function() { return true; };
 	ConnectionManager.supportedTransports[shortName] = NodeCometTransport;
 
-	NodeCometTransport.checkConnectivity = function(callback) {
-		var upUrl = Defaults.internetUpUrl;
-		/* NodeCometTransport unsuited to rest requests; just use node http package */
-		Http.getUri(null, upUrl, null, null, function(err, responseText) {
-			callback(null, (!err && responseText.toString().trim() === 'yes'));
-		});
-	};
-
 	NodeCometTransport.tryConnect = function(connectionManager, auth, params, callback) {
 		var transport = new NodeCometTransport(connectionManager, auth, params);
 		var errorCb = function(err) { callback({event: this.event, error: err}); };

--- a/nodejs/lib/util/defaults.js
+++ b/nodejs/lib/util/defaults.js
@@ -2,8 +2,11 @@
 this.Defaults = {
 	internetUpUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
 	/* Note: order matters here: the base transport is the leftmost one in the
-	* intersection of this list and the transports clientOption that's supported */
-	transports: ['comet', 'web_socket'],
+	* intersection of baseTransportOrder and the transports clientOption that's supported.
+	* (For node this is the same as the transportPreferenceOrder, but for
+	* browsers it's different*/
+	defaultTransports: ['web_socket'],
+	baseTransportOrder: ['comet', 'web_socket'],
 	transportPreferenceOrder: ['comet', 'web_socket'],
 	upgradeTransports: ['web_socket'],
 	restAgentOptions: {maxSockets: 40}

--- a/nodejs/lib/util/http.js
+++ b/nodejs/lib/util/http.js
@@ -163,5 +163,12 @@ this.Http = (function() {
 	Http.supportsAuthHeaders = true;
 	Http.supportsLinkHeaders = true;
 
+	Http.checkConnectivity = function(callback) {
+		var upUrl = Defaults.internetUpUrl;
+		Http.getUri(null, upUrl, null, null, function(err, responseText) {
+			callback(null, (!err && responseText.toString().trim() === 'yes'));
+		});
+	};
+
 	return Http;
 })();

--- a/spec/common/modules/client_module.js
+++ b/spec/common/modules/client_module.js
@@ -4,28 +4,17 @@
 
 define(['ably', 'globals', 'spec/common/modules/testapp_module'], function(Ably, ablyGlobals, testAppHelper) {
 	var utils = Ably.Realtime.Utils;
-	function mixinOptions(dest, src) {
-		for (var key in src) {
-			if (src.hasOwnProperty(key)) {
-				dest[key] = src[key];
-			}
-		}
-		return dest;
-	}
 
 	function ablyClientOptions(options) {
-		options = options || {};
-		var clientOptions = mixinOptions({}, ablyGlobals);
+		var clientOptions = utils.copy(ablyGlobals)
+		utils.mixin(clientOptions, options);
 		var authMethods = ['authUrl', 'authCallback', 'token', 'tokenDetails', 'key'];
-		if(options) {
-			mixinOptions(clientOptions, options);
 
-			/* Use a default api key if no auth methods provided */
-			if(utils.arrEvery(authMethods, function(method) {
-				return !(method in clientOptions);
-			})) {
-				clientOptions.key = testAppHelper.getTestApp().keys[0].keyStr;
-			}
+		/* Use a default api key if no auth methods provided */
+		if(utils.arrEvery(authMethods, function(method) {
+			return !(method in clientOptions);
+		})) {
+			clientOptions.key = testAppHelper.getTestApp().keys[0].keyStr;
 		}
 
 		return clientOptions;

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -7,7 +7,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 	function(testAppModule, clientModule, testAppManager, async) {
 		var utils = clientModule.Ably.Realtime.Utils;
 		var supportedTransports = utils.keysArray(clientModule.Ably.Realtime.ConnectionManager.supportedTransports),
-			/* Don't include jsonp in availableTransports if xhr worksk. Why? Because
+			/* Don't include jsonp in availableTransports if xhr works. Why? Because
 			 * you can't abort requests. So recv's stick around for 90s till realtime
 			 * ends them. So in a test, the browsers max-connections-per-host limit
 			 * fills up quickly, which messes up other comet transports too */

--- a/spec/realtime/connectivity.test.js
+++ b/spec/realtime/connectivity.test.js
@@ -4,9 +4,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	var exports = {},
 		closeAndFinish = helper.closeAndFinish,
 		monitorConnection = helper.monitorConnection,
-		utils = helper.Utils,
-		availableHttpTransports = utils.keysArray(Ably.Realtime.ConnectionManager.httpTransports);
-
+		utils = helper.Utils;
 
 	exports.setupConnectivity = function(test) {
 		test.expect(1);
@@ -24,32 +22,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Connect with available http transports; internet connectivity check should work
 	 */
 	exports.http_connectivity_check = function(test) {
-		test.expect(availableHttpTransports.length);
-		try {
-			var connectivity_test = function(transport) {
-				return function(cb) {
-					Ably.Realtime.ConnectionManager.httpTransports[transport].checkConnectivity(function(err, res) {
-						console.log("Transport " + transport + " connectivity check returned ", err, res)
-						test.ok(res, 'Connectivity check for ' + transport);
-						cb(err);
-					})
-				};
-			};
-			async.parallel(
-				utils.arrMap(availableHttpTransports, function(transport) {
-					return connectivity_test(transport);
-				}),
-				function(err) {
-					if(err) {
-						test.ok(false, helper.displayError(err));
-					}
-					test.done();
-				}
-			);
-		} catch(e) {
-			test.ok(false, 'connection failed with exception: ' + e.stack);
+		test.expect(1);
+		Ably.Realtime.Http.checkConnectivity(function(err, res) {
+			test.ok(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err)));
 			test.done();
-		}
+		})
 	};
 
 	return module.exports = helper.withTimeout(exports);

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -264,7 +264,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 			test.expect(2);
 			var realtime;
 			try {
-				realtime = helper.AblyRealtime();
+				realtime = helper.AblyRealtime({transports: helper.availableTransports});
 				test.equal(realtime.connection.connectionManager.baseTransport, 'comet');
 				test.deepEqual(realtime.connection.connectionManager.upgradeTransports, ['web_socket']);
 				closeAndFinish(test, realtime);

--- a/spec/realtime/message.test.js
+++ b/spec/realtime/message.test.js
@@ -79,7 +79,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		test.expect(100);
 		try {
 			var realtime = helper.AblyRealtime(realtimeOpts);
-			realtime.connection.on('connected', function() {
+			realtime.connection.once('connected', function() {
 				var channel = realtime.channels.get('publishfast_' + String(Math.random()).substr(2));
 				channel.attach(function(err) {
 					if(err) {
@@ -164,7 +164,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					publish(0);
 				},
 				function(cb) {
-					realtime.connection.on('connected', function() { cb(); });
+					realtime.connection.once('connected', function() { cb(); });
 					realtime.connection.connect();
 				}
 			], function() {

--- a/spec/realtime/upgrade.test.js
+++ b/spec/realtime/upgrade.test.js
@@ -44,7 +44,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Publish once with REST, before upgrade, verify message received
 	 */
 	exports.publishpreupgrade = function(test) {
-		var transportOpts = {useBinaryProtocol: true};
+		var transportOpts = {useBinaryProtocol: true, transports: helper.availableTransports};
 		test.expect(1);
 		try {
 			var realtime = helper.AblyRealtime(transportOpts);
@@ -89,7 +89,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Publish once with REST, after upgrade, verify message received on active transport
 	 */
 	exports.publishpostupgrade0 = function(test) {
-		var transportOpts = {useBinaryProtocol: true};
+		var transportOpts = {useBinaryProtocol: true, transports: helper.availableTransports};
 		test.expect(1);
 		try {
 			var realtime = helper.AblyRealtime(transportOpts);
@@ -150,7 +150,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Publish once with REST, after upgrade, verify message not received on inactive transport
 	 */
 	exports.publishpostupgrade1 = function(test) {
-		var transportOpts = {useBinaryProtocol: true};
+		var transportOpts = {useBinaryProtocol: true, transports: helper.availableTransports};
 		test.expect(1);
 		try {
 			var realtime = helper.AblyRealtime(transportOpts);
@@ -225,7 +225,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			--cbCount;
 			checkFinish();
 		};
-		var transportOpts = {useBinaryProtocol: false};
+		var transportOpts = {useBinaryProtocol: false, transports: helper.availableTransports};
 		var realtime = helper.AblyRealtime(transportOpts);
 		test.expect(count);
 		var channel = realtime.channels.get('upgradepublish0');
@@ -254,7 +254,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			--cbCount;
 			checkFinish();
 		};
-		var transportOpts = {useBinaryProtocol: true};
+		var transportOpts = {useBinaryProtocol: true, transports: helper.availableTransports};
 		var realtime = helper.AblyRealtime(transportOpts);
 		test.expect(count);
 		var channel = realtime.channels.get('upgradepublish1');
@@ -272,7 +272,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Base upgrade case
 	 */
 	exports.upgradebase0 = function(test) {
-		var transportOpts = {useBinaryProtocol: true};
+		var transportOpts = {useBinaryProtocol: true, transports: helper.availableTransports};
 		test.expect(2);
 		try {
 			var realtime = helper.AblyRealtime(transportOpts);
@@ -312,7 +312,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Check active heartbeat, text protocol
 	 */
 	exports.upgradeheartbeat0 = function(test) {
-		var transportOpts = {useBinaryProtocol: false};
+		var transportOpts = {useBinaryProtocol: false, transports: helper.availableTransports};
 		test.expect(1);
 		try {
 			var realtime = helper.AblyRealtime(transportOpts);
@@ -349,7 +349,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Check active heartbeat, binary protocol
 	 */
 	exports.upgradeheartbeat1 = function(test) {
-		var transportOpts = {useBinaryProtocol: true};
+		var transportOpts = {useBinaryProtocol: true, transports: helper.availableTransports};
 		test.expect(1);
 		try {
 			var realtime = helper.AblyRealtime(transportOpts);
@@ -386,7 +386,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Check heartbeat does not fire on inactive transport, text protocol
 	 */
 	exports.upgradeheartbeat2 = function(test) {
-		var transportOpts = {useBinaryProtocol: false};
+		var transportOpts = {useBinaryProtocol: false, transports: helper.availableTransports};
 		test.expect(1);
 		try {
 			var realtime = helper.AblyRealtime(transportOpts);
@@ -437,7 +437,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Check heartbeat does not fire on inactive transport, binary protocol
 	 */
 	exports.upgradeheartbeat3 = function(test) {
-		var transportOpts = {useBinaryProtocol: true};
+		var transportOpts = {useBinaryProtocol: true, transports: helper.availableTransports};
 		test.expect(1);
 		try {
 			var realtime = helper.AblyRealtime(transportOpts);
@@ -492,7 +492,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 
 		try {
 			/* on base transport active */
-			realtime = helper.AblyRealtime();
+			realtime = helper.AblyRealtime({transports: helper.availableTransports});
 			realtime.connection.connectionManager.once('transport.active', function(transport) {
 				test.ok(transport.toString().indexOf('/comet/') > -1, 'assert first transport to become active is a comet transport');
 				test.equal(realtime.connection.errorReason, null, 'Check connection.errorReason is initially null');
@@ -529,7 +529,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Check that an attach that times out on the base transport does not prevent an upgrade
 	 */
 	exports.attach_timeout_on_base_transport = function(test) {
-		var realtime = helper.AblyRealtime({realtimeRequestTimeout: 3000}),
+		var realtime = helper.AblyRealtime({transports: helper.availableTransports, realtimeRequestTimeout: 3000}),
 			channel = realtime.channels.get('timeout0'),
 			connectionManager = realtime.connection.connectionManager;
 
@@ -556,7 +556,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * seamlessly transferred to the websocket transport and published there
 	 */
 	exports.message_timeout_stalling_upgrade = function(test) {
-		var realtime = helper.AblyRealtime({httpRequestTimeout: 3000}),
+		var realtime = helper.AblyRealtime({transports: helper.availableTransports, httpRequestTimeout: 3000}),
 			channel = realtime.channels.get('timeout1'),
 			connectionManager = realtime.connection.connectionManager;
 
@@ -597,7 +597,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 */
 	exports.unresponsive_upgrade_sync = function(test) {
 		test.expect(5);
-		var realtime = helper.AblyRealtime({realtimeRequestTimeout: 2000}),
+		var realtime = helper.AblyRealtime({transports: helper.availableTransports, realtimeRequestTimeout: 2000}),
 			connection = realtime.connection;
 
 		connection.connectionManager.on('transport.pending', function(transport) {
@@ -644,7 +644,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * and subsequent connections do not upgrade
 	 */
 	exports.persist_transport_prefs = function(test) {
-		var realtime = helper.AblyRealtime(),
+		var realtime = helper.AblyRealtime({transports: helper.availableTransports}),
 			connection = realtime.connection,
 			connectionManager = connection.connectionManager;
 
@@ -686,7 +686,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Check that upgrades succeed even if the original transport dies before the sync
 	 */
 	exports.upgrade_original_transport_dies = function(test) {
-		var realtime = helper.AblyRealtime(),
+		var realtime = helper.AblyRealtime({transports: helper.availableTransports}),
 			connection = realtime.connection,
 			connectionManager = connection.connectionManager;
 


### PR DESCRIPTION
1.0.0's been out for almost 12 hours, so time for 1.0.1 :)

I was planning to get this in for 1.0 as it's arguably a breaking change, but missed Matt's message last night saying he was going to release it, oh well