### PR TITLE
Revert removing Message and PresenceMessage from public API

### DIFF
--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -15,6 +15,7 @@ import ClientOptions, { DeprecatedClientOptions, NormalisedClientOptions } from 
 
 import Platform from '../../platform';
 import Message from '../types/message';
+import PresenceMessage from '../types/presencemessage';
 
 const noop = function () {};
 class Rest {
@@ -238,6 +239,7 @@ class Rest {
   static Platform = Platform;
   static Crypto?: typeof Platform.Crypto;
   static Message?: typeof Message;
+  static PresenceMessage?: typeof PresenceMessage;
 }
 
 class Channels {

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -14,6 +14,7 @@ import { ErrnoException, IHttp, RequestParams } from '../../types/http';
 import ClientOptions, { DeprecatedClientOptions, NormalisedClientOptions } from '../../types/ClientOptions';
 
 import Platform from '../../platform';
+import Message from '../types/message';
 
 const noop = function () {};
 class Rest {
@@ -236,6 +237,7 @@ class Rest {
   static Callbacks = Rest;
   static Platform = Platform;
   static Crypto?: typeof Platform.Crypto;
+  static Message?: typeof Message;
 }
 
 class Channels {

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -19,6 +19,7 @@ import ConnectionManager from '../../common/lib/transport/connectionmanager';
 import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
+import Message from 'common/lib/types/message';
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
@@ -29,6 +30,9 @@ Platform.WebStorage = WebStorage;
 
 Rest.Crypto = Crypto;
 Realtime.Crypto = Crypto;
+
+Rest.Message = Message;
+Realtime.Message = Message;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -20,6 +20,7 @@ import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
 import Message from 'common/lib/types/message';
+import PresenceMessage from 'common/lib/types/presencemessage';
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
@@ -33,6 +34,9 @@ Realtime.Crypto = Crypto;
 
 Rest.Message = Message;
 Realtime.Message = Message;
+
+Rest.PresenceMessage = PresenceMessage;
+Realtime.PresenceMessage = PresenceMessage;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -16,6 +16,7 @@ import { getDefaults } from '../../common/lib/util/defaults';
 import ConnectionManager from '../../common/lib/transport/connectionmanager';
 import PlatformDefaults from './lib/util/defaults';
 import Message from 'common/lib/types/message';
+import PresenceMessage from 'common/lib/types/presencemessage';
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
@@ -29,6 +30,9 @@ Realtime.Crypto = Crypto;
 
 Rest.Message = Message;
 Realtime.Message = Message;
+
+Rest.PresenceMessage = PresenceMessage;
+Realtime.PresenceMessage = PresenceMessage;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -15,6 +15,7 @@ import Logger from '../../common/lib/util/logger';
 import { getDefaults } from '../../common/lib/util/defaults';
 import ConnectionManager from '../../common/lib/transport/connectionmanager';
 import PlatformDefaults from './lib/util/defaults';
+import Message from 'common/lib/types/message';
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
@@ -25,6 +26,9 @@ Platform.WebStorage = null;
 
 Rest.Crypto = Crypto;
 Realtime.Crypto = Crypto;
+
+Rest.Message = Message;
+Realtime.Message = Message;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -17,6 +17,7 @@ import ConnectionManager from '../../common/lib/transport/connectionmanager';
 import WebStorage from '../web/lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
+import Message from 'common/lib/types/message';
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
@@ -27,6 +28,9 @@ Platform.WebStorage = WebStorage;
 
 Rest.Crypto = Crypto;
 Realtime.Crypto = Crypto;
+
+Rest.Message = Message;
+Realtime.Message = Message;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -18,6 +18,7 @@ import WebStorage from '../web/lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
 import Message from 'common/lib/types/message';
+import PresenceMessage from 'common/lib/types/presencemessage';
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
@@ -31,6 +32,9 @@ Realtime.Crypto = Crypto;
 
 Rest.Message = Message;
 Realtime.Message = Message;
+
+Rest.PresenceMessage = PresenceMessage;
+Realtime.PresenceMessage = PresenceMessage;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/web-noencryption/index.ts
+++ b/src/platform/web-noencryption/index.ts
@@ -17,6 +17,7 @@ import WebStorage from '../web/lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
 import Message from 'common/lib/types/message';
+import PresenceMessage from 'common/lib/types/presencemessage';
 
 Platform.Crypto = null;
 Platform.BufferUtils = BufferUtils;
@@ -30,6 +31,9 @@ Realtime.Crypto = Crypto;
 
 Rest.Message = Message;
 Realtime.Message = Message;
+
+Rest.PresenceMessage = PresenceMessage;
+Realtime.PresenceMessage = PresenceMessage;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/web-noencryption/index.ts
+++ b/src/platform/web-noencryption/index.ts
@@ -16,6 +16,7 @@ import ConnectionManager from '../../common/lib/transport/connectionmanager';
 import WebStorage from '../web/lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
+import Message from 'common/lib/types/message';
 
 Platform.Crypto = null;
 Platform.BufferUtils = BufferUtils;
@@ -26,6 +27,9 @@ Platform.WebStorage = WebStorage;
 
 Rest.Crypto = Crypto;
 Realtime.Crypto = Crypto;
+
+Rest.Message = Message;
+Realtime.Message = Message;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -18,6 +18,7 @@ import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from './lib/util/defaults';
 import msgpack from './lib/util/msgpack';
 import Message from 'common/lib/types/message';
+import PresenceMessage from 'common/lib/types/presencemessage';
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
@@ -31,6 +32,9 @@ Realtime.Crypto = Crypto;
 
 Rest.Message = Message;
 Realtime.Message = Message;
+
+Rest.PresenceMessage = PresenceMessage;
+Realtime.PresenceMessage = PresenceMessage;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -17,6 +17,7 @@ import ConnectionManager from '../../common/lib/transport/connectionmanager';
 import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from './lib/util/defaults';
 import msgpack from './lib/util/msgpack';
+import Message from 'common/lib/types/message';
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
@@ -27,6 +28,9 @@ Platform.WebStorage = WebStorage;
 
 Rest.Crypto = Crypto;
 Realtime.Crypto = Crypto;
+
+Rest.Message = Message;
+Realtime.Message = Message;
 
 Realtime.ConnectionManager = ConnectionManager;
 

--- a/test/realtime/api.test.js
+++ b/test/realtime/api.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+define(['ably', 'chai'], function (Ably, chai) {
+  var expect = chai.expect;
+
+  describe('realtime/api', function () {
+    it('Client constructors', function () {
+      expect(typeof Ably.Realtime).to.equal('function');
+      expect(typeof Ably.Realtime.Promise).to.equal('function');
+      expect(typeof Ably.Realtime.Callbacks).to.equal('function');
+      expect(Ably.Realtime.Callbacks).to.equal(Ably.Realtime);
+    });
+
+    it('Crypto', function () {
+      expect(typeof Ably.Realtime.Crypto).to.equal('function');
+      expect(typeof Ably.Realtime.Crypto.getDefaultParams).to.equal('function');
+      expect(typeof Ably.Realtime.Crypto.generateRandomKey).to.equal('function');
+    });
+
+    it('Message', function () {
+      expect(typeof Ably.Realtime.Message).to.equal('function');
+      expect(typeof Ably.Realtime.Message.fromEncoded).to.equal('function');
+      expect(typeof Ably.Realtime.Message.fromEncodedArray).to.equal('function');
+    });
+
+    it('PresenceMessage', function () {
+      expect(typeof Ably.Realtime.PresenceMessage).to.equal('function');
+      expect(typeof Ably.Realtime.PresenceMessage.fromEncoded).to.equal('function');
+      expect(typeof Ably.Realtime.PresenceMessage.fromEncodedArray).to.equal('function');
+    });
+  });
+});

--- a/test/rest/api.test.js
+++ b/test/rest/api.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+define(['ably', 'chai'], function (Ably, chai) {
+  var expect = chai.expect;
+
+  describe('rest/api', function () {
+    it('Client constructors', function () {
+      expect(typeof Ably.Rest).to.equal('function');
+      expect(typeof Ably.Rest.Promise).to.equal('function');
+      expect(typeof Ably.Rest.Callbacks).to.equal('function');
+      expect(Ably.Rest.Callbacks).to.equal(Ably.Rest);
+    });
+
+    it('Crypto', function () {
+      expect(typeof Ably.Rest.Crypto).to.equal('function');
+      expect(typeof Ably.Rest.Crypto.getDefaultParams).to.equal('function');
+      expect(typeof Ably.Rest.Crypto.generateRandomKey).to.equal('function');
+    });
+
+    it('Message', function () {
+      expect(typeof Ably.Rest.Message).to.equal('function');
+      expect(typeof Ably.Rest.Message.fromEncoded).to.equal('function');
+      expect(typeof Ably.Rest.Message.fromEncodedArray).to.equal('function');
+    });
+
+    it('PresenceMessage', function () {
+      expect(typeof Ably.Rest.PresenceMessage).to.equal('function');
+      expect(typeof Ably.Rest.PresenceMessage.fromEncoded).to.equal('function');
+      expect(typeof Ably.Rest.PresenceMessage.fromEncodedArray).to.equal('function');
+    });
+  });
+});


### PR DESCRIPTION
I was working on #1002 and noticed that with 1.2.23 we also removed `Rest.Message`, `Rest.PresenceMessage`, `Realtime.Message`, and `Realtime.PresenceMessage`.

This PR adds these fields back to the library and adds tests to validate that they exist and have the correct runtime types.