### PR TITLE
Slight saving in npm package size by using files whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,17 @@
   "browser": {
     "./nodejs/index.js": "./browser/static/ably-commonjs.js"
   },
+  "files": [
+    "ably.d.ts",
+    "browser/**",
+    "callbacks.d.ts",
+    "callbacks.js",
+    "common/**",
+    "nodejs/**",
+    "promises.d.ts",
+    "promises.js",
+    "resources/**"
+  ],
   "dependencies": {
     "@ably/msgpack-js": "^0.3.2-v5",
     "request": "^2.87.0",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,7 @@
   "engines": {
     "node": ">=4.5.x"
   },
-  "repository": {
-    "type": "git",
-    "url": "ably/ably-js"
-  },
+  "repository": "ably/ably-js",
   "jspm": {
     "registry": "npm",
     "directories": {


### PR DESCRIPTION
Assuming it still works everywhere needed (!!) this brings file count down from 175 to 85, bringing the packaged size down from 1.2 MB to 1.0 MB.

Oh and a small optimisation to the repository key.