### PR TITLE
Add ambient module declaration for platform-base64

### DIFF
--- a/common/types/platform-base64.d.ts
+++ b/common/types/platform-base64.d.ts
@@ -1,0 +1,6 @@
+declare module 'platform-base64' {
+  const Base64: {
+    encode: (data: string) => string;
+  }
+  export default Base64;
+}


### PR DESCRIPTION
Context: We are using webpack to import a different Base64 encoding module depending on which platform we are building for. We use `import Base64 from 'platform-base64'` to import the Http client where 'platform-base64' is just an alias to the appropriate module for whatever platform.

This ambient module declaration tells TypeScript what type that 'platform-base64' module will be.
