### PR TITLE
Ensure a message id is included when serialised

### DIFF
--- a/common/lib/types/message.js
+++ b/common/lib/types/message.js
@@ -20,6 +20,7 @@ var Message = (function() {
 	Message.prototype.toJSON = function() {
 		var result = {
 			name: this.name,
+			id: this.id,
 			clientId: this.clientId,
 			connectionId: this.connectionId,
 			connectionKey: this.connectionKey,


### PR DESCRIPTION
This is required in order to support idempotent REST publishing (https://github.com/ably/realtime/pull/1811)