### PR TITLE
Stop CI from running webpack twice

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           node-version: 14.x
       - run: npm ci
-      - run: npm run build
       - run: npm run lint
       - run: npm run format:check
       - run: npm run check-closure-compiler

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -25,5 +25,4 @@ jobs:
         with:
           node-version: 14.x
       - run: npm ci
-      - run: npm run build
       - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.event.inputs.version }}

--- a/test/support/runPlaywrightTests.js
+++ b/test/support/runPlaywrightTests.js
@@ -28,6 +28,10 @@ const runTests = async (browserType) => {
       console.log(detail);
     });
 
+    page.on('console', (msg) => {
+      console.log(msg.text());
+    });
+
     // Expose a function inside the playwright browser to exit with the right status code when tests pass/fail
     page.exposeFunction('onTestResult', ({ detail }) => {
       console.log(`${browserType.name()} tests complete: ${detail.passes}/${detail.total} passed`);


### PR DESCRIPTION
`npm run build` is already executed as a postinstall hook from `npm ci` so this just makes these workflows about 30s faster.

Also pipes browser console output to stdout in playwright tests which will help a lot.