### PR TITLE
ClientOptions: Refactor host and fallback inference logic

### DIFF
--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -107,14 +107,14 @@ Defaults.normaliseOptions = function(options) {
 		if(options.fallbackHosts) {
 			var msg = 'fallbackHosts and fallbackHostsUseDefault cannot both be set';
 			Logger.logAction(Logger.LOG_ERROR, 'Defaults.normaliseOptions', msg);
-			throw new Error(msg);
+			throw new ErrorInfo(msg, 40000, 400);
 		}
 
 		/* default fallbacks can't be used with custom ports */
 		if(options.port || options.tlsPort) {
 			var msg = 'fallbackHostsUseDefault cannot be set when port or tlsPort are set';
 			Logger.logAction(Logger.LOG_ERROR, 'Defaults.normaliseOptions', msg);
-			throw new Error(msg);
+			throw new ErrorInfo(msg, 40000, 400);
 		}
 
 		/* emit an appropriate deprecation warning */

--- a/common/lib/util/logger.js
+++ b/common/lib/util/logger.js
@@ -62,8 +62,12 @@ var Logger = (function() {
 	};
 
 	Logger.deprecated = function(original, replacement) {
+		Logger.deprecatedWithMsg(original, "Please use '" + replacement + "' instead.");
+	}
+
+	Logger.deprecatedWithMsg = function(funcName, msg) {
 		if (Logger.shouldLog(LOG_ERROR)) {
-			logErrorHandler("Ably: Deprecation warning - '" + original + "' is deprecated and will be removed from a future version. Please use '" + replacement + "' instead.");
+			logErrorHandler("Ably: Deprecation warning - '" + funcName + "' is deprecated and will be removed from a future version. " + msg);
 		}
 	}
 

--- a/spec/rest/defaults.test.js
+++ b/spec/rest/defaults.test.js
@@ -67,6 +67,28 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.done();
 	};
 
+	/* init with given environment and default fallbacks */
+	/* will emit a deprecation warning */
+	exports.defaults_given_environment = function(test) {
+		test.expect(11);
+		var normalisedOptions = Defaults.normaliseOptions({environment: 'sandbox', fallbackHostsUseDefault: true});
+
+		test.equal(normalisedOptions.restHost, 'sandbox-rest.ably.io');
+		test.equal(normalisedOptions.realtimeHost, 'sandbox-realtime.ably.io');
+		test.equal(normalisedOptions.port, 80);
+		test.equal(normalisedOptions.tlsPort, 443);
+		test.deepEqual(normalisedOptions.fallbackHosts.sort(), Defaults.FALLBACK_HOSTS.sort());
+		test.equal(normalisedOptions.tls, true);
+
+		test.deepEqual(Defaults.getHosts(normalisedOptions).length, 4);
+		test.deepEqual(Defaults.getHosts(normalisedOptions)[0], normalisedOptions.restHost);
+		test.deepEqual(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', false), 'sandbox-rest.ably.io');
+		test.deepEqual(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', true), 'sandbox-realtime.ably.io');
+
+		test.equal(Defaults.getPort(normalisedOptions), 443);
+		test.done();
+	};
+
 	/* init with local environment and non-default ports */
 	exports.defaults_local_ports = function(test) {
 		test.expect(10);
@@ -135,6 +157,29 @@ define(['ably', 'shared_helper'], function(Ably, helper) {
 		test.equal(normalisedOptions.restHost, 'test.org');
 		test.equal(normalisedOptions.realtimeHost, 'ws.test.org');
 		test.deepEqual(normalisedOptions.fallbackHosts.sort(), Defaults.FALLBACK_HOSTS.sort());
+		test.done();
+	};
+
+	/* init with both fallbackHosts and fallbackHostsUseDefault */
+	/* will throw an error */
+	exports.defaults_given_fallbackHosts_and_fallbackHostsUseDefault = function(test) {
+		test.expect(1);
+		test.throws(function() {
+			Defaults.normaliseOptions({fallbackHosts: ['a.example.com', 'b.example.com'], fallbackHostsUseDefault: true});
+		}, "Check fallbackHosts and fallbackHostsUseDefault can't both be set");
+		test.done();
+	};
+
+	/* init with fallbackHostsUseDefault and port or tlsPort set */
+	/* will throw an error */
+	exports.defaults_given_fallbackHostsUseDefault_and_port_or_tlsPort = function(test) {
+		test.expect(2);
+		test.throws(function() {
+			Defaults.normaliseOptions({fallbackHostsUseDefault: true, port: 8080});
+		}, "Check fallbackHostsUseDefault and port can't both be set");
+		test.throws(function() {
+			Defaults.normaliseOptions({fallbackHostsUseDefault: true, tlsPort: 8081});
+		}, "Check fallbackHostsUseDefault and tlsPort can't both be set");
 		test.done();
 	};
 


### PR DESCRIPTION
This refactors the way the library infers hosts and fallbacks, and fixes the handling of the deprecated `fallbackHostsUseDefault` option.

@sacOO7 this should address the concerns you raised in https://github.com/ably/ably-js/pull/682, in particularly:

- an error is thrown if `fallbackHosts` and `fallbackHostsUseDefault` are both set

- an error is thrown if `fallbackHostsUseDefault` and either `port` or `tlsPort` is set (since fallbacks don't apply when using custom ports as documented in https://github.com/ably/docs/pull/978)

- a warning is emitted when `fallbackHostsUseDefault` and `environment` are both set (these could be a valid combination so no need for an error, but there is no need to set them both anymore since each environment now always maps to its correct fallbacks)

- a warning is emitted when `realtimeHost` is set to `restHost` so the user knows that has happened and can choose to set `realtimeHost` explicitly if that is incorrect

- `realtimeHost` is only inferred if it isn't explicitly set

Fixes https://github.com/ably/ably-js/issues/688.