### PR TITLE
Add example of subscribing to a channel with deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ See the [ably-js-react-native repo](https://github.com/ably/ably-js-react-native
 
 See the [ably-js-nativescript repo](https://github.com/ably/ably-js-nativescript) for NativeScript usage details.
 
+## Delta Plugin
+
+From version 1.2 this client library supports subscription to a stream of Vcdiff formatted delta messages from the Ably service. For certain applications this can bring significant data efficiency savings.
+This is an optional feature so our
+[Vcdiff Decoder plugin](https://github.com/ably-forks/vcdiff-decoder)
+must be supplied to the library in client options to enable this functionality.
+
+```js
+var vcdiffDecoder = require('@ably/vcdiff-decoder');
+
+var clientOptions = {
+  plugins: {
+    vcdiff: vcdiffDecoder,
+  },
+  // TODO provide auth option (e.g. key)
+};
+var client = new Ably.Realtime(clientOptions);
+```
+
+See also
+[Subscribing to a channel with deltas](#subscribing-to-a-channel-with-deltas),
+which describes how to request a delta stream when getting a channel.
+
 ## Using the Realtime API
 
 This readme gives some basic examples; for our full API documentation, please go to https://www.ably.io/documentation .
@@ -182,8 +205,27 @@ channel.subscribe('myEvent', function(message) {
 });
 ```
 
-### Publishing to a channel
+### Subscribing to a channel with deltas
 
+Provide the library with Vcdiff decoding capability - see
+[Delta Plugin](#delta-plugin).
+
+Request a Vcdiff formatted delta stream using channel options when you get the channel:
+
+```js
+var channelOptions = {
+  params: {
+    delta: 'vcdiff',
+  },
+};
+var channel = client.channels.get('test', channelOptions);
+```
+
+Beyond specifying channel options, the rest is transparent and requires no further changes to your application. The `message.data` instances that are delivered to your listening function continue to contain the values that were originally published.
+
+If you would like to inspect the `Message` instances in order to identify whether the `data` they present was rendered from a delta message from Ably then you can see if `extras.delta.format` equals `'vcdiff'`.
+
+### Publishing to a channel
 
 ```javascript
 // Publish a single message with name and data

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ var client = new Ably.Realtime(clientOptions);
 
 See also
 [Subscribing to a channel with deltas](#subscribing-to-a-channel-with-deltas),
-which describes how to request a delta stream when getting a channel.
+which describes how to enable delta compression when getting a channel.
 
 ## Using the Realtime API
 
@@ -206,6 +206,8 @@ channel.subscribe('myEvent', function(message) {
 ```
 
 ### Subscribing to a channel with deltas
+
+Subscribing to a channel in delta mode enables delta compression. This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
 
 Provide the library with Vcdiff decoding capability - see
 [Delta Plugin](#delta-plugin).

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ channel.subscribe('myEvent', function(message) {
 
 ### Subscribing to a channel with deltas
 
-Subscribing to a channel in delta mode enables delta compression. This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
+Subscribing to a channel in delta mode enables [delta compression](https://www.ably.io/documentation/realtime/channels/channel-parameters/deltas). This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
 
 Provide the library with Vcdiff decoding capability - see
 [Delta Plugin](#delta-plugin).


### PR DESCRIPTION
Matching https://github.com/ably/ably-java/pull/579

Slightly more complex for this client library due to the fact that there's also the requirement for the Vcdiff Decoder plugin to be installed.

I've decided to demonstrate the same [acknowledged curio](https://github.com/ably/ably-java/pull/579#issuecomment-634508717) in respect of extras delta format inspection ([internal prover](https://github.com/ably/hello-deltas-js/commit/8faff1cbb2c4c2a8325469511dadae12f1e3a733)).

We've used `var` throughout this readme so to keep my PR in keeping I've resisted the urge to use `const` instead. That's a job for another day.