### PR TITLE
Various connection state and idle timeout handling changes

### DIFF
--- a/browser/fragments/platform-browser.js
+++ b/browser/fragments/platform-browser.js
@@ -3,6 +3,7 @@ if(typeof window !== 'object') {
 }
 
 var Platform = {
+	libver: 'js-web-',
 	noUpgrade: navigator && navigator.userAgent.toString().match(/MSIE\s8\.0/),
 	binaryType: 'arraybuffer',
 	WebSocket: window.WebSocket || window.MozWebSocket,

--- a/browser/fragments/platform-nativescript.js
+++ b/browser/fragments/platform-nativescript.js
@@ -17,6 +17,7 @@ if (global.android) {
 }
 
 var Platform = {
+	libver: 'js-ns-',
 	noUpgrade: false,
 	binaryType: 'arraybuffer',
 	WebSocket: WebSocket,

--- a/browser/fragments/platform-reactnative.js
+++ b/browser/fragments/platform-reactnative.js
@@ -1,4 +1,5 @@
 var Platform = {
+	libver: 'js-rn-',
 	noUpgrade: false,
 	binaryType: 'arraybuffer',
 	WebSocket: WebSocket,

--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -46,7 +46,6 @@ var CometTransport = (function() {
 	 * A base comet transport class
 	 */
 	function CometTransport(connectionManager, auth, params) {
-		this.timeoutOnIdle = true;
 		/* binary not supported for comet, so just fall back to default */
 		params.format = undefined;
 		params.heartbeats = true;
@@ -110,8 +109,8 @@ var CometTransport = (function() {
 					err = err || new ErrorInfo('Request cancelled', 80000, 400);
 				}
 				self.recvRequest = null;
-				if(this.timeoutOnIdle) {
-					this.resetIdleTimeout();
+				if(this.maxIdleInterval) {
+					this.setIdleTimer();
 				}
 				if(err) {
 					if(err.code) {
@@ -275,10 +274,10 @@ var CometTransport = (function() {
 		});
 		recvRequest.on('complete', function(err) {
 			self.recvRequest = null;
-			if(this.timeoutOnIdle) {
+			if(this.maxIdleInterval) {
 				/* A request completing must be considered activity, as realtime sends
 				 * heartbeats every 15s since a request began, not every 15s absolutely */
-				this.resetIdleTimeout();
+				this.setIdleTimer();
 			}
 			if(err) {
 				if(err.code) {

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -102,6 +102,7 @@ var ConnectionManager = (function() {
 		this.connectionId = undefined;
 		this.connectionKey = undefined;
 		this.connectionSerial = undefined;
+		this.connectionStateTtl = timeouts.connectionStateTtl;
 
 		this.transports = Utils.intersect((options.transports || Defaults.defaultTransports), ConnectionManager.supportedTransports);
 		/* baseTransports selects the leftmost transport in the Defaults.baseTransportOrder list
@@ -683,7 +684,7 @@ var ConnectionManager = (function() {
 
 	ConnectionManager.prototype.checkConnectionStateFreshness = function() {
 		var sinceLast = Utils.now() - this.lastActivity;
-		if(sinceLast > this.options.timeouts.connectionStateTtl) {
+		if(sinceLast > this.connectionStateTtl) {
 			Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.checkConnectionStateFreshness()', 'Last known activity from realtime was ' + sinceLast + 'ms ago; discarding connection state');
 			this.clearConnection();
 		}
@@ -700,7 +701,7 @@ var ConnectionManager = (function() {
 				disconnectedAt: Utils.now(),
 				location: window.location,
 				clientId: this.realtime.auth.clientId
-			}, this.options.timeouts.connectionStateTtl);
+			}, this.connectionStateTtl);
 		}
 	};
 
@@ -784,7 +785,7 @@ var ConnectionManager = (function() {
 				self.states.connecting.queueEvents = false;
 				self.notifyState({state: 'suspended'});
 			}
-		}, this.options.timeouts.connectionStateTtl);
+		}, this.connectionStateTtl);
 	};
 
 	ConnectionManager.prototype.checkSuspendTimer = function(state) {
@@ -1490,6 +1491,10 @@ var ConnectionManager = (function() {
 				transport.fail(err);
 				return;
 			}
+		}
+		var connectionStateTtl = connectionDetails && connectionDetails.connectionStateTtl;
+		if(connectionStateTtl) {
+			this.connectionStateTtl = connectionStateTtl;
 		}
 		this.emit('connectiondetails', connectionDetails);
 	};

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -681,6 +681,14 @@ var ConnectionManager = (function() {
 		this.unpersistConnection();
 	};
 
+	ConnectionManager.prototype.checkConnectionStateFreshness = function() {
+		var sinceLast = Utils.now() - this.lastActivity;
+		if(sinceLast > this.options.timeouts.connectionStateTtl) {
+			Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.checkConnectionStateFreshness()', 'Last known activity from realtime was ' + sinceLast + 'ms ago; discarding connection state');
+			this.clearConnection();
+		}
+	};
+
 	/**
 	 * Called when the connectionmanager wants to persist transport
 	 * state for later recovery. Only applicable in the browser context.
@@ -926,6 +934,7 @@ var ConnectionManager = (function() {
 			self = this;
 
 		var connect = function() {
+			self.checkConnectionStateFreshness();
 			self.getTransportParams(function(transportParams) {
 				self.connectImpl(transportParams);
 			});

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -120,6 +120,7 @@ var ConnectionManager = (function() {
 		this.pendingTransports = [];
 		this.host = null;
 		this.lastAutoReconnectAttempt = null;
+		this.lastActivity = null;
 
 		Logger.logAction(Logger.LOG_MINOR, 'Realtime.ConnectionManager()', 'started');
 		Logger.logAction(Logger.LOG_MICRO, 'Realtime.ConnectionManager()', 'requested transports = [' + (options.transports || Defaults.defaultTransports) + ']');

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -684,6 +684,8 @@ var ConnectionManager = (function() {
 	};
 
 	ConnectionManager.prototype.checkConnectionStateFreshness = function() {
+		if(!this.lastActivity) { return; }
+
 		var sinceLast = Utils.now() - this.lastActivity;
 		if(sinceLast > this.connectionStateTtl + this.maxIdleInterval) {
 			Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.checkConnectionStateFreshness()', 'Last known activity from realtime was ' + sinceLast + 'ms ago; discarding connection state');

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -5,7 +5,6 @@ var WebSocketTransport = (function() {
 	/* public constructor */
 	function WebSocketTransport(connectionManager, auth, params) {
 		this.shortName = shortName;
-		this.timeoutOnIdle = true;
 		/* If is a browser, can't detect pings, so request protocol heartbeats */
 		params.heartbeats = Platform.useProtocolHeartbeats;
 		Transport.call(this, connectionManager, auth, params);
@@ -71,7 +70,7 @@ var WebSocketTransport = (function() {
 				if(wsConnection.on) {
 					/* node; browsers currently don't have a general eventemitter and can't detect
 					 * pings. Also, no need to reply with a pong explicitly, ws lib handles that */
-					wsConnection.on('ping', function() { self.resetIdleTimeout() });
+					wsConnection.on('ping', function() { self.setIdleTimer() });
 				}
 			} catch(e) {
 				Logger.logAction(Logger.LOG_ERROR, 'WebSocketTransport.connect()', 'Unexpected exception creating websocket: err = ' + (e.stack || e.message));

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -21,7 +21,7 @@ Defaults.TIMEOUTS = {
 Defaults.httpMaxRetryCount = 3;
 
 Defaults.version          = '1.0.1';
-Defaults.libstring        = 'js-' + Defaults.version;
+Defaults.libstring        = Platform.libver + Defaults.version;
 Defaults.apiVersion       = '1.0';
 
 Defaults.getHost = function(options, host, ws) {

--- a/nodejs/platform.js
+++ b/nodejs/platform.js
@@ -1,4 +1,5 @@
 this.Platform = {
+	libver: 'js-node-',
 	hasWindow: false,
 	userAgent: null,
 	binaryType: 'nodebuffer',

--- a/spec/realtime/resume.test.js
+++ b/spec/realtime/resume.test.js
@@ -428,7 +428,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			}
 		], function(err) {
 			if(err) test.ok(false, helper.displayError(err));
-			closeAndFinish(test, realtime);
+			closeAndFinish(test, [realtime, realtimeTwo]);
 		});
 	};
 

--- a/spec/realtime/resume.test.js
+++ b/spec/realtime/resume.test.js
@@ -385,7 +385,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Check channel resumed flag
 	 * TODO: enable once realtime supports this
 	 */
-	_exports.channel_resumed_flag = function(test) {
+	exports.channel_resumed_flag = function(test) {
 		var realtime = helper.AblyRealtime(),
 			realtimeTwo,
 			recoveryKey,
@@ -393,7 +393,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			channelName = 'channel_resumed_flag',
 			channel = realtime.channels.get(channelName);
 
-		test.expect(3);
+		test.expect(2);
 		async.series([
 			function(cb) {
 				connection.once('connected', function() { cb(); });

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -25,7 +25,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
 			test.ok(('X-Ably-Lib' in headers), 'Verify lib header exists');
 			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
-			test.equal(headers['X-Ably-Lib'], 'js-' + Defaults.version, 'Verify libstring');
+			test.ok(headers['X-Ably-Lib'].indexOf(Defaults.version) > -1, 'Verify libstring');
 		};
 
 		var post_inner = Ably.Rest.Http.post;
@@ -33,7 +33,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
 			test.ok(('X-Ably-Lib' in headers), 'Verify lib header exists');
 			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
-			test.equal(headers['X-Ably-Lib'], 'js-' + Defaults.version, 'Verify libstring');
+			test.ok(headers['X-Ably-Lib'].indexOf(Defaults.version) > -1, 'Verify libstring');
 		};
 
 		//Call all methods that use rest http calls


### PR DESCRIPTION
- Send the platform in the lib version string
- Remember lastActivity; use that for idle transport timeout (fixes https://github.com/ably/ably-js/issues/358)
- Don’t resume if last known activity was > connectionStateTtl ago (fixes https://github.com/ably/ably-js/issues/388)
- Use connectionStateTtl from connectionDetails