### PR TITLE
Ignore anything in the browser folder when searching within VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.exclude": {
+        "/browser/**": true
+    }
+}


### PR DESCRIPTION
Until we fix the build not to require this folder at all, this tweak makes the developer UX easier when using VS Code (which most of us do) to search for code in this repositroy.