### PR TITLE
Add JWT tests

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -333,9 +333,9 @@ var Auth = (function() {
 						return;
 					}
 					var json = contentType.indexOf('application/json') > -1,
-						text = contentType.indexOf('text/plain') > -1;
+						text = contentType.indexOf('text/plain') > -1 || contentType.indexOf('application/jwt') > -1;
 					if(!json && !text) {
-						cb(new ErrorInfo('authUrl responded with unacceptable content-type ' + contentType + ', should be either text/plain or application/json', 40170, 401));
+						cb(new ErrorInfo('authUrl responded with unacceptable content-type ' + contentType + ', should be either text/plain, application/jwt or application/json', 40170, 401));
 						return;
 					}
 					if(json) {

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -933,7 +933,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Request a JWT token that is about to expire, check that the client disconnects
 	 * and receives the expected reason in the state change.
 	 */
-
 	exports.auth_jwt_with_token_that_expires = function(test) {
 		test.expect(2);
 		var currentKey = helper.getTestApp().keys[0];
@@ -966,7 +965,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Request a JWT token that is about to be renewed, check that the client reauths
 	 * without going through a disconnected state.
 	 */
-
 	exports.auth_jwt_with_token_that_renews = function(test) {
 		test.expect(1);
 		var currentKey = helper.getTestApp().keys[0];

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -9,8 +9,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		monitorConnection = helper.monitorConnection,
 		testOnAllTransports = helper.testOnAllTransports,
 		mixin = helper.Utils.mixin,
+		http = Ably.Rest.Http,
 		jwtTestChannelName = 'JWT_test' + String(Math.floor(Math.random() * 10000) + 1),
-		echoServer = "http://echo.ably.io";
+		echoServer = "https://echo.ably.io";
 
 	exports.setupauth = function(test) {
 		test.expect(1);
@@ -826,20 +827,20 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * has the requested clientId.
 	 */
 	exports.auth_jwt_with_clientid = function(test) {
-		test.expect(1);
+		test.expect(2);
 		var currentKey = helper.getTestApp().keys[0];
 		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret};
-		var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
-		var rest = helper.AblyRest({authUrl: authUrl});
 		var clientId = 'testJWTClientId';
+		var authUrl = echoServer + '/createJWT' + utils.toQueryString(mixin(keys, {clientId: clientId}));
 		var authCallback = function(tokenParams, callback) {
-			rest.auth.requestToken({clientId: clientId}, function(err, tokenDetails) {
+			http.getUri(null, authUrl, null, null, function(err, body, headers) {
 				if(err) {
 					test.ok(false, displayError(err));
 					test.done();
 					return;
 				}
-				callback(null, tokenDetails.token);
+				test.equal(headers['content-type'], 'text/plain; charset=utf-8');
+				callback(null, body.toString());
 			});
 		};
 

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -17,8 +17,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	 * Helper function to fetch JWT tokens from the echo server
 	 */
 	function getJWT(params, callback) {
-		var authUrl = echoServer + '/createJWT' + utils.toQueryString(params);
-		http.getUri(null, authUrl, null, null, function(err, body) {
+		var authUrl = echoServer + '/createJWT'
+		http.getUri(null, authUrl, null, params, function(err, body) {
 			if(err) {
 				callback(err, null);
 			}

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -867,6 +867,37 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	};
 
 	/*
+	 * Request a token specifying a clientId and verify that the returned token
+	 * has the requested clientId. Token will be returned with content-type application/jwt.
+	 */
+	exports.auth_jwt_with_clientid_application_jwt = function(test) {
+		test.expect(1);
+		var currentKey = helper.getTestApp().keys[0];
+		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret, returnType: 'jwt'};
+		var clientId = 'testJWTClientId';
+		var params = mixin(keys, {clientId: clientId});
+		var authCallback = function(tokenParams, callback) {
+			getJWT(params, callback);
+		};
+
+		var realtime = helper.AblyRealtime({ authCallback: authCallback });
+
+		realtime.connection.on('connected', function() {
+			test.equal(realtime.auth.clientId, clientId);
+			realtime.connection.close();
+			test.done();
+			return;
+		});
+
+		realtime.connection.on('failed', function(err) {
+			realtime.close();
+			test.ok(false, "Failed: " + displayError(err));
+			test.done();
+			return;
+		});
+	};
+
+	/*
 	 * Request a token specifying subscribe-only capabilities and verify that posting
 	 * to a channel fails.
 	 */

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -10,9 +10,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		testOnAllTransports = helper.testOnAllTransports,
 		mixin = helper.Utils.mixin,
 		jwtTestChannelName = 'JWT_test' + String(Math.floor(Math.random() * 10000) + 1),
-		echoServer = "http://echo.ably.io",
+		echoServer = "http://echo.ably.io";
 		//echoServer = "http://localhost:5000";
-		jwtServer = 'https://ably-echoserver-staging.herokuapp.com'; // TODO: change this. Will become echoServer once deployed to echo.ably.io
 
 	exports.setupauth = function(test) {
 		test.expect(1);
@@ -831,7 +830,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		test.expect(1);
 		var currentKey = helper.getTestApp().keys[0];
 		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret};
-		var authUrl = jwtServer + '/createJWT' + utils.toQueryString(keys);
+		var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
 		var rest = helper.AblyRest({authUrl: authUrl});
 		var clientId = 'testJWTClientId';
 		var authCallback = function(tokenParams, callback) {
@@ -870,7 +869,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		test.expect(3);
 		var currentKey = helper.getTestApp().keys[3]; // get subscribe-only keys { "*":["subscribe"] }
 		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret};
-		var authUrl = jwtServer + '/createJWT' + utils.toQueryString(keys);
+		var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
 		var rest = helper.AblyRest({authUrl: authUrl});
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.requestToken(function(err, tokenDetails) {
@@ -904,7 +903,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		test.expect(1);
 		var currentKey = helper.getTestApp().keys[0];
 		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret};
-		var authUrl = jwtServer + '/createJWT' + utils.toQueryString(keys);
+		var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
 		var rest = helper.AblyRest({authUrl: authUrl});
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.requestToken(function(err, tokenDetails) {
@@ -940,7 +939,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		test.expect(2);
 		var currentKey = helper.getTestApp().keys[0];
 		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret, expiresIn: 5};
-		var authUrl = jwtServer + '/createJWT' + utils.toQueryString(keys);
+		var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
 		var rest = helper.AblyRest({authUrl: authUrl});
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.requestToken(function(err, tokenDetails) {
@@ -975,7 +974,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		// Sandbox sends an auth procolo message 30 seconds before a token expires.
 		// We create a token that lasts 35 so there's room to receive the update event message.
 		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret, expiresIn: 35};
-		var authUrl = jwtServer + '/createJWT' + utils.toQueryString(keys);
+		var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
 		var rest = helper.AblyRest({authUrl: authUrl});
 		var authCallback = function(tokenParams, callback) {
 			rest.auth.requestToken(function(err, tokenDetails) {

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -11,7 +11,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		mixin = helper.Utils.mixin,
 		jwtTestChannelName = 'JWT_test' + String(Math.floor(Math.random() * 10000) + 1),
 		echoServer = "http://echo.ably.io";
-		//echoServer = "http://localhost:5000";
 
 	exports.setupauth = function(test) {
 		test.expect(1);

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -896,7 +896,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
-	/*
+	/* RSA8c
 	 * Request a token with publish capabilities and verify that posting
 	 * to a channel succeeds.
 	 */
@@ -964,7 +964,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
-	/*
+	/* RTC8a4
 	 * Request a JWT token that is about to be renewed, check that the client reauths
 	 * without going through a disconnected state.
 	 */

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -996,5 +996,27 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
+	/* RSC1
+	 * Request a JWT token, initialize a realtime client with it and
+	 * verify it can make authenticated calls.
+	 */
+	exports.init_client_with_simple_jwt_tokem = function(test) {
+		var currentKey = helper.getTestApp().keys[0];
+		var params = {keyName: currentKey.keyName, keySecret: currentKey.keySecret};
+		getJWT(params, function(err, token) {
+			if(err) {
+				test.ok(false, displayError(err));
+				test.done();
+				return;
+			}
+			var realtime = helper.AblyRealtime({ token: token });
+			realtime.connection.once('connected', function() {
+				test.strictEqual(token, realtime.auth.tokenDetails.token, 'Verify that token is the same');
+				realtime.connection.close();
+				test.done();
+			});
+		});
+	};
+
 	return module.exports = helper.withTimeout(exports);
 });

--- a/spec/rest/auth.test.js
+++ b/spec/rest/auth.test.js
@@ -573,7 +573,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	/* RSC1, RSC1a, RSC1c, RSA4f, RSA8c, RSA3d
 	 * Tests the different combinations of authParams declared above, with valid keys
 	 */
-
 	testJWTAuthParams(exports, 'rest_jwt', function(params) { return function(test) {
 		test.expect(1);
 		var currentKey = helper.getTestApp().keys[0];
@@ -629,7 +628,6 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	/* RSA8g
 	 * Tests JWT with authCallback
 	 */
-
 	exports.rest_jwt_with_authCallback = function(test) {
 		test.expect(2);
 		var currentKey = helper.getTestApp().keys[0];
@@ -661,10 +659,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
-		/* RSA8g
+	/* RSA8g
 	 * Tests JWT with authCallback and invalid keys
 	 */
-
 	exports.rest_jwt_with_authCallback_and_invalid_keys = function(test) {
 		test.expect(3);
 		var keys = {keyName: 'invalid.invalid', keySecret: 'invalidinvalid'};

--- a/spec/rest/auth.test.js
+++ b/spec/rest/auth.test.js
@@ -3,7 +3,7 @@
 define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	var currentTime, rest, exports = {},
 		utils = helper.Utils,
-		echoServer = 'https://ably-echoserver-staging.herokuapp.com'; // TODO: change this. Will be echo.ably.io
+		echoServer = 'https://echo.ably.io';
 
 	var getServerTime = function(callback) {
 		rest.time(function(err, time) {

--- a/spec/rest/auth.test.js
+++ b/spec/rest/auth.test.js
@@ -570,7 +570,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	}
 
-	/*
+	/* RSC1, RSC1a, RSC1c, RSA4f, RSA8c, RSA3d
 	 * Tests the different combinations of authParams declared above, with valid keys
 	 */
 
@@ -626,7 +626,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
-	/*
+	/* RSA8g
 	 * Tests JWT with authCallback
 	 */
 
@@ -661,7 +661,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
-		/*
+		/* RSA8g
 	 * Tests JWT with authCallback and invalid keys
 	 */
 

--- a/spec/rest/auth.test.js
+++ b/spec/rest/auth.test.js
@@ -573,9 +573,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	testJWTAuthParams(exports, 'rest_jwt', function(params) { return function(test) {
 		test.expect(1);
 		var currentKey = helper.getTestApp().keys[0];
-		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret}
+		var keys = {keyName: currentKey.keyName, keySecret: currentKey.keySecret};
 		var authParams = utils.mixin(keys, params);
-		var authUrl = echoServer + '/createJWT' + utils.toQueryString(authParams);;
+		var authUrl = echoServer + '/createJWT' + utils.toQueryString(authParams);
 		var restJWTRequester = helper.AblyRest({authUrl: authUrl});
 
 		restJWTRequester.auth.requestToken(function(err, tokenDetails) {


### PR DESCRIPTION
Fix https://github.com/ably/ably-js/issues/505

- [X] Add tests that use `ClientOptions`
- [X] Add tests that use `authURL`
- [X] Add tests that use `authCallback`
- [X] Add tests with JWT wrapping an Ably native token `x-ably-token`
- [X] Add tests with encrypted token
- [X] Add example when token is returned with `application/jwt` Content-Type
- [X] Add tests with JWT that includes client_id
- [X] Add tests with JWT that includes publish/subscribe capabilities
- [X] Add tests for automatic reauth with and without disconnection
- [X] Add refs to spec items
- [x] Change URL of `auth_url` when echo server is deployed. See TODOs