### PR TITLE
fix: refer to global.setImmediate in nextTick check

### DIFF
--- a/browser/fragments/platform-browser.js
+++ b/browser/fragments/platform-browser.js
@@ -34,7 +34,7 @@ var Platform = {
 	preferBinary: false,
 	ArrayBuffer: global.ArrayBuffer,
 	atob: global.atob,
-	nextTick: typeof setImmediate !== 'undefined' ? global.setImmediate.bind(global) : function(f) { setTimeout(f, 0); },
+	nextTick: typeof global.setImmediate !== 'undefined' ? global.setImmediate.bind(global) : function(f) { setTimeout(f, 0); },
 	addEventListener: global.addEventListener,
 	inspect: JSON.stringify,
 	stringByteSize: function(str) {


### PR DESCRIPTION
Fixes a strange edge case that occurs wherein sometimes global may not refer to the actual global object in a given environment.