### PR TITLE
Give presence.subscribe callback arg the same behaviour as channel.subscribe

### DIFF
--- a/common/lib/client/realtime.js
+++ b/common/lib/client/realtime.js
@@ -57,7 +57,7 @@ var Realtime = (function() {
 			if(channel.state === 'attaching' || channel.state === 'detaching') {
 				channel.checkPendingState();
 			} else if(channel.state === 'suspended') {
-				channel.autonomousAttach();
+				channel.attach();
 			}
 		}
 	};

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -111,7 +111,11 @@ var RealtimeChannel = (function() {
 			callback = flags;
 			flags = null;
 		}
-		callback = callback || noop;
+		callback = callback || function(err) {
+			if(err) {
+				Logger.logAction(Logger.LOG_MAJOR, 'RealtimeChannel.attach()', 'Channel attach failed: ' + err.toString());
+			}
+		};
 		if(flags) {
 			this._requestedFlags = flags;
 		}
@@ -190,16 +194,6 @@ var RealtimeChannel = (function() {
 		}
 	};
 
-	RealtimeChannel.prototype.autonomousAttach = function() {
-		var self = this;
-		this.attach(function(err) {
-			if(err) {
-				var msg = 'Channel auto-attach failed: ' + err.toString();
-				Logger.logAction(Logger.LOG_MINOR, 'RealtimeChannel.autonomousAttach()', msg);
-			}
-		});
-	};
-
 	RealtimeChannel.prototype.detachImpl = function(callback) {
 		Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.detach()', 'sending DETACH message');
 		this.setInProgress(statechangeOp, true);
@@ -222,11 +216,7 @@ var RealtimeChannel = (function() {
 
 		subscriptions.on(event, listener);
 
-		if(callback) {
-			this.attach(callback);
-		} else {
-			this.autonomousAttach();
-		}
+		this.attach(callback);
 	};
 
 	RealtimeChannel.prototype.unsubscribe = function(/* [event], listener, [callback] */) {

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -106,7 +106,7 @@ var RealtimePresence = (function() {
 					break;
 				case 'initialized':
 				case 'detached':
-					channel.autonomousAttach();
+					channel.attach();
 				case 'attaching':
 					self.pendingPresence.push({
 						presence : presence,
@@ -412,11 +412,7 @@ var RealtimePresence = (function() {
 		}
 
 		this.subscriptions.on(event, listener);
-		if(callback) {
-			channel.attach(callback);
-		} else {
-			channel.autonomousAttach();
-		}
+		channel.attach(callback);
 	};
 
 	RealtimePresence.prototype.unsubscribe = function(/* [event], listener, [callback] */) {


### PR DESCRIPTION
writing a realtime presence test, was annoyed that the presence.subscribe callback arg was only called in the event of an attach error, wheras the channel.subscribe callback arg is called once attached. this makes them behave consistently