### PR TITLE
eventemitter: fix once with array using promise

### DIFF
--- a/src/common/lib/util/eventemitter.ts
+++ b/src/common/lib/util/eventemitter.ts
@@ -243,11 +243,8 @@ class EventEmitter {
     const argCount = args.length;
     if ((argCount === 0 || (argCount === 1 && typeof args[0] !== 'function')) && Platform.Config.Promise) {
       const event = args[0];
-      if (typeof event !== 'string') {
-        throw new Error('EventEmitter.once(): Invalid arguments:' + Platform.Config.inspect(args));
-      }
       return new Platform.Config.Promise((resolve) => {
-        this.once(event, resolve);
+        this.once(event as string | string[] | null, resolve);
       });
     }
 

--- a/test/realtime/event_emitter.test.js
+++ b/test/realtime/event_emitter.test.js
@@ -468,6 +468,32 @@ define(['shared_helper', 'chai'], function (helper, chai) {
               closeAndFinish(done, realtime, err);
             });
         });
+
+        it('anyEventsWithOnce', function (done) {
+          var realtime = helper.AblyRealtime({ autoConnect: false }),
+            eventEmitter = realtime.connection;
+
+          const p = eventEmitter.once();
+          eventEmitter.emit('b');
+          p.then(function () {
+            closeAndFinish(done, realtime);
+          }).catch(function (err) {
+            closeAndFinish(done, realtime, err);
+          });
+        });
+
+        it('arrayOfEventsWithOnce', function (done) {
+          var realtime = helper.AblyRealtime({ autoConnect: false }),
+            eventEmitter = realtime.connection;
+
+          const p = eventEmitter.once(['a', 'b', 'c']);
+          eventEmitter.emit('b');
+          p.then(function () {
+            closeAndFinish(done, realtime);
+          }).catch(function (err) {
+            closeAndFinish(done, realtime, err);
+          });
+        });
       });
     }
   });


### PR DESCRIPTION
when looking at upgrading the realtime test suite to use the latest SDK found `await conn.once(['foo', 'bar'])` no longer works using promises, throwing `Invalid arguments` (though callbacks is fine ie `conn.once(['foo', 'bar'], () => {})`

looks like a check was added in https://github.com/ably/ably-js/commit/32f8d04363df2e5ae40e2bae91c0248614111e48#diff-21811b221b0e30b57b9d5c084d2fd83f1709eb97a129e25732474b92b8fb63a6R237 - though I can't see what this is checking given its just calling itself so will be checked later (or if its just so typescript doesn't complain)?