### PR TITLE
base64-encode the x-ably-clientId header

### DIFF
--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -140,7 +140,7 @@ Defaults.normaliseOptions = function(options) {
 
 	if(options.clientId) {
 		var headers = options.headers = options.headers || {};
-		headers['X-Ably-ClientId'] = options.clientId;
+		headers['X-Ably-ClientId'] = BufferUtils.base64Encode(BufferUtils.utf8Encode(options.clientId));
 	}
 
 	if(!('idempotentRestPublishing' in options)) {


### PR DESCRIPTION
realtime will expect it to be encoded for ably-js 1.1.16 onwards