### PR TITLE
fix spelling/grammar errors and JSDoc inaccuracies

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -130,7 +130,7 @@ declare namespace Types {
 		}, callback: (shouldRecover: boolean) => void) => void);
 
 		/**
-		 * Use a non-secure connection connection. By default, a TLS connection is used to connect to Ably
+		 * Use a non-secure connection. By default, a TLS connection is used to connect to Ably
 		 */
 		tls?: boolean;
 		tlsPort?: number;
@@ -178,7 +178,7 @@ declare namespace Types {
 
 		/**
 		 * Optional clientId that can be used to specify the identity for this client. In most cases
-		 * it is preferable to instead specift a clientId in the token issued to this client.
+		 * it is preferable to instead specify a clientId in the token issued to this client.
 		 */
 		clientId?: string;
 	}

--- a/common/lib/client/auth.ts
+++ b/common/lib/client/auth.ts
@@ -826,7 +826,7 @@ class Auth {
 				return;
 			}
 			/* RSA4b1 -- if we have a server time offset set already, we can
-			 * auto remove expired tokens. Else just use the cached token. If it is
+			 * automatically remove expired tokens. Else just use the cached token. If it is
 			 * expired Ably will tell us and we'll discard it then. */
 			if(!this.isTimeOffsetSet() || !token.expires || (token.expires >= this.getTimestampUsingOffset())) {
 				Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'using cached token; expires = ' + token.expires);

