### PR TITLE
Fix sync connection serial in the event of a failed upgrade

### DIFF
--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -332,7 +332,7 @@ var ConnectionManager = (function() {
 	 * @param transport, the transport instance
 	 * @param connectionKey
 	 */
-	ConnectionManager.prototype.scheduleTransportActivation = function(error, transport, connectionKey, preUpgradeConnectionSerial, connectionId, connectionDetails) {
+	ConnectionManager.prototype.scheduleTransportActivation = function(error, transport, connectionKey, preSyncConnectionSerial, connectionId, connectionDetails) {
 		var self = this,
 			currentTransport = this.activeProtocol && this.activeProtocol.getTransport(),
 			abandon = function() {
@@ -387,7 +387,7 @@ var ConnectionManager = (function() {
 			* be a sync with the new connectionSerial (which will be -1). (And it
 			* needs to be set in the library, which is done by activateTransport). */
 			var connectionReset = connectionId !== self.connectionId,
-				syncConnectionSerial = connectionReset ? preUpgradeConnectionSerial : self.connectionSerial;
+				syncConnectionSerial = connectionReset ? preSyncConnectionSerial : self.connectionSerial;
 
 			if(connectionReset) {
 				Logger.logAction(Logger.LOG_ERROR, 'ConnectionManager.scheduleTransportActivation()', 'Upgrade resulted in new connectionId; resetting library connectionSerial from ' + self.connectionSerial + ' to ' + newConnectionSerial + '; upgrade error was ' + error);


### PR DESCRIPTION
And rename various connectionSerial variables for clarity

(context from slack: "when it was first written, that code was correct, because at the time, we activated the new transport before syncing, so the first newConnectionSerial was passed to activeTransport and served its purpose. Later on in an unrelated change (https://github.com/ably/realtime/issues/522), to address a race condition, we switched the order of those and started syncing first, but I clearly failed to notice that the logic for when the upgrade failed needed to be updated too")