### PR TITLE
YJS plugin

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -153,7 +153,7 @@ declare namespace Types {
 		httpOpenTimeout?: number;
 		httpRequestTimeout?: number;
 
-		plugins?: { vcdiff?: any };
+		plugins?: { vcdiff?: any, yjs?: any };
 	}
 
 	interface AuthOptions {

--- a/common/lib/client/realtime.ts
+++ b/common/lib/client/realtime.ts
@@ -11,10 +11,12 @@ import { ChannelOptions } from '../../types/channel';
 import { ErrCallback } from '../../types/utils';
 import ClientOptions, { DeprecatedClientOptions } from '../../types/ClientOptions';
 import * as API from '../../../ably';
+import YjsPlugin from '../../plugins/YjsPlugin';
 
 class Realtime extends Rest {
 	channels: any;
 	connection: Connection;
+	docs?: YjsPlugin;
 
 	constructor(options: ClientOptions) {
 		super(options);
@@ -23,6 +25,9 @@ class Realtime extends Rest {
 		this.channels = new Channels(this);
 		if(options.autoConnect !== false)
 			this.connect();
+		if(options.plugins?.yjs) {
+		  this.docs = new YjsPlugin(this);
+		}
 	}
 
 	connect(): void {

--- a/common/lib/index.js
+++ b/common/lib/index.js
@@ -11,6 +11,7 @@ import Resource from './client/resource';
 import ProtocolMessage from './types/protocolmessage';
 import ConnectionManager from './transport/connectionmanager';
 import msgpack from 'platform-msgpack';
+import YjsPlugin from '../plugins/YjsPlugin';
 
 Rest.Utils = Utils;
 Rest.BufferUtils = BufferUtils;
@@ -34,5 +35,6 @@ Realtime.ConnectionManager = ConnectionManager;
 export default {
   Rest,
   Realtime,
-  msgpack
+  msgpack,
+  YjsPlugin
 }

--- a/common/plugins/YjsPlugin.ts
+++ b/common/plugins/YjsPlugin.ts
@@ -1,0 +1,84 @@
+import Realtime from "../lib/client/realtime";
+import * as Y from 'yjs';
+import RealtimeChannel from "../lib/client/realtimechannel";
+import Message from "../lib/types/message";
+
+export default class Docs {
+  realtime: Realtime;
+  providers: Map<string, SyncInboxProvider>;
+
+  constructor(realtime: Realtime) {
+    this.realtime = realtime;
+    this.providers = new Map();
+  }
+
+  get(name: string) {
+    const doc = new Y.Doc();
+    this.providers.set(name, new SyncInboxProvider(this.realtime, name, doc));
+    return doc;
+  }
+}
+
+/**
+ * A Yjs provider which broadcasts sync requests and updates on a single
+ * channel, but receives sync replies on a client-specific inbox channel.
+ */
+export class SyncInboxProvider {
+  client: Realtime;
+  channel: RealtimeChannel;
+  doc: Y.Doc;
+  clientId: string;
+
+  constructor(client: Realtime, channel: string, doc: Y.Doc) {
+    this.client = client;
+    this.channel = client.channels.get(channel);
+    this.doc = doc;
+    this.clientId = doc.clientID.toString();
+
+    this.channel.subscribe(this.handleMessage.bind(this));
+
+    this.doc.on('update', this.handleUpdate.bind(this));
+
+    const inbox = client.channels.get(`${channel}:${this.clientId}`);
+    inbox.subscribe(this.handleMessage.bind(this));
+
+    const state = Y.encodeStateVector(doc);
+    this.log('publishing syncStep1');
+    this.channel.publish('syncStep1', state);
+  }
+
+  handleMessage(msg: Message) {
+    this.log('message received');
+    if (msg.clientId === this.clientId) return;
+    this.log('and it\'s not an echo');
+
+    switch (msg.name) {
+      case 'syncStep1': {
+        const inbox = this.client.channels.get(`${this.channel.name}:${msg.clientId}`);
+        const reply = Y.encodeStateAsUpdate(this.doc, new Uint8Array(msg.data));
+	this.log('publishing syncStep2');
+        inbox.publish('syncStep2', reply);
+        break;
+      }
+      case 'syncStep2':
+        Y.applyUpdate(this.doc, new Uint8Array(msg.data), this);
+        break;
+      case 'update':
+        Y.applyUpdate(this.doc, new Uint8Array(msg.data), this);
+        break;
+      default:
+        console.error(`Unexpected message: ${msg.name}`);
+        break;
+    }
+  }
+
+  handleUpdate(update: Uint8Array, origin: SyncInboxProvider) {
+    if (origin !== this) {
+      this.channel.publish('update', update);
+    }
+  }
+
+  log(message: string) {
+    // console.log(`${this.clientId}: ${message}`);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",
         "got": "^11.8.2",
-        "ws": "^5.1"
+        "ws": "^5.1",
+        "yjs": "^13.5.28"
       },
       "devDependencies": {
         "@ably/vcdiff-decoder": "1.0.4",
@@ -5117,6 +5118,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.4.tgz",
+      "integrity": "sha512-Y4NjZceAwaPXctwsHgNsmfuPxR8lJ3f8X7QTAkhltrX4oGIv+eTlgHLXn4tWysC9zGTi929gapnPp+8F8cg7nA==",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/jake": {
       "version": "10.8.2",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
@@ -5266,6 +5276,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.46",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.46.tgz",
+      "integrity": "sha512-U8V4Nc91EUSXLewvlJb0uSm9JI5rbiZKXBKHqWwPHX4g5cHx09dWAeD//UEZplm96xCrZ1BKDh5QaFHUIsnGIg==",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/liftup": {
@@ -9920,6 +9945,18 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "node_modules/yjs": {
+      "version": "13.5.28",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.5.28.tgz",
+      "integrity": "sha512-vvrSdobLkw/0whVnA5ztLD8rrDkQd9USlybS0XtHfQV96lyKLJ0/tuCwcCyHU9ZPjPqC5n+smx+te2PgG3oVFQ==",
+      "dependencies": {
+        "lib0": "^0.2.43"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     }
   },
   "dependencies": {
@@ -14004,6 +14041,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic.js": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.4.tgz",
+      "integrity": "sha512-Y4NjZceAwaPXctwsHgNsmfuPxR8lJ3f8X7QTAkhltrX4oGIv+eTlgHLXn4tWysC9zGTi929gapnPp+8F8cg7nA=="
+    },
     "jake": {
       "version": "10.8.2",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
@@ -14126,6 +14168,14 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lib0": {
+      "version": "0.2.46",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.46.tgz",
+      "integrity": "sha512-U8V4Nc91EUSXLewvlJb0uSm9JI5rbiZKXBKHqWwPHX4g5cHx09dWAeD//UEZplm96xCrZ1BKDh5QaFHUIsnGIg==",
+      "requires": {
+        "isomorphic.js": "^0.2.4"
       }
     },
     "liftup": {
@@ -17770,6 +17820,14 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "yjs": {
+      "version": "13.5.28",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.5.28.tgz",
+      "integrity": "sha512-vvrSdobLkw/0whVnA5ztLD8rrDkQd9USlybS0XtHfQV96lyKLJ0/tuCwcCyHU9ZPjPqC5n+smx+te2PgG3oVFQ==",
+      "requires": {
+        "lib0": "^0.2.43"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@ably/msgpack-js": "^0.4.0",
     "got": "^11.8.2",
-    "ws": "^5.1"
+    "ws": "^5.1",
+    "yjs": "^13.5.28"
   },
   "devDependencies": {
     "@ably/vcdiff-decoder": "1.0.4",


### PR DESCRIPTION
Adds a YJS plugin which augments the ably-js API with an API to create connected YJS `Doc`s. See the [YJS docs](https://docs.yjs.dev/) for information on using the YJS `Doc` API.

Example usage:
```ts
import * as Ably from 'ably';

options.key = '<your_api_key>';

// Providing the YjsPlugin as a client option will give the client new API methods allowing you to create connected Docs
options.plugins = {
  yjs: Ably.YjsPlugin,
}

const client = new Ably.Realtime(options);

/*
 * Get a YJS Doc instance that is connected to the given realtime channel name.
 *
 * We could extend the Yjs Doc class with our own AblyDoc class with our own API methods.
 */
const doc = client.docs.get(channelName);

// Now you can proceed to just use the YJS Doc API to create your multi user collaborative application
// Ably will automatically keep your YJS Doc synced with other docs from the same realtime channel

```

Current limitations (all of these can easily be solved)
- Type annotations for the `realtime.docs` aren't yet included in `ably.d.ts` so this won't work with TypeScript at the moment.
- The plugin is included with the default library import which means on this branch the YJS library is included in all bundles regardless of whether you're using a tree shaking module bundler.
- There are currently no methods to release/dispose of a connected Doc.