### PR TITLE
Use git protocol to install msgpack-js instead of https

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "./nodejs/index.js": "./browser/static/ably-commonjs.js"
   },
   "dependencies": {
-    "msgpack-js": "https://github.com/ably-forks/msgpack-js.git",
+    "msgpack-js": "git://github.com/ably-forks/msgpack-js.git",
     "request": "^2.87.0",
     "ws": "^5.1"
   },


### PR DESCRIPTION
`msgpack-js` does not get installed when using node 8.x (tested with 8.10.0). Updating the protocol to use `git://` instead of `https://` fixes this issue.