### PR TITLE
Fix bug where connectionSerial was not getting reset after a resume failure

### DIFF
--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -549,7 +549,7 @@ var ConnectionManager = (function() {
 
 		var connectionKey = connectionDetails.connectionKey;
 		if(connectionKey && this.connectionKey != connectionKey)  {
-			this.setConnection(connectionId, connectionDetails, connectionPosition);
+			this.setConnection(connectionId, connectionDetails, connectionPosition, true);
 		}
 
 		/* Rebroadcast any new connectionDetails from the active transport, which
@@ -707,7 +707,7 @@ var ConnectionManager = (function() {
 		});
 	};
 
-	ConnectionManager.prototype.setConnection = function(connectionId, connectionDetails, connectionPosition) {
+	ConnectionManager.prototype.setConnection = function(connectionId, connectionDetails, connectionPosition, forceSetPosition) {
 		/* if connectionKey changes but connectionId stays the same, then just a
 		 * transport change on the same connection. If connectionId changes, we're
 		 * on a new connection, with implications for msgSerial and channel state */
@@ -732,7 +732,7 @@ var ConnectionManager = (function() {
 		}
 		this.realtime.connection.id = this.connectionId = connectionId;
 		this.realtime.connection.key = this.connectionKey = connectionDetails.connectionKey;
-		this.setConnectionSerial(connectionPosition);
+		this.setConnectionSerial(connectionPosition, forceSetPosition);
 	};
 
 	ConnectionManager.prototype.clearConnection = function() {
@@ -743,10 +743,12 @@ var ConnectionManager = (function() {
 		this.unpersistConnection();
 	};
 
-	ConnectionManager.prototype.setConnectionSerial = function(connectionPosition) {
+	/* force: set the connectionSerial even if it's less than the current connectionSerial. Used when
+	 * activating a new transport, where the connectionSerial realtime tells us we have must be authoritative */
+	ConnectionManager.prototype.setConnectionSerial = function(connectionPosition, force) {
 		var timeSerial = connectionPosition.timeSerial;
 		if(timeSerial !== undefined) {
-			if(timeSerial <= this.timeSerial) {
+			if(timeSerial <= this.timeSerial && !force) {
 				Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.setConnectionSerial() received message with timeSerial ' + timeSerial + ', but current timeSerial is ' + this.timeSerial + '; assuming message is a duplicate and discarding it');
 				return;
 			}
@@ -756,7 +758,7 @@ var ConnectionManager = (function() {
 		}
 		var connectionSerial = connectionPosition.connectionSerial;
 		if(connectionSerial !== undefined) {
-			if(connectionSerial <= this.connectionSerial) {
+			if(connectionSerial <= this.connectionSerial && !force) {
 				Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.setConnectionSerial() received message with connectionSerial ' + connectionSerial + ', but current connectionSerial is ' + this.connectionSerial + '; assuming message is a duplicate and discarding it');
 				return;
 			}

--- a/spec/realtime/resume.test.js
+++ b/spec/realtime/resume.test.js
@@ -277,7 +277,7 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 			attachedChannel = realtime.channels.get(attachedChannelName),
 			suspendedChannel = realtime.channels.get(suspendedChannelName);
 
-		test.expect(3);
+		test.expect(6);
 		async.series([
 			function(cb) {
 				connection.once('connected', function() { cb(); });
@@ -290,6 +290,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				/* Sabotage the resume */
 				connection.connectionManager.connectionKey = '_____!ablyjs_test_fake-key____',
 				connection.connectionManager.connectionId = 'ablyjs_tes';
+				connection.connectionManager.connectionSerial = 17;
+				connection.connectionManager.msgSerial = 15;
 				connection.once('disconnected', function() { cb(); });
 				connection.connectionManager.disconnectAllTransports();
 			},
@@ -298,6 +300,9 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 					test.equal(stateChange.reason && stateChange.reason.code, 80008, 'Unable to recover connection correctly set in the stateChange');
 					test.equal(attachedChannel.state, 'attaching', 'Attached channel went into attaching');
 					test.equal(suspendedChannel.state, 'attaching', 'Suspended channel went into attaching');
+					test.equal(connection.connectionManager.msgSerial, 0, 'Check msgSerial is reset to 0');
+					test.equal(connection.connectionManager.connectionSerial, -1, 'Check connectionSerial is reset by the new CONNECTED');
+					test.ok(connection.connectionManager.connectionId !== 'ablyjs_tes', 'Check connectionId is set by the new CONNECTED');
 					cb();
 				});
 			}


### PR DESCRIPTION
Investigated one instance of `ConnectionMaster.syncForRequest_08() | Unexpected error getting channel backlog; err = [ErrorInfo: Invalid message id; statusCode=400; code=40007 ((fatal))]`, and it turned out to be a bug in ably-js: the connectionSerial was not getting reset back to -1 after a failed resume. (A single connection is then the cause of many instances of that log line -- one for every resume or transport upgrade after that until the number of messages received on the new connection catches up with the connectionSerial of the old).