### PR TITLE
Comet: Raise preconnect event if the server responds with a protocol message

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           node-version: 14.x
       - run: npm ci
-      - run: npm run lint
+      - run: npm run build
       - run: npm run check-closure-compiler

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,8 +59,8 @@ module.exports = function (grunt) {
 				/* By default, the compiler assumes you're using es6 and transpiles to
 				 * es3, adding various (unnecessary and undesired) polyfills. Specify
 				 * both in and out to es3 to avoid transpilation */
-				language_in: 'ECMASCRIPT3',
-				language_out: 'ECMASCRIPT3',
+				language_in: 'ECMASCRIPT5',
+				language_out: 'ECMASCRIPT5',
 				strict_mode_input: true,
 				checks_only: true,
 				warning_level: 'QUIET'
@@ -92,6 +92,7 @@ module.exports = function (grunt) {
 	]);
 
 	grunt.registerTask('check-closure-compiler', [
+		'build',
 		'closureCompiler:ably.js'
 	]);
 

--- a/common/lib/transport/connectionerror.js
+++ b/common/lib/transport/connectionerror.js
@@ -42,12 +42,13 @@ ConnectionError.isRetriable = function(err) {
 	if (!err.statusCode || !err.code || err.statusCode >= 500) {
 		return true;
 	}
-	for (const [{code}] of ConnectionError.values()) {
-		if (code == err.code) {
-			return true;
+	var retriable = false;
+	Utils.valuesArray(ConnectionError).forEach(function(connErr) {
+		if (connErr.code && connErr.code == err.code) {
+			retriable = true;
 		}
-	}
-	return false;
+	});
+	return retriable;
 };
 
 export default ConnectionError;

--- a/common/lib/transport/connectionerror.js
+++ b/common/lib/transport/connectionerror.js
@@ -38,4 +38,16 @@ var ConnectionError = {
 	})
 };
 
