### PR TITLE
Implement RTL5b and RTL5j

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -529,9 +529,9 @@ declare namespace Types {
 	}
 
 	class RealtimeChannelBase extends EventEmitter<channelEventCallback, ChannelStateChange, ChannelEvent, ChannelState> {
-		name: string;
+		readonly name: string;
 		errorReason: ErrorInfo;
-		state: ChannelState;
+		readonly state: ChannelState;
 		params: ChannelParams;
 		modes: ChannelModes;
 		unsubscribe: (eventOrListener?: string | Array<string> | messageCallback<Message>, listener?: messageCallback<Message>) => void;
@@ -630,7 +630,7 @@ declare namespace Types {
 		key: string;
 		recoveryKey: string;
 		serial: number;
-		state: ConnectionState;
+		readonly state: ConnectionState;
 		close: () => void;
 		connect: () => void;
 	}

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -308,6 +308,10 @@ var RealtimeChannel = (function() {
 			return;
 		}
 		switch(this.state) {
+                        case 'suspended':
+                                this.requestState('detached');
+                                callback();
+                                break;
 			case 'detached':
 			case 'failed':
 				callback();

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -309,7 +309,7 @@ var RealtimeChannel = (function() {
 		}
 		switch(this.state) {
                         case 'suspended':
-                                this.requestState('detached');
+                                this.notifyState('detached');
                                 callback();
                                 break;
 			case 'detached':

--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -313,8 +313,10 @@ var RealtimeChannel = (function() {
                                 callback();
                                 break;
 			case 'detached':
-			case 'failed':
 				callback();
+				break;
+			case 'failed':
+				callback(new ErrorInfo('Unable to detach; channel state = failed', 90001, 400));
 				break;
 			default:
 				this.requestState('detaching');

--- a/spec/realtime/channel.test.js
+++ b/spec/realtime/channel.test.js
@@ -1506,5 +1506,18 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 				}
 			);
 		});
+
+                // RTL5j
+                it('detaching from suspended channel transitions channel to detached state', function (done) {
+                    var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] });
+                    var channelName = 'detach_from_suspended';
+                    var channel = realtime.channels.get(channelName);
+
+                    channel.state = 'suspended';
+                    channel.detach(function () {
+                        expect(channel.state).to.equal('detached', 'Check that detach on suspended channel results in detached channel');
+                        done();
+                    });
+                });
 	});
 });

--- a/spec/realtime/channel.test.js
+++ b/spec/realtime/channel.test.js
@@ -1519,5 +1519,22 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                         done();
                     });
                 });
+
+                // RTL5b
+                it('detaching from failed channel results in error', function (done) {
+                    var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] });
+                    var channelName = 'detach_from_failed';
+                    var channel = realtime.channels.get(channelName);
+
+                    channel.state = 'failed';
+
+                    channel.detach(function(err) {
+                      if (!err) {
+                        done(new Error("expected detach to return error response"));
+                        return;
+                      }
+                      done();
+                    });
+                });
 	});
 });


### PR DESCRIPTION
Spec alignment issue reported internally; see slack thread: https://ably-real-time.slack.com/archives/C01K3K2V5HB/p1627940634005500

Adds/modifies switch cases for detaching from channels in the `suspended` and `failed` states, along with associated tests.