### PR TITLE
Auth: Fix multiple concurrent token requests

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -88,6 +88,8 @@ var Auth = (function() {
 	function Auth(client, options) {
 		this.client = client;
 		this.tokenParams = options.defaultTokenParams || {};
+		this.tokenRequestInProgress = false;
+		this.waitingForTokenRequest = null;
 
 		if(useTokenAuth(options)) {
 			/* Token auth */
@@ -689,8 +691,21 @@ var Auth = (function() {
 		var self = this,
 			token = this.tokenDetails;
 
+		if(this.tokenRequestInProgress) {
+			(this.waitingForTokenRequest || (this.waitingForTokenRequest = Multicaster())).push(callback);
+			return;
+		}
+
 		var requestToken = function() {
+			self.tokenRequestInProgress = true;
 			self.requestToken(self.tokenParams, self.authOptions, function(err, tokenResponse) {
+				self.tokenRequestInProgress = false;
+				var waiting = self.waitingForTokenRequest;
+				if(waiting) {
+					waiting.push(callback);
+					callback = waiting;
+					self.waitingForTokenRequest = null;
+				}
 				if(err) {
 					callback(err);
 					return;

--- a/nodejs/rest.js
+++ b/nodejs/rest.js
@@ -29,6 +29,7 @@ includeScript('../common/lib/util/defaults.js');
 includeScript('../common/lib/util/eventemitter.js');
 includeScript('../common/lib/util/logger.js');
 includeScript('../common/lib/util/utils.js');
+includeScript('../common/lib/util/multicaster.js');
 includeScript('./lib/util/crypto.js');
 includeScript('../common/lib/types/errorinfo.js');
 includeScript('../common/lib/types/message.js');

--- a/spec/rest/auth.test.js
+++ b/spec/rest/auth.test.js
@@ -2,6 +2,7 @@
 
 define(['ably', 'shared_helper', 'async', 'globals'], function(Ably, helper, async, globals) {
 	var currentTime, rest, exports = {},
+		_exports = {},
 		utils = helper.Utils,
 		echoServer = 'https://echo.ably.io';
 
@@ -703,6 +704,28 @@ define(['ably', 'shared_helper', 'async', 'globals'], function(Ably, helper, asy
 		}).catch(function(err) {
 			test.ok(false, 'a token request failed with error: ' + displayError(err));
 			test.done();
+		});
+	};
+
+	exports.auth_concurrent = function(test) {
+		var authCallbackInvocations = 0;
+		function authCallback(tokenParams, callback) {
+			authCallbackInvocations++;
+			rest.auth.createTokenRequest(tokenParams, callback);
+		}
+
+		/* Example client-side using the token */
+		var restClient = helper.AblyRest({ authCallback: authCallback });
+		var channel = restClient.channels.get('auth_concurrent');
+
+		async.parallel([
+			channel.history.bind(channel),
+			channel.history.bind(channel)
+		], function(err) {
+			test.ok(!err, err && helper.displayError(err));
+			test.equal(authCallbackInvocations, 1, 'Check authCallback only invoked once -- was: ' + authCallbackInvocations)
+			test.done();
+			return;
 		});
 	};
 


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/440

Could have just made Auth an eventemitter, but eh, seemed a bit overkill to do that just for one event, the multicaster works