### PR TITLE
fix channel names as object prototype keys

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Test",
+            "env": {
+                "ABLY_ENV": "sandbox",
+            },
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "node",
+            "runtimeArgs": ["--inspect-brk=9229", "node_modules/.bin/grunt", "test"],
+            "port": 9229
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             },
             "cwd": "${workspaceFolder}",
             "runtimeExecutable": "node",
-            "runtimeArgs": ["--inspect-brk=9229", "node_modules/.bin/grunt", "test"],
+            "runtimeArgs": ["--inspect-brk=9229", "node_modules/.bin/grunt", "test:mocha", "--test=${relativeFile}"],
             "port": 9229
         }
     ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,20 @@ Browser tests are run using [Karma test runner](http://karma-runner.github.io/0.
 
     npm run test:karma
 
+### Debugging the mocha tests locally with a debugger
+
+Run the following command to launch tests with the debugger enabled. The tests will block until you attach a debugger.
+
+    node --inspect-brk=9229 node_modules/.bin/grunt test:mocha
+
+Alternatively you can also run the tests for single file
+
+    node --inspect-brk=9229 node_modules/.bin/grunt test:mocha --test=test/spec/presence.test.js
+
+The included vscode launch config allows you to launch and attach the debugger in one step, simply open the test
+file you want to run and start debugging. Note that breakpoint setting for realtime code will be within the
+browser/static directory, not the raw source files, and breakpoints in files under spec/test should work directly.
+
 ### Debugging the tests in a browser with Mocha test runner
 
 Run the following command to start a local Mocha test runner web server

--- a/common/lib/client/auth.js
+++ b/common/lib/client/auth.js
@@ -53,7 +53,7 @@ var Auth = (function() {
 		if(typeof(capability) == 'string')
 			capability = JSON.parse(capability);
 
-		var c14nCapability = {};
+		var c14nCapability = Object.create(null);
 		var keys = Utils.keysArray(capability, true);
 		if(!keys)
 			return '';

--- a/common/lib/client/realtime.js
+++ b/common/lib/client/realtime.js
@@ -37,8 +37,8 @@ var Realtime = (function() {
 	function Channels(realtime) {
 		EventEmitter.call(this);
 		this.realtime = realtime;
-		this.all = {};
-		this.inProgress = {};
+		this.all = Object.create(null);
+		this.inProgress = Object.create(null);
 		var self = this;
 		realtime.connection.connectionManager.on('transport.active', function() {
 			self.onTransportActive();

--- a/common/lib/client/realtimepresence.js
+++ b/common/lib/client/realtimepresence.js
@@ -465,7 +465,7 @@ var RealtimePresence = (function() {
 	function PresenceMap(presence) {
 		EventEmitter.call(this);
 		this.presence = presence;
-		this.map = {};
+		this.map = Object.create(null);
 		this.syncInProgress = false;
 		this.residualMembers = null;
 	}

--- a/common/lib/client/rest.js
+++ b/common/lib/client/rest.js
@@ -175,7 +175,7 @@ var Rest = (function() {
 
 	function Channels(rest) {
 		this.rest = rest;
-		this.all = {};
+		this.all = Object.create(null);
 	}
 
 	Channels.prototype.get = function(name, channelOptions) {

--- a/common/lib/util/eventemitter.js
+++ b/common/lib/util/eventemitter.js
@@ -7,9 +7,9 @@ var EventEmitter = (function() {
 	/* public constructor */
 	function EventEmitter() {
 		this.any = [];
-		this.events = {};
+		this.events = Object.create(null);
 		this.anyOnce = [];
-		this.eventsOnce = {};
+		this.eventsOnce = Object.create(null);
 	}
 
 	/* Call the listener, catch any exceptions and log, but continue operation*/
@@ -87,9 +87,9 @@ var EventEmitter = (function() {
 	EventEmitter.prototype.off = function(event, listener) {
 		if(arguments.length == 0 || (Utils.isEmptyArg(event) && Utils.isEmptyArg(listener))) {
 			this.any = [];
-			this.events = {};
+			this.events = Object.create(null);
 			this.anyOnce = [];
-			this.eventsOnce = {};
+			this.eventsOnce = Object.create(null);
 			return;
 		}
 		if(arguments.length == 1) {

--- a/common/lib/util/eventemitter.js
+++ b/common/lib/util/eventemitter.js
@@ -2,6 +2,8 @@ import Utils from './utils';
 import Logger from './logger';
 import Platform from 'platform';
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
 var EventEmitter = (function() {
 
 	/* public constructor */
@@ -46,7 +48,7 @@ var EventEmitter = (function() {
 			} else if (Utils.isObject(listeners)) {
 				/* events */
 				for (eventName in listeners) {
-					if (listeners.hasOwnProperty(eventName) && Utils.isArray(listeners[eventName])) {
+					if (hasOwnProperty.call(listeners, eventName) && Utils.isArray(listeners[eventName])) {
 						removeListener([listeners], listener, eventName);
 					}
 				}

--- a/common/lib/util/utils.js
+++ b/common/lib/util/utils.js
@@ -2,6 +2,8 @@ import Platform from 'platform';
 import Defaults from './defaults';
 import BufferUtils from 'platform-bufferutils';
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
 var Utils = (function() {
 	var msgpack = Platform.msgpack;
 
@@ -21,9 +23,8 @@ var Utils = (function() {
 		for(var i = 1; i < arguments.length; i++) {
 			var source = arguments[i];
 			if(!source) { break; }
-			var hasOwnProperty = source.hasOwnProperty;
 			for(var key in source) {
-				if(!hasOwnProperty || hasOwnProperty.call(source, key)) {
+				if(hasOwnProperty.call(source, key)) {
 					target[key] = source[key];
 				}
 			}
@@ -235,7 +236,7 @@ var Utils = (function() {
 	Utils.keysArray = function(ob, ownOnly) {
 		var result = [];
 		for(var prop in ob) {
-			if(ownOnly && !ob.hasOwnProperty(prop)) continue;
+			if(ownOnly && !hasOwnProperty.call(ob, prop)) continue;
 			result.push(prop);
 		}
 		return result;
@@ -251,7 +252,7 @@ var Utils = (function() {
 	Utils.valuesArray = function(ob, ownOnly) {
 		var result = [];
 		for(var prop in ob) {
-			if(ownOnly && !ob.hasOwnProperty(prop)) continue;
+			if(ownOnly && !hasOwnProperty.call(ob, prop)) continue;
 			result.push(ob[prop]);
 		}
 		return result;
@@ -259,7 +260,7 @@ var Utils = (function() {
 
 	Utils.forInOwnNonNullProps = function(ob, fn) {
 		for (var prop in ob) {
-			if (Object.prototype.hasOwnProperty.call(ob, prop) && ob[prop]) {
+			if (hasOwnProperty.call(ob, prop) && ob[prop]) {
 				fn(prop);
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "1.2.9",
+  "version": "1.2.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "1.2.9",
+      "version": "1.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.3.3",

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -1471,7 +1471,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 						channel.attach(cb);
 					},
 					function (cb) {
-						channel.presence.members.waitSync(cb);
+						if (!channel.presence.syncComplete) {
+							channel.presence.members.waitSync(cb);
+						} else {
+							cb();
+						}
 					},
 					function (cb) {
 						channel.presence.enterClient('one', 'onedata');
@@ -1553,7 +1557,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 			);
 		});
 
-		/* RTP5c3
+		/* RTP17e
 		 * Test failed presence auto-re-entering */
 		it('presence_failed_auto_reenter', function (done) {
 			var channelName = 'presence_failed_auto_reenter',
@@ -1581,6 +1585,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 					},
 					function (cb) {
 						channel.attach(cb);
+					},
+					function (cb) {
+						if (!channel.presence.syncComplete) {
+							channel.presence.members.waitSync(cb);
+						} else {
+							cb();
+						}
 					},
 					function (cb) {
 						channel.presence.get(function (err, members) {

--- a/spec/realtime/presence.test.js
+++ b/spec/realtime/presence.test.js
@@ -357,8 +357,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 					return;
 				}
 				closeAndFinish(done, clientRealtime);
+			}, function onPresenceSubscribe(err) {
+				if (err) {
+					closeAndFinish(done, clientRealtime, err);
+					return;
+				}
+				clientChannel.presence.enter();
 			});
-			clientChannel.presence.enter();
 			monitorConnection(done, clientRealtime);
 		});
 


### PR DESCRIPTION
When an object key is free-form text, we should not use vanilla js objects, as this can cause key collisions with built-in prototype keys, such as `__proto__` or `toString`, etc. I have offered a quick solution for this issue, but it would be better tackled using an ES6 `Map`. I am happy for someone to replace these structures with Map instances if they would prefer. I'm not familiar with which versions of js we support and whether we would want a `Map` polyfill if things are being back-ported (babel?) for < ES6 compatibility.