### PR TITLE
Improve api typings

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -531,6 +531,10 @@ declare namespace Types {
 		unsubscribe: (eventOrListener?: string | Array<string> | messageCallback<Message>, listener?: messageCallback<Message>) => void;
 	}
 
+    type PublishOptions = {
+        quickAck?: boolean;
+    }
+
 	class RealtimeChannelCallbacks extends RealtimeChannelBase {
 		presence: RealtimePresenceCallbacks;
 		attach: (callback?: errorCallback) => void;
@@ -538,7 +542,9 @@ declare namespace Types {
 		history: (paramsOrCallback?: RealtimeHistoryParams | paginatedResultCallback<Message>, callback?: paginatedResultCallback<Message>) => void;
 		setOptions: (options: ChannelOptions, callback?: errorCallback) => void;
 		subscribe: (eventOrCallback: messageCallback<Message> | string | Array<string>, listener?: messageCallback<Message>, callbackWhenAttached?: errorCallback) => void;
-		publish: (messagesOrName: any, messageDataOrCallback?: errorCallback | any, callback?: errorCallback) => void;
+		publish(messages: any, callback?: errorCallback): void;
+		publish(name: string, messages: any, callback?: errorCallback): void;
+		publish(name: string, messages: any, options?: PublishOptions, callback?: errorCallback): void;
 		whenState: (targetState: ChannelState, callback: channelEventCallback) => void;
 	}
 
@@ -549,7 +555,8 @@ declare namespace Types {
 		history: (params?: RealtimeHistoryParams) => Promise<PaginatedResult<Message>>;
 		setOptions: (options: ChannelOptions) => Promise<void>;
 		subscribe: (eventOrCallback: messageCallback<Message> | string | Array<string>, listener?: messageCallback<Message>) => Promise<void>;
-		publish: (messagesOrName: any, messageData?: any) => Promise<void>;
+		publish(messages: any, options?: PublishOptions): Promise<void>;
+		publish(name: string, messages: any, options?: PublishOptions): Promise<void>;
 		whenState: (targetState: ChannelState) => Promise<ChannelStateChange>;
 	}
 

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -113,6 +113,11 @@ declare namespace Types {
 		fallbackHosts?: string[];
 		fallbackHostsUseDefault?: boolean;
 
+        restAgentOptions?: {
+            maxSockets?: number,
+            keepAlive?: boolean,
+        }
+
 		/**
 		 * Can be used to explicitly recover a connection.
 		 * See https://www.ably.io/documentation/realtime/connection#connection-state-recovery


### PR DESCRIPTION
Resolves #742, resolves #747.

Adds typings for `ClientOptions.restAgentOptions` and publish options (only used for `quickAck` at the moment). Also refactors the typings for `RealtimeChannel.publish` which currently uses class properties with function typings. I've refactored these to use class methods which allows us to overload function signatures which is much more developer-friendly.