### PR TITLE
Use setImmediate if available in browser

### DIFF
--- a/browser/fragments/platform-browser.js
+++ b/browser/fragments/platform-browser.js
@@ -34,7 +34,7 @@ var Platform = {
 	preferBinary: false,
 	ArrayBuffer: global.ArrayBuffer,
 	atob: global.atob,
-	nextTick: function(f) { setTimeout(f, 0); },
+	nextTick: typeof setImmediate !== 'undefined' ? setImmediate : function(f) { setTimeout(f, 0); },
 	addEventListener: global.addEventListener,
 	inspect: JSON.stringify,
 	stringByteSize: function(str) {


### PR DESCRIPTION
Resolves #768 

Opening as a draft for now just to run this through CI. Resolves an issue with recent versions of chrome throttling chained timers in hidden tabs.