### PR TITLE
Fix deprecated Buffer constructor usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,17 @@ addons:
   firefox: "58.0"
 matrix:
   include:
-    - node_js: '4'
+    - node_js: '6'
       env: RUN_TESTS=./test/bin/ci-travis-firefox.sh
-    - node_js: '4'
-      env: RUN_TESTS=./test/bin/ci-travis-nodeunit.sh
     - node_js: '6'
       env: RUN_TESTS=./test/bin/ci-travis-nodeunit.sh
     - node_js: '8'
       env: RUN_TESTS=./test/bin/ci-travis-nodeunit.sh
+    - node_js: '10'
+      env: RUN_TESTS=./test/bin/ci-travis-nodeunit.sh
     - node_js: 'node' # means latest stable
       env: RUN_TESTS=./test/bin/ci-travis-nodeunit.sh
-    - node_js: '4'
+    - node_js: '6'
       env: RUN_TESTS=./test/bin/ci-travis-all.sh
 script:
   - $RUN_TESTS

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This SDK supports the following platforms:
 
 **Webpack:** see [using Webpack in browsers](#using-webpack), or [our guide for serverside Webpack](#serverside-usage-with-webpack)
 
-**Node.js:** version 4.5 or newer
+**Node.js:** version 5.10 or newer
 
 **React Native:** see [ably-js-react-native](https://github.com/ably/ably-js-react-native)
 

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -22,7 +22,7 @@ var Auth = (function() {
 
 	var hmac, toBase64;
 	if(Platform.createHmac) {
-		toBase64 = function(str) { return (new Buffer(str, 'ascii')).toString('base64'); };
+		toBase64 = function(str) { return (Buffer.from(str, 'ascii')).toString('base64'); };
 		hmac = function(text, key) {
 			var inst = Platform.createHmac('SHA256', key);
 			inst.update(text);

--- a/nodejs/lib/transport/nodecomettransport.js
+++ b/nodejs/lib/transport/nodecomettransport.js
@@ -111,7 +111,7 @@ var NodeCometTransport = (function() {
 			method = 'POST';
 			if(!Buffer.isBuffer(body)) {
 				if(typeof(body) == 'object') body = JSON.stringify(body);
-				body = new Buffer(body);
+				body = Buffer.from(body);
 			}
 			this.body = body;
 			headers['Content-Length'] = body.length;

--- a/nodejs/lib/util/bufferutils.js
+++ b/nodejs/lib/util/bufferutils.js
@@ -13,13 +13,13 @@ this.BufferUtils = (function() {
 
 	BufferUtils.base64Encode = function(buf) { return Buffer.from(buf).toString('base64'); };
 
-	BufferUtils.base64Decode = function(string) { return new Buffer(string, 'base64'); };
+	BufferUtils.base64Decode = function(string) { return Buffer.from(string, 'base64'); };
 
 	BufferUtils.hexEncode = function(buf) { return Buffer.from(buf).toString('hex'); };
 
-	BufferUtils.hexDecode = function(string) { return new Buffer(string, 'hex'); };
+	BufferUtils.hexDecode = function(string) { return Buffer.from(string, 'hex'); };
 
-	BufferUtils.utf8Encode = function(string) { return new Buffer(string, 'utf8'); };
+	BufferUtils.utf8Encode = function(string) { return Buffer.from(string, 'utf8'); };
 
 	/* For utf8 decoding we apply slightly stricter input validation than to
 	 * hexEncode/base64Encode/etc: in those we accept anything that Buffer.from

--- a/nodejs/lib/util/crypto.js
+++ b/nodejs/lib/util/crypto.js
@@ -48,12 +48,12 @@ var Crypto = (function() {
 	/**
 	 * Internal: a block containing zeros
 	 */
-	var emptyBlock = new Buffer(DEFAULT_BLOCKLENGTH);
+	var emptyBlock = Buffer.alloc(DEFAULT_BLOCKLENGTH);
 
 	/**
 	 * Internal: obtain the pkcs5 padding string for a given padded length;
 	 */
-	function filledBuffer(length, value) { var result = new Buffer(length); result.fill(value); return result; }
+	function filledBuffer(length, value) { var result = Buffer.alloc(length); result.fill(value); return result; }
 	var pkcs5Padding = [ filledBuffer(16, 16) ];
 	for(var i = 1; i <= 16; i++) pkcs5Padding.push(filledBuffer(i, i));
 
@@ -63,7 +63,7 @@ var Crypto = (function() {
 	 * @returns {Buffer}
 	 */
 	function toBuffer(bufferOrString) {
-		return (typeof(bufferOrString) == 'string') ? new Buffer(bufferOrString, 'binary') : bufferOrString;
+		return (typeof(bufferOrString) == 'string') ? Buffer.from(bufferOrString, 'binary') : bufferOrString;
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "shelljs": "~0.3"
   },
   "engines": {
-    "node": ">=4.5.x"
+    "node": ">=5.10.x"
   },
   "repository": "ably/ably-js",
   "jspm": {

--- a/spec/common/modules/testapp_manager.js
+++ b/spec/common/modules/testapp_manager.js
@@ -53,7 +53,7 @@ define(['globals', 'browser-base64', 'ably'], function(ablyGlobals, base64, ably
 		if (isBrowser) {
 			return base64.encode;
 		} else {
-			return function (str) { return (new Buffer(str, 'ascii')).toString('base64'); };
+			return function (str) { return (Buffer.from(str, 'ascii')).toString('base64'); };
 		}
 	}
 

--- a/test/browser-srv/framework/teardown.js
+++ b/test/browser-srv/framework/teardown.js
@@ -1,7 +1,7 @@
 var https = require('https');
 
 exports.deleteAccount = function (testVars, testAccount, console, callback) {
-	var auth = 'Basic ' + new Buffer(testAccount.appId + '.' + testAccount.key0Id + ':' + testAccount.key0Value).toString('base64');
+	var auth = 'Basic ' + Buffer.from(testAccount.appId + '.' + testAccount.key0Id + ':' + testAccount.key0Value).toString('base64');
 	var delOptions = {
 		host: testVars.realtimeHost,
 		port: testVars.realtimeTlsPort,

--- a/tools/crypto/generate-test-data.js
+++ b/tools/crypto/generate-test-data.js
@@ -56,7 +56,7 @@ function padPlaintext(plaintext) {
 	var unpaddedLength = plaintext.length,
 		paddedLength = getPaddedLength(unpaddedLength),
 		paddingLength = paddedLength - unpaddedLength,
-		padding = new Buffer(paddingLength);
+		padding = Buffer.alloc(paddingLength);
 
 	padding.fill(paddingLength);
 	return Buffer.concat([plaintext, padding]);
@@ -110,13 +110,13 @@ for(var i = 1; i < process.argv.length; i++) {
 			case 'key':
 				try {
 					var keyHex = optMatch[2].replace(/ /g, '');
-					key = new Buffer(keyHex, 'hex');
+					key = Buffer.from(keyHex, 'hex');
 				} catch(e) { usage(e.message); }
 				break;
 			case 'iv':
 				try {
 					var ivHex = optMatch[2].replace(/ /g, '');
-					iv = new Buffer(ivHex, 'hex');
+					iv = Buffer.from(ivHex, 'hex');
 				} catch(e) { usage(e.message); }
 				break;
 			case 'data':
@@ -132,7 +132,7 @@ for(var i = 1; i < process.argv.length; i++) {
 			case 'iv':
 				try {
 					var ivHex = optMatch[2].replace(/ /g, '');
-					iv = new Buffer(ivHex, 'hex');
+					iv = Buffer.from(ivHex, 'hex');
 				} catch(e) { usage(e.message); }
 				break;
 			case 'save':
@@ -167,12 +167,12 @@ if(!iv) {
 var items;
 if(data) {
 	if(encoding)
-		data = new Buffer(data, encoding);
+		data = Buffer.from(data, encoding);
 	items = [data];
 } else {
 	items = [
 		'The quick brown fox jumped over the lazy dog',
-		new Buffer('000102030405060708090a0b0c0d0e0f', 'hex'),
+		Buffer.from('000102030405060708090a0b0c0d0e0f', 'hex'),
 		{example: {json: 'Object'}},
 		['example', 'json', 'array']
 	];
@@ -253,7 +253,7 @@ function generate_test_data_for(data) {
 	verboseOutput('Plaintext before encryption (without padding):');
 	var plaintext = data;
 	if(isString) {
-		plaintext = new Buffer(plaintext);
+		plaintext = Buffer.from(plaintext);
 		encoding = (encoding ? (encoding + '/') : '') + 'utf-8';
 	}
 	hexdump(plaintext);


### PR DESCRIPTION
This fixes the annoying deprecation warnings on recent node versions, but would raise the minimum node version to 5.10 (see eg [here](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_string_encoding)), wdyt?

(if we have to we can abstract over them in platform-nodejs to get both, but bit of a faff)