### PR TITLE
Update publish action to use GitHub OIDC for AWS access

### DIFF
--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.version }}
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_PRODUCTION }}:role/github-actions-sdk
+          aws-region: us-east-1
       - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
@@ -20,6 +24,3 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.event.inputs.version }}
-        env:
-          AWS_ACCESS_KEY: ${{ secrets.CDN_PUBLISH_AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CDN_PUBLISH_AWS_SET_ACCESS_KEY }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,13 +6,23 @@ Deploys correctly versioned code and source maps to the CDN.
 
 Arguments:
 
-**--bucket**: The S3 bucket name to deploy to, defaults to `cdn.ably.io`.
-**--root**: The base directory inside the bucket to deploy to, defaults to `lib`.
-**--s3Key**: S3 Access Key. Can also be set with `AWS_ACCESS_KEY` env variable.
-**--s3Secret**: S3 Secret Access Key. Can also be set with `AWS_SECRET_ACCESS_KEY` env variable.
-**--path**: The local path to retrieve source files from. Defaults to `.`.
-**--includeDirs**: A comma separated list of directories to include. Defaults to `.`.
-**--excludeDirs**: A comma separated list of directories to exclude. Defaults to `node_modules,.git`.
-**--fileRegex**: A regular expression to test file names against for upload. Defaults to `^(?!\.).*\.(map|js|html)$`.
-**--endpoint**: Optional. The S3 endpoint to deploy to.
-**--skipCheckout**: Optional. Skip checking out the branch before running.
+* **--bucket**: The S3 bucket name to deploy to, defaults to `cdn.ably.io`.
+* **--root**: The base directory inside the bucket to deploy to, defaults to `lib`.
+* **--path**: The local path to retrieve source files from. Defaults to `.`.
+* **--includeDirs**: A comma separated list of directories to include. Defaults to `.`.
+* **--excludeDirs**: A comma separated list of directories to exclude. Defaults to `node_modules,.git`.
+* **--fileRegex**: A regular expression to test file names against for upload. Defaults to `^(?!\.).*\.(map|js|html)$`.
+* **--skipCheckout**: Optional. Skip checking out the branch before running.
+
+#### AWS Access
+
+Expects AWS access to be configured in the surrounding environment. To run
+locally, first set some temporary AWS credentials as environment variables
+using `ably-env`:
+
+```
+source <(ably-env secrets print-aws)
+```
+
+See [AWS Access](https://ably.atlassian.net/wiki/spaces/ENG/pages/665190401/AWS+Access)
+for more information about gaining access to AWS.

--- a/scripts/cdn_deploy.js
+++ b/scripts/cdn_deploy.js
@@ -15,9 +15,6 @@ async function run() {
 		bucket: S3_DEFAULT_BUCKET,
 		// The root folder inside the S3 bucket where the files should be places
 		root: S3_DEFAULT_ROOT,
-		// S3 Credentials
-		s3Key: process.env.AWS_ACCESS_KEY,
-		s3Secret: process.env.AWS_SECRET_ACCESS_KEY,
 		// Local path to start from
 		path: ".",
 		// Comma separated directories (relative to `path`) to upload
@@ -29,20 +26,12 @@ async function run() {
 		...argv,
 	};
 
-	if (!config.s3Key || !config.s3Secret)
-		throw new Error(`Missing S3 credentials, provide either --s3Key and --s3Secret or environment variables AWS_ACCESS_KEY and AWS_SECRET_ACCESS_KEY`);
-
 	// Resolve all the paths into full paths
 	config.path = path.resolve(config.path);
 	config.includeDirs = config.includeDirs.split(",").map((dir) => path.resolve(dir));
 	config.excludeDirs = config.excludeDirs.split(",").map((dir) => path.resolve(dir));
 
-	const s3 = new AWS.S3({
-		region: "REGION",
-		accessKeyId: config.s3Key,
-		secretAccessKey: config.s3Secret,
-		endpoint: config.endpoint,
-	});
+	const s3 = new AWS.S3();
 
 	// If no tag is specified, run an output displaying all available tags
 	if (!config.tag) {


### PR DESCRIPTION
This updates the publish GitHub action to use GitHub OIDC to obtain short-lived AWS credentials in place of the current long lived stored in the secrets.

The AWS IAM role (`github-actions-sdk`) is managed by the internal infrastructure team.