### PR TITLE
`fail-fast` for test-node workflow

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   test-node:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 14.x]
     steps:

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test-node:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]


### PR DESCRIPTION
Stops node test workflows from being cancelled as soon as one of them fails.