### PR TITLE
Fix _uncheckedSetClientId

### DIFF
--- a/browser/fragments/platform-reactnative.js
+++ b/browser/fragments/platform-reactnative.js
@@ -28,22 +28,11 @@ var Platform = {
 			str.length;
 	},
 	Promise: window.Promise,
-	getRandomValues: (function(randomBytes) {
-		return function(arr, callback) {
-			randomBytes(arr.length, function(err, bytes) {
-				if (err) {
-					callback(err);
-					return;
-				}
-
-				for (var i = 0; i < arr.length; i++) {
-					arr[i] = bytes[i];
-				}
-				if(callback) {
-					callback(null);
-				}
+	getRandomWordArray: (function(RNRandomBytes) {
+		return function(byteLength, callback) {
+			RNRandomBytes.randomBytes(byteLength, function(err, base64String) {
+				callback(err, !err && CryptoJS.enc.Base64.parse(base64String));
 			});
 		};
-	})(require('react-native-randombytes').randomBytes)
+	})(require('react-native').NativeModules.RNRandomBytes)
 };
-

--- a/browser/lib/util/crypto.js
+++ b/browser/lib/util/crypto.js
@@ -14,7 +14,9 @@ var Crypto = (function() {
 	 * @param callback
 	 */
 	var generateRandom;
-	if(typeof Uint32Array !== 'undefined' && Platform.getRandomValues) {
+	if(Platform.getRandomWordArray) {
+		generateRandom = Platform.getRandomWordArray;
+	} else if(typeof Uint32Array !== 'undefined' && Platform.getRandomValues) {
 		var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
 		generateRandom = function(bytes, callback) {
 			var words = bytes / 4, nativeArray = (words == DEFAULT_BLOCKLENGTH_WORDS) ? blockRandomArray : new Uint32Array(words);

--- a/browser/static/ably-commonjs.js
+++ b/browser/static/ably-commonjs.js
@@ -9625,19 +9625,11 @@ var Auth = (function() {
 
 	/* Ably-set: no typechecking, '*' is allowed but not set on this.clientId), return errors to the caller */
 	Auth.prototype._uncheckedSetClientId = function(clientId) {
-		if(this._tokenClientIdMismatch(clientId)) {
-			/* Should never happen in normal circumstances as realtime should
-			 * recognise mismatch and return an error */
-			var msg = 'Unexpected clientId mismatch: client has ' + this.clientId + ', requested ' + clientId;
-			var err = new ErrorInfo(msg, 40102, 401);
-			Logger.logAction(Logger.LOG_ERROR, 'Auth._uncheckedSetClientId()', msg);
-			return err;
-		} else {
-			/* RSA7a4: if options.clientId is provided and is not
-			 * null, it overrides defaultTokenParams.clientId */
-			this.clientId = this.tokenParams.clientId = clientId;
-			return null;
-		}
+		/* RSA7a4: if options.clientId is provided and is not
+			* null, it overrides defaultTokenParams.clientId */
+		this.clientId = this.tokenParams.clientId = clientId;
+		return null;
+		
 	};
 
 	Auth.prototype._tokenClientIdMismatch = function(tokenClientId) {


### PR DESCRIPTION
There is currently no way to set a new clientId if it has changed since `_tokenClientIdMismatch` will always return `true` for another id