### PR TITLE
Check for alternative casing in x-ably-errorcode header

### DIFF
--- a/browser/lib/transport/xhrrequest.js
+++ b/browser/lib/transport/xhrrequest.js
@@ -221,7 +221,7 @@ var XHRRequest = (function() {
 				return;
 			}
 
-			var err = headers['x-ably-errorcode'] && responseBody.error && ErrorInfo.fromValues(responseBody.error);
+			var err = (headers['x-ably-errorcode'] | headers['X-Ably-ErrorCode']) && responseBody.error && ErrorInfo.fromValues(responseBody.error);
 			if(!err) {
 				err = new ErrorInfo('Error response received from server: ' + statusCode + ' body was: ' + Utils.inspect(responseBody), null, statusCode);
 			}


### PR DESCRIPTION
Some parts of the realtime app use X-Ably-ErrorCode instead of x-ably-errorcode for some reason which was causing problems in some of the browser tests.