### PR TITLE
default to closeOnUnload unless we have some indication that a user may want to recover the connection

### DIFF
--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -73,8 +73,14 @@ Defaults.normaliseOptions = function(options) {
 	}
 
 	if(typeof options.recover === 'function' && options.closeOnUnload === true) {
-		Logger.logAction(LOG_ERROR, 'Defaults.normaliseOptions', 'closeOnUnload was true and a session recovery function was set - these are mutually exclusive, so unsetting the latter');
+		Logger.logAction(Logger.LOG_ERROR, 'Defaults.normaliseOptions', 'closeOnUnload was true and a session recovery function was set - these are mutually exclusive, so unsetting the latter');
 		options.recover = null;
+	}
+
+	if(!('closeOnUnload' in options)) {
+		/* Have closeOnUnload default to true unless we have any indication that
+		 * the user may want to recover the connection */
+		options.closeOnUnload = !options.recover;
 	}
 
 	if(options.transports && Utils.arrIn(options.transports, 'xhr')) {

--- a/spec/browser/connection.test.js
+++ b/spec/browser/connection.test.js
@@ -203,7 +203,7 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 	};
 
 	exports.page_refresh_with_manual_recovery = function(test) {
-		var realtime = helper.AblyRealtime(),
+		var realtime = helper.AblyRealtime({ closeOnUnload: false }),
 			refreshEvent = new Event('beforeunload', {'bubbles': true});
 
 		test.expect(2);

--- a/spec/rest/defaults.test.js
+++ b/spec/rest/defaults.test.js
@@ -179,5 +179,33 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.done();
 	};
 
+	exports.defaults_closeOnUnload = function(test) {
+		test.expect(6);
+		var options;
+
+		/* Default to true */
+		options = Defaults.normaliseOptions({});
+		test.equal(options.closeOnUnload, true);
+
+		/* Default to false if using manual recovery */
+		options = Defaults.normaliseOptions({recover: 'someRecoveryKey'});
+		test.equal(options.closeOnUnload, false);
+
+		/* Default to false if using autorecovery */
+		options = Defaults.normaliseOptions({recover: function(){}});
+		test.equal(options.closeOnUnload, false);
+
+		/* can override default with manual recovery */
+		options = Defaults.normaliseOptions({recover: 'someRecoveryKey', closeOnUnload: true});
+		test.equal(options.closeOnUnload, true);
+
+		/* can override default with autorecovery only at the cost of unsetting autorecovery */
+		options = Defaults.normaliseOptions({recover: function(){}, closeOnUnload: true});
+		test.equal(options.closeOnUnload, true);
+		test.ok(!options.recover);
+
+		test.done();
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/409

Bringing forward as we've had so many support tickets about this, and even though it's technically a breaking change, it's unlikely to affect anyone if we only apply it to people who don't use `recover`.