### PR TITLE
Move Webstorage to instance scope; implement in nodejs

### DIFF
--- a/browser/lib/util/nativescript-webstorage.js
+++ b/browser/lib/util/nativescript-webstorage.js
@@ -22,9 +22,12 @@ var WebStorage = (function() {
 		return wrappedValue.value;
 	}
 
-	WebStorage.set    = function(name, value, ttl) { return set(name, value, ttl); };
-	WebStorage.get    = function(name) { return get(name); };
-	WebStorage.remove = function(name) { return appSettings.remove(name); };
+	WebStorage.prototype.supportsLocal = true;
+	WebStorage.prototype.supportsSession = false;
+
+	WebStorage.prototype.set    = function(name, value, ttl) { return set(name, value, ttl); };
+	WebStorage.prototype.get    = function(name) { return get(name); };
+	WebStorage.prototype.remove = function(name) { return appSettings.remove(name); };
 
 	return WebStorage;
 })();

--- a/browser/lib/util/webstorage.js
+++ b/browser/lib/util/webstorage.js
@@ -53,16 +53,18 @@ var WebStorage = (function() {
 		return storageInterface(session).removeItem(name);
 	}
 
+	WebStorage.prototype.supportsLocal = localSupported;
 	if(localSupported) {
-		WebStorage.set    = function(name, value, ttl) { return set(name, value, ttl, false); };
-		WebStorage.get    = function(name) { return get(name, false); };
-		WebStorage.remove = function(name) { return remove(name, false); };
+		WebStorage.prototype.set    = function(name, value, ttl) { return set(name, value, ttl, false); };
+		WebStorage.prototype.get    = function(name) { return get(name, false); };
+		WebStorage.prototype.remove = function(name) { return remove(name, false); };
 	}
 
+	WebStorage.prototype.supportsSession = sessionSupported;
 	if(sessionSupported) {
-		WebStorage.setSession    = function(name, value, ttl) { return set(name, value, ttl, true); };
-		WebStorage.getSession    = function(name) { return get(name, true); };
-		WebStorage.removeSession = function(name) { return remove(name, true); };
+		WebStorage.prototype.setSession    = function(name, value, ttl) { return set(name, value, ttl, true); };
+		WebStorage.prototype.getSession    = function(name) { return get(name, true); };
+		WebStorage.prototype.removeSession = function(name) { return remove(name, true); };
 	}
 
 	return WebStorage;

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -45,6 +45,7 @@ var Rest = (function() {
 		this.serverTimeOffset = null;
 		this.auth = new Auth(this, options);
 		this.channels = new Channels(this);
+		this.storage = new WebStorage(this);
 	}
 
 	Rest.prototype.stats = function(params, callback) {

--- a/nodejs/lib/util/webstorage.js
+++ b/nodejs/lib/util/webstorage.js
@@ -1,0 +1,109 @@
+"use strict";
+var WebStorage = (function() {
+	var path = require('path');
+	var os = require('os');
+	var mkdirs = require('node-mkdirs');
+	var JSONStorage = require('node-localstorage').JSONStorage;
+
+	function storedItem(value, ttl) {
+		var item = {
+			value: value
+		};
+		if(ttl) {
+			item.expires = (Date.now() + ttl);
+		}
+		return item;
+	}
+
+	function valid(item) {
+		var expires = item.expires;
+		return !expires || (Date.now() < expires);
+	}
+
+	function WebStorage(client) {
+		this.client = client;
+		this.storagePath = null;
+		this.localStorage = null;
+		this.sessionStorage = new Map();
+	}
+
+	WebStorage.prototype.supportsLocal = true;
+	WebStorage.prototype.supportsSession = true;
+
+	WebStorage.prototype.initPath = function() {
+		var storagePath = this.storagePath;
+		if(!storagePath) {
+			var options = this.client.options, appId;
+			if(options.key) {
+				appId = options.key.split('.')[0];
+			} else {
+				var authOptions = this.client.auth.authOptions,
+					token = authOptions.tokenDetails.token;
+				if(!token) {
+					throw new Error('Unable to initialise WebStorage; no key or token available');
+				}
+				appId = token.split('.')[0];
+			}
+			storagePath = this.storagePath = path.resolve(os.homedir(), '.ably-js/localStorage', appId);
+		}
+		return storagePath;
+	};
+
+	WebStorage.prototype.init = function() {
+		var localStorage = this.localStorage;
+		if(!localStorage) {
+			var storagePath = this.initPath();
+			mkdirs(storagePath);
+			console.log('**** storage path: ' + storagePath);
+			localStorage = this.localStorage = new JSONStorage(storagePath);
+		}
+		return localStorage;
+	};
+
+	WebStorage.prototype.set = function(name, value, ttl) {
+		this.init().setItem(name, storedItem(value, ttl));
+	};
+
+	WebStorage.prototype.get = function(name) {
+		var localStorage = this.localStorage;
+		if(localStorage) {
+			var storedItem = localStorage.getItem(name);
+			if(storedItem) {
+				if(valid(storedItem)) {
+					return storedItem.value;
+				}
+				localStorage.removeItem(name);
+			}
+		}
+		return null;
+	};
+
+	WebStorage.prototype.remove = function(name) {
+		var localStorage = this.localStorage;
+		if(localStorage) {
+			localStorage.removeItem(name);
+		}
+	};
+
+	WebStorage.prototype.setSession = function(name, value, ttl) {
+		this.sessionStorage.set(name, storedItem(value, ttl));
+	};
+
+	WebStorage.prototype.getSession = function(name) {
+		var sessionStorage = this.sessionStorage;
+		var storedItem = sessionStorage.get(name);
+		if(storedItem) {
+			if(valid(storedItem)) {
+				return storedItem.value;
+			}
+			sessionStorage.delete(name);
+		}
+		return null;
+	};
+
+	WebStorage.prototype.removeSession = function(name) {
+		this.sessionStorage.delete(name);
+	};
+
+	return WebStorage;
+})();

--- a/nodejs/realtime.js
+++ b/nodejs/realtime.js
@@ -25,6 +25,7 @@ includeScript('./platform.js');
 includeScript('./lib/util/defaults.js');
 includeScript('./lib/util/bufferutils.js');
 includeScript('./lib/util/http.js');
+includeScript('./lib/util/webstorage.js');
 includeScript('../common/lib/util/defaults.js');
 includeScript('../common/lib/util/eventemitter.js');
 includeScript('../common/lib/util/logger.js');

--- a/nodejs/rest.js
+++ b/nodejs/rest.js
@@ -25,6 +25,7 @@ includeScript('./platform.js');
 includeScript('./lib/util/defaults.js');
 includeScript('./lib/util/bufferutils.js');
 includeScript('./lib/util/http.js');
+includeScript('./lib/util/webstorage.js');
 includeScript('../common/lib/util/defaults.js');
 includeScript('../common/lib/util/eventemitter.js');
 includeScript('../common/lib/util/logger.js');

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "msgpack-js": "git://github.com/ably-forks/msgpack-js",
+    "node-localstorage": "^1.3.0",
+    "node-mkdirs": "0.0.1",
     "request": "^2.74.0",
     "ws": "^1.1.1"
   },

--- a/spec/all.js
+++ b/spec/all.js
@@ -20,6 +20,7 @@ function findAll(dir, pattern) {
 	return result;
 }
 
+exports.util = findAll('util', /(\w+)\.test\.js/);
 exports.rest = findAll('rest', /(\w+)\.test\.js/);
 exports.realtime = findAll('realtime', /(\w+)\.test\.js/);
 

--- a/spec/util/webstorage.test.js
+++ b/spec/util/webstorage.test.js
@@ -1,0 +1,51 @@
+"use strict";
+
+function randomString() { return String(Math.random()).slice(2); }
+
+define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
+	var rest, exports = {},
+		utils = helper.Utils;
+
+	exports.setup_storage = function(test) {
+		helper.setupApp(function() {
+			rest = helper.AblyRest();
+			test.done();
+		});
+	};
+
+	/*
+	 * Session storage
+	 */
+	exports.session_storage = function(test) {
+		var webStorage = rest.storage,
+			testKey = randomString(),
+			testValue = {a: randomString()};
+
+		test.equal(webStorage.getSession(testKey), null, 'Verify value initially not present');
+		webStorage.setSession(testKey, testValue);
+		test.deepEqual(webStorage.getSession(testKey), testValue, 'Verify value present');
+		webStorage.removeSession(testKey);
+		test.equal(webStorage.getSession(testKey), null, 'Verify value removed');
+		test.done();
+	};
+
+	/*
+	 * Local storage
+	 */
+	exports.local_storage = function(test) {
+		var webStorage = rest.storage,
+			testKey = randomString(),
+			testValue = {a: randomString()};
+
+		test.equal(webStorage.get(testKey), null, 'Verify value initially not present');
+		webStorage.set(testKey, testValue);
+		console.log('*** testValue: ' + require('util').inspect(testValue));
+		console.log('*** got: ' + require('util').inspect(webStorage.get(testKey)));
+		test.deepEqual(webStorage.get(testKey), testValue, 'Verify value present');
+		webStorage.remove(testKey);
+		test.equal(webStorage.get(testKey), null, 'Verify value removed');
+		test.done();
+	};
+
+	return module.exports = helper.withTimeout(exports);
+});


### PR DESCRIPTION
We need persistent storage for push of a deviceId and other credentials; currently this is only available for the browser. Our support push for nodejs will only be for testing purposes, but we do want it to be functional, and so we require storage.

This PR adds persistent storage for nodejs by persisting to a file whose name is derived from the `keyName` so that stored data survives between sessions, but realistic development use-cases do not give rise to conflicts between persisted data for different apps.

This in turn means that the `WebStorage` functionality needs to be initialised on a per-instance basis and cannot simply be static as before.