### PR TITLE
fix idle timeout handling on node with heartbeats=false

### DIFF
--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -109,9 +109,7 @@ var CometTransport = (function() {
 					err = err || new ErrorInfo('Request cancelled', 80000, 400);
 				}
 				self.recvRequest = null;
-				if(this.maxIdleInterval) {
-					this.setIdleTimer();
-				}
+				self.onActivity();
 				if(err) {
 					if(err.code) {
 						/* A protocol error received from realtime. TODO: once realtime
@@ -274,11 +272,9 @@ var CometTransport = (function() {
 		});
 		recvRequest.on('complete', function(err) {
 			self.recvRequest = null;
-			if(this.maxIdleInterval) {
-				/* A request completing must be considered activity, as realtime sends
-				 * heartbeats every 15s since a request began, not every 15s absolutely */
-				this.setIdleTimer();
-			}
+			/* A request completing must be considered activity, as realtime sends
+			 * heartbeats every 15s since a request began, not every 15s absolutely */
+			self.onActivity();
 			if(err) {
 				if(err.code) {
 					/* A protocol error received from realtime. TODO: once realtime

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -70,7 +70,7 @@ var WebSocketTransport = (function() {
 				if(wsConnection.on) {
 					/* node; browsers currently don't have a general eventemitter and can't detect
 					 * pings. Also, no need to reply with a pong explicitly, ws lib handles that */
-					wsConnection.on('ping', function() { self.setIdleTimer() });
+					wsConnection.on('ping', function() { self.onActivity(); });
 				}
 			} catch(e) {
 				Logger.logAction(Logger.LOG_ERROR, 'WebSocketTransport.connect()', 'Unexpected exception creating websocket: err = ' + (e.stack || e.message));

--- a/nodejs/platform.js
+++ b/nodejs/platform.js
@@ -4,7 +4,7 @@ this.Platform = {
 	userAgent: null,
 	binaryType: 'nodebuffer',
 	WebSocket: require('ws'),
-	useProtocolHeartbeats: true,
+	useProtocolHeartbeats: false,
 	createHmac: require('crypto').createHmac,
 	msgpack: require('msgpack-js'),
 	supportsBinary: true,


### PR DESCRIPTION
https://github.com/ably/ably-js/pull/389 slightly broke idle timeout handling on node with heartbeats=false, not caught since realtime didn't act on that yet.

Not a blocker for realtime as heartbeats=false was previously disabled.

Will wait till realtime with heartbeats=false is on sandbox and this passes ci with that before merging.