### PR TITLE
Remove most recent message in detachImpl

### DIFF
--- a/common/lib/client/realtimechannel.js
+++ b/common/lib/client/realtimechannel.js
@@ -340,6 +340,9 @@ var RealtimeChannel = (function() {
 	};
 
 	RealtimeChannel.prototype.detachImpl = function(callback) {
+		if (this.connectionManager.mostRecentMsg && this.connectionManager.mostRecentMsg.channel === this.name) {
+			this.connectionManager.mostRecentMsg = null;
+		}
 		Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.detach()', 'sending DETACH message');
 		this.setInProgress(statechangeOp, true);
 		var msg = ProtocolMessage.fromValues({action: actions.DETACH, channel: this.name});
@@ -449,9 +452,6 @@ var RealtimeChannel = (function() {
 		case actions.DETACHED:
 			var err = message.error ? ErrorInfo.fromValues(message.error) : new ErrorInfo('Channel detached', 90001, 404);
 			if(this.state === 'detaching') {
-                                if (this.connectionManager.mostRecentMsg && this.connectionManager.mostRecentMsg.channel === this.name) {
-                                  this.connectionManager.mostRecentMsg = null;
-                                }
 				this.notifyState('detached', err);
 			} else if(this.state === 'attaching') {
 				/* Only retry immediately if we were previously attached. If we were


### PR DESCRIPTION
Previous we made it so that once detached from a channel, if `ConnectionManager.mostRecentMsg` was a message from the detached channel then this would be cleared so that on re-attaching to the channel rewind would still work. This change makes it so that this mechanism works even if the detach is superseded by a subsequent ATTACH message.

It is maybe possible after this change that a client may (1) receive a message from Ably (2) detach from the channel (3) receive a duplicate of the first message. In that case the message would not be ignored since mostRecentMsg is cleared as soon as the detach message is sent.