### PR TITLE
Bind setImmediate to global object in browsers

### DIFF
--- a/browser/fragments/platform-browser.js
+++ b/browser/fragments/platform-browser.js
@@ -34,7 +34,7 @@ var Platform = {
 	preferBinary: false,
 	ArrayBuffer: global.ArrayBuffer,
 	atob: global.atob,
-	nextTick: typeof setImmediate !== 'undefined' ? setImmediate : function(f) { setTimeout(f, 0); },
+	nextTick: typeof setImmediate !== 'undefined' ? global.setImmediate.bind(global) : function(f) { setTimeout(f, 0); },
 	addEventListener: global.addEventListener,
 	inspect: JSON.stringify,
 	stringByteSize: function(str) {


### PR DESCRIPTION
This fixes an error in IE9-11 where calls to `setImmediate` would fail with `Invalid calling object`.