### PR TITLE
Remove semicolons to fix TS1036

### DIFF
--- a/promises.d.ts
+++ b/promises.d.ts
@@ -1,3 +1,3 @@
 import Ably = require('./ably');
-export declare class Realtime extends Ably.Realtime.Promise {};
-export declare class Rest extends Ably.Rest.Promise {};
+export declare class Realtime extends Ably.Realtime.Promise {}
+export declare class Rest extends Ably.Rest.Promise {}


### PR DESCRIPTION
These semicolons causes

> TS1036: Statements are not allowed in ambient contexts.

when using it with

```typescript
import Ably from "ably/promises";
```