### PR TITLE
Http host when connected

### DIFF
--- a/browser/lib/util/http.js
+++ b/browser/lib/util/http.js
@@ -13,6 +13,20 @@ var Http = (function() {
 			(statusCode >= 500 && statusCode <= 504);
 	}
 
+	function getHosts(client) {
+		/* If we're a connected realtime client, try the endpoint we're connected
+		 * to first -- but still have fallbacks, being connected is not an absolute
+		 * guarantee that a datacenter has free capacity to service REST requests. */
+		var connection = client.connection,
+			connectionHost = connection && connection.connectionManager.host;
+
+		if(connectionHost) {
+			return [connectionHost].concat(Defaults.getFallbackHosts(client.options));
+		}
+
+		return Defaults.getHosts(client.options);
+	}
+
 	/**
 	 * Perform an HTTP GET request for a given path against prime and fallback Ably hosts
 	 * @param rest
@@ -25,12 +39,7 @@ var Http = (function() {
 		callback = callback || noop;
 		var uri = (typeof(path) == 'function') ? path : function(host) { return rest.baseUri(host) + path; };
 		var binary = (headers && headers.accept != 'application/json');
-
-		var hosts, connection = rest.connection;
-		if(connection && connection.state == 'connected')
-			hosts = [connection.connectionManager.host];
-		else
-			hosts = Defaults.getHosts(rest.options);
+		var hosts = getHosts(rest);
 
 		/* if there is only one host do it */
 		if(hosts.length == 1) {
@@ -77,12 +86,7 @@ var Http = (function() {
 		callback = callback || noop;
 		var uri = (typeof(path) == 'function') ? path : function(host) { return rest.baseUri(host) + path; };
 		var binary = (headers && headers.accept != 'application/json');
-
-		var hosts, connection = rest.connection;
-		if(connection && connection.state == 'connected')
-			hosts = [connection.connectionManager.host];
-		else
-			hosts = Defaults.getHosts(rest.options);
+		var hosts = getHosts(rest);
 
 		/* if there is only one host do it */
 		if(hosts.length == 1) {

--- a/browser/lib/util/http.js
+++ b/browser/lib/util/http.js
@@ -26,6 +26,7 @@ var Http = (function() {
 
 		return Defaults.getHosts(client.options);
 	}
+	Http._getHosts = getHosts;
 
 	/**
 	 * Perform an HTTP GET request for a given path against prime and fallback Ably hosts

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -381,11 +381,12 @@ var Auth = (function() {
 		var client = this.client;
 		var tokenRequest = function(signedTokenParams, tokenCb) {
 			var keyName = signedTokenParams.keyName,
-				tokenUri = function(host) { return client.baseUri(host) + '/keys/' + keyName + '/requestToken'; };
+				path = '/keys/' + keyName + '/requestToken',
+				tokenUri = function(host) { return client.baseUri(host) + path; };
 
 			var requestHeaders = Utils.defaultPostHeaders();
 			if(authOptions.requestHeaders) Utils.mixin(requestHeaders, authOptions.requestHeaders);
-			Logger.logAction(Logger.LOG_MICRO, 'Auth.requestToken().requestToken', 'Sending POST; ' + tokenUri + '; Token params: ' + JSON.stringify(signedTokenParams));
+			Logger.logAction(Logger.LOG_MICRO, 'Auth.requestToken().requestToken', 'Sending POST to ' + path + '; Token params: ' + JSON.stringify(signedTokenParams));
 			signedTokenParams = JSON.stringify(signedTokenParams);
 			Http.post(client, tokenUri, requestHeaders, signedTokenParams, null, tokenCb);
 		};

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -41,15 +41,15 @@ Defaults.getHttpScheme = function(options) {
 	return options.tls ? 'https://' : 'http://';
 };
 
-Defaults.getHosts = function(options) {
-	var hosts = [options.restHost],
-		fallbackHosts = options.fallbackHosts,
+Defaults.getFallbackHosts = function(options) {
+	var fallbackHosts = options.fallbackHosts,
 		httpMaxRetryCount = typeof(options.httpMaxRetryCount) !== 'undefined' ? options.httpMaxRetryCount : Defaults.httpMaxRetryCount;
 
-	if(fallbackHosts) {
-		hosts = hosts.concat(Utils.arrChooseN(fallbackHosts, httpMaxRetryCount));
-	}
-	return hosts;
+	return fallbackHosts ? Utils.arrChooseN(fallbackHosts, httpMaxRetryCount) : [];
+};
+
+Defaults.getHosts = function(options) {
+	return [options.restHost].concat(Defaults.getFallbackHosts(options));
 };
 
 Defaults.normaliseOptions = function(options) {

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -52,6 +52,15 @@ Defaults.getHosts = function(options) {
 	return [options.restHost].concat(Defaults.getFallbackHosts(options));
 };
 
+function checkHost(host) {
+	if(typeof host !== 'string') {
+		throw new ErrorInfo('host must be a string; was a ' + typeof host, 40000, 400);
+	};
+	if(!host.length) {
+		throw new ErrorInfo('host must not be zero-length', 40000, 400);
+	};
+}
+
 Defaults.normaliseOptions = function(options) {
 	/* Deprecated options */
 	if(options.host) {
@@ -102,6 +111,8 @@ Defaults.normaliseOptions = function(options) {
 		options.realtimeHost = production ? Defaults.REALTIME_HOST : environment + '-' + Defaults.REALTIME_HOST;
 	}
 	options.fallbackHosts = (production || options.fallbackHostsUseDefault) ? Defaults.FALLBACK_HOSTS : options.fallbackHosts;
+	Utils.arrForEach((options.fallbackHosts || []).concat(options.restHost, options.realtimeHost), checkHost);
+
 	options.port = options.port || Defaults.PORT;
 	options.tlsPort = options.tlsPort || Defaults.TLS_PORT;
 	options.maxMessageSize = options.maxMessageSize || Defaults.maxMessageSize;

--- a/nodejs/lib/util/http.js
+++ b/nodejs/lib/util/http.js
@@ -75,6 +75,7 @@ this.Http = (function() {
 
 		return Defaults.getHosts(client.options);
 	}
+	Http._getHosts = getHosts;
 
 	/**
 	 * Perform an HTTP GET request for a given path against prime and fallback Ably hosts

--- a/nodejs/lib/util/http.js
+++ b/nodejs/lib/util/http.js
@@ -62,6 +62,20 @@ this.Http = (function() {
 			(statusCode >= 500 && statusCode <= 504);
 	}
 
+	function getHosts(client) {
+		/* If we're a connected realtime client, try the endpoint we're connected
+		 * to first -- but still have fallbacks, being connected is not an absolute
+		 * guarantee that a datacenter has free capacity to service REST requests. */
+		var connection = client.connection,
+			connectionHost = connection && connection.connectionManager.host;
+
+		if(connectionHost) {
+			return [connectionHost].concat(Defaults.getFallbackHosts(client.options));
+		}
+
+		return Defaults.getHosts(client.options);
+	}
+
 	/**
 	 * Perform an HTTP GET request for a given path against prime and fallback Ably hosts
 	 * @param rest
@@ -72,7 +86,7 @@ this.Http = (function() {
 	 */
 	Http.get = function(rest, path, headers, params, callback) {
 		var uri = (typeof(path) == 'function') ? path : function(host) { return rest.baseUri(host) + path; };
-		var hosts = Defaults.getHosts(rest.options);
+		var hosts = getHosts(rest);
 
 		/* see if we have one or more than one host */
 		if(hosts.length == 1) {
@@ -127,7 +141,7 @@ this.Http = (function() {
 	 */
 	Http.post = function(rest, path, headers, body, params, callback) {
 		var uri = (typeof(path) == 'function') ? path : function(host) { return rest.baseUri(host) + path; };
-		var hosts = Defaults.getHosts(rest.options);
+		var hosts = getHosts(rest);
 
 		/* see if we have one or more than one host */
 		if(hosts.length == 1) {

--- a/spec/realtime/init.test.js
+++ b/spec/realtime/init.test.js
@@ -306,5 +306,36 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		}
 	};
 
+	exports.init_fallbacks_once_connected = function(test) {
+		var realtime = helper.AblyRealtime({
+			httpMaxRetryCount: 3,
+			fallbackHosts: ['a', 'b', 'c']
+		});
+		realtime.connection.once('connected', function() {
+			var hosts = Ably.Rest.Http._getHosts(realtime);
+			/* restHost rather than realtimeHost as that's what connectionManager
+			 * knows about; converted to realtimeHost by the websocketTransport */
+			test.equal(hosts[0], realtime.options.restHost, 'Check connected realtime host is the first option');
+			test.equal(hosts.length, 4, 'Check also have three fallbacks');
+			closeAndFinish(test, realtime);
+		})
+	};
+
+	exports.init_fallbacks_once_connected_2 = function(test) {
+		var goodHost = helper.AblyRest().options.realtimeHost;
+		var realtime = helper.AblyRealtime({
+			httpMaxRetryCount: 3,
+			restHost: 'a',
+			fallbackHosts: [goodHost, 'b', 'c']
+		});
+		realtime.connection.once('connected', function() {
+			var hosts = Ably.Rest.Http._getHosts(realtime);
+			/* restHost rather than realtimeHost as that's what connectionManager
+			 * knows about; converted to realtimeHost by the websocketTransport */
+			test.equal(hosts[0], goodHost, 'Check connected realtime host is the first option');
+			closeAndFinish(test, realtime);
+		})
+	}
+
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js/issues/565. Also fixes the anomaly where if you're connected, http requests don't use fallbacks -- being connected is not a guarantee that a datacenter has free capacity to service REST requests. (Considered just making it ignore the connected host and always go for Defaults.getHosts, but figured it's probably still worth it to go there first for efficient untilAttached history requests)