### PR TITLE
Bump protocol version to 1.2

### DIFF
--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -30,7 +30,7 @@ Defaults.errorReportingHeaders = {
 
 Defaults.version          = '1.2.1';
 Defaults.libstring        = Platform.libver + '-' + Defaults.version;
-Defaults.apiVersion       = '1.1';
+Defaults.apiVersion       = '1.2';
 
 Defaults.getHost = function(options, host, ws) {
 	if(ws)

--- a/spec/rest/http.test.js
+++ b/spec/rest/http.test.js
@@ -24,7 +24,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		Ably.Rest.Http.get = function (rest, path, headers, params, callback) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
 			test.ok(('X-Ably-Lib' in headers), 'Verify lib header exists');
-			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
+			
+			// This test should not directly validate version against Defaults.version, as
+			// ultimately the version header has been derived from that value.
+			test.equal(headers['X-Ably-Version'], '1.2', 'Verify current version number');
+
 			test.ok(headers['X-Ably-Lib'].indexOf(Defaults.version) > -1, 'Verify libstring');
 		};
 
@@ -32,7 +36,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		Ably.Rest.Http.post = function (rest, path, headers, body, params, callback) {
 			test.ok(('X-Ably-Version' in headers), 'Verify version header exists');
 			test.ok(('X-Ably-Lib' in headers), 'Verify lib header exists');
-			test.equal(headers['X-Ably-Version'], Defaults.apiVersion, 'Verify current version number');
+
+			// This test should not directly validate version against Defaults.version, as
+			// ultimately the version header has been derived from that value.
+			test.equal(headers['X-Ably-Version'], '1.2', 'Verify current version number');
+			
 			test.ok(headers['X-Ably-Lib'].indexOf(Defaults.version) > -1, 'Verify libstring');
 		};
 


### PR DESCRIPTION
In response to [this comment](https://github.com/ably/docs/pull/845#issuecomment-652352048).

Matching the [equivalent PR raised in ably-cocoa](https://github.com/ably/ably-cocoa/pull/1058)...

...except for the fact that I've not been able to find an obvious place to insert a test to assert the `v` query param. for realtime connections (WebSocket). @SimonWoolf, do you have any suggestions for how to test this is being sent?