### PR TITLE
xhrrequest: send as POST if body is not null/undefined (even if empty string)

### DIFF
--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -96,7 +96,7 @@ var XHRRequest = (function() {
 				xhr.abort();
 			}, timeout),
 			body = this.body,
-			method = body ? 'POST' : 'GET',
+			method = Utils.isEmptyArg(body) ? 'GET' : 'POST',
 			headers = this.headers,
 			xhr = this.xhr = new XMLHttpRequest(),
 			accept = headers['accept'],

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -338,8 +338,9 @@ var Auth = (function() {
 					}
 					cb(null, body);
 				};
-				Logger.logAction(Logger.LOG_MICRO, 'Auth.requestToken().tokenRequestCallback', 'Sending; ' + authOptions.authUrl + '; Params: ' + JSON.stringify(authParams));
-				if(authOptions.authMethod && authOptions.authMethod.toLowerCase() === 'post') {
+				var usePost = authOptions.authMethod && authOptions.authMethod.toLowerCase() === 'post';
+				Logger.logAction(Logger.LOG_MICRO, 'Auth.requestToken().tokenRequestCallback', 'Requesting token from ' + authOptions.authUrl + '; Params: ' + JSON.stringify(authParams) + '; method: ' + (usePost ? 'POST' : 'GET'));
+				if(usePost) {
 					/* send body form-encoded */
 					var headers = authHeaders || {};
 					headers['content-type'] = 'application/x-www-form-urlencoded';


### PR DESCRIPTION
In particular, Utils.toQueryString (used for token requests if authMethod is POST) returns an empty string if no authParams, and we want that to use POST