### PR TITLE
Http requests with useBinaryProtocol: true

### DIFF
--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -165,17 +165,23 @@ var XHRRequest = (function() {
 			try {
 				var contentType = getHeader(xhr, 'content-type'),
 					headers,
-					server,
+					responseBody,
+					/* Be liberal in what we accept; buggy auth servers may respond
+					 * without the correct contenttype, but assume they're still
+					 * responding with json */
 					json = contentType ? (contentType.indexOf('application/json') >= 0) : (xhr.responseType == 'text');
 
-				responseBody = json ? xhr.responseText : xhr.response;
-
 				if(json) {
-					responseBody = String(responseBody);
+					/* If we requested msgpack but server responded with json, then since
+					 * we set the responseType expecting msgpack, the response will be
+					 * an ArrayBuffer containing json */
+					responseBody = (xhr.responseType === 'arraybuffer') ? BufferUtils.utf8Decode(xhr.response) : String(xhr.responseText);
 					if(responseBody.length) {
 						responseBody = JSON.parse(responseBody);
 					}
 					unpacked = true;
+				} else {
+					responseBody = xhr.response;
 				}
 
 				if(responseBody.response !== undefined) {

--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -104,7 +104,7 @@ var XHRRequest = (function() {
 
 		if(!accept) {
 			headers['accept'] = 'application/json';
-		} else if(accept.indexOf('application/json') === -1) {
+		} else if(accept.indexOf('application/x-msgpack') === 0) {
 			responseType = 'arraybuffer';
 		}
 
@@ -113,7 +113,6 @@ var XHRRequest = (function() {
 			if(contentType.indexOf('application/json') > -1 && typeof(body) != 'string')
 				body = JSON.stringify(body);
 		}
-
 
 		xhr.open(method, this.uri, true);
 		xhr.responseType = responseType;

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -1,5 +1,4 @@
 var Auth = (function() {
-	var msgpack = Platform.msgpack;
 	var MAX_TOKENOBJECT_LENGTH = Math.pow(2, 17);
 	var MAX_TOKENSTRING_LENGTH = 384;
 	function noop() {}
@@ -285,7 +284,6 @@ var Auth = (function() {
 		authOptions = authOptions || this.authOptions;
 		tokenParams = tokenParams || Utils.copy(this.tokenParams);
 		callback = callback || noop;
-		var format = authOptions.format || 'json';
 
 		/* first set up whatever callback will be used to get signed
 		 * token requests */
@@ -371,10 +369,10 @@ var Auth = (function() {
 			var keyName = signedTokenParams.keyName,
 				tokenUri = function(host) { return client.baseUri(host) + '/keys/' + keyName + '/requestToken'; };
 
-			var requestHeaders = Utils.defaultPostHeaders(format);
+			var requestHeaders = Utils.defaultPostHeaders();
 			if(authOptions.requestHeaders) Utils.mixin(requestHeaders, authOptions.requestHeaders);
 			Logger.logAction(Logger.LOG_MICRO, 'Auth.requestToken().requestToken', 'Sending POST; ' + tokenUri + '; Token params: ' + JSON.stringify(signedTokenParams));
-			signedTokenParams = (format == 'msgpack') ? msgpack.encode(signedTokenParams, true) : JSON.stringify(signedTokenParams);
+			signedTokenParams = JSON.stringify(signedTokenParams);
 			Http.post(client, tokenUri, requestHeaders, signedTokenParams, null, tokenCb);
 		};
 
@@ -439,7 +437,7 @@ var Auth = (function() {
 					callback(err);
 					return;
 				}
-				if(!unpacked) tokenResponse = (format == 'msgpack') ? msgpack.decode(tokenResponse) : JSON.parse(tokenResponse);
+				if(!unpacked) tokenResponse = JSON.parse(tokenResponse);
 				Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'token received');
 				callback(null, tokenResponse);
 			});

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -307,7 +307,7 @@ var Auth = (function() {
 						authParams = Utils.mixin(params, authOptions.authParams);
 				var authUrlRequestCallback = function(err, body, headers, unpacked) {
 					if (err) {
-						Logger.logAction(Logger.LOG_MICRO, 'Auth.requestToken().tokenRequestCallback', 'Received Error; ' + JSON.stringify(err));
+						Logger.logAction(Logger.LOG_MICRO, 'Auth.requestToken().tokenRequestCallback', 'Received Error; ' + Utils.inspectError(err));
 					} else {
 						Logger.logAction(Logger.LOG_MICRO, 'Auth.requestToken().tokenRequestCallback', 'Received; body: ' + (BufferUtils.isBuffer(body) ? body.toString() : body));
 					}

--- a/common/lib/client/paginatedresource.js
+++ b/common/lib/client/paginatedresource.js
@@ -46,7 +46,7 @@ var PaginatedResource = (function() {
 
 	PaginatedResource.prototype.handlePage = function(err, body, headers, unpacked, statusCode, callback) {
 		if(err) {
-			Logger.logAction(Logger.LOG_ERROR, 'PaginatedResource.handlePage()', 'Unexpected error getting resource: err = ' + JSON.stringify(err));
+			Logger.logAction(Logger.LOG_ERROR, 'PaginatedResource.handlePage()', 'Unexpected error getting resource: err = ' + Utils.inspectError(err));
 			callback(err);
 			return;
 		}

--- a/common/lib/client/resource.js
+++ b/common/lib/client/resource.js
@@ -79,7 +79,7 @@ var Resource = (function() {
 	function logResponseHandler(callback, verb, path, params) {
 		return function(err, body, headers, unpacked, statusCode) {
 			if (err) {
-				Logger.logAction(Logger.LOG_MICRO, 'Resource.' + verb + '()', 'Received Error; ' + urlFromPathAndParams(path, params) + '; Error: ' + JSON.stringify(err));
+				Logger.logAction(Logger.LOG_MICRO, 'Resource.' + verb + '()', 'Received Error; ' + urlFromPathAndParams(path, params) + '; Error: ' + Utils.inspectError(err));
 			} else {
 				Logger.logAction(Logger.LOG_MICRO, 'Resource.' + verb + '()',
 					'Received; ' + urlFromPathAndParams(path, params) + '; Headers: ' + paramString(headers) + '; StatusCode: ' + statusCode + '; Body: ' + (BufferUtils.isBuffer(body) ? body.toString() : body));
@@ -139,7 +139,7 @@ var Resource = (function() {
 					try {
 						decodedBody = msgpack.decode(body);
 					} catch (decodeErr) {
-						Logger.logAction(Logger.LOG_MICRO, 'Resource.post()', 'Sending MsgPack Decoding Error: ' + JSON.stringify(decodeErr));
+						Logger.logAction(Logger.LOG_MICRO, 'Resource.post()', 'Sending MsgPack Decoding Error: ' + Utils.inspectError(decodeErr));
 					}
 				}
 				Logger.logAction(Logger.LOG_MICRO, 'Resource.post()', 'Sending; ' + urlFromPathAndParams(path, params) + '; Body: ' + decodedBody);

--- a/common/lib/client/resource.js
+++ b/common/lib/client/resource.js
@@ -137,7 +137,7 @@ var Resource = (function() {
 				var decodedBody = body;
 				if ((headers['content-type'] || '').indexOf('msgpack') > 0) {
 					try {
-						body = msgpack.decode(body);
+						decodedBody = msgpack.decode(body);
 					} catch (decodeErr) {
 						Logger.logAction(Logger.LOG_MICRO, 'Resource.post()', 'Sending MsgPack Decoding Error: ' + JSON.stringify(decodeErr));
 					}

--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -224,7 +224,7 @@ var CometTransport = (function() {
 			sendRequest = this.sendRequest = self.createRequest(self.sendUri, null, self.authParams, this.encodeRequest(items), REQ_SEND);
 
 		sendRequest.on('complete', function(err, data) {
-			if(err) Logger.logAction(Logger.LOG_ERROR, 'CometTransport.sendItems()', 'on complete: err = ' + JSON.stringify(err));
+			if(err) Logger.logAction(Logger.LOG_ERROR, 'CometTransport.sendItems()', 'on complete: err = ' + Utils.inspectError(err));
 			self.sendRequest = null;
 
 			/* the results of the request usually get handled as protocol responses instead of send errors */

--- a/common/lib/util/utils.js
+++ b/common/lib/util/utils.js
@@ -367,7 +367,11 @@ var Utils = (function() {
 	Utils.inspect = Platform.inspect;
 
 	Utils.inspectError = function(x) {
-		return (x && (x.constructor.name == 'ErrorInfo' || x.constructor.name == 'Error')) ?
+		/* redundant, but node vmcontext issue makes instanceof unreliable, and
+		 * can't use just constructor test as could be a TypeError constructor etc. */
+		return (x && (x.constructor.name == 'ErrorInfo' ||
+			x.constructor.name == 'Error' ||
+			x instanceof Error)) ?
 			x.toString() :
 			Utils.inspect(x);
 	};

--- a/common/lib/util/utils.js
+++ b/common/lib/util/utils.js
@@ -313,8 +313,7 @@ var Utils = (function() {
 	};
 
 	Utils.defaultGetHeaders = function(format) {
-		format = format || 'json';
-		var accept = (format === 'json') ? contentTypes.json : contentTypes[format];
+		var accept = contentTypes[format || 'json'];
 		return {
 			accept: accept,
 			'X-Ably-Version': Defaults.apiVersion,
@@ -323,9 +322,8 @@ var Utils = (function() {
 	};
 
 	Utils.defaultPostHeaders = function(format) {
-		format = format || 'json';
 		var accept, contentType;
-		accept = contentType = (format === 'json') ? contentTypes.json : contentTypes[format];
+		accept = contentType = contentTypes[format || 'json'];
 
 		return {
 			accept: accept,

--- a/common/lib/util/utils.js
+++ b/common/lib/util/utils.js
@@ -314,7 +314,7 @@ var Utils = (function() {
 
 	Utils.defaultGetHeaders = function(format) {
 		format = format || 'json';
-		var accept = (format === 'json') ? contentTypes.json : contentTypes[format] + ',' + contentTypes.json;
+		var accept = (format === 'json') ? contentTypes.json : contentTypes[format];
 		return {
 			accept: accept,
 			'X-Ably-Version': Defaults.apiVersion,
@@ -324,8 +324,8 @@ var Utils = (function() {
 
 	Utils.defaultPostHeaders = function(format) {
 		format = format || 'json';
-		var accept = (format === 'json') ? contentTypes.json : contentTypes[format] + ',' + contentTypes.json,
-			contentType = (format === 'json') ? contentTypes.json : contentTypes[format];
+		var accept, contentType;
+		accept = contentType = (format === 'json') ? contentTypes.json : contentTypes[format];
 
 		return {
 			accept: accept,

--- a/spec/common/modules/shared_helper.js
+++ b/spec/common/modules/shared_helper.js
@@ -126,6 +126,11 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			}
 		}
 
+		function restTestOnJsonMsgpack(exports, name, testFn) {
+			exports[name + '_binary'] = function(test) { testFn(test, new clientModule.AblyRest({useBinaryProtocol: true}), name + '_binary'); };
+			exports[name + '_text'] = function(test) { testFn(test, new clientModule.AblyRest({useBinaryProtocol: false}), name + '_text'); };
+		}
+
 		/* Wraps all tests with a timeout so that they don't run indefinitely */
 		/* Also clears transport preferences, so each test starts fresh */
 		function withTimeout(exports, defaultTimeout) {
@@ -220,6 +225,7 @@ define(['spec/common/modules/testapp_module', 'spec/common/modules/client_module
 			becomeSuspended:           becomeSuspended,
 			withTimeout:               withTimeout,
 			testOnAllTransports:       testOnAllTransports,
+			restTestOnJsonMsgpack:     restTestOnJsonMsgpack,
 			availableTransports:       availableTransports,
 			bestTransport:             bestTransport,
 			clearTransportPreference:  clearTransportPreference,

--- a/spec/rest/history.test.js
+++ b/spec/rest/history.test.js
@@ -1,7 +1,8 @@
 "use strict";
 
 define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
-	var currentTime, rest, exports = {},
+	var currentTime, rest, restBinary, exports = {},
+			restTestOnJsonMsgpack = helper.restTestOnJsonMsgpack,
 			displayError = helper.displayError,
 			utils = helper.Utils,
 			testMessages = [
@@ -30,9 +31,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
-	exports.history_simple = function(test) {
+	restTestOnJsonMsgpack(exports, 'history_simple', function(test, rest, channelName) {
 		test.expect(2);
-		var testchannel = rest.channels.get('persisted:history_simple');
+		var testchannel = rest.channels.get('persisted:' + channelName);
 
 		/* first, send a number of events to this channel */
 
@@ -62,7 +63,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 						return;
 					}
 					/* verify all messages are received */
-		  var messages = resultPage.items;
+					var messages = resultPage.items;
 					test.equal(messages.length, testMessages.length, 'Verify correct number of messages found');
 
 					/* verify message ids are unique */
@@ -75,11 +76,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		} catch(e) {
 			console.log(e.stack);
 		}
-	};
+	});
 
-	exports.history_multiple = function(test) {
+	restTestOnJsonMsgpack(exports, 'history_multiple', function(test, rest, channelName) {
 		test.expect(2);
-		var testchannel = rest.channels.get('persisted:history_multiple');
+		var testchannel = rest.channels.get('persisted:' + channelName);
 
 		/* first, send a number of events to this channel */
 		var publishTasks = [function(publishCb) {
@@ -119,10 +120,10 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		} catch(e) {
 			console.log(e.stack);
 		}
-	};
+	});
 
-	exports.history_simple_paginated_b = function(test) {
-		var testchannel = rest.channels.get('persisted:history_simple_paginated_b');
+	restTestOnJsonMsgpack(exports, 'history_simple_paginated_b', function(test, rest, channelName) {
+		var testchannel = rest.channels.get('persisted:' + channelName);
 
 		/* first, send a number of events to this channel */
 		test.expect(5 * testMessages.length - 1);
@@ -187,7 +188,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		} catch(e) {
 			console.log(e.stack);
 		}
-	};
+	});
 
 	exports.history_simple_paginated_f = function(test) {
 		var testchannel = rest.channels.get('persisted:history_simple_paginated_f');
@@ -384,8 +385,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		}
 	};
 
-	exports.history_encoding_errors = function(test) {
-		var testchannel = rest.channels.get('persisted:history_encoding_errors');
+	restTestOnJsonMsgpack(exports, 'history_encoding_errors', function(test, rest, channelName) {
+		var testchannel = rest.channels.get('persisted:' + channelName);
 		var badMessage = {name: 'jsonUtf8string', encoding: 'json/utf-8', data: '{\"foo\":\"bar\"}'};
 		test.expect(2);
 		try {
@@ -413,7 +414,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		} catch(e) {
 			console.log(e.stack);
 		}
-	};
+	});
 
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
There were several issue with using `useBinaryProtocol: true` with rest requests in a browser environment. Main one was that the `accept` header was being set to `application/x-msgpack,application/json`, and xhrrequest was treating any accept header with `application/json` in as setting the responseType to be set to `text`, but we need to set the responseType before exec-ing the request so we can't do that on the basis of the content-type of the response, and there's no reliable way of converting a string to an ArrayBuffer. Aargh.

So this fixes that and simplifies a few areas (only setting a single value in 'accept', given we know realtime supports both; removes support for a `format` authOption (it was undocumented and pretty unlikely anyone used it); makes sure that responseType is set to 'arraybuffer' if we request msgpack (and handling it if the server responds with json, since we can convert an arraybuffer that's valid utf8 to a string easily enough), etc.). And fixes a couple other bugs, and adds a bit of test coverage for REST requests with format=msgpack.
