### PR TITLE
Add state check to channels.release()

### DIFF
--- a/common/lib/client/realtime.js
+++ b/common/lib/client/realtime.js
@@ -132,11 +132,19 @@ var Realtime = (function() {
 		return channel;
 	};
 
+	/* Included to support certain niche use-cases; most users should ignore this.
+	 * Please do not use this unless you know what you're doing */
 	Channels.prototype.release = function(name) {
+		name = String(name);
 		var channel = this.all[name];
-		if(channel) {
-			delete this.all[name];
+		if(!channel) {
+			return;
 		}
+		var releaseErr = channel.getReleaseErr();
+		if(releaseErr) {
+			throw releaseErr;
+		}
+		delete this.all[name];
 	};
 
 	/* Records operations currently pending on a transport; used by connectionManager to decide when

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -723,5 +723,14 @@ var RealtimeChannel = (function() {
 		return EventEmitter.prototype.whenState.call(this, state, this.state, listener);
 	}
 
+	/* @returns null (if can safely be released) | ErrorInfo (if cannot) */
+	RealtimeChannel.prototype.getReleaseErr = function() {
+		var s = this.state;
+		if(s === 'initialized' || s === 'detached' || s === 'failed') {
+			return null;
+		}
+		return new ErrorInfo('Can only release a channel in a state where there is no possibility of further updates from the server being received (initialized, detached, or failed); was ' + s, 90001, 400);
+	}
+
 	return RealtimeChannel;
 })();

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -163,14 +163,14 @@ var Rest = (function() {
 
 	function Channels(rest) {
 		this.rest = rest;
-		this.attached = {};
+		this.all = {};
 	}
 
 	Channels.prototype.get = function(name, channelOptions) {
 		name = String(name);
-		var channel = this.attached[name];
+		var channel = this.all[name];
 		if(!channel) {
-			this.attached[name] = channel = new Channel(this.rest, name, channelOptions);
+			this.all[name] = channel = new Channel(this.rest, name, channelOptions);
 		} else if(channelOptions) {
 			channel.setOptions(channelOptions);
 		}
@@ -181,7 +181,7 @@ var Rest = (function() {
 	/* Included to support certain niche use-cases; most users should ignore this.
 	 * Please do not use this unless you know what you're doing */
 	Channels.prototype.release = function(name) {
-		delete this.attached[String(name)];
+		delete this.all[String(name)];
 	};
 
 	return Rest;

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -178,6 +178,8 @@ var Rest = (function() {
 		return channel;
 	};
 
+	/* Included to support certain niche use-cases; most users should ignore this.
+	 * Please do not use this unless you know what you're doing */
 	Channels.prototype.release = function(name) {
 		delete this.attached[String(name)];
 	};


### PR DESCRIPTION
Plus comment warning off anyone who's just browsing the source code and thinks that because it's there they should use it.

Plus noticed channels in the rest client were kept in an object called 'attached', which makes no sense since rest channels have no concept of attachment. Changed it to 'all', which matches the realtime client. This is technically a breaking change, but we've never documented or told anyone to enumerate channels using rest.channels.attached, so hopefully no-one is.