### PR TITLE
Increase realtimeRequestTimeout in idle transport test

### DIFF
--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -507,7 +507,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     );
 
     it('idle_transport_timeout', function (done) {
-      var realtime = helper.AblyRealtime({ realtimeRequestTimeout: 100 }),
+      var realtime = helper.AblyRealtime({ realtimeRequestTimeout: 2000 }),
         originalOnProtocolMessage;
 
       realtime.connection.connectionManager.on('transport.pending', function (transport) {


### PR DESCRIPTION
Fixes an issue where the transport setup would timeout due to changes in #1035