+ConnectionError.isRetriable = function(err) {
+	if (!err.statusCode || !err.code || err.statusCode >= 500) {
+		return true;
+	}
+	for (const [{code}] of ConnectionError.values()) {
+		if (code == err.code) {
+			return true;
+		}
+	}
+	return false;
+};
+
 export default ConnectionError;

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -328,7 +328,7 @@ var ConnectionManager = (function() {
 					self.notifyState({state: 'failed', error: wrappedErr.error});
 					callback(true);
 				} else if(wrappedErr.event === 'disconnected') {
-					if(wrappedErr.error.code && wrappedErr.error.statusCode > 400 && wrappedErr.error.statusCode < 500) {
+					if(!ConnectionError.isRetriable(wrappedErr)) {
 						/* Error received from the server that does not call for trying a fallback host, eg a rate limit */
 						self.notifyState({state: self.states.connecting.failState, error: wrappedErr.error});
 						callback(true);

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -330,7 +330,7 @@ var ConnectionManager = (function() {
 				} else if(wrappedErr.event === 'disconnected') {
 					if(wrappedErr.error.code && wrappedErr.error.statusCode < 500) {
 						/* Error received from the server that does not call for trying a fallback host, eg a rate limit */
-						self.notifyState({state: 'disconnected', error: wrappedErr.error});
+						self.notifyState({state: self.states.connecting.failState, error: wrappedErr.error});
 						callback(true);
 					} else {
 						/* Error with that transport only; continue trying other fallback hosts */

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -328,7 +328,7 @@ var ConnectionManager = (function() {
 					self.notifyState({state: 'failed', error: wrappedErr.error});
 					callback(true);
 				} else if(wrappedErr.event === 'disconnected') {
-					if(wrappedErr.error.code && wrappedErr.error.statusCode < 500) {
+					if(wrappedErr.error.code && wrappedErr.error.statusCode > 400 && wrappedErr.error.statusCode < 500) {
 						/* Error received from the server that does not call for trying a fallback host, eg a rate limit */
 						self.notifyState({state: self.states.connecting.failState, error: wrappedErr.error});
 						callback(true);

--- a/common/lib/transport/connectionmanager.js
+++ b/common/lib/transport/connectionmanager.js
@@ -328,8 +328,14 @@ var ConnectionManager = (function() {
 					self.notifyState({state: 'failed', error: wrappedErr.error});
 					callback(true);
 				} else if(wrappedErr.event === 'disconnected') {
-					/* Error with that transport only */
-					callback(false);
+					if(wrappedErr.error.code && wrappedErr.error.statusCode < 500) {
+						/* Error received from the server that does not call for trying a fallback host, eg a rate limit */
+						self.notifyState({state: 'disconnected', error: wrappedErr.error});
+						callback(true);
+					} else {
+						/* Error with that transport only; continue trying other fallback hosts */
+						callback(false);
+					}
 				}
 				return;
 			}

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -139,7 +139,7 @@ var WebSocketTransport = function(connectionManager) {
 			this.finish('disconnected', err);
 		} else {
 			var msg = 'Unclean disconnection of WebSocket ; code = ' + code,
-				err = new ErrorInfo(msg, 80003, 500);
+				err = new ErrorInfo(msg, 80003, 400);
 			Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.onWsClose()', msg);
 			this.finish('disconnected', err);
 		}

--- a/common/lib/transport/websockettransport.js
+++ b/common/lib/transport/websockettransport.js
@@ -139,7 +139,7 @@ var WebSocketTransport = function(connectionManager) {
 			this.finish('disconnected', err);
 		} else {
 			var msg = 'Unclean disconnection of WebSocket ; code = ' + code,
-				err = new ErrorInfo(msg, 80003, 400);
+				err = new ErrorInfo(msg, 80003, 500);
 			Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.onWsClose()', msg);
 			this.finish('disconnected', err);
 		}


### PR DESCRIPTION
Even if the message is an error.

There was a realtime CI regression on upgrading to ably-js 1.2.5 (from 1.2.1). Rate enforcement errors for comet were being swallowed by the client and a no hosts error being raised in response.  On realtime sending a response of:
```
ProtocolMessage; action=DISCONNECTED; error=[ErrorInfo: Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metric = connections.maxRate; statusCode=429; code=80021; see https://help.ably.io/error/80021 ]
```
We expected the connection to be disconnected with error:
```
[ErrorInfo: Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metric = connections.maxRate; statusCode=429; code=80021;]
```
but instead saw:
```
[ErrorInfo: Unable to connect (and no more fallback hosts to try); statusCode=404; code=80003]
```

This is because the `preconnect` event was no longer being raised in error cases as a result of https://github.com/ably/ably-js/pull/698. That PR was a sensible fix for the case where the host is unreachable but if the host does respond then the `preconnect` event should be raised. I've used `code` being set in the `ErrorInfo` to discern this as it seems to be used elsewhere but it's a bit subtle for my taste so I'm happy for you to suggest more elaborate changes.

Ably js logs of failing test:
```
20:26:06.279 Ably: Transport.onProtocolMessage(): received on comet: [ProtocolMessage; action=DISCONNECTED; error=[ErrorInfo: Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metric = connections.maxRate; statusCode=429; code=80021; see https://help.ably.io/error/80021 ]]; connectionId = undefined
20:26:06.279 Ably: Transport.onDisconnect(): err = [ErrorInfo: Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metric = connections.maxRate; statusCode=429; code=80021; see https://help.ably.io/error/80021 ]
20:26:06.279 Ably: ConnectionManager.tryATransport(): transport comet disconnected, err: [ErrorInfo: Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metric = connections.maxRate; statusCode=429; code=80021; see https://help.ably.io/error/80021 ]
20:26:06.279 Ably: ConnectionManager.notifyState(): new state: disconnected
20:26:06.279 Ably: ConnectionManager.cancelTransitionTimer():
20:26:06.280 Ably: Connection state: disconnected; reason: [ErrorInfo: Unable to connect (and no more fallback hosts to try); statusCode=404; code=80003]
20:26:06.280 Ably: ConnectionManager.enactStateChange: setting new state: disconnected; reason = Unable to connect (and no more fallback hosts to try)
```

Now Passing:
```
10:01:15.958 Ably: Transport.onProtocolMessage(): received on comet: [ProtocolMessage; action=DISCONNECTED; error=[ErrorInfo: Maximum account-wide instantaneous connections rate excee
ded; permitted rate = 1; metric = connections.maxRate; statusCode=429; code=80021; see https://help.ably.io/error/80021 ]]; connectionId = undefined
10:01:15.958 Ably: Transport.onDisconnect(): err = [ErrorInfo: Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metric = connections.maxRate; statusCo
de=429; code=80021; see https://help.ably.io/error/80021 ]
10:01:15.958 Ably: ConnectionManager.deactivateTransport(): transport = NodeCometTransport; uri=https://local-rest.ably.io:8081/comet/; isConnected=false; format=undefined; stream=tru
e
10:01:15.958 Ably: ConnectionManager.deactivateTransport(): state = disconnected; was pending
10:01:15.958 Ably: ConnectionManager.deactivateTransport(): reason =  Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metric = connections.maxRate
10:01:15.958 Ably: ConnectionManager.notifyState(): new state: disconnected
10:01:15.958 Ably: ConnectionManager.cancelTransitionTimer(): 
10:01:15.958 Ably: Connection state: disconnected; reason: [ErrorInfo: Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metric = connections.maxRate; 
statusCode=429; code=80021; see https://help.ably.io/error/80021 ]
10:01:15.958 Ably: ConnectionManager.enactStateChange: setting new state: disconnected; reason = Maximum account-wide instantaneous connections rate exceeded; permitted rate = 1; metr
ic = connections.maxRate
10:01:15.958 Ably: CometTransport.dispose():
10:01:15.958 Ably: ConnectionManager.disconnectAllTransports(): Disconnecting all transports
```