### PR TITLE
[CAP-48] remove connectionTimeserial spike stuff

### DIFF
--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -17,7 +17,6 @@ class Connection extends EventEmitter {
   key?: string;
   id?: string;
   serial: undefined;
-  timeSerial: undefined;
   recoveryKey?: string | null;
   errorReason: ErrorInfo | null;
 
@@ -29,7 +28,6 @@ class Connection extends EventEmitter {
     this.key = undefined;
     this.id = undefined;
     this.serial = undefined;
-    this.timeSerial = undefined;
     this.recoveryKey = undefined;
     this.errorReason = null;
 

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -76,7 +76,6 @@ class ProtocolMessage {
   presence?: PresenceMessage[];
   auth?: unknown;
   connectionDetails?: Record<string, unknown>;
-  timeSerial?: number;
 
   static Action = actions;
 


### PR DESCRIPTION
removes unused `timeSerial` added in https://github.com/ably/ably-js/commit/3779562813ce589083cd23a2093716082d15dd27#diff-4950999f00a83f9a58097a13788e54b21306f3b895c03c8a5b85ae06bf30447e (so we can add changes for CAP-44 later)