### PR TITLE
Fix nonsensical error in RealtimePresence.leaveClient when channel state is invalid

### DIFF
--- a/common/lib/client/realtimepresence.ts
+++ b/common/lib/client/realtimepresence.ts
@@ -233,9 +233,7 @@ class RealtimePresence extends Presence {
 				callback?.(err);
 				break;
 			default:
-				/* there is no connection; therefore we let
-				 * any entered status timeout by itself */
-				callback?.(ConnectionErrors.failed);
+				callback?.(RealtimeChannel.invalidStateError(channel.state));
 		}
 	}
 


### PR DESCRIPTION
Resolves #702 