### PR TITLE
Fix faulty import of JSONP transport to React Native and NativeScript

### DIFF
--- a/browser/lib/transport/withoutjsonp.js
+++ b/browser/lib/transport/withoutjsonp.js
@@ -1,3 +1,6 @@
+/**
+ * This file exists for React Native and Nativescript in order to exclude the unsupported JSONP transport from these platforms.
+ */
 import XHRPollingTransport from './xhrpollingtransport';
 import XHRStreamingTransport from './xhrstreamingtransport';
 

--- a/browser/lib/transport/withoutjsonp.js
+++ b/browser/lib/transport/withoutjsonp.js
@@ -1,0 +1,7 @@
+import XHRPollingTransport from './xhrpollingtransport';
+import XHRStreamingTransport from './xhrstreamingtransport';
+
+export default [
+  XHRPollingTransport,
+  XHRStreamingTransport
+];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -121,16 +121,8 @@ const nativeScriptConfig = {
       'platform-crypto': path.resolve(browserPath, 'lib', 'util', 'crypto'),
       'platform-webstorage': path.resolve(browserPath, 'lib', 'util', 'webstorage'),
       'platform-msgpack': path.resolve(browserPath, 'lib', 'util', 'msgpack'),
-      'platform-transports': path.resolve(browserPath, 'lib', 'transport'),
+      'platform-transports': path.resolve(browserPath, 'lib', 'transport', 'withoutjsonp'),
 		},
-	},
-	module: {
-		rules: [
-			{
-				test: /(jsonptransport\.js|domevent\.js)/,
-				use: 'null-loader',
-			},
-		],
 	},
 	node: {
 		crypto: 'empty',
@@ -166,16 +158,8 @@ const reactNativeConfig = {
       'platform-crypto': path.resolve(browserPath, 'lib', 'util', 'crypto'),
       'platform-webstorage': path.resolve(browserPath, 'lib', 'util', 'webstorage'),
       'platform-msgpack': path.resolve(browserPath, 'lib', 'util', 'msgpack'),
-      'platform-transports': path.resolve(browserPath, 'lib', 'transport'),
+      'platform-transports': path.resolve(browserPath, 'lib', 'transport', 'withoutjsonp'),
 		},
-	},
-	module: {
-		rules: [
-			{
-				test: /jsonptransport\.js/,
-				use: 'null-loader',
-			},
-		],
 	},
 	node: {
 		crypto: 'empty',


### PR DESCRIPTION
Resolves an issue which would cause the library to throw an error on import in React Native and NativeScript.

To summarise, the issue was that each platform was using an array of 'Transports' and explicitly initialising each one as soon as the library is loaded, but it was also using `null-loader` to omit the JSONP platform from React Native and NativeScript builds so it was essentially attempting to initialise an empty module as if it were a Transport. This PR adds a separate array of transports without JSONP to fix this error.

This PR would also allow React Native users to use the `ably` NPM module directly since the recent work around ES6 modules displaces the need for the `ably-js-react-native` wrapper.