### PR TITLE
Add release PR stage to release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,14 +16,18 @@
 ## Release Process
 
 1. Make sure the tests are passing in CI for the branch you're building
-2. Update the CHANGELOG.md with any customer-affecting changes since the last release and add this to the git index
-3. Run `npm run grunt -- release:patch` (or: "major", "minor", "patch", "prepatch") - creates commit and local tag
-4. Ensure that the infrastructure repository is in the same directory as `ably-js` and is up to date with the remote main branch
-5. Run `npm run grunt -- release:deploy` (requires the SDKDeveloper AWS role) - pushes commit and tag, then publishes to the Ably CDN
-6. Run `npm publish .` (should require OTP) - publishes to NPM
-7. Visit https://github.com/ably/ably-js/tags and add release notes to the release (generally you can just copy the notes you added to the CHANGELOG)
-8. For nontrivial releases: update the ably-js submodule ref in the realtime repo
-9. Update the Ably changelog with these changes (again, you can just copy the notes you added to the CHANGELOG)
+2. Create a new branch for the release, for example `release/1.2.3`
+3. Update the CHANGELOG.md with any customer-affecting changes since the last release and add this to the git index
+4. Run `npm version <VERSION_NUMBER> --no-git-tag-version` with the new version and add the changes to the git index
+5. Create a PR for the release branch
+6. Once the release PR is landed to the `main` branch, checkout the `main` branch locally and run `npm run build`
+7. Run `git tag <VERSION_NUMBER>` with the new version
+8. Ensure that the infrastructure repository is in the same directory as `ably-js` and is up to date with the remote main branch
+9. Run `npm run grunt -- release:deploy` (requires the SDKDeveloper AWS role) - pushes commit and tag, then publishes to the Ably CDN
+10. Run `npm publish .` (should require OTP) - publishes to NPM
+11. Visit https://github.com/ably/ably-js/tags and add release notes to the release (generally you can just copy the notes you added to the CHANGELOG)
+12. For nontrivial releases: update the ably-js submodule ref in the realtime repo
+13. Update the Ably changelog with these changes (again, you can just copy the notes you added to the CHANGELOG)
 
 ## Test suite
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@
 3. Update the CHANGELOG.md with any customer-affecting changes since the last release and add this to the git index
 4. Run `npm version <VERSION_NUMBER> --no-git-tag-version` with the new version and add the changes to the git index
 5. Create a PR for the release branch
-6. Once the release PR is landed to the `main` branch, checkout the `main` branch locally and run `npm run build`
-7. Run `git tag <VERSION_NUMBER>` with the new version
+6. Once the release PR is landed to the `main` branch, checkout the `main` branch locally (remember to pull the remote changes) and run `npm run build`
+7. Run `git tag <VERSION_NUMBER>` with the new version and push the tag to git
 8. Ensure that the infrastructure repository is in the same directory as `ably-js` and is up to date with the remote main branch
 9. Run `npm run grunt -- release:deploy` (requires the SDKDeveloper AWS role) - pushes commit and tag, then publishes to the Ably CDN
 10. Run `npm publish .` (should require OTP) - publishes to NPM


### PR DESCRIPTION
Modifies the release process slightly so that a release PR can be created and reviewed before the release. Previously the whole release process happened directly on the `main` branch and didn't allow for a release PR to be created.