### PR TITLE
 Deduce streaming from lack of content-length even if no transfer-encoding

### DIFF
--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -30,13 +30,15 @@ var XHRRequest = (function() {
 		return xhr.getResponseHeader && xhr.getResponseHeader(header);
 	}
 
-	/* Safari mysteriously returns 'Identity' for transfer-encoding
-	 * when in fact it is 'chunked'. So instead, decide that it is
-	 * chunked when transfer-encoding is present, content-length is absent */
+	/* Safari mysteriously returns 'Identity' for transfer-encoding when in fact
+	 * it is 'chunked'. So instead, decide that it is chunked when
+	 * transfer-encoding is present or content-length is absent.  ('or' because
+	 * while streaming does not work with cloudflare, it still strips the
+	 * transfer-encoding header out) */
 	function isEncodingChunked(xhr) {
 		return xhr.getResponseHeader
-			&& xhr.getResponseHeader('transfer-encoding')
-			&& !xhr.getResponseHeader('content-length');
+			&& (xhr.getResponseHeader('transfer-encoding')
+			|| !xhr.getResponseHeader('content-length'));
 	}
 
 	function getHeadersAsObject(xhr) {

--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -5,20 +5,6 @@ var CometTransport = (function() {
 		REQ_RECV_POLL = 2,
 		REQ_RECV_STREAM = 3;
 
-	function actOnConnectHeaders(headers, host, connectionManager) {
-		if(headers && headers.server && (headers.server.indexOf('cloudflare') > -1)) {
-			/* Cloudflare doesn't support xhr streaming */
-			var blacklist = connectionManager.transportHostBlacklist[host];
-			if(!blacklist) {
-				connectionManager.transportHostBlacklist[host] = ['xhr_streaming'];
-				return;
-			}
-			if(!Utils.arrIn(blacklist, 'xhr_streaming')) {
-				blacklist.push('xhr_streaming');
-			}
-		}
-	}
-
 	/* TODO: can remove once realtime sends protocol message responses for comet errors */
 	function shouldBeErrorAction(err) {
 		var UNRESOLVABLE_ERROR_CODES = [80015, 80017, 80030];
@@ -103,7 +89,6 @@ var CometTransport = (function() {
 				self.onData(data);
 			});
 			connectRequest.on('complete', function(err, _body, headers) {
-				actOnConnectHeaders(headers, host, self.connectionManager);
 				if(!self.recvRequest) {
 					/* the transport was disposed before we connected */
 					err = err || new ErrorInfo('Request cancelled', 80000, 400);

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -141,8 +141,6 @@ var ConnectionManager = (function() {
 		* transport, it'll just be that one. */
 		this.baseTransport = Utils.intersect(Defaults.baseTransportOrder, this.transports)[0];
 		this.upgradeTransports = Utils.intersect(this.transports, Defaults.upgradeTransports);
-		/* Map of hosts to an array of transports to not be tried for that host */
-		this.transportHostBlacklist = {};
 		this.transportPreference = null;
 
 		this.httpHosts = Defaults.getHosts(options);
@@ -271,10 +269,6 @@ var ConnectionManager = (function() {
 	ConnectionManager.prototype.tryATransport = function(transportParams, candidate, callback) {
 		var self = this, host = transportParams.host;
 		Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.tryATransport()', 'trying ' + candidate);
-		if((host in this.transportHostBlacklist) && Utils.arrIn(this.transportHostBlacklist[host], candidate)) {
-			Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.tryATransport()', candidate + ' transport is blacklisted for host ' + transportParams.host);
-			return;
-		}
 		(ConnectionManager.supportedTransports[candidate]).tryConnect(this, this.realtime.auth, transportParams, function(wrappedErr, transport) {
 			var state = self.state;
 			if(state == self.states.closing || state == self.states.closed || state == self.states.failed) {


### PR DESCRIPTION
and remove cloudflare xhr_streaming blacklist.

Apparently at some point since https://github.com/ably/realtime/issues/714 and https://github.com/ably/ably-js/pull/342 , xhr streaming started working on cloudflare. It still strips off the `transfer-encoding: chunked` header, but it does now actually stream the response (as opposed to what it was doing two years ago, which was withholding all bits of the response until the request was actually complete).

I'm confused as to why exactly it's still stripping the transfer-encoding header. We can follow up with their support, perhaps. In the meantime we can deduce it from the lack of content-length.