### PR TITLE
Ensure that Ably-Agent is always URI encoded

### DIFF
--- a/common/lib/transport/connectionmanager.ts
+++ b/common/lib/transport/connectionmanager.ts
@@ -154,7 +154,7 @@ export class TransportParams {
       params.heartbeats = this.heartbeats;
     }
     params.v = Defaults.apiVersion;
-    params.agent = Defaults.agent;
+    params.agent = encodeURIComponent(Defaults.agent);
     if (options.transportParams !== undefined) {
       Utils.mixin(params, options.transportParams);
     }

--- a/common/lib/transport/websockettransport.ts
+++ b/common/lib/transport/websockettransport.ts
@@ -58,7 +58,7 @@ class WebSocketTransport extends Transport {
       for (const key in connectParams) uri += (paramCount++ ? '&' : '?') + key + '=' + connectParams[key];
     }
     this.uri = uri;
-    return new WebSocket(encodeURI(uri));
+    return new WebSocket(uri);
   }
 
   toString() {

--- a/common/lib/transport/websockettransport.ts
+++ b/common/lib/transport/websockettransport.ts
@@ -58,7 +58,7 @@ class WebSocketTransport extends Transport {
       for (const key in connectParams) uri += (paramCount++ ? '&' : '?') + key + '=' + connectParams[key];
     }
     this.uri = uri;
-    return new WebSocket(uri);
+    return new WebSocket(encodeURI(uri));
   }
 
   toString() {

--- a/common/lib/util/utils.ts
+++ b/common/lib/util/utils.ts
@@ -352,7 +352,7 @@ export function defaultGetHeaders(format?: Format): Record<string, string> {
   return {
     accept: accept,
     'X-Ably-Version': Defaults.apiVersion,
-    'Ably-Agent': Defaults.agent,
+    'Ably-Agent': encodeURIComponent(Defaults.agent),
   };
 }
 
@@ -364,7 +364,7 @@ export function defaultPostHeaders(format?: Format): Record<string, string> {
     accept: accept,
     'content-type': contentType,
     'X-Ably-Version': Defaults.apiVersion,
-    'Ably-Agent': Defaults.agent,
+    'Ably-Agent': encodeURIComponent(Defaults.agent),
   };
 }
 


### PR DESCRIPTION
This fixes a bug in the react-native library where the websocket constructor would throw an error because the Ably-Agent query param was not being URI encoded.