### PR TITLE
Explicitly specify workflow `permissions` required to succeed when our org switches default access from 'permissive' to 'restricted'

### DIFF
--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -24,6 +24,8 @@ jobs:
             npm run sourcemap -- --html bundle-reports/index.html
             npm run sourcemap:noencryption -- --html bundle-reports/noencryption.html
       - uses: ably/sdk-upload-action@v1
+        permissions:
+          deployments: write
         with:
           s3AccessKeyId: ${{ secrets.SDK_S3_ACCESS_KEY_ID }}
           s3AccessKey: ${{ secrets.SDK_S3_ACCESS_KEY }}

--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   bundle-report:
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
     steps:
       - uses: actions/checkout@v2
       - name: Reconfigure git to use HTTP authentication
@@ -24,8 +26,6 @@ jobs:
             npm run sourcemap -- --html bundle-reports/index.html
             npm run sourcemap:noencryption -- --html bundle-reports/noencryption.html
       - uses: ably/sdk-upload-action@v1
-        permissions:
-          deployments: write
         with:
           s3AccessKeyId: ${{ secrets.SDK_S3_ACCESS_KEY_ID }}
           s3AccessKey: ${{ secrets.SDK_S3_ACCESS_KEY }}


### PR DESCRIPTION
Initial prototype: https://github.com/ably/ably-asset-tracking-android/pull/441

See [this internal Slack thread](https://ably-real-time.slack.com/archives/CF7GGBF2N/p1631814436061500) for more context.