### PR TITLE
Add ambient module declaration for platform-http

### DIFF
--- a/common/types/platform-http.d.ts
+++ b/common/types/platform-http.d.ts
@@ -1,0 +1,4 @@
+declare module 'platform-http' {
+  const Http: typeof import('./http').IHttp;
+  export default Http;
+}


### PR DESCRIPTION
Context: We are using webpack to import a different Http client module depending on which platform we are building for. We use `import Http from 'platform-http'` to import the Http client where 'platform-http' is just an alias to the appropriate client for whatever platform.

This [ambient module declaration](https://www.typescriptlang.org/docs/handbook/modules.html#ambient-modules) tells TypeScript that when we import from that alias we are getting an `IHttp` instance where `IHttp` is an interface which all of the platform-specific Http clients implement.