### PR TITLE
Rest.request: handle msgpack and errors with contentful bodies

### DIFF
--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -211,7 +211,7 @@ var XHRRequest = (function() {
 			if(!err) {
 				err = new ErrorInfo('Error response received from server: ' + statusCode + ' body was: ' + Utils.inspect(responseBody), null, statusCode);
 			}
-			self.complete(err);
+			self.complete(err, responseBody, headers, unpacked, statusCode);
 		}
 
 		function onProgress() {

--- a/common/lib/client/resource.js
+++ b/common/lib/client/resource.js
@@ -23,7 +23,7 @@ var Resource = (function() {
 
 	function unenvelope(callback, format) {
 		return function(err, body, headers, unpacked, statusCode) {
-			if(err) {
+			if(err && !body) {
 				callback(err);
 				return;
 			}
@@ -49,16 +49,16 @@ var Resource = (function() {
 
 			if(statusCode < 200 || statusCode >= 300) {
 				/* handle wrapped errors */
-				var err = response && response.error;
+				var wrappedErr = (response && response.error) || err;
 				if(!err) {
 					err = new Error(String(res));
 					err.statusCode = statusCode;
 				}
-				callback(err);
+				callback(wrappedErr, response, headers, true, statusCode);
 				return;
 			}
 
-			callback(null, response, headers, true, statusCode);
+			callback(err, response, headers, true, statusCode);
 		};
 	}
 

--- a/nodejs/lib/util/http.js
+++ b/nodejs/lib/util/http.js
@@ -1,6 +1,7 @@
 "use strict";
 this.Http = (function() {
 	var request = require('request');
+	var msgpack = Platform.msgpack;
 	var noop = function() {};
 
 	/***************************************************
@@ -26,7 +27,13 @@ this.Http = (function() {
 			}
 			var statusCode = response.statusCode, headers = response.headers;
 			if(statusCode >= 300) {
-				if(headers['content-type'] == 'application/json') body = JSON.parse(body);
+				switch(headers['content-type']) {
+					case 'application/json':
+						body = JSON.parse(body);
+						break;
+					case 'application/x-msgpack':
+						body = msgpack.decode(body);
+				}
 				var error = body.error || {
 					statusCode: statusCode,
 					code: headers['x-ably-errorcode'],

--- a/spec/realtime/encoding.test.js
+++ b/spec/realtime/encoding.test.js
@@ -97,7 +97,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				return;
 			}
 			test.expect(testData.messages.length * 5);
-			var realtime = helper.AblyRealtime(),
+			var realtime = helper.AblyRealtime({useBinaryProtocol: false}),
 				binaryrealtime = helper.AblyRealtime({useBinaryProtocol: true}),
 				channelName = 'message_encoding',
 				channelPath = '/channels/' + channelName + '/messages',

--- a/spec/rest/request.test.js
+++ b/spec/rest/request.test.js
@@ -4,7 +4,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	var rest,
 		exports = {},
 		_exports = {},
-		utils = helper.Utils;
+		utils = helper.Utils,
+		restTestOnJsonMsgpack = helper.restTestOnJsonMsgpack;
 
 	exports.setuptime = function(test) {
 		test.expect(1);
@@ -21,8 +22,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
-	exports.request_time = function(test) {
-		test.expect(5);
+	restTestOnJsonMsgpack(exports, 'request_time', function(test, rest) {
 		rest.request('get', '/time', null, null, null, function(err, res) {
 			test.ok(!err, err && helper.displayError(err));
 			test.equal(res.statusCode, 200, 'Check statusCode');
@@ -31,25 +31,50 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			test.equal(res.items.length, 1, 'Check array was of length 1');
 			test.done();
 		});
-	};
+	});
 
-	exports.request_404 = function(test) {
-		test.expect(2);
+	restTestOnJsonMsgpack(exports, 'request_404', function(test, rest) {
 		/* NB: can't just use /invalid or something as the CORS preflight will
 		 * fail. Need something superficially a valid path but where the actual
 		 * request fails */
 		rest.request('get', '/keys/ablyjs.test/requestToken', null, null, null, function(err, res) {
-			test.equal(err.statusCode, 404, 'Check statusCode');
-			test.equal(err.code, 40400, 'Check code');
+			test.equal(err, null, 'Check that we do not get an error response for a failure that returns an actual ably error code');
+			test.equal(res.success, false, 'Check res.success is false for a failure');
+			test.equal(res.statusCode, 404, 'Check HPR.statusCode is 404');
+			test.equal(res.errorCode, 40400, 'Check HPR.errorCode is 40400');
+			test.ok(res.errorMessage, 'Check have an HPR.errorMessage');
+			test.done();
+		});
+	});
+
+	restTestOnJsonMsgpack(exports, 'request_404', function(test, rest) {
+		/* NB: can't just use /invalid or something as the CORS preflight will
+		 * fail. Need something superficially a valid path but where the actual
+		 * request fails */
+		rest.request('get', '/keys/ablyjs.test/requestToken', null, null, null, function(err, res) {
+			test.equal(err, null, 'Check that we do not get an error response for a failure that returns an actual ably error code');
+			test.equal(res.success, false, 'Check res.success is false for a failure');
+			test.equal(res.statusCode, 404, 'Check HPR.statusCode is 404');
+			test.equal(res.errorCode, 40400, 'Check HPR.errorCode is 40400');
+			test.ok(res.errorMessage, 'Check have an HPR.errorMessage');
+			test.done();
+		});
+	});
+
+	/* With a network issue, should get an actual err, not an HttpPaginatedResponse with error members */
+	exports.request_network_error = function(test) {
+		rest = helper.AblyRest({restHost: helper.unroutableAddress})
+		rest.request('get', '/time', null, null, null, function(err, res) {
+			test.ok(err, 'Check get an err');
+			test.ok(!res, 'Check do not get a res');
 			test.done();
 		});
 	};
 
 	/* Use the request feature to publish, then retrieve (one at a time), some messages */
-	exports.request_post_get_messages = function(test) {
+	restTestOnJsonMsgpack(exports, 'request_post_get_messages', function(test, rest, channelName) {
 		test.expect(23);
-		var channelName = 'request_post_get_messages',
-			channelPath = '/channels/' + channelName + '/messages',
+		var channelPath = '/channels/' + channelName + '/messages',
 			msgone = {name: 'faye', data: 'whittaker'},
 			msgtwo = {name: 'martin', data: 'reed'};
 
@@ -106,7 +131,48 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		], function() {
 			test.done();
 		})
-	}
+	});
+
+	restTestOnJsonMsgpack(exports, 'request_batch_api_success', function(test, rest, name) {
+		var body = {channels: [name + '1', name + '2'], messages: {data: 'foo'}};
+
+		rest.request("POST", "/messages", {}, body, {}, function(err, res) {
+			test.equal(err, null, 'Check that we do not get an error response for a success');
+			test.equal(res.success, true, 'Check res.success is true for a success');
+			test.equal(res.statusCode, 201, 'Check res.statusCode is 201 for a success');
+			test.equal(res.errorCode, null, 'Check res.errorCode is null for a success');
+			test.equal(res.errorMessage, null, 'Check res.errorMessage is null for a success');
+
+			test.ok(!res.items[0].batchResponse, 'Check no batchResponse, since items is now just a flat array of channel responses');
+			test.equal(res.items.length, 2, 'Verify batched response includes response for each channel');
+			test.ok(!res.items[0].error, 'Verify channel1 response is not an error');
+			test.equal(res.items[0].channel, name + '1', 'Verify channel1 response includes correct channel');
+			test.ok(!res.items[1].error, 'Verify channel2 response is not an error');
+			test.equal(res.items[1].channel, name + '2', 'Verify channel2 response includes correct channel');
+			test.done();
+		});
+	});
+
+	restTestOnJsonMsgpack(exports, 'request_batch_api_partial_success', function(test, rest, name) {
+		var body = {channels: [name, '[invalid', ''], messages: {data: 'foo'}};
+
+		rest.request("POST", "/messages", {}, body, {}, function(err, res) {
+			test.equal(err, null, 'Check that we do not get an error response for a partial success');
+			test.equal(res.success, false, 'Check res.success is false for a partial failure');
+			test.equal(res.statusCode, 400, 'Check HPR.statusCode is 400 for a partial failure');
+			test.equal(res.errorCode, 40020, 'Check HPR.errorCode is 40020 for a partial failure');
+			test.ok(res.errorMessage, 'Check have an HPR.errorMessage');
+
+			var response = res.items[0];
+			test.equal(response.error.code, 40020, 'Verify response has an errorCode');
+			test.equal(response.batchResponse.length, 3, 'Verify batched response includes response for each channel');
+			test.equal(response.batchResponse[0].channel, name, 'Verify channel1 response includes correct channel');
+			test.ok(!response.batchResponse[0].error, 'Verify first channel response is not an error');
+			test.equal(response.batchResponse[1].error.code, 40010, 'Verify [invalid response includes an error with the right code');
+			test.equal(response.batchResponse[2].error.code, 40010, 'Verify empty channel response includes an error with the right code');
+			test.done();
+		});
+	});
 
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
Fixes a bunch of bugs I found while looking into rest.request and batch publishing today, and brings HttpPaginatedResponse in line with the spec, so we now return an HPR instead of an error for any actual response from Ably (ie anything except network errors etc).

Tests rely on https://github.com/ably/realtime/pull/1607 and https://github.com/ably/realtime/pull/1609 , so won't pass on sandbox for the moment until those are deployed there.