### PR TITLE
Add support for promises to public api

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -169,7 +169,12 @@ var Auth = (function() {
 			callback = authOptions;
 			authOptions = null;
 		}
-		callback = callback || noop;
+		if(!callback) {
+			if(Platform.promisify) {
+				return Platform.promisify(this.authorize).apply(this, arguments);
+			}
+			callback = noop;
+		}
 		var self = this;
 
 		/* RSA10a: authorize() call implies token auth. If a key is passed it, we
@@ -289,6 +294,9 @@ var Auth = (function() {
 		else if(typeof(authOptions) == 'function' && !callback) {
 			callback = authOptions;
 			authOptions = null;
+		}
+		if(!callback && Platform.promisify) {
+			return Platform.promisify(this.requestToken).apply(this, arguments);
 		}
 
 		/* RSA8e: if authOptions passed in, they're used instead of stored, don't merge them */
@@ -497,6 +505,9 @@ var Auth = (function() {
 		} else if(typeof(authOptions) == 'function' && !callback) {
 			callback = authOptions;
 			authOptions = null;
+		}
+		if(!callback && Platform.promisify) {
+			return Platform.promisify(this.createTokenRequest).apply(this, arguments);
 		}
 
 		/* RSA9h: if authOptions passed in, they're used instead of stored, don't merge them */

--- a/common/lib/client/channel.js
+++ b/common/lib/client/channel.js
@@ -36,6 +36,9 @@ var Channel = (function() {
 				callback = params;
 				params = null;
 			} else {
+				if(Platform.promisify) {
+					return Platform.promisify(this.history).apply(this, arguments);
+				}
 				callback = noop;
 			}
 		}
@@ -66,6 +69,9 @@ var Channel = (function() {
 			self = this;
 
 		if(typeof(callback) !== 'function') {
+			if(Platform.promisify) {
+				return Platform.promisify(this.publish).apply(this, arguments);
+			}
 			callback = noop;
 			++argCount;
 		}

--- a/common/lib/client/connection.js
+++ b/common/lib/client/connection.js
@@ -1,4 +1,5 @@
 var Connection = (function() {
+	function noop() {}
 
 	/* public constructor */
 	function Connection(ably, options) {
@@ -39,7 +40,12 @@ var Connection = (function() {
 
 	Connection.prototype.ping = function(callback) {
 		Logger.logAction(Logger.LOG_MINOR, 'Connection.ping()', '');
-		callback = callback || function() {};
+		if(!callback) {
+			if(Platform.promisify) {
+				return Platform.promisify(this.ping).apply(this, arguments);
+			}
+			callback = noop;
+		}
 		this.connectionManager.ping(null, callback);
 	};
 

--- a/common/lib/client/presence.js
+++ b/common/lib/client/presence.js
@@ -14,6 +14,9 @@ var Presence = (function() {
 				callback = params;
 				params = null;
 			} else {
+				if(Platform.promisify) {
+					return Platform.promisify(this.get).apply(this, arguments);
+				}
 				callback = noop;
 			}
 		}
@@ -43,6 +46,9 @@ var Presence = (function() {
 				callback = params;
 				params = null;
 			} else {
+				if(Platform.promisify) {
+					return Platform.promisify(this._history).apply(this, arguments);
+				}
 				callback = noop;
 			}
 		}

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -52,29 +52,32 @@ var RealtimePresence = (function() {
 	RealtimePresence.prototype.enter = function(data, callback) {
 		if(isAnonymous(this))
 			throw new ErrorInfo('clientId must be specified to enter a presence channel', 40012, 400);
-		this._enterOrUpdateClient(undefined, data, callback, 'enter');
+		return this._enterOrUpdateClient(undefined, data, 'enter', callback);
 	};
 
 	RealtimePresence.prototype.update = function(data, callback) {
 		if(isAnonymous(this))
 			throw new ErrorInfo('clientId must be specified to update presence data', 40012, 400);
-		this._enterOrUpdateClient(undefined, data, callback, 'update');
+		return this._enterOrUpdateClient(undefined, data, 'update', callback);
 	};
 
 	RealtimePresence.prototype.enterClient = function(clientId, data, callback) {
-		this._enterOrUpdateClient(clientId, data, callback, 'enter');
+		return this._enterOrUpdateClient(clientId, data, 'enter', callback);
 	};
 
 	RealtimePresence.prototype.updateClient = function(clientId, data, callback) {
-		this._enterOrUpdateClient(clientId, data, callback, 'update');
+		return this._enterOrUpdateClient(clientId, data, 'update', callback);
 	};
 
-	RealtimePresence.prototype._enterOrUpdateClient = function(clientId, data, callback, action) {
+	RealtimePresence.prototype._enterOrUpdateClient = function(clientId, data, action, callback) {
 		if (!callback) {
 			if (typeof(data)==='function') {
 				callback = data;
 				data = null;
 			} else {
+				if(Platform.promisify) {
+					return Platform.promisify(this._enterOrUpdateClient).call(this, clientId, data, action);
+				}
 				callback = noop;
 			}
 		}
@@ -124,7 +127,7 @@ var RealtimePresence = (function() {
 	RealtimePresence.prototype.leave = function(data, callback) {
 		if(isAnonymous(this))
 			throw new ErrorInfo('clientId must have been specified to enter or leave a presence channel', 40012, 400);
-		this.leaveClient(undefined, data, callback);
+		return this.leaveClient(undefined, data, callback);
 	};
 
 	RealtimePresence.prototype.leaveClient = function(clientId, data, callback) {
@@ -133,6 +136,9 @@ var RealtimePresence = (function() {
 				callback = data;
 				data = null;
 			} else {
+				if(Platform.promisify) {
+					return Platform.promisify(this.leaveClient).call(this, clientId, data);
+				}
 				callback = noop;
 			}
 		}
@@ -180,8 +186,15 @@ var RealtimePresence = (function() {
 			args.unshift(null);
 
 		var params = args[0],
-			callback = args[1] || noop,
-			waitForSync = !params || ('waitForSync' in params ? params.waitForSync : true)
+			callback = args[1],
+			waitForSync = !params || ('waitForSync' in params ? params.waitForSync : true);
+
+		if(!callback) {
+			if(Platform.promisify) {
+				return Platform.promisify(this.get).apply(this, arguments);
+			}
+			callback = noop;
+		}
 
 		function returnMembers(members) {
 			callback(null, params ? members.list(params) : members.values());
@@ -222,6 +235,9 @@ var RealtimePresence = (function() {
 				callback = params;
 				params = null;
 			} else {
+				if(Platform.promisify) {
+					return Platform.promisify(this.history).apply(this, arguments);
+				}
 				callback = noop;
 			}
 		}
@@ -365,7 +381,7 @@ var RealtimePresence = (function() {
 			if(!(memberKey in members.map)) {
 				var entry = myMembers.map[memberKey];
 				Logger.logAction(Logger.LOG_MICRO, 'RealtimePresence._ensureMyMembersPresent()', 'Auto-reentering clientId "' + entry.clientId + '" into the presence set');
-				this._enterOrUpdateClient(entry.clientId, entry.data, reenterCb, 'enter');
+				this._enterOrUpdateClient(entry.clientId, entry.data, 'enter', reenterCb);
 				delete myMembers.map[memberKey];
 			}
 		}
@@ -406,6 +422,13 @@ var RealtimePresence = (function() {
 		var channel = this.channel;
 		var self = this;
 
+		if(!callback) {
+			if(Platform.promisify) {
+				return Platform.promisify(this.subscribe).call(this, event, listener);
+			}
+			callback = noop;
+		}
+
 		if(channel.state === 'failed') {
 			callback(ErrorInfo.fromValues(RealtimeChannel.invalidStateError('failed')));
 			return;
@@ -421,12 +444,20 @@ var RealtimePresence = (function() {
 		var listener = args[1];
 		var callback = args[2];
 
+		if(!callback) {
+			if(Platform.promisify) {
+				return Platform.promisify(this.unsubscribe).call(this, event, listener);
+			}
+			callback = noop;
+		}
+
 		if(this.channel.state === 'failed') {
 			callback(ErrorInfo.fromValues(RealtimeChannel.invalidStateError('failed')));
 			return;
 		}
 
 		this.subscriptions.off(event, listener);
+		callback();
 	};
 
 	function PresenceMap(presence) {

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -59,6 +59,9 @@ var Rest = (function() {
 				callback = params;
 				params = null;
 			} else {
+				if(Platform.promisify) {
+					return Platform.promisify(this.stats).apply(this, arguments);
+				}
 				callback = noop;
 			}
 		}
@@ -83,6 +86,9 @@ var Rest = (function() {
 				callback = params;
 				params = null;
 			} else {
+				if(Platform.promisify) {
+					return Platform.promisify(this.time).apply(this, arguments);
+				}
 				callback = noop;
 			}
 		}
@@ -119,6 +125,13 @@ var Rest = (function() {
 			envelope = Http.supportsLinkHeaders ? undefined : format,
 			params = params || {},
 			headers = Utils.copy(method == 'get' ? Utils.defaultGetHeaders(format) : Utils.defaultPostHeaders(format));
+
+		if(callback === undefined) {
+			if(Platform.promisify) {
+				return Platform.promisify(this.request).apply(this, arguments);
+			}
+			callback = noop;
+		}
 
 		if(typeof body !== 'string') {
 			body = encoder(body);

--- a/nodejs/platform.js
+++ b/nodejs/platform.js
@@ -13,5 +13,6 @@ this.Platform = {
 	nextTick: process.nextTick,
 	inspect: require('util').inspect,
 	inherits: require('util').inherits,
-	addEventListener: null
+	addEventListener: null,
+	promisify: require('util').promisify
 };


### PR DESCRIPTION
Did most of this this a while ago when I was rewriting the realtime limits tests in async/await style -- I wanted to be able to write things like `await channel.publish(name, data)` and `await realtime.connection.once('connected')` -- just didn't get around to writing tests for it until now.

Currently only works on nodejs as it uses `util.promisify`. At some point when there's enough call for it I'll  rewrite to support browsers too.