### PR TITLE
`npm rm ejs`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "copy-webpack-plugin": "^6.4.1",
         "cors": "~2.7",
         "crypto-js": "ably-forks/crypto-js#crypto-lite",
-        "ejs": "~2.5",
         "eslint": "^7.13.0",
         "eslint-plugin-security": "^1.4.0",
         "express": "^4.17.1",
@@ -2790,15 +2789,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
-    },
-    "node_modules/ejs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-      "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -12492,12 +12482,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
-    },
-    "ejs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-      "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ==",
       "dev": true
     },
     "elliptic": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "copy-webpack-plugin": "^6.4.1",
     "cors": "~2.7",
     "crypto-js": "ably-forks/crypto-js#crypto-lite",
-    "ejs": "~2.5",
     "eslint": "^7.13.0",
     "eslint-plugin-security": "^1.4.0",
     "express": "^4.17.1",


### PR DESCRIPTION
- Not being used anywhere as far as I can tell, and not required as a peer dependency anywhere.