### PR TITLE
Node http: specify keepalive through explicit agentOption rather than forever: true

### DIFF
--- a/nodejs/lib/util/defaults.js
+++ b/nodejs/lib/util/defaults.js
@@ -9,5 +9,5 @@ this.Defaults = {
 	baseTransportOrder: ['comet', 'web_socket'],
 	transportPreferenceOrder: ['comet', 'web_socket'],
 	upgradeTransports: ['web_socket'],
-	restAgentOptions: {maxSockets: 40}
+	restAgentOptions: {maxSockets: 40, keepAlive: true}
 };

--- a/nodejs/lib/util/http.js
+++ b/nodejs/lib/util/http.js
@@ -107,7 +107,7 @@ this.Http = (function() {
 		* (Ably and perhaps an auth server), so for efficiency, use the
 		* foreverAgent to keep the TCP stream alive between requests where possible */
 		var agentOptions = (rest && rest.options.restAgentOptions) || Defaults.restAgentOptions;
-		var getOptions = {headers: headers, encoding: null, forever: true, agentOptions: agentOptions};
+		var getOptions = {headers: headers, encoding: null, agentOptions: agentOptions};
 		if(params)
 			getOptions.qs = params;
 
@@ -158,7 +158,7 @@ this.Http = (function() {
 	 */
 	Http.postUri = function(rest, uri, headers, body, params, callback) {
 		var agentOptions = (rest && rest.options.restAgentOptions) || Defaults.restAgentOptions;
-		var postOptions = {headers: headers, body: body, encoding: null, forever: true, agentOptions: agentOptions};
+		var postOptions = {headers: headers, body: body, encoding: null, agentOptions: agentOptions};
 		if(params)
 			postOptions.qs = params;
 


### PR DESCRIPTION
To allow it to be overridden by passed-in restAgentOptions. These days that's all the forever:true option does, see https://github.com/request/request/blob/8162961dfdb73dc35a5a4bfeefb858c2ed2ccbb7/request.js#L480