### PR TITLE
CometTransport.sendRequest: fix interpretation of non-ProtocolMessage errors

### DIFF
--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -80,8 +80,9 @@ var XHRRequest = (function() {
 	XHRRequest.prototype.complete = function(err, body, headers, unpacked, statusCode) {
 		if(!this.requestComplete) {
 			this.requestComplete = true;
-			if(body)
+			if(!err && body) {
 				this.emit('data', body);
+			}
 			this.emit('complete', err, body, headers, unpacked, statusCode);
 			this.dispose();
 		}

--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -96,6 +96,12 @@ var CometTransport = (function() {
 					err = err || new ErrorInfo('Request cancelled', 80003, 400);
 				}
 				self.recvRequest = null;
+				/* Connect request may complete without a emitting 'data' event since that is not
+				 * emitted for e.g. a non-streamed error response. Still implies preconnect. */
+				if(!preconnected) {
+					preconnected = true;
+					self.emit('preconnect');
+				}
 				self.onActivity();
 				if(err) {
 					if(err.code) {


### PR DESCRIPTION
Bug introduced by me in 1f511f48a, which made xhrrequest emit both the full response body even in the case of an error response in order that rest.request() could populate the httpPaginatedResponse. The comettransport code assumed that at most one of err and body was set, and checked the latter first.