### PR TITLE
Transports: implement timeouts in tryConnect()

### DIFF
--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -13,7 +13,7 @@ import Auth from 'common/lib/client/auth';
 import Message from 'common/lib/types/message';
 import Multicaster, { MulticasterInstance } from 'common/lib/util/multicaster';
 import WebSocketTransport from './websockettransport';
-import Transport from './transport';
+import Transport, { TransportCtor } from './transport';
 import * as API from '../../../../ably';
 import { ErrCallback } from 'common/types/utils';
 import HttpStatusCodes from 'common/constants/HttpStatusCodes';
@@ -401,7 +401,7 @@ class ConnectionManager extends EventEmitter {
    * transport management
    *********************/
 
-  static supportedTransports: Record<string, typeof Transport> = {};
+  static supportedTransports: Record<string, TransportCtor> = {};
 
   static initTransports() {
     WebSocketTransport(ConnectionManager);
@@ -484,7 +484,9 @@ class ConnectionManager extends EventEmitter {
    */
   tryATransport(transportParams: TransportParams, candidate: string, callback: Function): void {
     Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.tryATransport()', 'trying ' + candidate);
-    ConnectionManager.supportedTransports[candidate].tryConnect?.(
+
+    Transport.tryConnect(
+      ConnectionManager.supportedTransports[candidate],
       this,
       this.realtime.auth,
       transportParams,

--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -48,7 +48,7 @@ class WebSocketTransport extends Transport {
 
     const realtimeRequestTimeout = connectionManager.options.timeouts.realtimeRequestTimeout;
     transportAttemptTimer = setTimeout(() => {
-      transport.off(['wsopen', 'disconnected', 'failed']);
+      transport.off(['preconnect', 'disconnected', 'failed']);
       transport.dispose();
       errorCb.call(
         { event: 'disconnected' },
@@ -57,7 +57,7 @@ class WebSocketTransport extends Transport {
     }, realtimeRequestTimeout);
 
     transport.on(['failed', 'disconnected'], errorCb);
-    transport.on('wsopen', function () {
+    transport.on('preconnect', function () {
       Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.tryConnect()', 'viable transport ' + transport);
       clearTimeout(transportAttemptTimer);
       transport.off(['failed', 'disconnected'], errorCb);
@@ -169,7 +169,7 @@ class WebSocketTransport extends Transport {
 
   onWsOpen() {
     Logger.logAction(Logger.LOG_MINOR, 'WebSocketTransport.onWsOpen()', 'opened WebSocket');
-    this.emit('wsopen');
+    this.emit('preconnect');
   }
 
   onWsClose(ev: number | CloseEvent) {

--- a/src/platform/nodejs/lib/transport/nodecomettransport.js
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.js
@@ -33,20 +33,6 @@ var NodeCometTransport = function (connectionManager) {
   };
   connectionManager.supportedTransports[shortName] = NodeCometTransport;
 
-  NodeCometTransport.tryConnect = function (connectionManager, auth, params, callback) {
-    var transport = new NodeCometTransport(connectionManager, auth, params);
-    var errorCb = function (err) {
-      callback({ event: this.event, error: err });
-    };
-    transport.on(['failed', 'disconnected'], errorCb);
-    transport.on('preconnect', function () {
-      Logger.logAction(Logger.LOG_MINOR, 'NodeCometTransport.tryConnect()', 'viable transport ' + transport);
-      transport.off(['failed', 'disconnected'], errorCb);
-      callback(null, transport);
-    });
-    transport.connect();
-  };
-
   NodeCometTransport.prototype.toString = function () {
     return (
       'NodeCometTransport; uri=' +

--- a/src/platform/web/lib/transport/jsonptransport.ts
+++ b/src/platform/web/lib/transport/jsonptransport.ts
@@ -9,7 +9,6 @@ import Auth from 'common/lib/client/auth';
 import HttpMethods from 'common/constants/HttpMethods';
 import { RequestParams } from 'common/types/http';
 import ConnectionManager, { TransportParams } from 'common/lib/transport/connectionmanager';
-import { TryConnectCallback } from 'common/lib/transport/transport';
 import XHRStates from 'common/constants/XHRStates';
 
 // Workaround for salesforce lightning locker compatibility
@@ -68,29 +67,6 @@ class JSONPTransport extends CometTransport {
 
   static isAvailable() {
     return Platform.Config.jsonpSupported && Platform.Config.allowComet;
-  }
-
-  /* connectivity check; since this has a hard-coded callback id,
-   * we just make sure that we handle concurrent requests (but the
-   * connectionmanager should ensure this doesn't happen anyway */
-
-  static tryConnect(
-    connectionManager: ConnectionManager,
-    auth: Auth,
-    params: TransportParams,
-    callback: TryConnectCallback
-  ) {
-    const transport = new JSONPTransport(connectionManager, auth, params);
-    const errorCb = function (this: { event: string }, err: ErrorInfo) {
-      callback({ event: this.event, error: err });
-    };
-    transport.on(['failed', 'disconnected'], errorCb);
-    transport.on('preconnect', function () {
-      Logger.logAction(Logger.LOG_MINOR, 'JSONPTransport.tryConnect()', 'viable transport ' + transport);
-      transport.off(['failed', 'disconnected'], errorCb);
-      callback(null, transport);
-    });
-    transport.connect();
   }
 
   toString() {

--- a/src/platform/web/lib/transport/xhrpollingtransport.js
+++ b/src/platform/web/lib/transport/xhrpollingtransport.js
@@ -1,6 +1,4 @@
 import * as Utils from '../../../../common/lib/util/utils';
-import ErrorInfo from '../../../../common/lib/types/errorinfo';
-import Logger from '../../../../common/lib/util/logger';
 import Platform from '../../../../common/platform';
 import CometTransport from '../../../../common/lib/transport/comettransport';
 import XHRRequest from './xhrrequest';
@@ -17,35 +15,6 @@ var XHRPollingTransport = function (connectionManager) {
 
   XHRPollingTransport.isAvailable = function () {
     return Platform.Config.xhrSupported && Platform.Config.allowComet;
-  };
-
-  XHRPollingTransport.tryConnect = function (connectionManager, auth, params, callback) {
-    var transport = new XHRPollingTransport(connectionManager, auth, params);
-
-    var transportAttemptTimer;
-    var errorCb = function (err) {
-      clearTimeout(transportAttemptTimer);
-      callback({ event: this.event, error: err });
-    };
-
-    var realtimeRequestTimeout = connectionManager.options.timeouts.realtimeRequestTimeout;
-    transportAttemptTimer = setTimeout(function () {
-      transport.off(['preconnect', 'disconnected', 'failed']);
-      transport.dispose();
-      errorCb.call(
-        { event: 'disconnected' },
-        new ErrorInfo('Timeout waiting for transport to indicate itself viable', 50000, 500)
-      );
-    }, realtimeRequestTimeout);
-
-    transport.on(['failed', 'disconnected'], errorCb);
-    transport.on('preconnect', function () {
-      Logger.logAction(Logger.LOG_MINOR, 'XHRPollingTransport.tryConnect()', 'viable transport ' + transport);
-      clearTimeout(transportAttemptTimer);
-      transport.off(['failed', 'disconnected'], errorCb);
-      callback(null, transport);
-    });
-    transport.connect();
   };
 
   XHRPollingTransport.prototype.toString = function () {

--- a/src/platform/web/lib/transport/xhrpollingtransport.js
+++ b/src/platform/web/lib/transport/xhrpollingtransport.js
@@ -1,4 +1,5 @@
 import * as Utils from '../../../../common/lib/util/utils';
+import ErrorInfo from '../../../../common/lib/types/errorinfo';
 import Logger from '../../../../common/lib/util/logger';
 import Platform from '../../../../common/platform';
 import CometTransport from '../../../../common/lib/transport/comettransport';
@@ -20,12 +21,27 @@ var XHRPollingTransport = function (connectionManager) {
 
   XHRPollingTransport.tryConnect = function (connectionManager, auth, params, callback) {
     var transport = new XHRPollingTransport(connectionManager, auth, params);
+
+    var transportAttemptTimer;
     var errorCb = function (err) {
+      clearTimeout(transportAttemptTimer);
       callback({ event: this.event, error: err });
     };
+
+    var realtimeRequestTimeout = connectionManager.options.timeouts.realtimeRequestTimeout;
+    transportAttemptTimer = setTimeout(function () {
+      transport.off(['preconnect', 'disconnected', 'failed']);
+      transport.dispose();
+      errorCb.call(
+        { event: 'disconnected' },
+        new ErrorInfo('Timeout waiting for transport to indicate itself viable', 50000, 500)
+      );
+    }, realtimeRequestTimeout);
+
     transport.on(['failed', 'disconnected'], errorCb);
     transport.on('preconnect', function () {
       Logger.logAction(Logger.LOG_MINOR, 'XHRPollingTransport.tryConnect()', 'viable transport ' + transport);
+      clearTimeout(transportAttemptTimer);
       transport.off(['failed', 'disconnected'], errorCb);
       callback(null, transport);
     });

--- a/src/platform/web/lib/transport/xhrstreamingtransport.js
+++ b/src/platform/web/lib/transport/xhrstreamingtransport.js
@@ -1,7 +1,5 @@
 import * as Utils from '../../../../common/lib/util/utils';
 import CometTransport from '../../../../common/lib/transport/comettransport';
-import ErrorInfo from '../../../../common/lib/types/errorinfo';
-import Logger from '../../../../common/lib/util/logger';
 import Platform from '../../../../common/platform';
 import XHRRequest from './xhrrequest';
 
@@ -17,37 +15,6 @@ var XHRStreamingTransport = function (connectionManager) {
 
   XHRStreamingTransport.isAvailable = function () {
     return Platform.Config.xhrSupported && Platform.Config.streamingSupported && Platform.Config.allowComet;
-  };
-
-  XHRStreamingTransport.tryConnect = function (connectionManager, auth, params, callback) {
-    var transport = new XHRStreamingTransport(connectionManager, auth, params);
-
-    var transportAttemptTimer;
-    var errorCb = function (err) {
-      clearTimeout(transportAttemptTimer);
-      callback({ event: this.event, error: err });
-    };
-
-    var realtimeRequestTimeout = connectionManager.options.timeouts.realtimeRequestTimeout;
-    transportAttemptTimer = setTimeout(function () {
-      transport.off(['preconnect', 'disconnected', 'failed']);
-      transport.dispose();
-      errorCb.call(
-        { event: 'disconnected' },
-        new ErrorInfo('Timeout waiting for transport to indicate itself viable', 50000, 500)
-      );
-    }, realtimeRequestTimeout);
-
-    transport.on(['failed', 'disconnected'], errorCb);
-
-    transport.on('preconnect', function () {
-      Logger.logAction(Logger.LOG_MINOR, 'XHRStreamingTransport.tryConnect()', 'viable transport ' + transport);
-      clearTimeout(transportAttemptTimer);
-      transport.off(['failed', 'disconnected'], errorCb);
-      callback(null, transport);
-    });
-
-    transport.connect();
   };
 
   XHRStreamingTransport.prototype.toString = function () {

--- a/test/browser/connection.test.js
+++ b/test/browser/connection.test.js
@@ -401,6 +401,38 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         }
         closeAndFinish(done, realtime);
       });
+
+      /*
+       * Check behaviour when going through a proxy which doesn't send any xhr streaming
+       * responses until the stream closes (simulated by a transportparam interpreted by
+       * realtime)
+       */
+      it('connection behaviour with a proxy through which streaming is broken', function (done) {
+        const realtime = helper.AblyRealtime({
+          transportParams: {
+            simulateNoStreamingProxy: true,
+            maxStreamDuration: 7500,
+          },
+          realtimeRequestTimeout: 5000,
+          transports: ['xhr_polling', 'xhr_streaming'],
+        });
+        realtime.connection.once('connected', function () {
+          const connectionEvents = [];
+          realtime.connection.on(function () {
+            connectionEvents.push(this.event);
+          });
+          // After 10s, we should have remained connected, and still be on xhr_polling;
+          // xhr_streaming should have failed to connect after 5s, and in particular
+          // should not have completed the upgrade after 7.5s.
+          setTimeout(function () {
+            expect(realtime.connection.state).to.equal('connected');
+            const transport = realtime.connection.connectionManager.activeProtocol.getTransport();
+            expect(transport.shortName).to.equal('xhr_polling');
+            expect(connectionEvents.length).to.equal(0);
+            closeAndFinish(done, realtime);
+          }, 10000);
+        });
+      });
     });
   }
 });

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1352,7 +1352,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       /* Use a fixed transport as attaches are resent when the transport changes */
       var realtime = helper.AblyRealtime({
           transports: [helper.bestTransport],
-          realtimeRequestTimeout: 100,
+          realtimeRequestTimeout: 2000,
           channelRetryTimeout: 100,
         }),
         channelName = 'channel_attach_timeout',
@@ -1423,7 +1423,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             channel.sendMessage = function (msg) {
               expect(false, 'Channel tried to send a message ' + JSON.stringify(msg)).to.be.ok;
             };
-            realtime.options.timeouts.realtimeRequestTimeout = 100;
+            realtime.options.timeouts.realtimeRequestTimeout = 2000;
 
             helper.becomeSuspended(realtime, function () {
               /* nextTick as connection event is emitted before channel state is changed */

--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -325,7 +325,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     });
 
     it('attach_timeout', function (done) {
-      var realtime = helper.AblyRealtime({ realtimeRequestTimeout: 10, channelRetryTimeout: 10 }),
+      var realtime = helper.AblyRealtime({ realtimeRequestTimeout: 2000, channelRetryTimeout: 1000 }),
         channel = realtime.channels.get('failed_attach'),
         originalOnMessage = channel.onMessage.bind(channel);
 
@@ -363,7 +363,6 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var channelRetryTimeout = 150;
         var realtime = helper.AblyRealtime({
             channelRetryTimeout: channelRetryTimeout,
-            realtimeRequestTimeout: 1,
             transports: [transport],
           }),
           channel = realtime.channels.get('failed_attach'),
@@ -380,32 +379,37 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           originalOnMessage(message);
         };
 
-        channel.attach(function (err) {
-          if (err) {
-            var lastSuspended = performance.now();
-            channel.on(function (stateChange) {
-              if (stateChange.current === 'suspended') {
-                if (retryCount > 4) {
-                  closeAndFinish(done, realtime);
-                  return;
+        realtime.connection.on('connected', function () {
+          realtime.options.timeouts.realtimeRequestTimeout = 1;
+          channel.attach(function (err) {
+            if (err) {
+              var lastSuspended = performance.now();
+              channel.on(function (stateChange) {
+                if (stateChange.current === 'suspended') {
+                  if (retryCount > 4) {
+                    closeAndFinish(done, realtime);
+                    return;
+                  }
+                  var elapsedSinceSuspneded = performance.now() - lastSuspended;
+                  lastSuspended = performance.now();
+                  try {
+                    // JS timers don't work precisely and realtimeRequestTimeout can't be 0 so add 5ms to the max timeout length each retry
+                    expect(elapsedSinceSuspneded).to.be.below(
+                      channelRetryTimeout + Math.min(retryCount, 3) * 50 + 5 * (retryCount + 1)
+                    );
+                    expect(elapsedSinceSuspneded).to.be.above(
+                      0.8 * (channelRetryTimeout + Math.min(retryCount, 3) * 50)
+                    );
+                    retryCount += 1;
+                  } catch (err) {
+                    closeAndFinish(done, realtime, err);
+                  }
                 }
-                var elapsedSinceSuspneded = performance.now() - lastSuspended;
-                lastSuspended = performance.now();
-                try {
-                  // JS timers don't work precisely and realtimeRequestTimeout can't be 0 so add 5ms to the max timeout length each retry
-                  expect(elapsedSinceSuspneded).to.be.below(
-                    channelRetryTimeout + Math.min(retryCount, 3) * 50 + 5 * (retryCount + 1)
-                  );
-                  expect(elapsedSinceSuspneded).to.be.above(0.8 * (channelRetryTimeout + Math.min(retryCount, 3) * 50));
-                  retryCount += 1;
-                } catch (err) {
-                  closeAndFinish(done, realtime, err);
-                }
-              }
-            });
-          } else {
-            closeAndFinish(done, realtime, new Error('Expected channel attach to timeout'));
-          }
+              });
+            } else {
+              closeAndFinish(done, realtime, new Error('Expected channel attach to timeout'));
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
In tryConnect rather than in connectionManager#tryATransport so that it can properly dispose of the transport if it times out.

NB: the test requires a realtime that has https://github.com/ably/realtime/pull/4231 running.