### PR TITLE
Fix nativescript bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,6 +119,7 @@ const nativeScriptConfig = {
   output: {
     ...baseConfig.output,
     filename: 'ably-nativescript.js',
+    globalObject: 'global',
   },
   resolve: {
     ...baseConfig.resolve,


### PR DESCRIPTION
- Explicitly sets the `output.globalObject` property on the nativescript webpack config.
- This resolves an issue where the package would error on import to a nativescript projects since `window` (the default globalObject for web bundles) isn't defined in nativescript and webpack doesn't have a nativescript target.