--- a/common/lib/client/auth.ts
+++ b/common/lib/client/auth.ts
@@ -180,14 +180,14 @@ class Auth {
 	 *
 	 * - ttl:        (optional) the requested life of any new token in ms. If none
 	 *               is specified a default of 1 hour is provided. The maximum lifetime
-	 *               is 24hours; any request exceeeding that lifetime will be rejected
+	 *               is 24hours; any request exceeding that lifetime will be rejected
 	 *               with an error.
 	 *
 	 * - capability: (optional) the capability to associate with the access token.
 	 *               If none is specified, a token will be requested with all of the
 	 *               capabilities of the specified key.
 	 *
-	 * - clientId:   (optional) a client Id to associate with the token
+	 * - clientId:   (optional) a client ID to associate with the token
 	 *
 	 * - timestamp:  (optional) the time in ms since the epoch. If none is specified,
 	 *               the system will be queried for a time value to use.
@@ -206,14 +206,14 @@ class Auth {
 	 *
 	 * - ttl:        (optional) the requested life of any new token in ms. If none
 	 *               is specified a default of 1 hour is provided. The maximum lifetime
-	 *               is 24hours; any request exceeeding that lifetime will be rejected
+	 *               is 24hours; any request exceeding that lifetime will be rejected
 	 *               with an error.
 	 *
 	 * - capability: (optional) the capability to associate with the access token.
 	 *               If none is specified, a token will be requested with all of the
 	 *               capabilities of the specified key.
 	 *
-	 * - clientId:   (optional) a client Id to associate with the token
+	 * - clientId:   (optional) a client ID to associate with the token
 	 *
 	 * - timestamp:  (optional) the time in ms since the epoch. If none is specified,
 	 *               the system will be queried for a time value to use.
@@ -346,13 +346,13 @@ class Auth {
 	 * an object containing the parameters for the requested token:
 	 * - ttl:          (optional) the requested life of the token in milliseconds. If none is specified
 	 *                  a default of 1 hour is provided. The maximum lifetime is 24hours; any request
-	 *                  exceeeding that lifetime will be rejected with an error.
+	 *                  exceeding that lifetime will be rejected with an error.
 	 *
 	 * - capability:    (optional) the capability to associate with the access token.
 	 *                  If none is specified, a token will be requested with all of the
 	 *                  capabilities of the specified key.
 	 *
-	 * - clientId:      (optional) a client Id to associate with the token; if not
+	 * - clientId:      (optional) a client ID to associate with the token; if not
 	 *                  specified, a clientId passed in constructing the Rest interface will be used
 	 *
 	 * - timestamp:     (optional) the time in ms since the epoch. If none is specified,
@@ -368,13 +368,13 @@ class Auth {
 	 * an object containing the parameters for the requested token:
 	 * - ttl:          (optional) the requested life of the token in milliseconds. If none is specified
 	 *                  a default of 1 hour is provided. The maximum lifetime is 24hours; any request
-	 *                  exceeeding that lifetime will be rejected with an error.
+	 *                  exceeding that lifetime will be rejected with an error.
 	 *
 	 * - capability:    (optional) the capability to associate with the access token.
 	 *                  If none is specified, a token will be requested with all of the
 	 *                  capabilities of the specified key.
 	 *
-	 * - clientId:      (optional) a client Id to associate with the token; if not
+	 * - clientId:      (optional) a client ID to associate with the token; if not
 	 *                  specified, a clientId passed in constructing the Rest interface will be used
 	 *
 	 * - timestamp:     (optional) the time in ms since the epoch. If none is specified,
@@ -614,18 +614,19 @@ class Auth {
 	 * an object containing the parameters for the requested token:
 	 * - ttl:       (optional) the requested life of the token in ms. If none is specified
 	 *                  a default of 1 hour is provided. The maximum lifetime is 24hours; any request
-	 *                  exceeeding that lifetime will be rejected with an error.
+	 *                  exceeding that lifetime will be rejected with an error.
 	 *
 	 * - capability:    (optional) the capability to associate with the access token.
 	 *                  If none is specified, a token will be requested with all of the
 	 *                  capabilities of the specified key.
 	 *
-	 * - clientId:      (optional) a client Id to associate with the token; if not
+	 * - clientId:      (optional) a client ID to associate with the token; if not
 	 *                  specified, a clientId passed in constructing the Rest interface will be used
 	 *
 	 * - timestamp:     (optional) the time in ms since the epoch. If none is specified,
 	 *                  the system will be queried for a time value to use.
 	 *
+	 * @param callback
 	 */
 	createTokenRequest(tokenParams: TokenParams | null, authOptions: AuthOptions, callback: Function) {
 		/* shuffle and normalise arguments as necessary */
@@ -825,7 +826,7 @@ class Auth {
 				return;
 			}
 			/* RSA4b1 -- if we have a server time offset set already, we can
-			 * autoremove expired tokens. Else just use the cached token. If it is
+			 * auto remove expired tokens. Else just use the cached token. If it is
 			 * expired Ably will tell us and we'll discard it then. */
 			if(!this.isTimeOffsetSet() || !token.expires || (token.expires >= this.getTimestampUsingOffset())) {
 				Logger.logAction(Logger.LOG_MINOR, 'Auth.getToken()', 'using cached token; expires = ' + token.expires);

--- a/common/lib/transport/comettransport.ts
+++ b/common/lib/transport/comettransport.ts
@@ -287,7 +287,7 @@ abstract class CometTransport extends Transport {
 			if(err) {
 				if(err.code) {
 					/* A protocol error received from realtime. TODO: once realtime
-					 * consistendly sends errors wrapped in protocol messages, should be
+					 * consistently sends errors wrapped in protocol messages, should be
 					 * able to remove this */
 					this.onData(protocolMessageFromRawError(err));
 				} else {

--- a/common/lib/transport/connectionmanager.ts
+++ b/common/lib/transport/connectionmanager.ts
@@ -379,7 +379,7 @@ class ConnectionManager extends EventEmitter {
 
 	/**
 	 * Attempt to connect using a given transport
-	 * @param transportParam
+	 * @param transportParams
 	 * @param candidate, the transport to try
 	 * @param callback
 	 */
@@ -437,9 +437,9 @@ class ConnectionManager extends EventEmitter {
 
 
 	/**
-	 * Called when a transport is indicated to be viable, and the connectionmanager
+	 * Called when a transport is indicated to be viable, and the ConnectionManager
 	 * expects to activate this transport as soon as it is connected.
-	 * @param host
+	 * @param transport
 	 * @param transportParams
 	 */
 	setTransportPending(transport: Transport, transportParams: TransportParams): void {
@@ -492,7 +492,7 @@ class ConnectionManager extends EventEmitter {
 	 * @param transport
 	 * @param connectionId
 	 * @param connectionDetails
-	 * @param connectedMessage
+	 * @param upgradeConnectionPosition
 	 */
 	scheduleTransportActivation(error: ErrorInfo, transport: Transport, connectionId: string, connectionDetails: Record<string, any>, upgradeConnectionPosition?: ConnectionManager): void {
 			const currentTransport = this.activeProtocol && this.activeProtocol.getTransport(),
@@ -502,7 +502,7 @@ class ConnectionManager extends EventEmitter {
 			};
 
 		if(this.state !== this.states.connected && this.state !== this.states.connecting) {
-			/* This is most likely to happen for the delayed xhrs, when xhrs and ws are scheduled in parallel*/
+			/* This is most likely to happen for the delayed XHRs, when XHRs and ws are scheduled in parallel*/
 			Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.scheduleTransportActivation()', 'Current connection state (' + this.state.state + (this.state === this.states.synchronizing ? ', but with an upgrade already in progress' : '') + ') is not valid to upgrade in; abandoning upgrade to ' + transport.shortName);
 			abandon();
 			return;
@@ -1518,7 +1518,7 @@ class ConnectionManager extends EventEmitter {
 				this.send(authMsg);
 
 				/* The answer will come back as either a connectiondetails event
-				 * (realtime sends a CONNECTED to asknowledge the reauth) or a
+				 * (realtime sends a CONNECTED to acknowledge the reauth) or a
 				 * statechange to failed */
 				const successListener = () => {
 					this.off(failureListener);
@@ -1803,7 +1803,7 @@ class ConnectionManager extends EventEmitter {
 	}
 
 	/* This method is only used during connection attempts, so implements RSA4c1,
-	 * RSA4c2, and RSA4d. In particular it is not invoked for
+	 * RSA4c2, and RSA4d. In particular, it is not invoked for
 	 * serverside-triggered reauths or manual reauths, so RSA4c3 does not apply */
 	actOnErrorFromAuthorize(err: ErrorInfo): void {
 		if(err.code === 40171) {

--- a/common/lib/util/eventemitter.ts
+++ b/common/lib/util/eventemitter.ts
@@ -104,9 +104,6 @@ class EventEmitter {
 
 	/**
 	 * Remove one or more event listeners
-	 * @param event (optional) the name of the event whose listener
-	 *        is to be removed. If not supplied, the listener is
-	 *        treated as an 'any' listener
 	 * @param listener (optional) the listener to remove. If not
 	 *        supplied, all listeners are removed.
 	 */
@@ -293,6 +290,7 @@ class EventEmitter {
 	 * @param targetState the name of the state event to listen to
 	 * @param currentState the name of the current state of this object
 	 * @param listener the listener to be called
+	 * @param listenerArgs
 	 */
 	private whenState(targetState: string, currentState: string, listener: Function, ...listenerArgs: unknown[]) {
 		const eventThis = { event: targetState };

--- a/common/types/AuthOptions.ts
+++ b/common/types/AuthOptions.ts
@@ -27,7 +27,7 @@ export default interface AuthOptions {
 
   /**
    * Optional clientId that can be used to specify the identity for this client. In most cases
-   * it is preferable to instead specift a clientId in the token issued to this client.
+   * it is preferable to instead specify a clientId in the token issued to this client.
    */
   clientId?: string;
 }

--- a/common/types/ClientOptions.ts
+++ b/common/types/ClientOptions.ts
@@ -52,7 +52,7 @@ export default interface ClientOptions extends AuthOptions {
   }, callback: (shouldRecover: boolean) => void) => void);
 
   /**
-   * Use a non-secure connection connection. By default, a TLS connection is used to connect to Ably
+   * Use a non-secure connection. By default, a TLS connection is used to connect to Ably
    */
   tls?: boolean;
   tlsPort?: number;


### PR DESCRIPTION
A (hopefully) small PR to fix some inaccuracies and spelling/grammar mistakes in the JSDoc for typescript functions