### PR TITLE
Remove buggy callback argument from channel#unsubscribe()

### DIFF
--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -234,8 +234,6 @@ var RealtimeChannel = (function() {
 		var event = args[0];
 		var listener = args[1];
 		var callback = args[2];
-		var subscriptions = this.subscriptions;
-		var events;
 
 		if(!callback) {
 			if(this.realtime.options.promises) {
@@ -249,25 +247,16 @@ var RealtimeChannel = (function() {
 			return;
 		}
 
-		subscriptions.on(event, listener);
+		this.subscriptions.on(event, listener);
 
 		return this.attach(callback);
 	};
 
-	RealtimeChannel.prototype.unsubscribe = function(/* [event], listener, [callback] */) {
+	RealtimeChannel.prototype.unsubscribe = function(/* [event], listener */) {
 		var args = RealtimeChannel.processListenerArgs(arguments);
 		var event = args[0];
 		var listener = args[1];
-		var callback = args[2];
-		var subscriptions = this.subscriptions;
-		var events;
-
-		if(this.state === 'failed') {
-			callback(ErrorInfo.fromValues(RealtimeChannel.invalidStateError('failed')));
-			return;
-		}
-
-		subscriptions.off(event, listener);
+		this.subscriptions.off(event, listener);
 	};
 
 	RealtimeChannel.prototype.sync = function() {

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -444,17 +444,10 @@ var RealtimePresence = (function() {
 		channel.attach(callback);
 	};
 
-	RealtimePresence.prototype.unsubscribe = function(/* [event], listener, [callback] */) {
+	RealtimePresence.prototype.unsubscribe = function(/* [event], listener */) {
 		var args = RealtimeChannel.processListenerArgs(arguments);
 		var event = args[0];
 		var listener = args[1];
-		var callback = args[2];
-
-		if(this.channel.state === 'failed') {
-			callback(ErrorInfo.fromValues(RealtimeChannel.invalidStateError('failed')));
-			return;
-		}
-
 		this.subscriptions.off(event, listener);
 	};
 


### PR DESCRIPTION
Was throwing an error in the case of unsubscribe() called with no callback on a failed channel.

I don't like the idea of a method taking a callback that is only ever called as a failure condition, and otherwise remains uncalled. And it's inconsistent with the convention of how callbacks are used in the rest
of the library, which is that if a method takes a callback it is (a) guaranteed to be called eventually (on either success or failure), and (b) the method returns a promise if no callback is supplied. Neither of which is true for unsubscribe().

And there's no reason to conceptualize unsubscribe() as failing if called on a failed channel anyway, we can still remove the listener perfectly well. The channel is not going to receive any more messages anyway, but then that's also true of a detached channel. And nothing in the spec requires unsubscribe to fail if called on a failed channel.