### PR TITLE
React-Native: switch to using RNRandomBytes directly rather than going through react-native-randombytes

### DIFF
--- a/browser/fragments/platform-reactnative.js
+++ b/browser/fragments/platform-reactnative.js
@@ -28,22 +28,11 @@ var Platform = {
 			str.length;
 	},
 	Promise: window.Promise,
-	getRandomValues: (function(randomBytes) {
-		return function(arr, callback) {
-			randomBytes(arr.length, function(err, bytes) {
-				if (err) {
-					callback(err);
-					return;
-				}
-
-				for (var i = 0; i < arr.length; i++) {
-					arr[i] = bytes[i];
-				}
-				if(callback) {
-					callback(null);
-				}
+	getRandomWordArray: (function(RNRandomBytes) {
+		return function(byteLength, callback) {
+			RNRandomBytes.randomBytes(byteLength, function(err, base64String) {
+				callback(err, !err && CryptoJS.enc.Base64.parse(base64String));
 			});
 		};
-	})(require('react-native-randombytes').randomBytes)
+	})(require('react-native').NativeModules.RNRandomBytes)
 };
-

--- a/browser/lib/util/crypto.js
+++ b/browser/lib/util/crypto.js
@@ -14,7 +14,9 @@ var Crypto = (function() {
 	 * @param callback
 	 */
 	var generateRandom;
-	if(typeof Uint32Array !== 'undefined' && Platform.getRandomValues) {
+	if(Platform.getRandomWordArray) {
+		generateRandom = Platform.getRandomWordArray;
+	} else if(typeof Uint32Array !== 'undefined' && Platform.getRandomValues) {
 		var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
 		generateRandom = function(bytes, callback) {
 			var words = bytes / 4, nativeArray = (words == DEFAULT_BLOCKLENGTH_WORDS) ? blockRandomArray : new Uint32Array(words);


### PR DESCRIPTION
Fixes https://github.com/ably/ably-js-react-native/issues/11

- Avoids the need to fork the library to avoid loading sjcl at runtime
- Avoids the unnecessary round-tripping of decoding base64 into a polyfilled buffer in r-n-rb, then extracting into a UInt32Array, then convert into a WordArray
- Fixes broken insufficient-randomness on react native

Haven't got a convenient react-native setup to actually test, but [apparently it works](https://github.com/ably/ably-js-react-native/issues/11#issuecomment-461894857)