### PR TITLE
DevicePushDetails should contain error not errorReason

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -338,7 +338,7 @@ declare namespace Types {
 	interface DevicePushDetails {
 		recipient: any;
 		state?: DevicePushState;
-		errorReason?: ErrorInfo;
+		error?: ErrorInfo;
 	}
 
 	interface DeviceRegistrationParams {

--- a/common/lib/types/devicedetails.js
+++ b/common/lib/types/devicedetails.js
@@ -77,6 +77,7 @@ var DeviceDetails = (function() {
 	};
 
 	DeviceDetails.fromValues = function(values) {
+		values.error = values.error && ErrorInfo.fromValues(values.error); 
 		return Utils.mixin(new DeviceDetails(), values);
 	};
 

--- a/common/lib/types/devicedetails.js
+++ b/common/lib/types/devicedetails.js
@@ -11,7 +11,7 @@ var DeviceDetails = (function() {
 		this.push = {
 			recipient: undefined,
 			state: undefined,
-			errorReason: undefined
+			error: undefined
 		};
 	}
 
@@ -31,7 +31,7 @@ var DeviceDetails = (function() {
 			push: {
 				recipient: this.push.recipient,
 				state: this.push.state,
-				errorReason: this.push.errorReason
+				error: this.push.error
 			}
 		};
 	};
@@ -54,8 +54,8 @@ var DeviceDetails = (function() {
 			result += '; push.recipient=' + JSON.stringify(this.push.recipient);
 		if(this.push.state)
 			result += '; push.state=' + this.push.state;
-		if(this.push.errorReason)
-			result += '; push.errorReason=' + this.push.errorReason;
+		if(this.push.error)
+			result += '; push.error=' + JSON.stringify(this.push.error);
 		if(this.push.metadata)
 			result += '; push.metadata=' + this.push.metadata;
 		result += ']';


### PR DESCRIPTION
The DevicePushDetails struct was initially made with an `errorReason` field that was never filled by the server. `error` is now being sent from the frontends. 
