### PR TITLE
Switch from git protocol to https for msgpack dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "./nodejs/index.js": "./browser/static/ably-commonjs.js"
   },
   "dependencies": {
-    "msgpack-js": "git://github.com/ably-forks/msgpack-js.git",
+    "msgpack-js": "https://github.com/ably-forks/msgpack-js.git",
     "request": "^2.83.0",
     "ws": "~4.0"
   },


### PR DESCRIPTION
Apparently some environments block the git protocol port, see https://app.intercom.io/a/apps/ua39m1ld/inbox/inbox/conversation/16992208828