### PR TITLE
Make `Connection.id` and `Connection.key` optional

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -770,8 +770,8 @@ declare namespace Types {
 
   class ConnectionBase extends EventEmitter<connectionEventCallback, ConnectionStateChange, ConnectionEvent> {
     errorReason: ErrorInfo;
-    id: string;
-    key: string;
+    id?: string;
+    key?: string;
     recoveryKey: string;
     serial: number;
     readonly state: ConnectionState;

--- a/common/lib/client/connection.ts
+++ b/common/lib/client/connection.ts
@@ -13,7 +13,7 @@ class Connection extends EventEmitter {
   ably: Realtime;
   connectionManager: ConnectionManager;
   state: string;
-  key?: never;
+  key?: string;
   id?: string;
   serial: undefined;
   timeSerial: undefined;


### PR DESCRIPTION
- Both of these fields aren't set until the connection details are received from ably so may be undefined.