### PR TITLE
Fix IE10 crypto

### DIFF
--- a/browser/fragments/platform-browser.js
+++ b/browser/fragments/platform-browser.js
@@ -21,10 +21,12 @@ var Platform = {
 	addEventListener: window.addEventListener,
 	inspect: JSON.stringify,
 	getRandomValues: (function(crypto) {
+		if (crypto === undefined) {
+			return undefined;
+		}
 		return function(arr, callback) {
 			crypto.getRandomValues(arr);
 			callback(null);
 		};
 	})(window.crypto || window.msCrypto) // mscrypto for IE11
 };
-

--- a/browser/lib/util/crypto.js
+++ b/browser/lib/util/crypto.js
@@ -14,7 +14,7 @@ var Crypto = (function() {
 	 * @param callback
 	 */
 	var generateRandom;
-	if(typeof Uint32Array !== 'undefined' && Platform.getRandomValues && window.crypto) {
+	if(typeof Uint32Array !== 'undefined' && Platform.getRandomValues) {
 		var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
 		generateRandom = function(bytes, callback) {
 			var words = bytes / 4, nativeArray = (words == DEFAULT_BLOCKLENGTH_WORDS) ? blockRandomArray : new Uint32Array(words);

--- a/browser/lib/util/crypto.js
+++ b/browser/lib/util/crypto.js
@@ -14,7 +14,7 @@ var Crypto = (function() {
 	 * @param callback
 	 */
 	var generateRandom;
-	if(typeof Uint32Array !== 'undefined' && Platform.getRandomValues) {
+	if(typeof Uint32Array !== 'undefined' && Platform.getRandomValues && window.crypto) {
 		var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
 		generateRandom = function(bytes, callback) {
 			var words = bytes / 4, nativeArray = (words == DEFAULT_BLOCKLENGTH_WORDS) ? blockRandomArray : new Uint32Array(words);

--- a/spec/common/modules/testapp_manager.js
+++ b/spec/common/modules/testapp_manager.js
@@ -75,8 +75,7 @@ define(['globals', 'browser-base64', 'ably'], function(ablyGlobals, base64, ably
 					content: options.body
 				}).then(function (results) {
 					callback(null, results.content.toString());
-				})
-				['catch'](function(err) {
+				})['catch'](function(err) {
 					callback(err);
 				});
 			};

--- a/spec/common/modules/testapp_manager.js
+++ b/spec/common/modules/testapp_manager.js
@@ -76,7 +76,7 @@ define(['globals', 'browser-base64', 'ably'], function(ablyGlobals, base64, ably
 				}).then(function (results) {
 					callback(null, results.content.toString());
 				})
-				.catch(function(err) {
+				['catch'](function(err) {
 					callback(err);
 				});
 			};


### PR DESCRIPTION
In particular this makes the following tests pass also on IE10:

```
2.generateRandomKey0 (2, 0, 2)
3.generateRandomKey1 (2, 0, 2)
4.getDefaultParams_wordArray_key (2, 0, 2)
5.getDefaultParams_base64_key (2, 0, 2)
6.getDefaultParams_check_keylength (2, 0, 2)
7.getDefaultParams_preserves_custom_algorithms (2, 0, 2)
15.single_send_128_with_web_socket_binary_transport (2, 0, 2)
16.single_send_128_with_web_socket_text_transport (2, 0, 2)
17.single_send_128_with_xhr_streaming_binary_transport (2, 0, 2)
18.single_send_128_with_xhr_streaming_text_transport (2, 0, 2)
19.single_send_128_with_xhr_polling_binary_transport (2, 0, 2)
20.single_send_128_with_xhr_polling_text_transport (2, 0, 2)
21.single_send_128_with_binary_transport (2, 0, 2)
22.single_send_128_with_text_transport (2, 0, 2)
23.single_send_256_with_web_socket_binary_transport (2, 0, 2)
24.single_send_256_with_web_socket_text_transport (2, 0, 2)
25.single_send_256_with_xhr_streaming_binary_transport (2, 0, 2)
26.single_send_256_with_xhr_streaming_text_transport (2, 0, 2)
27.single_send_256_with_xhr_polling_binary_transport (2, 0, 2)
28.single_send_256_with_xhr_polling_text_transport (2, 0, 2)
29.single_send_256_with_binary_transport (2, 0, 2)
30.single_send_256_with_text_transport (2, 0, 2)
31.multiple_send_binary_2_200 (2, 0, 2)
32.multiple_send_text_2_200 (2, 0, 2)
33.multiple_send_binary_20_100 (2, 0, 2)
```