### PR TITLE
Avoid xhr with local files on chrome 65+

### DIFF
--- a/browser/fragments/platform-browser.js
+++ b/browser/fragments/platform-browser.js
@@ -2,13 +2,22 @@ if(typeof window !== 'object') {
 	console.log("Warning: this distribution of Ably is intended for browsers. On nodejs, please use the 'ably' package on npm");
 }
 
+function allowComet() {
+	/* xhr requests from local files are unreliable in some browsers, such as Chrome 65 and higher -- see eg
+	 * https://stackoverflow.com/questions/49256429/chrome-65-unable-to-make-post-requests-from-local-files-to-flask
+	 * So if websockets are supported, then just forget about comet transports and use that */
+	var loc = window.location;
+	return (!window.WebSocket || !loc || !loc.origin || loc.origin.indexOf("http") > -1);
+}
+
 var Platform = {
 	libver: 'js-web-',
 	logTimestamps: true,
 	noUpgrade: navigator && navigator.userAgent.toString().match(/MSIE\s8\.0/),
 	binaryType: 'arraybuffer',
 	WebSocket: window.WebSocket || window.MozWebSocket,
-	xhrSupported: (window.XMLHttpRequest && 'withCredentials' in new XMLHttpRequest()),
+	xhrSupported: (window.XMLHttpRequest && 'withCredentials' in new XMLHttpRequest() && allowComet()),
+	jsonpSupported: (typeof(document) !== 'undefined') && allowComet(),
 	streamingSupported: true,
 	useProtocolHeartbeats: true,
 	createHmac: null,

--- a/browser/fragments/platform-nativescript.js
+++ b/browser/fragments/platform-nativescript.js
@@ -23,6 +23,7 @@ var Platform = {
 	binaryType: 'arraybuffer',
 	WebSocket: WebSocket,
 	xhrSupported: XMLHttpRequest,
+	jsonpSupported: false,
 	streamingSupported: false,
 	useProtocolHeartbeats: true,
 	createHmac: null,

--- a/browser/fragments/platform-reactnative.js
+++ b/browser/fragments/platform-reactnative.js
@@ -5,6 +5,7 @@ var Platform = {
 	binaryType: 'arraybuffer',
 	WebSocket: WebSocket,
 	xhrSupported: XMLHttpRequest,
+	jsonpSupported: false,
 	streamingSupported: true,
 	useProtocolHeartbeats: true,
 	createHmac: null,

--- a/browser/lib/transport/jsonptransport.js
+++ b/browser/lib/transport/jsonptransport.js
@@ -10,8 +10,7 @@ var JSONPTransport = (function() {
 	 */
 	_._ = function(id) { return _['_' + id] || noop; };
 	var idCounter = 1;
-	var isSupported = (typeof(document) !== 'undefined');
-	var head = isSupported ? document.getElementsByTagName('head')[0] : null;
+	var head = null;
 	var shortName = 'jsonp';
 
 	/* public constructor */
@@ -22,9 +21,12 @@ var JSONPTransport = (function() {
 	}
 	Utils.inherits(JSONPTransport, CometTransport);
 
-	JSONPTransport.isAvailable = function() { return isSupported; };
-	if(isSupported) {
+	JSONPTransport.isAvailable = function() {
+		return Platform.jsonpSupported;
+	};
+	if(Platform.jsonpSupported) {
 		ConnectionManager.supportedTransports[shortName] = JSONPTransport;
+		head = document.getElementsByTagName('head')[0];
 	}
 
 	/* connectivity check; since this has a hard-coded callback id,


### PR DESCRIPTION
Fixes the problem @tomczoink reported with CORS errors when using a local file in chrome 65+. (See e.g. https://stackoverflow.com/questions/49256429/chrome-65-unable-to-make-post-requests-from-local-files-to-flask or https://stackoverflow.com/questions/49336294/read-write-error-with-cloud-firestore-the-access-control-allow-origin-header ).

The effect of this is currently to make the base transport jsonp. (Half-wondering about just getting rid of jsonp in this case and make websockets the only transport, any opinions on that?)