### PR TITLE
[WIP] [CAP-49] no connection serials

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2989,7 +2989,7 @@ declare namespace Types {
     /**
      * The recovery key string can be used by another client to recover this connection's state in the recover client options property. See [connection state recover options](https://ably.com/docs/realtime/connection#connection-state-recover-options) for more information.
      */
-    getRecoveryKey: () => string | null;
+    createRecoveryKey: () => string | null;
     /**
      * The serial number of the last message to be received on this connection, used automatically by the library when recovering or resuming a connection. When recovering a connection explicitly, the `recoveryKey` is used in the recover client options as it contains both the key and the last message serial.
      */

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2989,7 +2989,7 @@ declare namespace Types {
     /**
      * The recovery key string can be used by another client to recover this connection's state in the recover client options property. See [connection state recover options](https://ably.com/docs/realtime/connection#connection-state-recover-options) for more information.
      */
-    recoveryKey: string;
+    getRecoveryKey: () => string | null;
     /**
      * The serial number of the last message to be received on this connection, used automatically by the library when recovering or resuming a connection. When recovering a connection explicitly, the `recoveryKey` is used in the recover client options as it contains both the key and the last message serial.
      */

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -63,7 +63,7 @@ class Channel extends EventEmitter {
     this.channelOptions = normaliseChannelOptions(channelOptions);
   }
 
-  setOptions(options: ChannelOptions): void {
+  setOptions(options?: ChannelOptions): void {
     this.channelOptions = normaliseChannelOptions(options);
   }
 

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -16,7 +16,6 @@ class Connection extends EventEmitter {
   state: string;
   key?: string;
   id?: string;
-  serial: undefined;
   errorReason: ErrorInfo | null;
 
   constructor(ably: Realtime, options: NormalisedClientOptions) {
@@ -26,7 +25,6 @@ class Connection extends EventEmitter {
     this.state = this.connectionManager.state.state;
     this.key = undefined;
     this.id = undefined;
-    this.serial = undefined;
     this.errorReason = null;
 
     this.connectionManager.on('connectionstate', (stateChange: ConnectionStateChange) => {

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -17,7 +17,6 @@ class Connection extends EventEmitter {
   key?: string;
   id?: string;
   serial: undefined;
-  recoveryKey?: string | null;
   errorReason: ErrorInfo | null;
 
   constructor(ably: Realtime, options: NormalisedClientOptions) {
@@ -28,7 +27,6 @@ class Connection extends EventEmitter {
     this.key = undefined;
     this.id = undefined;
     this.serial = undefined;
-    this.recoveryKey = undefined;
     this.errorReason = null;
 
     this.connectionManager.on('connectionstate', (stateChange: ConnectionStateChange) => {
@@ -73,6 +71,10 @@ class Connection extends EventEmitter {
   close(): void {
     Logger.logAction(Logger.LOG_MINOR, 'Connection.close()', 'connectionKey = ' + this.key);
     this.connectionManager.requestState({ state: 'closing' });
+  }
+
+  getRecoveryKey(): string | null {
+    return this.connectionManager.getRecoveryKey();
   }
 }
 

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -71,6 +71,10 @@ class Connection extends EventEmitter {
     this.connectionManager.requestState({ state: 'closing' });
   }
 
+  get recoveryKey(): string | null {
+    return this.createRecoveryKey();
+  }
+
   createRecoveryKey(): string | null {
     return this.connectionManager.createRecoveryKey();
   }

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -71,8 +71,8 @@ class Connection extends EventEmitter {
     this.connectionManager.requestState({ state: 'closing' });
   }
 
-  getRecoveryKey(): string | null {
-    return this.connectionManager.getRecoveryKey();
+  createRecoveryKey(): string | null {
+    return this.connectionManager.createRecoveryKey();
   }
 }
 

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -125,30 +125,6 @@ class Channels extends EventEmitter {
     }
   }
 
-  resetAttachedMsgIndicators() {
-    for (const channelId in this.all) {
-      const channel = this.all[channelId];
-      if (channel.state === 'attached') {
-        channel._attachedMsgIndicator = false;
-      }
-    }
-  }
-
-  checkAttachedMsgIndicators(connectionId: string) {
-    for (const channelId in this.all) {
-      const channel = this.all[channelId];
-      if (channel.state === 'attached' && channel._attachedMsgIndicator === false) {
-        const msg =
-          '30s after a resume, found channel which has not received an attached; channelId = ' +
-          channelId +
-          '; connectionId = ' +
-          connectionId;
-        Logger.logAction(Logger.LOG_ERROR, 'Channels.checkAttachedMsgIndicators()', msg);
-        channel.requestState('attaching');
-      }
-    }
-  }
-
   /* Connection interruptions (ie when the connection will no longer queue
    * events) imply connection state changes for any channel which is either
    * attached, pending, or will attempt to become attached in the future */

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -8,7 +8,6 @@ import Defaults from '../util/defaults';
 import ErrorInfo from '../types/errorinfo';
 import ProtocolMessage from '../types/protocolmessage';
 import { ChannelOptions } from '../../types/channel';
-import { ErrCallback } from '../../types/utils';
 import ClientOptions, { DeprecatedClientOptions } from '../../types/ClientOptions';
 import * as API from '../../../../ably';
 import ConnectionManager from '../transport/connectionmanager';
@@ -55,13 +54,11 @@ class Realtime extends Rest {
 class Channels extends EventEmitter {
   realtime: Realtime;
   all: Record<string, RealtimeChannel>;
-  inProgress: Record<string, RealtimeChannel>;
 
   constructor(realtime: Realtime) {
     super();
     this.realtime = realtime;
     this.all = Object.create(null);
-    this.inProgress = Object.create(null);
     realtime.connection.connectionManager.on('transport.active', () => {
       this.onTransportActive();
     });
@@ -107,9 +104,7 @@ class Channels extends EventEmitter {
   }
 
   /* called when a transport becomes connected; reattempt attach/detach
-   * for channels that are attaching or detaching.
-   * Note that this does not use inProgress as inProgress is only channels which have already made
-   * at least one attempt to attach/detach */
+   * for channels that are attaching or detaching. */
   onTransportActive() {
     for (const channelName in this.all) {
       const channel = this.all[channelName];
@@ -177,37 +172,6 @@ class Channels extends EventEmitter {
       throw releaseErr;
     }
     delete this.all[name];
-    delete this.inProgress[name];
-  }
-
-  /* Records operations currently pending on a transport; used by connectionManager to decide when
-   * it's safe to upgrade. Note that a channel might be in the attaching state without any pending
-   * operations (eg if attached while the connection state is connecting) - such a channel must not
-   * hold up an upgrade, so is not considered inProgress.
-   * Operation is currently one of either 'statechange' or 'sync' */
-  setInProgress(channel: RealtimeChannel, operation: string, inProgress: boolean) {
-    this.inProgress[channel.name] = this.inProgress[channel.name] || {};
-    (this.inProgress[channel.name] as any)[operation] = inProgress;
-    if (!inProgress && this.hasNopending()) {
-      this.emit('nopending');
-    }
-  }
-
-  onceNopending(listener: ErrCallback) {
-    if (this.hasNopending()) {
-      listener();
-      return;
-    }
-    this.once('nopending', listener);
-  }
-
-  hasNopending() {
-    return Utils.arrEvery(
-      Utils.valuesArray(this.inProgress, true) as any,
-      function (operations: Record<string, unknown>) {
-        return !Utils.containsValue(operations, true);
-      }
-    );
   }
 }
 

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -67,6 +67,23 @@ class Channels extends EventEmitter {
     });
   }
 
+  channelSerials(): { [ name: string ]: string } {
+    let serials: { [ name: string ]: string } = {};
+    for (const [name, channel] of Object.entries(this.all)) {
+      if (channel.channelSerial) {
+        serials[name] = channel.channelSerial;
+      }
+    }
+    return serials;
+  }
+
+  setRecoveryChannelSerials(channelSerials: { [ name: string ]: string }) {
+    for (const [name, serial] of Object.entries(channelSerials)) {
+      const channel = this.get(name);
+      channel.channelSerial = serial;
+    }
+  }
+
   onChannelMessage(msg: ProtocolMessage) {
     const channelName = msg.channel;
     if (channelName === undefined) {
@@ -153,7 +170,7 @@ class Channels extends EventEmitter {
     }
   }
 
-  get(name: string, channelOptions: ChannelOptions) {
+  get(name: string, channelOptions?: ChannelOptions) {
     name = String(name);
     let channel = this.all[name];
     if (!channel) {

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -67,8 +67,8 @@ class Channels extends EventEmitter {
   channelSerials(): { [name: string]: string } {
     let serials: { [name: string]: string } = {};
     for (const [name, channel] of Object.entries(this.all)) {
-      if (channel.channelSerial) {
-        serials[name] = channel.channelSerial;
+      if (channel.properties.channelSerial) {
+        serials[name] = channel.properties.channelSerial;
       }
     }
     return serials;
@@ -77,7 +77,7 @@ class Channels extends EventEmitter {
   setRecoveryChannelSerials(channelSerials: { [name: string]: string }) {
     for (const [name, serial] of Object.entries(channelSerials)) {
       const channel = this.get(name);
-      channel.channelSerial = serial;
+      channel.properties.channelSerial = serial;
     }
   }
 

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -64,8 +64,8 @@ class Channels extends EventEmitter {
     });
   }
 
-  channelSerials(): { [ name: string ]: string } {
-    let serials: { [ name: string ]: string } = {};
+  channelSerials(): { [name: string]: string } {
+    let serials: { [name: string]: string } = {};
     for (const [name, channel] of Object.entries(this.all)) {
       if (channel.channelSerial) {
         serials[name] = channel.channelSerial;
@@ -74,7 +74,7 @@ class Channels extends EventEmitter {
     return serials;
   }
 
-  setRecoveryChannelSerials(channelSerials: { [ name: string ]: string }) {
+  setRecoveryChannelSerials(channelSerials: { [name: string]: string }) {
     for (const [name, serial] of Object.entries(channelSerials)) {
       const channel = this.get(name);
       channel.channelSerial = serial;

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -100,17 +100,10 @@ class Channels extends EventEmitter {
         channel.checkPendingState();
       } else if (channel.state === 'suspended') {
         channel._attach(false, null);
-      }
-    }
-  }
-
-  reattach(reason: ErrorInfo) {
-    for (const channelId in this.all) {
-      const channel = this.all[channelId];
-      /* NB this should not trigger for merely attaching channels, as they will
-       * be reattached anyway through the onTransportActive checkPendingState */
-      if (channel.state === 'attached') {
-        channel.requestState('attaching', reason);
+      } else if (channel.state === 'attached') {
+        // Note explicity request the state, channel.attach() would do nothing
+        // as its already attached.
+        channel.requestState('attaching');
       }
     }
   }

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -79,6 +79,7 @@ class RealtimeChannel extends Channel {
   stateTimer?: number | NodeJS.Timeout | null;
   retryTimer?: number | NodeJS.Timeout | null;
   retryCount: number = 0;
+  channelSerial?: string | null;
 
   constructor(realtime: Realtime, name: string, options: API.Types.ChannelOptions) {
     super(realtime, name, options);
@@ -112,6 +113,7 @@ class RealtimeChannel extends Channel {
     /* Only differences between this and the public event emitter is that this emits an
      * update event for all ATTACHEDs, whether resumed or not */
     this._allChannelChanges = new EventEmitter();
+    this.channelSerial = null;
   }
 
   static invalidStateError(state: string): ErrorInfo {
@@ -596,6 +598,14 @@ class RealtimeChannel extends Channel {
   }
 
   onMessage(message: ProtocolMessage): void {
+    if (
+      message.action === actions.ATTACHED ||
+      message.action === actions.MESSAGE ||
+      message.action === actions.PRESENCE
+    ) {
+      this.setChannelSerial(message.channelSerial);
+    }
+
     let syncChannelSerial,
       isSync = false;
     switch (message.action) {
@@ -1009,6 +1019,16 @@ class RealtimeChannel extends Channel {
       90001,
       400
     );
+  }
+
+  setChannelSerial(channelSerial?: string | null): void {
+    Logger.logAction(
+      Logger.LOG_MICRO,
+      'RealtimeChannel.setChannelSerial()',
+      'Updating channel serial; serial = ' + channelSerial + '; previous = ' + this.channelSerial
+    );
+
+    this.channelSerial = channelSerial;
   }
 }
 

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -65,7 +65,6 @@ class RealtimeChannel extends Channel {
   errorReason: ErrorInfo | string | null;
   _requestedFlags: Array<API.Types.ChannelMode> | null;
   _mode?: null | number;
-  _attachedMsgIndicator: boolean;
   _attachResume: boolean;
   _decodingContext: { channelOptions: API.Types.ChannelOptions; plugins: any; baseEncodedPreviousPayload: undefined };
   _lastPayload: {
@@ -97,8 +96,6 @@ class RealtimeChannel extends Channel {
     this.errorReason = null;
     this._requestedFlags = null;
     this._mode = null;
-    /* Temporary; only used for the checkChannelsOnResume option */
-    this._attachedMsgIndicator = false;
     this._attachResume = false;
     this._decodingContext = {
       channelOptions: this.channelOptions,
@@ -611,7 +608,6 @@ class RealtimeChannel extends Channel {
       isSync = false;
     switch (message.action) {
       case actions.ATTACHED: {
-        this._attachedMsgIndicator = true;
         this.properties.attachSerial = message.channelSerial;
         this._mode = message.getMode();
         this.params = (message as any).params || {};

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -351,6 +351,7 @@ class RealtimeChannel extends Channel {
       action: actions.ATTACH,
       channel: this.name,
       params: this.channelOptions.params,
+      channelSerial: this.channelSerial,
     });
     if (this._requestedFlags) {
       attachMsg.encodeModesToFlags(this._requestedFlags);

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -1007,7 +1007,11 @@ class RealtimeChannel extends Channel {
       'Updating channel serial; serial = ' + channelSerial + '; previous = ' + this.channelSerial
     );
 
-    this.channelSerial = channelSerial;
+    // Only update the channel serial if its present (such as it won't be for
+    // inbound occupancy) (RTP17h).
+    if (channelSerial) {
+      this.channelSerial = channelSerial;
+    }
   }
 }
 

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -806,6 +806,10 @@ class RealtimeChannel extends Channel {
     );
     this.clearStateTimer();
 
+    if (['detached', 'suspended', 'failed'].includes(state)) {
+      this.channelSerial = null;
+    }
+
     if (state === this.state) {
       return;
     }

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -26,8 +26,6 @@ interface RealtimeHistoryParams {
 
 const actions = ProtocolMessage.Action;
 const noop = function () {};
-const statechangeOp = 'statechange';
-const syncOp = 'sync';
 
 function validateChannelOptions(options?: API.Types.ChannelOptions) {
   if (options && 'params' in options && !Utils.isObject(options.params)) {
@@ -120,11 +118,6 @@ class RealtimeChannel extends Channel {
       message: 'Channel operation failed as channel state is ' + state,
     };
   }
-
-  static progressOps = {
-    statechange: statechangeOp,
-    sync: syncOp,
-  };
 
   static processListenerArgs(args: unknown[]): any[] {
     /* [event], listener, [callback] */
@@ -343,7 +336,6 @@ class RealtimeChannel extends Channel {
 
   attachImpl(): void {
     Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.attachImpl()', 'sending ATTACH message');
-    this.setInProgress(statechangeOp, true);
     const attachMsg = ProtocolMessage.fromValues({
       action: actions.ATTACH,
       channel: this.name,
@@ -418,7 +410,6 @@ class RealtimeChannel extends Channel {
       this.connectionManager.mostRecentMsg = null;
     }
     Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.detach()', 'sending DETACH message');
-    this.setInProgress(statechangeOp, true);
     const msg = ProtocolMessage.fromValues({ action: actions.DETACH, channel: this.name });
     this.sendMessage(msg, callback || noop);
   }
@@ -618,7 +609,6 @@ class RealtimeChannel extends Channel {
         if (this.state === 'attached') {
           /* attached operations to change options set the inprogress mutex, but leave
            * channel in the attached state */
-          this.setInProgress(statechangeOp, false);
           if (!resumed) {
             /* On a loss of continuity, the presence set needs to be re-synced */
             this.presence.onAttached(hasPresence);
@@ -833,11 +823,6 @@ class RealtimeChannel extends Channel {
     /* Note: we don't set inProgress for pending states until the request is actually in progress */
     if (state === 'attached') {
       this.onAttached();
-      this.setInProgress(syncOp, hasPresence);
-      this.setInProgress(statechangeOp, false);
-    } else if (state === 'detached' || state === 'failed' || state === 'suspended') {
-      this.setInProgress(statechangeOp, false);
-      this.setInProgress(syncOp, false);
     }
 
     if (state === 'attached') {
@@ -957,10 +942,6 @@ class RealtimeChannel extends Channel {
       clearTimeout(this.retryTimer as NodeJS.Timeout);
       this.retryTimer = null;
     }
-  }
-
-  setInProgress(operation: string, value: unknown): void {
-    this.rest.channels.setInProgress(this, operation, value);
   }
 
   history = function (

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -29,7 +29,7 @@ const noop = function () {};
 const statechangeOp = 'statechange';
 const syncOp = 'sync';
 
-function validateChannelOptions(options: API.Types.ChannelOptions) {
+function validateChannelOptions(options?: API.Types.ChannelOptions) {
   if (options && 'params' in options && !Utils.isObject(options.params)) {
     return new ErrorInfo('options.params must be an object', 40000, 400);
   }
@@ -81,7 +81,7 @@ class RealtimeChannel extends Channel {
   retryCount: number = 0;
   channelSerial?: string | null;
 
-  constructor(realtime: Realtime, name: string, options: API.Types.ChannelOptions) {
+  constructor(realtime: Realtime, name: string, options?: API.Types.ChannelOptions) {
     super(realtime, name, options);
     Logger.logAction(Logger.LOG_MINOR, 'RealtimeChannel()', 'started; name = ' + name);
     this.realtime = realtime;
@@ -141,7 +141,7 @@ class RealtimeChannel extends Channel {
     return args;
   }
 
-  setOptions(options: API.Types.ChannelOptions, callback?: ErrCallback): void | Promise<void> {
+  setOptions(options?: API.Types.ChannelOptions, callback?: ErrCallback): void | Promise<void> {
     if (!callback) {
       if (this.rest.options.promises) {
         return Utils.promisify(this, 'setOptions', arguments);
@@ -185,8 +185,8 @@ class RealtimeChannel extends Channel {
     }
   }
 
-  _shouldReattachToSetOptions(options: API.Types.ChannelOptions) {
-    return (this.state === 'attached' || this.state === 'attaching') && (options.params || options.modes);
+  _shouldReattachToSetOptions(options?: API.Types.ChannelOptions) {
+    return options && (this.state === 'attached' || this.state === 'attaching') && (options.params || options.modes);
   }
 
   publish(...args: any[]): void | Promise<void> {

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -406,9 +406,6 @@ class RealtimeChannel extends Channel {
   }
 
   detachImpl(callback?: ErrCallback): void {
-    if (this.connectionManager.mostRecentMsg && this.connectionManager.mostRecentMsg.channel === this.name) {
-      this.connectionManager.mostRecentMsg = null;
-    }
     Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.detach()', 'sending DETACH message');
     const msg = ProtocolMessage.fromValues({ action: actions.DETACH, channel: this.name });
     this.sendMessage(msg, callback || noop);

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -59,7 +59,10 @@ class RealtimeChannel extends Channel {
     Map<API.Types.MessageFilter, API.Types.messageCallback<Message>[]>
   >;
   syncChannelSerial?: string | null;
-  properties: { attachSerial: string | null | undefined };
+  properties: {
+    attachSerial: string | null | undefined;
+    channelSerial: string | null | undefined;
+  };
   errorReason: ErrorInfo | string | null;
   _requestedFlags: Array<API.Types.ChannelMode> | null;
   _mode?: null | number;
@@ -76,7 +79,6 @@ class RealtimeChannel extends Channel {
   stateTimer?: number | NodeJS.Timeout | null;
   retryTimer?: number | NodeJS.Timeout | null;
   retryCount: number = 0;
-  channelSerial?: string | null;
 
   constructor(realtime: Realtime, name: string, options?: API.Types.ChannelOptions) {
     super(realtime, name, options);
@@ -89,6 +91,7 @@ class RealtimeChannel extends Channel {
     this.syncChannelSerial = undefined;
     this.properties = {
       attachSerial: undefined,
+      channelSerial: undefined,
     };
     this.setOptions(options);
     this.errorReason = null;
@@ -108,7 +111,6 @@ class RealtimeChannel extends Channel {
     /* Only differences between this and the public event emitter is that this emits an
      * update event for all ATTACHEDs, whether resumed or not */
     this._allChannelChanges = new EventEmitter();
-    this.channelSerial = null;
   }
 
   static invalidStateError(state: string): ErrorInfo {
@@ -340,7 +342,7 @@ class RealtimeChannel extends Channel {
       action: actions.ATTACH,
       channel: this.name,
       params: this.channelOptions.params,
-      channelSerial: this.channelSerial,
+      channelSerial: this.properties.channelSerial,
     });
     if (this._requestedFlags) {
       attachMsg.encodeModesToFlags(this._requestedFlags);
@@ -584,6 +586,9 @@ class RealtimeChannel extends Channel {
   }
 
   onMessage(message: ProtocolMessage): void {
+    // Note setting channel serial here rather than the switch below to be
+    // explicit (as with fall throughs its easy to update from the wrong
+    // message).
     if (
       message.action === actions.ATTACHED ||
       message.action === actions.MESSAGE ||
@@ -790,7 +795,7 @@ class RealtimeChannel extends Channel {
     this.clearStateTimer();
 
     if (['detached', 'suspended', 'failed'].includes(state)) {
-      this.channelSerial = null;
+      this.properties.channelSerial = null;
     }
 
     if (state === this.state) {
@@ -1004,13 +1009,13 @@ class RealtimeChannel extends Channel {
     Logger.logAction(
       Logger.LOG_MICRO,
       'RealtimeChannel.setChannelSerial()',
-      'Updating channel serial; serial = ' + channelSerial + '; previous = ' + this.channelSerial
+      'Updating channel serial; serial = ' + channelSerial + '; previous = ' + this.properties.channelSerial
     );
 
     // Only update the channel serial if its present (such as it won't be for
     // inbound occupancy) (RTP17h).
     if (channelSerial) {
-      this.channelSerial = channelSerial;
+      this.properties.channelSerial = channelSerial;
     }
   }
 }

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -21,7 +21,7 @@ interface RealtimeHistoryParams {
   direction?: string;
   limit?: number;
   untilAttach?: boolean;
-  from_serial?: number;
+  from_serial?: string;
 }
 
 const actions = ProtocolMessage.Action;
@@ -60,8 +60,8 @@ class RealtimeChannel extends Channel {
     API.Types.messageCallback<Message>,
     Map<API.Types.MessageFilter, API.Types.messageCallback<Message>[]>
   >;
-  syncChannelSerial?: number | null;
-  properties: { attachSerial: number | null | undefined };
+  syncChannelSerial?: string | null;
+  properties: { attachSerial: string | null | undefined };
   errorReason: ErrorInfo | string | null;
   _requestedFlags: Array<API.Types.ChannelMode> | null;
   _mode?: null | number;
@@ -70,7 +70,7 @@ class RealtimeChannel extends Channel {
   _decodingContext: { channelOptions: API.Types.ChannelOptions; plugins: any; baseEncodedPreviousPayload: undefined };
   _lastPayload: {
     messageId?: string | null;
-    protocolMessageChannelSerial?: number | null;
+    protocolMessageChannelSerial?: string | null;
     decodeFailureRecoveryInProgress: null | boolean;
   };
   _allChannelChanges: EventEmitter;

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -382,7 +382,6 @@ class RealtimePresence extends Presence {
     /* if this is the last (or only) message in a sequence of sync updates, end the sync */
     if (isSync && !syncCursor) {
       members.endSync();
-      this.channel.setInProgress(RealtimeChannel.progressOps.sync, false);
       this.channel.syncChannelSerial = null;
     }
 

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -380,8 +380,6 @@ class RealtimePresence extends Presence {
     /* if this is the last (or only) message in a sequence of sync updates, end the sync */
     if (isSync && !syncCursor) {
       members.endSync();
-      /* RTP5c2: re-enter our own members if they haven't shown up in the sync */
-      this._ensureMyMembersPresent();
       this.channel.setInProgress(RealtimeChannel.progressOps.sync, false);
       this.channel.syncChannelSerial = null;
     }
@@ -405,8 +403,8 @@ class RealtimePresence extends Presence {
     } else {
       this._synthesizeLeaves(this.members.values());
       this.members.clear();
-      this._ensureMyMembersPresent();
     }
+    this._ensureMyMembersPresent();
 
     /* NB this must be after the _ensureMyMembersPresent call, which may add items to pendingPresence */
     const pendingPresence = this.pendingPresence,

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -23,7 +23,7 @@ interface RealtimeHistoryParams {
   direction?: string;
   limit?: number;
   untilAttach?: boolean;
-  from_serial?: number | null;
+  from_serial?: string | null;
 }
 
 const noop = function () {};

--- a/src/common/lib/transport/comettransport.ts
+++ b/src/common/lib/transport/comettransport.ts
@@ -207,7 +207,7 @@ abstract class CometTransport extends Transport {
 
     /* the connectionKey in a comet connected response is really
      * <instId>-<connectionKey> */
-    const connectionStr = message.connectionKey;
+    const connectionStr = message.connectionDetails?.connectionKey;
     Transport.prototype.onConnect.call(this, message);
 
     const baseConnectionUri = (this.baseUri as string) + connectionStr;

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1165,22 +1165,12 @@ class ConnectionManager extends EventEmitter {
       Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.setConnection()', 'Resetting msgSerial');
       this.msgSerial = 0;
     }
-    /* but do need to reattach channels, for channels that were previously in
-     * the attached state even though the connection mode was 'clean' due to a
-     * freshness check - see https://github.com/ably/ably-js/issues/394 */
     if (this.connectionId !== connectionId) {
       Logger.logAction(
         Logger.LOG_MINOR,
         'ConnectionManager.setConnection()',
-        'New connectionId; reattaching any attached channels'
+        'New connectionId'
       );
-      /* Wait till next tick before reattaching channels, so that connection
-       * state will be updated and so that it will be applied after
-       * Channels#onTransportUpdate, else channels will not have an ATTACHED
-       * sent twice (once from this and once from that). */
-      Platform.Config.nextTick(() => {
-        this.realtime.channels.reattach();
-      });
     } else if (this.options.checkChannelsOnResume) {
       /* For attached channels, set the attached msg indicator variable to false,
        * wait 30s, and check we got an attached for each one.

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1117,6 +1117,8 @@ class ConnectionManager extends EventEmitter {
     if (connIdChanged || recoverFailure) {
       Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.setConnection()', 'Resetting msgSerial');
       this.msgSerial = 0;
+      // RTN19a2 -- in the event of a new connectionId, previous msgSerials are meaningless
+      this.queuedMessages.resetSendAttempted();
     }
     if (this.connectionId !== connectionId) {
       Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.setConnection()', 'New connectionId');

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -112,9 +112,6 @@ export class TransportParams {
         break;
       case 'resume':
         params.resume = this.connectionKey as string;
-        if (this.connectionSerial !== undefined) {
-          params.connectionSerial = this.connectionSerial;
-        }
         break;
       case 'recover': {
         const match = (options.recover as string).split(':');

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1132,7 +1132,7 @@ class ConnectionManager extends EventEmitter {
     this.unpersistConnection();
   }
 
-  getRecoveryKey(): string | null {
+  createRecoveryKey(): string | null {
     if (!this.connectionKey) {
       return null;
     }
@@ -1168,7 +1168,7 @@ class ConnectionManager extends EventEmitter {
    */
   persistConnection(): void {
     if (haveSessionStorage()) {
-      const recoveryKey = this.getRecoveryKey();
+      const recoveryKey = this.createRecoveryKey();
       if (recoveryKey) {
         setSessionRecoverData({
           recoveryKey: recoveryKey,

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -753,6 +753,15 @@ class ConnectionManager extends EventEmitter {
           'ConnectionManager.scheduleTransportActivation()',
           'Activating transport; transport = ' + transport
         );
+
+        // TODO(AD) make ACTIVATE once https://github.com/ably/realtime/pull/4352
+        // merged
+        transport.send(
+          ProtocolMessage.fromValues({
+            action: actions.SYNC,
+          })
+        );
+
         this.activateTransport(error, transport, connectionId, connectionDetails);
         /* Restore pre-sync state. If state has changed in the meantime,
          * don't touch it -- since the websocket transport waits a tick before

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -248,7 +248,6 @@ class ConnectionManager extends EventEmitter {
   mostRecentMsg: ProtocolMessage | null;
   forceFallbackHost: boolean;
   connectCounter: number;
-  channelResumeCheckTimer?: number | NodeJS.Timeout;
   transitionTimer?: number | NodeJS.Timeout | null;
   suspendTimer?: number | NodeJS.Timeout | null;
   retryTimer?: number | NodeJS.Timeout | null;
@@ -1067,7 +1066,6 @@ class ConnectionManager extends EventEmitter {
         (currentProtocol as Protocol).clearPendingMessages();
       });
       this.activeProtocol = this.host = null;
-      clearTimeout(this.channelResumeCheckTimer as number);
     }
 
     this.emit('transport.inactive', transport);
@@ -1190,22 +1188,6 @@ class ConnectionManager extends EventEmitter {
         'ConnectionManager.setConnection()',
         'New connectionId'
       );
-    } else if (this.options.checkChannelsOnResume) {
-      /* For attached channels, set the attached msg indicator variable to false,
-       * wait 30s, and check we got an attached for each one.
-       * 30s was chosen to be 5s longer than the transport idle timeout expire
-       * time, in an attempt to avoid false positives due to a transport
-       * silently failing immediately after a resume */
-      Logger.logAction(
-        Logger.LOG_MINOR,
-        'ConnectionManager.setConnection()',
-        'Same connectionId; checkChannelsOnResume is enabled'
-      );
-      clearTimeout(this.channelResumeCheckTimer as number);
-      this.realtime.channels.resetAttachedMsgIndicators();
-      this.channelResumeCheckTimer = setTimeout(() => {
-        this.realtime.channels.checkAttachedMsgIndicators(connectionId);
-      }, 30000);
     }
     this.realtime.connection.id = this.connectionId = connectionId;
     this.realtime.connection.key = this.connectionKey = connectionDetails.connectionKey;

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -818,13 +818,7 @@ class ConnectionManager extends EventEmitter {
       }
     };
 
-    // No point waiting for pending attaches if there's no active transport, just sync and
-    // activate the new one immediately, attaches will be retried on the new one
-    if (currentTransport) {
-      this.realtime.channels.onceNopending(onReadyToUpgrade);
-    } else {
-      onReadyToUpgrade();
-    }
+    onReadyToUpgrade();
   }
 
   /**
@@ -884,8 +878,7 @@ class ConnectionManager extends EventEmitter {
     /* remove this transport from pending transports */
     Utils.arrDeleteValue(this.pendingTransports, transport);
 
-    /* if the transport is not connected (eg because it failed during a
-     * scheduleTransportActivation#onceNoPending wait) then don't activate it */
+    /* if the transport is not connected then don't activate it */
     if (!transport.isConnected) {
       Logger.logAction(
         Logger.LOG_MINOR,

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -245,7 +245,6 @@ class ConnectionManager extends EventEmitter {
   host: string | null;
   lastAutoReconnectAttempt: number | null;
   lastActivity: number | null;
-  mostRecentMsg: ProtocolMessage | null;
   forceFallbackHost: boolean;
   connectCounter: number;
   transitionTimer?: number | NodeJS.Timeout | null;
@@ -351,7 +350,6 @@ class ConnectionManager extends EventEmitter {
     this.host = null;
     this.lastAutoReconnectAttempt = null;
     this.lastActivity = null;
-    this.mostRecentMsg = null;
     this.forceFallbackHost = false;
     this.connectCounter = 0;
 
@@ -2034,25 +2032,12 @@ class ConnectionManager extends EventEmitter {
 
   onChannelMessage(message: ProtocolMessage, transport: Transport): void {
     const onActiveTransport = this.activeProtocol && transport === this.activeProtocol.getTransport(),
-      onUpgradeTransport = Utils.arrIn(this.pendingTransports, transport) && this.state == this.states.synchronizing,
-      notControlMsg = message.action === actions.MESSAGE || message.action === actions.PRESENCE;
+      onUpgradeTransport = Utils.arrIn(this.pendingTransports, transport) && this.state == this.states.synchronizing;
 
     /* As the lib now has a period where the upgrade transport is synced but
      * before it's become active (while waiting for the old one to become
      * idle), message can validly arrive on it even though it isn't active */
     if (onActiveTransport || onUpgradeTransport) {
-      if (notControlMsg) {
-        if (ProtocolMessage.isDuplicate(message, this.mostRecentMsg)) {
-          Logger.logAction(
-            Logger.LOG_ERROR,
-            'ConnectionManager.onChannelMessage()',
-            'received message with the same message id as a previous; discarding; id = ' +
-              message.id
-          );
-          return;
-        }
-        this.mostRecentMsg = message;
-      }
       this.realtime.channels.onChannelMessage(message);
     } else {
       // Message came in on a defunct transport. Allow only acks, nacks, & errors for outstanding

--- a/src/common/lib/transport/messagequeue.ts
+++ b/src/common/lib/transport/messagequeue.ts
@@ -64,6 +64,12 @@ class MessageQueue extends EventEmitter {
     this.completeMessages(0, Number.MAX_SAFE_INTEGER || Number.MAX_VALUE, err);
   }
 
+  resetSendAttempted(): void {
+    for(let msg of this.messages) {
+      msg.sendAttempted = false;
+    }
+  }
+
   clear(): void {
     Logger.logAction(Logger.LOG_MICRO, 'MessageQueue.clear()', 'clearing ' + this.messages.length + ' messages');
     this.messages = [];

--- a/src/common/lib/transport/messagequeue.ts
+++ b/src/common/lib/transport/messagequeue.ts
@@ -65,7 +65,7 @@ class MessageQueue extends EventEmitter {
   }
 
   resetSendAttempted(): void {
-    for(let msg of this.messages) {
+    for (let msg of this.messages) {
       msg.sendAttempted = false;
     }
   }

--- a/src/common/lib/transport/transport.ts
+++ b/src/common/lib/transport/transport.ts
@@ -33,7 +33,6 @@ const disconnectMessage = ProtocolMessage.fromValues({ action: actions.DISCONNEC
  * failed           error
  * disposed
  * connected        null error, connectionId, connectionDetails
- * sync             connectionId
  * event            channel message object
  */
 
@@ -154,12 +153,6 @@ abstract class Transport extends EventEmitter {
         this.emit('nack', message.msgSerial, message.count, message.error);
         break;
       case actions.SYNC:
-        if (message.connectionId !== undefined) {
-          /* a transport SYNC */
-          this.emit('sync', message.connectionId, message.connectionId);
-          break;
-        }
-        /* otherwise it's a channel SYNC, so handle it in the channel */
         this.connectionManager.onChannelMessage(message, this);
         break;
       case actions.AUTH:

--- a/src/common/lib/transport/transport.ts
+++ b/src/common/lib/transport/transport.ts
@@ -32,8 +32,8 @@ const disconnectMessage = ProtocolMessage.fromValues({ action: actions.DISCONNEC
  * closed           error
  * failed           error
  * disposed
- * connected        null error, connectionSerial, connectionId, connectionDetails
- * sync             connectionSerial, connectionId
+ * connected        null error, connectionId, connectionDetails
+ * sync             connectionId
  * event            channel message object
  */
 
@@ -139,7 +139,7 @@ abstract class Transport extends EventEmitter {
         break;
       case actions.CONNECTED:
         this.onConnect(message);
-        this.emit('connected', message.error, message.connectionId, message.connectionDetails, message);
+        this.emit('connected', message.error, message.connectionId, message.connectionDetails);
         break;
       case actions.CLOSED:
         this.onClose(message);

--- a/src/common/lib/types/presencemessage.ts
+++ b/src/common/lib/types/presencemessage.ts
@@ -47,6 +47,7 @@ class PresenceMessage {
    * @return {*}
    */
   toJSON(): {
+    id?: string;
     clientId?: string;
     action: number;
     data: string | Buffer | Uint8Array;
@@ -70,6 +71,7 @@ class PresenceMessage {
       }
     }
     return {
+      id: this.id,
       clientId: this.clientId,
       /* Convert presence action back to an int for sending to Ably */
       action: toActionValue(this.action as string),

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -57,7 +57,7 @@ function toStringArray(array?: any[]): string {
 }
 
 const simpleAttributes =
-  'id channel channelSerial connectionId connectionKey connectionSerial count msgSerial timestamp'.split(' ');
+  'id channel channelSerial connectionId connectionKey count msgSerial timestamp'.split(' ');
 
 class ProtocolMessage {
   action?: number;
@@ -68,7 +68,6 @@ class ProtocolMessage {
   error?: ErrorInfo;
   connectionId?: string;
   connectionKey?: string;
-  connectionSerial?: number;
   channel?: string;
   channelSerial?: string | null;
   msgSerial?: number;

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -160,37 +160,6 @@ class ProtocolMessage {
     result += ']';
     return result;
   };
-
-  /* Only valid for channel messages */
-  static isDuplicate = function (a: any, b: any): boolean {
-    if (a && b) {
-      if (
-        (a.action === actions.MESSAGE || a.action === actions.PRESENCE) &&
-        a.action === b.action &&
-        a.channel === b.channel &&
-        a.id === b.id
-      ) {
-        if (a.action === actions.PRESENCE) {
-          return true;
-        } else if (a.messages.length === b.messages.length) {
-          for (let i = 0; i < a.messages.length; i++) {
-            const aMessage = a.messages[i];
-            const bMessage = b.messages[i];
-            if (
-              (aMessage.extras && aMessage.extras.delta && aMessage.extras.delta.format) !==
-              (bMessage.extras && bMessage.extras.delta && bMessage.extras.delta.format)
-            ) {
-              return false;
-            }
-          }
-
-          return true;
-        }
-      }
-    }
-
-    return false;
-  };
 }
 
 export default ProtocolMessage;

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -70,7 +70,7 @@ class ProtocolMessage {
   connectionKey?: string;
   connectionSerial?: number;
   channel?: string;
-  channelSerial?: number | null;
+  channelSerial?: string | null;
   msgSerial?: number;
   messages?: Message[];
   presence?: PresenceMessage[];

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -57,8 +57,7 @@ function toStringArray(array?: any[]): string {
   return '[ ' + result.join(', ') + ' ]';
 }
 
-const simpleAttributes =
-  'id channel channelSerial connectionId connectionKey count msgSerial timestamp'.split(' ');
+const simpleAttributes = 'id channel channelSerial connectionId connectionKey count msgSerial timestamp'.split(' ');
 
 class ProtocolMessage {
   action?: number;

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -23,6 +23,7 @@ const actions = {
   MESSAGE: 15,
   SYNC: 16,
   AUTH: 17,
+  ACTIVATE: 18,
 };
 
 const ActionName: string[] = [];

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -76,7 +76,7 @@ const Defaults = {
   maxMessageSize: 65536,
 
   version,
-  apiVersion: '1.2',
+  apiVersion: '2.0',
   agent,
   getHost,
   getPort,

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -4,7 +4,6 @@ import * as API from '../../../ably';
 export default interface ClientOptions extends API.Types.ClientOptions {
   restAgentOptions?: { keepAlive: boolean; maxSockets: number };
   pushFullWait?: boolean;
-  checkChannelsOnResume?: boolean;
   agents?: string[];
 }
 

--- a/test/common/modules/client_module.js
+++ b/test/common/modules/client_module.js
@@ -26,7 +26,10 @@ define(['ably', 'globals', 'test/common/modules/testapp_module'], function (Ably
     return new Ably.Rest(ablyClientOptions(options));
   }
 
-  function ablyRealtime(options) {
+  function ablyRealtime(options, promises) {
+    if (promises) {
+      return new Ably.Realtime.Promise(ablyClientOptions(options));
+    }
     return new Ably.Realtime(ablyClientOptions(options));
   }
 

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -614,15 +614,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               },
             });
             var testData = 'Test data';
-            channel.subscribe(function (message) {
-              try {
-                expect(message.data).to.equal(testData, 'Check data');
-                closeAndFinish(done, realtime);
-              } catch (err) {
+            channel.attach(function (err) {
+              if (err) {
                 closeAndFinish(done, realtime, err);
+                return;
               }
+              channel.subscribe(function (message) {
+                try {
+                  expect(message.data).to.equal(testData, 'Check data');
+                  closeAndFinish(done, realtime);
+                } catch (err) {
+                  closeAndFinish(done, realtime, err);
+                }
+              });
+              channel.publish(undefined, testData);
             });
-            channel.publish(undefined, testData);
           });
           monitorConnection(done, realtime);
         } catch (err) {

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -68,7 +68,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime = helper.AblyRealtime();
         realtime.connection.on('connected', function () {
           try {
-            const recoveryKey = realtime.connection.getRecoveryKey();
+            const recoveryKey = realtime.connection.createRecoveryKey();
             const recoveryContext = JSON.parse(recoveryKey);
             expect(recoveryContext.connectionKey).to.equal(realtime.connection.key, 'verify correct recovery key');
             expect(recoveryContext.msgSerial).to.equal(
@@ -91,7 +91,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 function (cb) {
                   channel.subscribe(function () {
                     setTimeout(function () {
-                      const recoveryKey = realtime.connection.getRecoveryKey();
+                      const recoveryKey = realtime.connection.createRecoveryKey();
                       const recoveryContext = JSON.parse(recoveryKey);
                       expect(recoveryContext.connectionKey).to.equal(
                         realtime.connection.key,
@@ -117,7 +117,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 realtime.connection.close();
                 realtime.connection.whenState('closed', function () {
                   try {
-                    expect(realtime.connection.getRecoveryKey()).to.equal(null, 'verify recovery key null after close');
+                    expect(realtime.connection.createRecoveryKey()).to.equal(null, 'verify recovery key null after close');
                     closeAndFinish(done, realtime);
                   } catch (err) {
                     closeAndFinish(done, realtime, err);

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -70,10 +70,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           try {
             const recoveryKey = realtime.connection.getRecoveryKey();
             const recoveryContext = JSON.parse(recoveryKey);
-            expect(recoveryContext.connectionKey).to.equal(
-              realtime.connection.key,
-              'verify correct recovery key'
-            );
+            expect(recoveryContext.connectionKey).to.equal(realtime.connection.key, 'verify correct recovery key');
             expect(recoveryContext.msgSerial).to.equal(
               realtime.connection.connectionManager.msgSerial,
               'verify correct recovery key'
@@ -139,9 +136,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('unrecoverableConnection', function (done) {
       var realtime;
       const fakeRecoveryKey = JSON.stringify({
-        'connectionKey': '_____!ablyjs_test_fake-key____',
-        'msgSerial': '5',
-        'channelSerials': {},
+        connectionKey: '_____!ablyjs_test_fake-key____',
+        msgSerial: '5',
+        channelSerials: {},
       });
       try {
         realtime = helper.AblyRealtime({ recover: fakeRecoveryKey });
@@ -180,7 +177,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * without being merged with new messages)
      */
     it('connectionQueuing', function (done) {
-      var realtime = helper.AblyRealtime({ transports: [helper.bestTransport]}),
+      var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
         channel = realtime.channels.get('connectionQueuing'),
         connectionManager = realtime.connection.connectionManager;
 

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -117,7 +117,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 realtime.connection.close();
                 realtime.connection.whenState('closed', function () {
                   try {
-                    expect(realtime.connection.createRecoveryKey()).to.equal(null, 'verify recovery key null after close');
+                    expect(realtime.connection.createRecoveryKey()).to.equal(
+                      null,
+                      'verify recovery key null after close'
+                    );
                     closeAndFinish(done, realtime);
                   } catch (err) {
                     closeAndFinish(done, realtime, err);

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -68,7 +68,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime = helper.AblyRealtime();
         realtime.connection.on('connected', function () {
           try {
-            const recoveryKey = realtime.connection.createRecoveryKey();
+            const recoveryKey = realtime.connection.recoveryKey;
             const recoveryContext = JSON.parse(recoveryKey);
             expect(recoveryContext.connectionKey).to.equal(realtime.connection.key, 'verify correct recovery key');
             expect(recoveryContext.msgSerial).to.equal(
@@ -91,7 +91,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 function (cb) {
                   channel.subscribe(function () {
                     setTimeout(function () {
-                      const recoveryKey = realtime.connection.createRecoveryKey();
+                      const recoveryKey = realtime.connection.recoveryKey;
                       const recoveryContext = JSON.parse(recoveryKey);
                       expect(recoveryContext.connectionKey).to.equal(
                         realtime.connection.key,
@@ -117,10 +117,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 realtime.connection.close();
                 realtime.connection.whenState('closed', function () {
                   try {
-                    expect(realtime.connection.createRecoveryKey()).to.equal(
-                      null,
-                      'verify recovery key null after close'
-                    );
+                    expect(realtime.connection.recoveryKey).to.equal(null, 'verify recovery key null after close');
                     closeAndFinish(done, realtime);
                   } catch (err) {
                     closeAndFinish(done, realtime, err);

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -145,11 +145,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime.connection.on('connected', function (stateChange) {
           try {
             expect(stateChange.reason.code).to.equal(
-              80008,
+              80018,
               'verify unrecoverable-connection error set in stateChange.reason'
             );
             expect(realtime.connection.errorReason.code).to.equal(
-              80008,
+              80018,
               'verify unrecoverable-connection error set in connection.errorReason'
             );
             expect(realtime.connection.connectionManager.msgSerial).to.equal(

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -334,10 +334,6 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             try {
               if (message.action === 4) {
                 expect(message.connectionDetails.connectionKey).to.be.ok;
-                expect(message.connectionDetails.connectionKey).to.equal(
-                  message.connectionKey,
-                  'connection keys should match'
-                );
                 message.connectionDetails.connectionKey = 'importantConnectionKey';
                 message.connectionDetails.clientId = 'customClientId';
               }

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -34,7 +34,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             var transport = realtime.connection.connectionManager.activeProtocol.transport;
             var connectUri = helper.isWebsocket(transport) ? transport.uri : transport.recvRequest.uri;
             try {
-              expect(connectUri.indexOf('v=1.2') > -1, 'Check uri includes v=1.2').to.be.ok;
+              expect(connectUri.indexOf('v=2.0') > -1, 'Check uri includes v=2.0').to.be.ok;
             } catch (err) {
               closeAndFinish(done, realtime, err);
               return;

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -619,53 +619,6 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       };
     });
 
-    it('duplicateMsgId', function (done) {
-      var realtime = helper.AblyRealtime({ log: { level: 4 } }),
-        channel = realtime.channels.get('duplicateMsgId'),
-        received = 0;
-
-      channel.subscribe(function (_msg) {
-        received++;
-      });
-      channel.once('attached', function () {
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 15,
-            channel: channel.name,
-            id: 'foo:0',
-            connectionSerial: 0,
-            messages: [{ name: null, data: null }],
-          })
-        );
-
-        /* add some nonmessage channel message inbetween */
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 11,
-            channel: channel.name,
-          })
-        );
-
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 15,
-            channel: channel.name,
-            id: 'foo:0',
-            connectionSerial: 1,
-            messages: [{ name: null, data: null }],
-          })
-        );
-
-        try {
-          expect(received).to.equal(1);
-        } catch (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        closeAndFinish(done, realtime);
-      });
-    });
-
     /* Authenticate with a clientId and ensure that the clientId is not sent in the Message
 	   and is implicitly added when published */
     it('implicit_client_id_0', function (done) {

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -666,45 +666,6 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
     });
 
-    it('duplicateConnectionId', function (done) {
-      var realtime = helper.AblyRealtime({ log: { level: 4 } }),
-        channel = realtime.channels.get('duplicateConnectionId'),
-        received = 0;
-
-      channel.subscribe(function (_msg) {
-        received++;
-      });
-      channel.once('attached', function () {
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 15,
-            channel: channel.name,
-            id: 'foo:0',
-            connectionSerial: 0,
-            messages: [{ name: null, data: null }],
-          })
-        );
-
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 15,
-            channel: channel.name,
-            id: 'bar:0',
-            connectionSerial: 0,
-            messages: [{ name: null, data: null }],
-          })
-        );
-
-        try {
-          expect(received).to.equal(1);
-        } catch (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        closeAndFinish(done, realtime);
-      });
-    });
-
     /* Authenticate with a clientId and ensure that the clientId is not sent in the Message
 	   and is implicitly added when published */
     it('implicit_client_id_0', function (done) {

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -467,7 +467,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 cb(err);
                 return;
               }
-              recoveryKey = connection.createRecoveryKey();
+              recoveryKey = connection.recoveryKey;
               cb();
             });
           },
@@ -654,7 +654,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       );
 
       // Get the recovery key before becoming suspended as it will be reset.
-      const recoveryKey = rxRealtime.connection.createRecoveryKey();
+      const recoveryKey = rxRealtime.connection.recoveryKey;
 
       await new Promise((resolve) => helper.becomeSuspended(rxRealtime, resolve));
 

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -297,7 +297,6 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 /* Sabotage the resume */
                 (connection.connectionManager.connectionKey = '_____!ablyjs_test_fake-key____'),
                   (connection.connectionManager.connectionId = 'ablyjs_tes');
-                connection.connectionManager.connectionSerial = 17;
                 connection.connectionManager.msgSerial = 15;
                 connection.once('disconnected', function () {
                   cb();
@@ -314,10 +313,6 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                     expect(attachedChannel.state).to.equal('attaching', 'Attached channel went into attaching');
                     expect(suspendedChannel.state).to.equal('attaching', 'Suspended channel went into attaching');
                     expect(connection.connectionManager.msgSerial).to.equal(0, 'Check msgSerial is reset to 0');
-                    expect(connection.connectionManager.connectionSerial).to.equal(
-                      -1,
-                      'Check connectionSerial is reset by the new CONNECTED'
-                    );
                     expect(
                       connection.connectionManager.connectionId !== 'ablyjs_tes',
                       'Check connectionId is set by the new CONNECTED'

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -307,7 +307,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 connection.once('connected', function (stateChange) {
                   try {
                     expect(stateChange.reason && stateChange.reason.code).to.equal(
-                      80008,
+                      80018,
                       'Unable to recover connection correctly set in the stateChange'
                     );
                     expect(attachedChannel.state).to.equal('attaching', 'Attached channel went into attaching');

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -467,7 +467,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 cb(err);
                 return;
               }
-              recoveryKey = connection.getRecoveryKey();
+              recoveryKey = connection.createRecoveryKey();
               cb();
             });
           },
@@ -654,7 +654,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       );
 
       // Get the recovery key before becoming suspended as it will be reset.
-      const recoveryKey = rxRealtime.connection.getRecoveryKey();
+      const recoveryKey = rxRealtime.connection.createRecoveryKey();
 
       await new Promise((resolve) => helper.becomeSuspended(rxRealtime, resolve));
 

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -472,7 +472,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 cb(err);
                 return;
               }
-              recoveryKey = connection.recoveryKey;
+              recoveryKey = connection.getRecoveryKey();
               cb();
             });
           },
@@ -628,6 +628,68 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       } catch (err) {
         closeAndFinish(done, [sender_realtime, receiver_realtime, resumed_receiver_realtime], err);
       }
+    });
+
+    it('recover multiple channels', async function () {
+      const NUM_MSGS = 5;
+
+      const txRest = helper.AblyRest();
+      const rxRealtime = helper.AblyRealtime({ transports: [helper.bestTransport] }, true);
+
+      const channelNames = Array(5).fill().map(() => String(Math.random()));
+      const rxChannels = channelNames.map((name) => rxRealtime.channels.get(name));
+
+      await Promise.all(rxChannels.map((channel) => channel.attach()));
+
+      // Do a few publishes on each channel so the channelSerial is set.
+      await Promise.all(channelNames.map(async (name) => {
+        const tx = txRest.channels.get(name);
+        const rx = rxRealtime.channels.get(name);
+        await rx.attach();
+
+        for (let i = 0; i < NUM_MSGS; i++) {
+          const pSubscribe = rx.subscriptions.once();
+          await tx.publish(null, null);
+          await pSubscribe;
+        }
+      }));
+
+      // Get the recovery key before becoming suspended as it will be reset.
+      const recoveryKey = rxRealtime.connection.getRecoveryKey();
+
+      await new Promise((resolve) => helper.becomeSuspended(rxRealtime, resolve));
+
+      // Send some messages after we've detached that should be recovered.
+      for (const name of channelNames) {
+        const tx = txRest.channels.get(name);
+        for (let i = 0; i < NUM_MSGS; i++) {
+          await tx.publish('sentWhileDisconnected', null);
+        }
+      }
+
+      const rxRealtimeRecover = helper.AblyRealtime({ recover: recoveryKey });
+      const rxRecoverChannels = channelNames.map((name) => rxRealtimeRecover.channels.get(name));
+
+      // Attach recovered channels and check we receive the expected messages.
+      await Promise.all(rxRecoverChannels.map(async (channel) => {
+        await channel.attach();
+
+        await new Promise((resolve) => {
+          let recoveredCount = 0;
+          channel.subscribe((msg) => {
+            // Check we don't receive unexpected messages.
+            expect(msg.name).to.equal('sentWhileDisconnected');
+
+            recoveredCount++;
+            if (recoveredCount === NUM_MSGS) {
+              resolve();
+            }
+          });
+        });
+      }));
+
+      await rxRealtime.close();
+      await rxRealtimeRecover.close();
     });
   });
 });

--- a/test/realtime/upgrade.test.js
+++ b/test/realtime/upgrade.test.js
@@ -498,10 +498,10 @@ define(['shared_helper', 'async', 'chai', 'ably'], function (helper, async, chai
             /* on upgrade failure */
             realtime.connection.once('update', function (stateChange) {
               try {
-                expect(stateChange.reason.code).to.equal(80008, 'Check correct (unrecoverable connection) error');
+                expect(stateChange.reason.code).to.equal(80018, 'Check correct (unrecoverable connection) error');
                 expect(stateChange.current).to.equal('connected', 'Check current is connected');
                 expect(realtime.connection.errorReason.code).to.equal(
-                  80008,
+                  80018,
                   'Check error set in connection.errorReason'
                 );
                 expect(realtime.connection.state).to.equal('connected', 'Check still connected');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es3",
+    "target": "es5",
     "module": "commonjs",
     "lib": ["ES5", "DOM", "webworker"],
     "strict": true,


### PR DESCRIPTION
Add support for no connection serials as described in https://github.com/ably/specification/pull/88.

(**Note** I've updated the original PR to try to make it clearer which commits implement which spec items - so should be easier to walk though commit by commit if thats useful when implementing the other SDKs - and I've moved the ably-js specific upgrade stuff into the last two commits so those can be ignored)

**Changes**
* updates the protocol version to `2.0` (*RSC7a*)
  * *testing*: covered already by `initbase0`
* fix channel serial type
  * `message.channelSerial` is a string not a number (eg `'e02Tut8QwBFsQM05921682:5'`)
* tracks channel serial of last message/presence (*RTL15b*)
  * note unlike with connection serials we arn't checking for duplicates by comparing serials - this was only needed since the old upgrade scheme could potentially lead to duplicates which is no longer the case, and we want to keep the `channelSerial` opaque rather than having to parse it to compare
  * *testing*: covered already by `resume_active`
* includes `channelSerial` in `ATTACH` (*RTL4c1*)
  * *testing*: covered already by `resume_active`
* remove `connectionSerial` from resume request (*RTN15b2*)
  * *testing*: covered already by `resume_active`
* reattaches channels once connected
  * reattaches `attached` channels once connected (*RTN15c6*/*RTN15c7*)
  * `attaching` and `suspended` states aleady go though the attach sequence on connected (*RTN15c6*/*RTN15c7*)
  * no longer need to reattach all `attached` channels in `ConnectionManager` as this is now always done when we get a new connection, regardless of whether the connection id changed (*RTN15c3*)
  * `msgSerial` is already reset and `errorReason` is already set (*RTN15c7*)
  * already processes queued messages upon connection (*RTN15c6*/*RTN15c7*)
* clears `channelSerial` when detached/suspended/failed (*RTP5a1*)
  * *testing*: covered by channel `rewind works on channel after reattaching` test (if we don't clear the rewind will fail)
* adds recovery with channel serials
  * *RTN16f* is already implemented - this just updates to use the new serialised recovery key 
  * loads the recovery channel serials, applies to any existing channels (which are not yet attached) and stores for later (*RTN16j*)
    * note currently this doesn't clear the recovery channel serials, so if the developer releases the channel then reattaches it uses the recovered channel serial again (not defined in the spec)
  * *RTN16k* is already implemented - this just updates to use the new serialised recovery key  
  * encodes the recovery key as JSON (*RTN16g*) 
  * *RTN16d* is implemented already since in those states the `connectionKey` is `undefined`
  * channel recovery keys are only loaded in `connect`, since the `recover` param may be a user defined callback it can't be loaded in the constructor, and by the time we get to `connect` we know theres no attached channels but `recover` has been resolved into a string (by `getTransportParams`)
  * *testing*: added a test for recovering multiple channels
* presence changes
  * sends the member ID on re-entry (`data` and `channelId` already sent) (*RTP17g*)
  * updates presencemessage to include the id when encoding
  * re-enter whenever we become `ATTACHED` (*RTP17f*) (regardless of if `HAS_PRESENCE` has been set (*RTP17c2*))
  * no longer re-enter when we complete sync (*RTP17c1*)
  * when re-entering sends all members with our `connectionId`, regardless of whether its in the main presence map, and no longer removes from the 'my members' presence map (*RTP17g*/*RTP17d*)
  * *testing*: already tested by `presence_auth_reenter`
* removes connection serial (*RTN10*/*RTN15b2*)
  * this breaks upgrade - which will be fixed later - though prefered to group all the spec changes together (then add the ably-js specific upgrade stuff later)
  * removes `duplicateConnectionId` test as now redundant
* removes `checkChannelsOnResume` options
  * given we're already reattaching each channel on resume, reattaching again after 30s is redundant
* channel doesn't wait for `channelSerial` if empty (*RTP17h*)
* presence index mymembers by client ID (*RTP17h*)

**Upgrade Changes**
(ably-js only - from https://github.com/ably/realtime/issues/4216#issuecomment-1221407649)
* replaces upgrade `SYNC` with `ACTIVATE`
* doesn't wait for no channels pending before upgrading
* removes `mostRecentMessage` as this is no longer needed in the new upgrade scheme (and causes a bug - see [thread](https://ably-real-time.slack.com/archives/C02P7F81DPS/p1663751041394809))
  * removes `duplicateMsgId` test as now redundant