### PR TITLE
Add module declaration for crypto-js hmac-sha256

### DIFF
--- a/common/types/crypto-js.d.ts
+++ b/common/types/crypto-js.d.ts
@@ -20,3 +20,8 @@ declare module 'crypto-js/build/lib-typedarrays' {
     import CryptoJS from 'crypto-js';
     export default CryptoJS.lib.WordArray;
 }
+
+declare module 'crypto-js/build/hmac-sha256' {
+    import CryptoJS from 'crypto-js';
+    export default CryptoJS.HmacSHA256;
+}


### PR DESCRIPTION
This ambient module declaration tell TypeScript what type the relative imports from crypto-js will be since that module doesn't provide its own TypeScript interface.