### PR TITLE
Fail connection immediately if authorize() called and 403 returned

### DIFF
--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -211,7 +211,7 @@ var XHRRequest = (function() {
 				return;
 			}
 
-			var err = responseBody.error;
+			var err = responseBody.error && ErrorInfo.fromValues(responseBody.error);
 			if(!err) {
 				err = new ErrorInfo('Error response received from server: ' + statusCode + ' body was: ' + Utils.inspect(responseBody), null, statusCode);
 			}

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -214,9 +214,16 @@ var Auth = (function() {
 
 		this._forceNewToken(tokenParams, authOptions, function(err, tokenDetails) {
 			if(err) {
+				if(self.client.connection) {
+					/* We interpret RSA4d as including requests made by a client lib to
+					 * authenticate triggered by an explicit authorize() or an AUTH received from
+					 * ably, not just connect-sequence-triggered token fetches */
+					self.client.connection.connectionManager.actOnErrorFromAuthorize(err);
+				}
 				callback(err);
 				return;
 			}
+
 			/* RTC8
 			 * - When authorize called by an end user and have a realtime connection,
 			 * don't call back till new token has taken effect.

--- a/nodejs/lib/util/http.js
+++ b/nodejs/lib/util/http.js
@@ -34,11 +34,11 @@ this.Http = (function() {
 					case 'application/x-msgpack':
 						body = msgpack.decode(body);
 				}
-				var error = body.error || {
-					statusCode: statusCode,
-					code: headers['x-ably-errorcode'],
-					message: headers['x-ably-errormessage']
-				};
+				var error = body.error ? ErrorInfo.fromValues(body.error) : new ErrorInfo(
+					headers['x-ably-errormessage'] || 'Error response received from server: ' + statusCode + ' body was: ' + Utils.inspect(body),
+					headers['x-ably-errorcode'],
+					statusCode
+				);
 				callback(error, body, headers, true, statusCode);
 				return;
 			}

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -517,6 +517,37 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 		authUrl: echoServer + '/respondwith?status=403'
 	}, true); /* expectFailed: */
 
+	exports.authUrl_403_previously_active = function(test) {
+		var realtime, rest = helper.AblyRest();
+		rest.auth.requestToken(null, null, function(err, tokenDetails) {
+			if(err) {
+				test.ok(false, displayError(err));
+				closeAndFinish(test, realtime);
+				return;
+			}
+
+			var authPath = echoServer + "/?type=json&body=" + encodeURIComponent(JSON.stringify(tokenDetails));
+
+			realtime = helper.AblyRealtime({ authUrl: authPath });
+
+			realtime.connection.on('connected', function() {
+				test.ok(true, 'Connected to Ably using authUrl with TokenDetails JSON payload');
+
+				/* replace the authUrl and reauth */
+				realtime.auth.authorize(null, {authUrl: echoServer + '/respondwith?status=403'}, function(err, tokenDetails) {
+					test.equal(err && err.statusCode, 403, 'Check err statusCode');
+					test.equal(err && err.code, 40300, 'Check err code');
+					/* auth endpoints don't envelope, so this won't work with jsonp */
+					if(helper.bestTransport !== 'jsonp') {
+						test.equal(realtime.connection.state, 'failed', 'Check connection goes to the failed state');
+						test.equal(realtime.connection.errorReason && realtime.connection.errorReason.statusCode, 403, 'Check correct cause error code');
+					}
+					closeAndFinish(test, realtime);
+				});
+			});
+		});
+	};
+
 	/*
 	 * Check state change reason is propogated during a disconnect
 	 * (when connecting with a token that expires while connected)

--- a/spec/realtime/auth.test.js
+++ b/spec/realtime/auth.test.js
@@ -518,6 +518,11 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 	}, true); /* expectFailed: */
 
 	exports.authUrl_403_previously_active = function(test) {
+		if(helper.bestTransport === 'jsonp') {
+			/* auth endpoints don't envelope, so this won't work with jsonp */
+			test.done();
+			return;
+		}
 		var realtime, rest = helper.AblyRest();
 		rest.auth.requestToken(null, null, function(err, tokenDetails) {
 			if(err) {
@@ -537,11 +542,8 @@ define(['ably', 'shared_helper', 'async'], function(Ably, helper, async) {
 				realtime.auth.authorize(null, {authUrl: echoServer + '/respondwith?status=403'}, function(err, tokenDetails) {
 					test.equal(err && err.statusCode, 403, 'Check err statusCode');
 					test.equal(err && err.code, 40300, 'Check err code');
-					/* auth endpoints don't envelope, so this won't work with jsonp */
-					if(helper.bestTransport !== 'jsonp') {
-						test.equal(realtime.connection.state, 'failed', 'Check connection goes to the failed state');
-						test.equal(realtime.connection.errorReason && realtime.connection.errorReason.statusCode, 403, 'Check correct cause error code');
-					}
+					test.equal(realtime.connection.state, 'failed', 'Check connection goes to the failed state');
+					test.equal(realtime.connection.errorReason && realtime.connection.errorReason.statusCode, 403, 'Check correct cause error code');
 					closeAndFinish(test, realtime);
 				});
 			});


### PR DESCRIPTION
That is: interpret RSA4d as including requests made by a client lib to authenticate triggered by an explicit authorize() or an AUTH received from ably, not just to connect-sequence-triggered token fetches.

We might want to clarify the spec on this point.