### PR TITLE
Update kexec for node 12 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -348,8 +348,8 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "git://github.com/ably-forks/async.git#76306396b3d3a25316be0170ab6483ccbaaaa097",
+      "version": "git://github.com/ably-forks/async.git#76306396b3d3a25316be0170ab6483ccbaaaa097",
+      "from": "git://github.com/ably-forks/async.git#requirejs",
       "dev": true
     },
     "async-each": {
@@ -3787,10 +3787,12 @@
       }
     },
     "kexec": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/kexec/-/kexec-2.0.2.tgz",
-      "integrity": "sha1-ML4S5pQsebM/15Fi5NmjS4QLNmU=",
-      "dev": true
+      "version": "git://github.com/ably-forks/node-kexec.git#f29f54037c7db6ad29e1781463b182e5929215a0",
+      "from": "git://github.com/ably-forks/node-kexec.git#update-for-node-12",
+      "dev": true,
+      "requires": {
+        "nan": "^2.13.2"
+      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -4112,8 +4114,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "karma-nodeunit": "~0.2",
     "karma-requirejs": "~0.2",
     "karma-story-reporter": "~0.3",
-    "kexec": "^2.0.2",
+    "kexec": "git://github.com/ably-forks/node-kexec.git#update-for-node-12",
     "nodeunit": "^0.11.3",
     "requirejs": "~2.1",
     "shelljs": "~0.3"


### PR DESCRIPTION
https://github.com/jprichardson/node-kexec/issues/36

Fixes https://github.com/ably/ably-js/issues/597 , by using [Meteor's fork of kexec](https://github.com/meteor/node-kexec/tree/update-for-node-12)

(only used for karma, so a devdependency, so shouldn't have affected customers)