### PR TITLE
Fixes for calling authorize() before connected, and multiple times in succession

### DIFF
--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -200,7 +200,7 @@ var Auth = (function() {
 
 		/* RSA10a: authorize() call implies token auth. If a key is passed it, we
 		 * just check if it doesn't clash and assume we're generating a token from it */
-		if(authOptions && authOptions.key && (this.key !== authOptions.key)) {
+		if(authOptions && authOptions.key && (this.authOptions.key !== authOptions.key)) {
 			throw new ErrorInfo('Unable to update auth options with incompatible key', 40102, 401);
 		}
 

--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -42,7 +42,6 @@ var CometTransport = (function() {
 		this.recvRequest = null;
 		this.pendingCallback = null;
 		this.pendingItems = null;
-		this.disposed = false;
 	}
 	Utils.inherits(CometTransport, Transport);
 
@@ -66,6 +65,9 @@ var CometTransport = (function() {
 		this.auth.getAuthParams(function(err, authParams) {
 			if(err) {
 				self.disconnect(err);
+				return;
+			}
+			if(self.isDisposed) {
 				return;
 			}
 			self.authParams = authParams;
@@ -144,8 +146,8 @@ var CometTransport = (function() {
 
 	CometTransport.prototype.dispose = function() {
 		Logger.logAction(Logger.LOG_MINOR, 'CometTransport.dispose()', '');
-		if(!this.disposed) {
-			this.disposed = true;
+		if(!this.isDisposed) {
+			this.isDisposed = true;
 			if(this.recvRequest) {
 				Logger.logAction(Logger.LOG_MINOR, 'CometTransport.dispose()', 'aborting recv request');
 				this.recvRequest.abort();
@@ -163,7 +165,9 @@ var CometTransport = (function() {
 
 	CometTransport.prototype.onConnect = function(message) {
 		/* if this transport has been disposed whilst awaiting connection, do nothing */
-		if(this.disposed) return;
+		if(this.isDisposed) {
+			return;
+		}
 
 		/* the connectionKey in a comet connected response is really
 		 * <instId>-<connectionKey> */

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -1101,7 +1101,7 @@ var ConnectionManager = (function() {
 				/* Force a refetch of a new token */
 				auth._forceNewToken(null, null, authCb);
 			} else {
-				auth._ensureValidAuthCredentials(authCb);
+				auth._ensureValidAuthCredentials(false, authCb);
 			}
 		}
 	};

--- a/common/lib/transport/transport.js
+++ b/common/lib/transport/transport.js
@@ -27,6 +27,7 @@ var Transport = (function() {
 		this.format = params.format;
 		this.isConnected = false;
 		this.isFinished = false;
+		this.isDisposed = false;
 		this.maxIdleInterval = null;
 		this.idleTimer = null;
 		this.lastActivity = null;
@@ -182,6 +183,7 @@ var Transport = (function() {
 
 	Transport.prototype.dispose = function() {
 		Logger.logAction(Logger.LOG_MINOR, 'Transport.dispose()', '');
+		this.isDisposed = true;
 		this.off();
 	};
 

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -53,6 +53,9 @@ var WebSocketTransport = (function() {
 		var wsUri = wsScheme + this.wsHost + ':' + Defaults.getPort(options) + '/';
 		Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.connect()', 'uri: ' + wsUri);
 		this.auth.getAuthParams(function(err, authParams) {
+			if(self.isDisposed) {
+				return;
+			}
 			var paramStr = ''; for(var param in authParams) paramStr += ' ' + param + ': ' + authParams[param] + ';';
 			Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.connect()', 'authParams:' + paramStr + ' err: ' + err);
 			if(err) {
@@ -148,6 +151,7 @@ var WebSocketTransport = (function() {
 
 	WebSocketTransport.prototype.dispose = function() {
 		Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.dispose()', '');
+		this.isDisposed = true;
 		var wsConnection = this.wsConnection;
 		if(wsConnection) {
 			/* Ignore any messages that come through after dispose() is called but before

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -1126,5 +1126,21 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		});
 	};
 
+	testOnAllTransports(exports, 'authorize_immediately_after_init', function(realtimeOpts) { return function(test) {
+		test.expect(1);
+		var realtime = helper.AblyRealtime({useTokenAuth: true, defaultTokenParams: { capability: {'wrong': ['*']} }});
+		realtime.auth.authorize({ capability: {'right': ['*']} })
+		realtime.connection.once('disconnected', function() {
+			test.ok(false, 'Connection should not have become disconnected');
+			closeAndFinish(test, realtime);
+		});
+		realtime.connection.once('connected', function() {
+			realtime.channels.get('right').attach(function(err) {
+				test.ok(!err, err && displayError(err) || 'Successfully attached');
+				closeAndFinish(test, realtime);
+			});
+		});
+	}});
+
 	return module.exports = helper.withTimeout(exports);
 });


### PR DESCRIPTION
Ensures that in all cases the token from most recent authorize() call takes precedence, and things waiting for a new token (including connectionmanager) will wait for that one to complete.

Also fixes a bug where if authorize() was called in the early stages of the connection (before a transport had been proposed), you'd get multiple concurrent connection sequences.

