### PR TITLE
Replace Base64.js with CryptoJS in browser

### DIFF
--- a/common/lib/client/auth.ts
+++ b/common/lib/client/auth.ts
@@ -7,6 +7,7 @@ import * as BufferUtils from 'platform-bufferutils';
 import ErrorInfo from '../types/errorinfo';
 import HmacSHA256 from 'crypto-js/build/hmac-sha256';
 import { stringify as stringifyBase64 } from 'crypto-js/build/enc-base64';
+import { parse as parseUtf8 } from 'crypto-js/build/enc-utf8';
 import { createHmac } from 'crypto';
 import { ErrnoException, RequestCallback, RequestParams } from '../../types/http';
 import * as API from '../../../ably';
@@ -51,7 +52,7 @@ if(Platform.createHmac) {
 		return inst.digest('base64');
 	};
 } else {
-	toBase64 = (str)=>CryptoJS.enc.Base64.stringify(CryptoJS.enc.Utf8.parse(str));
+	toBase64 = (str)=>stringifyBase64(parseUtf8(str));
 	hmac = function(text, key) {
 		return stringifyBase64(HmacSHA256(text, key));
 	};

--- a/common/lib/client/auth.ts
+++ b/common/lib/client/auth.ts
@@ -42,14 +42,16 @@ function normaliseAuthcallbackError(err: any) {
 }
 
 let hmac: (text: string, key: string) => string;
-let toBase64 = (str: string)=>Buffer.from(str, 'ascii').toString("base64");
+let toBase64: (str: string) => string;
 if(Platform.createHmac) {
+	toBase64 = (str)=>Buffer.from(str, 'ascii').toString("base64");
 	hmac = function(text, key) {
 		const inst = (Platform.createHmac as typeof createHmac) ('SHA256', key);
 		inst.update(text);
 		return inst.digest('base64');
 	};
 } else {
+	toBase64 = (str)=>CryptoJS.enc.Base64.stringify(CryptoJS.enc.Utf8.parse(str));
 	hmac = function(text, key) {
 		return stringifyBase64(HmacSHA256(text, key));
 	};

--- a/common/lib/client/auth.ts
+++ b/common/lib/client/auth.ts
@@ -5,7 +5,6 @@ import Http from 'platform-http';
 import Multicaster from '../util/multicaster';
 import * as BufferUtils from 'platform-bufferutils';
 import ErrorInfo from '../types/errorinfo';
-import Base64 from 'platform-base64';
 import HmacSHA256 from 'crypto-js/build/hmac-sha256';
 import { stringify as stringifyBase64 } from 'crypto-js/build/enc-base64';
 import { createHmac } from 'crypto';
@@ -43,16 +42,14 @@ function normaliseAuthcallbackError(err: any) {
 }
 
 let hmac: (text: string, key: string) => string;
-let toBase64: typeof Base64.encode;
+let toBase64 = (str: string)=>Buffer.from(str, 'ascii').toString("base64");
 if(Platform.createHmac) {
-	toBase64 = function(str: string) { return (Buffer.from(str, 'ascii')).toString('base64'); };
 	hmac = function(text, key) {
 		const inst = (Platform.createHmac as typeof createHmac) ('SHA256', key);
 		inst.update(text);
 		return inst.digest('base64');
 	};
 } else {
-	toBase64 = Base64.encode;
 	hmac = function(text, key) {
 		return stringifyBase64(HmacSHA256(text, key));
 	};

--- a/common/types/platform-base64.d.ts
+++ b/common/types/platform-base64.d.ts
@@ -1,6 +1,0 @@
-declare module 'platform-base64' {
-  const Base64: {
-    encode: (data: string) => string;
-  }
-  export default Base64;
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,6 @@ const nodeConfig = {
             'platform-crypto': path.resolve(nodePath, 'lib', 'util', 'crypto'),
             'platform-transports': path.resolve(nodePath, 'lib', 'transport'),
             // webpack null-loader is used to ensure that the following modules resolve to null - webpack won't compile unless these aliases are pointing at a valid module so these values are irrelevant.
-            'platform-base64': path.resolve(browserPath, 'lib', 'util', 'base64'),
             'platform-msgpack': path.resolve(browserPath, 'lib', 'util', 'msgpack'),
             'platform-webstorage': path.resolve(browserPath, 'lib', 'util', 'webstorage'),
         },
@@ -68,7 +67,7 @@ const nodeConfig = {
         rules: [
             ...baseConfig.module.rules,
             {
-                test: /(platform-base64|platform-webstorage|platform-msgpack)/,
+                test: /(platform-webstorage|platform-msgpack)/,
                 use: 'null-loader',
             },
         ],
@@ -95,7 +94,6 @@ const browserConfig = {
             platform: path.resolve(browserPath, 'fragments', 'platform-browser'),
             'platform-http': path.resolve(browserPath, 'lib', 'util', 'http'),
             'platform-bufferutils': path.resolve(browserPath, 'lib', 'util', 'bufferutils'),
-            'platform-base64': path.resolve(browserPath, 'lib', 'util', 'base64'),
             'platform-defaults': path.resolve(browserPath, 'lib', 'util', 'defaults'),
             'platform-crypto': path.resolve(browserPath, 'lib', 'util', 'crypto'),
             'platform-webstorage': path.resolve(browserPath, 'lib', 'util', 'webstorage'),
@@ -127,7 +125,6 @@ const nativeScriptConfig = {
             platform: path.resolve(browserPath, 'fragments', 'platform-nativescript'),
             'platform-http': path.resolve(browserPath, 'lib', 'util', 'http'),
             'platform-bufferutils': path.resolve(browserPath, 'lib', 'util', 'bufferutils'),
-            'platform-base64': path.resolve(browserPath, 'lib', 'util', 'base64'),
             'platform-defaults': path.resolve(browserPath, 'lib', 'util', 'defaults'),
             'platform-crypto': path.resolve(browserPath, 'lib', 'util', 'crypto'),
             'platform-webstorage': path.resolve(browserPath, 'lib', 'util', 'webstorage'),
@@ -164,7 +161,6 @@ const reactNativeConfig = {
             platform: path.resolve(browserPath, 'fragments', 'platform-reactnative'),
             'platform-http': path.resolve(browserPath, 'lib', 'util', 'http'),
             'platform-bufferutils': path.resolve(browserPath, 'lib', 'util', 'bufferutils'),
-            'platform-base64': path.resolve(browserPath, 'lib', 'util', 'base64'),
             'platform-defaults': path.resolve(browserPath, 'lib', 'util', 'defaults'),
             'platform-crypto': path.resolve(browserPath, 'lib', 'util', 'crypto'),
             'platform-webstorage': path.resolve(browserPath, 'lib', 'util', 'webstorage'),


### PR DESCRIPTION
Fixes #372. Removed base64.js and replaced with CryptoJS. Node library already uses Buffer instead, so this only affects the browser.