### PR TITLE
Update TypeScript to 4.6.4 and TypeDoc to 0.23.8

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -1232,6 +1232,12 @@ declare namespace Types {
   /**
    * Not yet documented.
    *
+   * @param shouldRecover - Not yet documented.
+   */
+  type recoverConnectionCompletionCallback = (shouldRecover: boolean) => void;
+  /**
+   * Not yet documented.
+   *
    * @param lastConnectionDetails - Not yet documented.
    * @param callback - Not yet documented.
    */
@@ -1254,12 +1260,7 @@ declare namespace Types {
        */
       clientId: string | null;
     },
-    /**
-     * Not yet documented.
-     *
-     * @param shouldRecover - Not yet documented.
-     */
-    callback: (shouldRecover: boolean) => void
+    callback: recoverConnectionCompletionCallback
   ) => void;
   /**
    * Not yet documented.

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "tslib": "^2.3.1",
         "typedoc": "^0.22.18",
-        "typescript": "^4.2.4",
+        "typescript": "^4.6.4",
         "webpack": "^4.44.2",
         "webpack-cli": "^4.2.0"
       },
@@ -9263,9 +9263,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -17502,9 +17502,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "ts-loader": "^8.2.0",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "tslib": "^2.3.1",
-        "typedoc": "^0.22.18",
+        "typedoc": "^0.23.8",
         "typescript": "^4.6.4",
         "webpack": "^4.44.2",
         "webpack-cli": "^4.2.0"
@@ -9201,12 +9201,11 @@
       "dev": true
     },
     "node_modules/typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.8.tgz",
+      "integrity": "sha512-NLRTY/7XSrhiowR3xnH/nlfTnHk+dkzhHWAMT8guoZ6RHCQZIu3pJREMCqzdkWVCC5+dr9We7TtNeprR3Qy6Ag==",
       "dev": true,
       "dependencies": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
         "marked": "^4.0.16",
         "minimatch": "^5.1.0",
@@ -9216,10 +9215,10 @@
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+        "typescript": "4.6.x || 4.7.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -9229,25 +9228,6 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/typedoc/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
@@ -17456,12 +17436,11 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.8.tgz",
+      "integrity": "sha512-NLRTY/7XSrhiowR3xnH/nlfTnHk+dkzhHWAMT8guoZ6RHCQZIu3pJREMCqzdkWVCC5+dr9We7TtNeprR3Qy6Ag==",
       "dev": true,
       "requires": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
         "marked": "^4.0.16",
         "minimatch": "^5.1.0",
@@ -17475,19 +17454,6 @@
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
           }
         },
         "minimatch": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "tslib": "^2.3.1",
     "typedoc": "^0.22.18",
-    "typescript": "^4.2.4",
+    "typescript": "^4.6.4",
     "webpack": "^4.44.2",
     "webpack-cli": "^4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ts-loader": "^8.2.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "tslib": "^2.3.1",
-    "typedoc": "^0.22.18",
+    "typedoc": "^0.23.8",
     "typescript": "^4.6.4",
     "webpack": "^4.44.2",
     "webpack-cli": "^4.2.0"

--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -38,7 +38,11 @@ function unenvelope<T>(callback: ResourceCallback<T>, format: Utils.Format | nul
       try {
         body = Utils.decodeBody(body, format);
       } catch (e) {
-        callback(e);
+        if (Utils.isErrorInfo(e)) {
+          callback(e);
+        } else {
+          callback(new ErrorInfo(Utils.inspectError(e), null));
+        }
         return;
       }
     }

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -396,8 +396,8 @@ export const now =
     return new Date().getTime();
   };
 
-export function isErrorInfo(err: Error | ErrorInfo): err is ErrorInfo {
-  return err.constructor.name == 'ErrorInfo';
+export function isErrorInfo(err: unknown): err is ErrorInfo {
+  return typeof err == 'object' && err !== null && err.constructor.name == 'ErrorInfo';
 }
 
 export function inspectError(err: unknown): string {

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -4,6 +4,7 @@ import ConnectionManager from './lib/transport/connectionmanager';
 import IDefaults from './types/IDefaults';
 import IWebStorage from './types/IWebStorage';
 import IBufferUtils from './types/IBufferUtils';
+import Transport from './lib/transport/transport';
 
 export default class Platform {
   static Config: IPlatform;


### PR DESCRIPTION
Updates TypeDoc to 0.23.8 (so I can use [declaration references](https://typedoc.org/guides/declaration-references/) in an upcoming PR), which requires that I update TypeScript to at least 4.6, so I do that too. It fixes a couple of TypeScript errors that I guess result from stricter compiler checks. It also fixes one error that TypeDoc starts to throw.

(Note that the target here is `integration/docs`, not `main`.)