### PR TITLE
Tests: add fix for no_connection_lifecycle

### DIFF
--- a/common/lib/transport/comettransport.js
+++ b/common/lib/transport/comettransport.js
@@ -98,7 +98,7 @@ var CometTransport = (function() {
 				self.recvRequest = null;
 				/* Connect request may complete without a emitting 'data' event since that is not
 				 * emitted for e.g. a non-streamed error response. Still implies preconnect. */
-				if(!preconnected) {
+				if(!preconnected && !err) {
 					preconnected = true;
 					self.emit('preconnect');
 				}

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -288,7 +288,8 @@ var ConnectionManager = (function() {
 				/* Comet transport onconnect token errors can be dealt with here.
 				* Websocket ones only happen after the transport claims to be viable,
 				* so are dealt with as non-onconnect token errors */
-				if(Auth.isTokenErr(wrappedErr.error)) {
+				if(Auth.isTokenErr(wrappedErr.error) && !(self.errorReason && Auth.isTokenErr(self.errorReason))) {
+					self.errorReason = wrappedErr.error;
 					/* re-get a token and try again */
 					self.realtime.auth._forceNewToken(null, null, function(err) {
 						if(err) {


### PR DESCRIPTION
Resolves #661 

This test was failing because the lib didn't properly implement RTN14b in the case of a comet 'preconnect'. [internal discussion](https://ably-real-time.slack.com/archives/C017C5EPYG0/p1604597877014800).