### PR TITLE
Fix promisification errors

### DIFF
--- a/common/lib/client/connection.ts
+++ b/common/lib/client/connection.ts
@@ -64,7 +64,7 @@ class Connection extends EventEmitter {
     Logger.logAction(Logger.LOG_MINOR, 'Connection.ping()', '');
     if (!callback) {
       if (this.ably.options.promises) {
-        return Utils.promisify(this, 'ping', [callback]);
+        return Utils.promisify(this, 'ping', arguments);
       }
       callback = noop;
     }

--- a/common/lib/client/paginatedresource.ts
+++ b/common/lib/client/paginatedresource.ts
@@ -184,29 +184,30 @@ export class PaginatedResult<T> {
     this.resource = resource;
     this.items = items;
 
+    const self = this;
     if (relParams) {
       if ('first' in relParams) {
-        this.first = (callback: (result?: ErrorInfo | null) => void) => {
-          if (!callback && this.resource.rest.options.promises) {
-            return Utils.promisify(this, 'first', []);
+        this.first = function (callback: (result?: ErrorInfo | null) => void) {
+          if (!callback && self.resource.rest.options.promises) {
+            return Utils.promisify(self, 'first', arguments);
           }
-          this.get(relParams.first, callback);
+          self.get(relParams.first, callback);
         };
       }
       if ('current' in relParams) {
-        this.current = (callback: (results?: ErrorInfo | null) => void) => {
-          if (!callback && this.resource.rest.options.promises) {
-            return Utils.promisify(this, 'current', []);
+        this.current = function (callback: (results?: ErrorInfo | null) => void) {
+          if (!callback && self.resource.rest.options.promises) {
+            return Utils.promisify(self, 'current', arguments);
           }
-          this.get(relParams.current, callback);
+          self.get(relParams.current, callback);
         };
       }
-      this.next = (callback: (results?: ErrorInfo | null) => void) => {
-        if (!callback && this.resource.rest.options.promises) {
-          return Utils.promisify(this, 'next', []);
+      this.next = function (callback: (results?: ErrorInfo | null) => void) {
+        if (!callback && self.resource.rest.options.promises) {
+          return Utils.promisify(self, 'next', arguments);
         }
         if ('next' in relParams) {
-          this.get(relParams.next, callback);
+          self.get(relParams.next, callback);
         } else {
           callback(null);
         }

--- a/common/lib/client/presence.ts
+++ b/common/lib/client/presence.ts
@@ -29,7 +29,7 @@ class Presence extends EventEmitter {
         params = null;
       } else {
         if (this.channel.rest.options.promises) {
-          return Utils.promisify(this, 'get', [params, callback]);
+          return Utils.promisify(this, 'get', arguments);
         }
         callback = noop;
       }
@@ -64,7 +64,7 @@ class Presence extends EventEmitter {
         params = null;
       } else {
         if (this.channel.rest.options.promises) {
-          return Utils.promisify(this, '_history', [params, callback]);
+          return Utils.promisify(this, '_history', arguments);
         }
         callback = noop;
       }

--- a/common/lib/client/realtimepresence.ts
+++ b/common/lib/client/realtimepresence.ts
@@ -311,7 +311,7 @@ class RealtimePresence extends Presence {
         params = null;
       } else {
         if (this.channel.realtime.options.promises) {
-          return Utils.promisify(this, 'history', [params, callback]);
+          return Utils.promisify(this, 'history', arguments);
         }
         callback = noop;
       }
@@ -529,7 +529,7 @@ class RealtimePresence extends Presence {
 
     if (!callback) {
       if (this.channel.realtime.options.promises) {
-        return Utils.promisify(this, 'subscribe', [event, listener]);
+        return Utils.promisify(this, 'subscribe', arguments);
       }
       callback = noop;
     }

--- a/test/rest/presence.test.js
+++ b/test/rest/presence.test.js
@@ -145,5 +145,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         done(err);
       }
     });
+
+    if (typeof Promise !== 'undefined') {
+      it('presencePromise', function (done) {
+        var rest = helper.AblyRest({ promises: true });
+        var channel = rest.channels.get('some_channel');
+
+        channel.presence
+          .get()
+          .then(function () {
+            done();
+          })
+          ['catch'](function (err) {
+            done(err);
+          });
+      });
+    }
   });
 });


### PR DESCRIPTION
Resolves #943.

Also adds a simple test to check `RestPromise.get` promisification works. We need to make sure we're testing this for all the promisified methods but that work will be tracked by #944.