### PR TITLE
Stop network error trading a token request for a token failing the connection

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -394,7 +394,7 @@ var Auth = (function() {
 
 			if(err) {
 				Logger.logAction(Logger.LOG_ERROR, 'Auth.requestToken()', 'token request signing call returned error; err = ' + Utils.inspectError(err));
-				if(!(err && err.code)) {
+				if(!err.code) {
 					/* network errors don't have an error code, so assign them
 					 * 40170 so they'll by connectionManager as nonfatal */
 					err = new ErrorInfo(Utils.inspectError(err), 40170, 401);
@@ -437,6 +437,11 @@ var Auth = (function() {
 			tokenRequest(tokenRequestOrDetails, function(err, tokenResponse, headers, unpacked) {
 				if(err) {
 					Logger.logAction(Logger.LOG_ERROR, 'Auth.requestToken()', 'token request API call returned error; err = ' + Utils.inspectError(err));
+					if(!err.code) {
+						/* network errors don't have an error code, so assign them
+						 * 40170 so they'll be seen by connectionManager as nonfatal */
+						err = new ErrorInfo(Utils.inspectError(err), 40170, 401);
+					}
 					callback(err);
 					return;
 				}


### PR DESCRIPTION
c.f. customer report at https://app.intercom.io/a/apps/ua39m1ld/respond/inbox/all/conversations/12117963267

> What's happened is that you've run into an interesting bug, because of running an auth server locally. If the library can't obtain a token request due to network conditions, it will go to disconnected , as expected. If it obtains a token but can't connect, similarly. But if it obtains a token request fine, but can't exchange that for a token, then the bug is triggered it goes into failed.

> The reason this hasn't been reported before is because it's a condition that basically only happens if you're running an auth server locally -- it production, it's never the case that a client's internet connection is down but it can still talk to the auth server.
