### PR TITLE
Platform types

### DIFF
--- a/browser/fragments/platform-reactnative.ts
+++ b/browser/fragments/platform-reactnative.ts
@@ -1,27 +1,28 @@
 import msgpack from '../lib/util/msgpack';
 import { parse as parseBase64 } from 'crypto-js/build/enc-base64';
+import IPlatform from '../../common/types/IPlatform';
 
-var Platform = {
+const Platform: IPlatform = {
 	libver: 'js-rn',
 	logTimestamps: true,
 	noUpgrade: false,
 	binaryType: 'arraybuffer',
 	WebSocket: WebSocket,
-	xhrSupported: XMLHttpRequest,
+	xhrSupported: true,
 	allowComet: true,
 	jsonpSupported: false,
 	streamingSupported: true,
 	useProtocolHeartbeats: true,
 	createHmac: null,
 	msgpack: msgpack,
-	supportsBinary: (typeof TextDecoder !== 'undefined') && TextDecoder,
+	supportsBinary: ((typeof TextDecoder !== 'undefined') && TextDecoder) ? true : false,
 	preferBinary: false,
 	ArrayBuffer: (typeof ArrayBuffer !== 'undefined') && ArrayBuffer,
 	atob: global.atob,
-	nextTick: function(f) { setTimeout(f, 0); },
+	nextTick: function(f: Function) { setTimeout(f, 0); },
 	addEventListener: null,
 	inspect: JSON.stringify,
-	stringByteSize: function(str) {
+	stringByteSize: function(str: string) {
 		/* str.length will be an underestimate for non-ascii strings. But if we're
 		 * in a browser too old to support TextDecoder, not much we can do. Better
 		 * to underestimate, so if we do go over-size, the server will reject the
@@ -34,8 +35,8 @@ var Platform = {
 	TextDecoder: global.TextDecoder,
 	Promise: global.Promise,
 	getRandomWordArray: (function(RNRandomBytes) {
-		return function(byteLength, callback) {
-			RNRandomBytes.randomBytes(byteLength, function(err, base64String) {
+		return function(byteLength: number, callback: Function) {
+			RNRandomBytes.randomBytes(byteLength, function(err: Error, base64String: string) {
 				callback(err, !err && parseBase64(base64String));
 			});
 		};

--- a/common/types/IPlatform.d.ts
+++ b/common/types/IPlatform.d.ts
@@ -1,0 +1,38 @@
+import { createHmac, Hmac } from 'crypto';
+import ws from 'ws';
+import msgpack from '@ably/msgpack';
+import { inspect } from 'util';
+
+export type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array;
+
+export default interface IPlatform {
+    libver: string;
+    logTimestamps: boolean;
+    binaryType: string;
+    WebSocket: unknown;
+    useProtocolHeartbeats: boolean;
+    createHmac: typeof createHmac | null;
+    msgpack: typeof msgpack;
+    supportsBinary: boolean;
+    preferBinary: boolean;
+    nextTick: process.nextTick;
+    inspect: (value: unknown) => string;
+    stringByteSize: Buffer.byteLength;
+    addEventListener: null;
+    Promise: typeof Promise;
+    getRandomValues?: ((arr: TypedArray, callback?: (error: Error | null) => void) => void) | unknown;
+    userAgent?: string | null;
+    inherits?: typeof inspect;
+    addEventListener?: typeof window.addEventListener;
+    currentUrl?: string;
+    noUpgrade?: boolean | string;
+    xhrSupported?: boolean;
+    jsonpSupported?: boolean;
+    allowComet?: boolean;
+    streamingSupported?: boolean;
+    ArrayBuffer?: typeof ArrayBuffer | false;
+    atob?: typeof atob | null;
+    TextEncoder?: typeof TextEncoder;
+    TextDecoder?: typeof TextDecoder;
+    getRandomWordArray?: (byteLength: number, callback: Function) => void;
+}

--- a/common/types/crypto-js.d.ts
+++ b/common/types/crypto-js.d.ts
@@ -1,0 +1,4 @@
+declare module 'crypto-js/build/enc-base64' {
+    import CryptoJS from 'crypto-js';
+    export const parse: typeof CryptoJS.enc.Base64.parse;
+}

--- a/nodejs/platform.ts
+++ b/nodejs/platform.ts
@@ -1,4 +1,6 @@
-var Platform = {
+import IPlatform, { TypedArray } from '../common/types/IPlatform';
+
+const Platform: IPlatform = {
 	libver: 'js-node',
 	logTimestamps: true,
 	userAgent: null,
@@ -14,7 +16,7 @@ var Platform = {
 	stringByteSize: Buffer.byteLength,
 	inherits: require('util').inherits,
 	addEventListener: null,
-	getRandomValues: function(arr, callback) {
+	getRandomValues: function(arr: TypedArray, callback: Function) {
 		var bytes = require('crypto').randomBytes(arr.length);
 		arr.set(bytes);
 		if(callback) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,13 @@
   "compilerOptions": {
     "target": "es3",
     "module": "commonjs",
-    "lib": ["ES5"],
+    "lib": ["ES5", "DOM", "webworker"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+        "platform": ["./nodejs/platform", "./browser/fragments/platform-browser", "./browser/fragments/platform-reactnative"]
+    }
   }
 }


### PR DESCRIPTION
Creates a common interface for `Platform` config files, based off crypto-js types PR.

I didn't convert the NativeScript platform config file, because it would be a lot of effort to annotate all of the weird NativeScript globals and is ultimately not too important.