### PR TITLE
Use package.json version directly in library

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,7 +87,6 @@ module.exports = function (grunt) {
 	grunt.initConfig(gruntConfig);
 
 	grunt.registerTask('build', [
-		'set-library-version',
 		'webpack'
 	]);
 
@@ -102,21 +101,6 @@ module.exports = function (grunt) {
 
 	var browsers = grunt.option('browsers') || 'default';
 	var optionsDescription = '\nOptions:\n  --browsers [browsers] e.g. Chrome,PhantomJS (Firefox is default)';
-
-	grunt.registerTask('set-library-version',
-		'Set the library version string used for loading dependencies',
-		function() {
-			var defaultsFile = gruntConfig.dirs.common + '/lib/util/defaults.js';
-			var defaultsText = grunt.file.read(defaultsFile).replace(/(version\s*=\s*)'([\w\.\-]+)'/, '$1\'' + gruntConfig.pkgVersion + '\'');
-			grunt.file.write(defaultsFile, defaultsText);
-
-			var licenseFile = gruntConfig.dirs.fragments + '/license.js';
-			var licenseText = grunt.file.read(licenseFile).
-													replace(/(Ably JavaScript Library v)([\w\.\-]+)/i, '$1' + gruntConfig.pkgVersion).
-													replace(/(Copyright )(\d{4,})/i, '$1' + new Date().getFullYear())
-			grunt.file.write(licenseFile, licenseText);
-		}
-	);
 
 	grunt.registerTask('test',
 		'Concat files and run the entire test suite (Jasmine with node & Karma in a browser)' + optionsDescription,

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ However, we aim to be compatible with a much wider set of platforms and browsers
 Ably-js has fallback mechanisms in order to be able to support older browsers; specifically it supports comet-based connections for browsers that do not support websockets, and this includes JSONP for browsers that do not support cross-origin XHR. Each of these fallback transport mechanisms is supported and tested on all the browsers we test against, even when those browsers do not themselves require those fallbacks. These mean that the library should be compatible with nearly any browser on most platforms.
 Known browser incompatibilities will be documented as an issue in this repository using the ["compatibility" label](https://github.com/ably/ably-js/issues?q=is%3Aissue+is%3Aopen+label%3A%22compatibility%22).
 
-#### Version: 1.2.14
-
-The latest stable version of the Ably JavaScript client library is version: 1.2.14 .
-
 For complete API documentation, see the [Ably documentation](https://www.ably.com/documentation).
 
 ## Installation

--- a/browser/fragments/license.js
+++ b/browser/fragments/license.js
@@ -1,6 +1,8 @@
+const { version } = require('../../package.json');
+
 module.exports = `@license Copyright 2021, Ably
 
-Ably JavaScript Library v1.2.14
+Ably JavaScript Library v${version}
 https://github.com/ably/ably-js
 
 Ably Realtime Messaging

--- a/common/lib/util/defaults.js
+++ b/common/lib/util/defaults.js
@@ -4,6 +4,7 @@ import Utils from './utils';
 import BufferUtils from 'platform-bufferutils';
 import Logger from './logger';
 import ErrorInfo from '../types/errorinfo';
+import { version } from '../../../package.json';
 
 Defaults.ENVIRONMENT              = '';
 Defaults.REST_HOST                = 'rest.ably.io';
@@ -35,7 +36,7 @@ Defaults.errorReportingHeaders = {
 	"Content-Type": "application/json"
 };
 
-Defaults.version          = '1.2.14';
+Defaults.version          = version;
 Defaults.apiVersion       = '1.2';
 
 var agent = 'ably-js/' + Defaults.version;


### PR DESCRIPTION
This works because webpack can automatically resolve JSON modules as plain JS objects. We will need to add the `resolveJsonModule` compiler option when these files are migrated to TypeScript.

This PR also removes a section of the README which advertises the current library version. IMO this is an improvement because people will know where to look for the version if that's what they're looking for (probably in the releases/tags section or over at npmjs.com) so if someone has scrolled that far down the README then they're gonna be looking for something else.