### PR TITLE
Configurable internetUpUrl

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -210,6 +210,15 @@ declare namespace Types {
      */
     useBinaryProtocol?: boolean;
 
+    /**
+     * Override the URL used by the realtime client to check if the internet is available.
+     *
+     * In the event of a failure to connect to the primary endpoint, the client will send a
+     * GET request to this URL to check if the internet is available. If this request returns
+     * a success response the client will attempt to connect to a fallback host.
+     */
+    connectivityCheckUrl?: string;
+
     disconnectedRetryTimeout?: number;
     suspendedRetryTimeout?: number;
     closeOnUnload?: boolean;

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -219,6 +219,12 @@ declare namespace Types {
      */
     connectivityCheckUrl?: string;
 
+    /**
+     * Disable the check used by the realtime client to check if the internet
+     * is available before connecting to a fallback host.
+     */
+    disableConnectivityCheck?: boolean;
+
     disconnectedRetryTimeout?: number;
     suspendedRetryTimeout?: number;
     closeOnUnload?: boolean;

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -78,7 +78,7 @@ class Rest {
     this._currentFallback = null;
 
     this.serverTimeOffset = null;
-    this.http = new Platform.Http();
+    this.http = new Platform.Http(normalOptions);
     this.auth = new Auth(this, normalOptions);
     this.channels = new Channels(this);
     this.push = new Push(this);

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -295,6 +295,17 @@ export function normaliseOptions(options: DeprecatedClientOptions): NormalisedCl
     }
   }
 
+  let connectivityCheckParams = null;
+  let connectivityCheckUrl = options.connectivityCheckUrl;
+  if (options.connectivityCheckUrl) {
+    let [uri, qs] = options.connectivityCheckUrl.split('?');
+    connectivityCheckParams = qs ? Utils.parseQueryString(qs) : {};
+    if (uri.indexOf('://') === -1) {
+      uri = 'https://' + uri;
+    }
+    connectivityCheckUrl = uri;
+  }
+
   return {
     ...options,
     useBinaryProtocol:
@@ -305,6 +316,8 @@ export function normaliseOptions(options: DeprecatedClientOptions): NormalisedCl
     restHost,
     maxMessageSize: options.maxMessageSize || Defaults.maxMessageSize,
     timeouts,
+    connectivityCheckParams,
+    connectivityCheckUrl,
   };
 }
 

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -30,5 +30,6 @@ export type NormalisedClientOptions = Modify<
     keySecret?: string;
     timeouts: Record<string, number>;
     maxMessageSize: number;
+    connectivityCheckParams: Record<string, string> | null;
   }
 >;

--- a/src/common/types/IDefaults.d.ts
+++ b/src/common/types/IDefaults.d.ts
@@ -1,7 +1,7 @@
 import TransportNames from '../constants/TransportNames';
 
 export default interface IDefaults {
-  internetUpUrl: string;
+  connectivityCheckUrl: string;
   jsonpInternetUpUrl?: string;
   defaultTransports: TransportNames[];
   baseTransportOrder: TransportNames[];

--- a/src/common/types/http.d.ts
+++ b/src/common/types/http.d.ts
@@ -15,12 +15,15 @@ export type RequestCallback = (
 export type RequestParams = Record<string, string> | null;
 
 export declare class IHttp {
+  constructor(options: NormalisedClientOptions);
   static methods: Array<HttpMethods>;
   static methodsWithBody: Array<HttpMethods>;
   static methodsWithoutBody: Array<HttpMethods>;
   supportsAuthHeaders: boolean;
   supportsLinkHeaders: boolean;
   agent?: { http: http.Agent; https: https.Agent } | null;
+  options: NormalisedClientOptions;
+
   Request?: (
     method: HttpMethods,
     rest: Rest | null,

--- a/src/platform/nodejs/lib/util/defaults.ts
+++ b/src/platform/nodejs/lib/util/defaults.ts
@@ -2,7 +2,7 @@ import IDefaults from '../../../../common/types/IDefaults';
 import TransportNames from '../../../../common/constants/TransportNames';
 
 const Defaults: IDefaults = {
-  internetUpUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
+  connectivityCheckUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
   /* Note: order matters here: the base transport is the leftmost one in the
    * intersection of baseTransportOrder and the transports clientOption that's supported.
    * (For node this is the same as the transportPreferenceOrder, but for

--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -226,6 +226,10 @@ const Http: typeof IHttp = class {
   }
 
   checkConnectivity = (callback: (errorInfo: ErrorInfo | null, connected?: boolean) => void): void => {
+    if (this.options.disableConnectivityCheck) {
+      callback(null, true);
+      return;
+    }
     const connectivityCheckUrl = this.options.connectivityCheckUrl || Defaults.connectivityCheckUrl;
     const connectivityCheckParams = this.options.connectivityCheckParams;
     const connectivityUrlIsDefault = !this.options.connectivityCheckUrl;

--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -229,7 +229,7 @@ const Http: typeof IHttp = class {
     this.doUri(
       HttpMethods.Get,
       null as any,
-      Defaults.internetUpUrl,
+      Defaults.connectivityCheckUrl,
       null,
       null,
       null,

--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -8,6 +8,7 @@ import http from 'http';
 import https from 'https';
 import Rest from 'common/lib/client/rest';
 import Realtime from 'common/lib/client/realtime';
+import { NormalisedClientOptions } from 'common/types/ClientOptions';
 
 /***************************************************
  *
@@ -91,6 +92,11 @@ const Http: typeof IHttp = class {
   _getHosts = getHosts;
   supportsAuthHeaders = true;
   supportsLinkHeaders = true;
+  options: NormalisedClientOptions;
+
+  constructor(options: NormalisedClientOptions) {
+    this.options = options || {};
+  }
 
   /* Unlike for doUri, the 'rest' param here is mandatory, as it's used to generate the hosts */
   do(

--- a/src/platform/web/lib/util/defaults.ts
+++ b/src/platform/web/lib/util/defaults.ts
@@ -2,7 +2,7 @@ import IDefaults from 'common/types/IDefaults';
 import TransportNames from 'common/constants/TransportNames';
 
 const Defaults: IDefaults = {
-  internetUpUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
+  connectivityCheckUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
   jsonpInternetUpUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up-0-9.js',
   /* Order matters here: the base transport is the leftmost one in the
    * intersection of baseTransportOrder and the transports clientOption that's

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -11,6 +11,7 @@ import XHRStates from 'common/constants/XHRStates';
 import Logger from 'common/lib/util/logger';
 import { StandardCallback } from 'common/types/utils';
 import { createRequest, Request } from '../transport/jsonptransport';
+import { NormalisedClientOptions } from 'common/types/ClientOptions';
 
 function shouldFallback(errorInfo: ErrorInfo) {
   const statusCode = errorInfo.statusCode as number;
@@ -43,8 +44,11 @@ const Http: typeof IHttp = class {
   static methodsWithoutBody = [HttpMethods.Get, HttpMethods.Delete];
   static methodsWithBody = [HttpMethods.Post, HttpMethods.Put, HttpMethods.Patch];
   checksInProgress: Array<StandardCallback<boolean>> | null = null;
+  options: NormalisedClientOptions;
 
-  constructor() {
+  constructor(options: NormalisedClientOptions) {
+    this.options = options || {};
+
     if (Platform.Config.xhrSupported) {
       this.supportsAuthHeaders = true;
       this.Request = function (

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -75,7 +75,7 @@ const Http: typeof IHttp = class {
       };
 
       this.checkConnectivity = function (callback: (err: ErrorInfo | null, connectivity: boolean) => void) {
-        const upUrl = Defaults.internetUpUrl;
+        const upUrl = Defaults.connectivityCheckUrl;
         Logger.logAction(Logger.LOG_MICRO, '(XHRRequest)Http.checkConnectivity()', 'Sending; ' + upUrl);
         this.doUri(
           HttpMethods.Get,

--- a/test/realtime/connectivity.test.js
+++ b/test/realtime/connectivity.test.js
@@ -32,5 +32,86 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         done();
       });
     });
+
+    describe('configured_connectivity_check_url', function () {
+      var urlScheme = 'https://';
+      var echoServer = 'echo.ably.io';
+      var successUrl = echoServer + '/respondwith?status=200';
+      var failUrl = echoServer + '/respondwith?status=500';
+
+      function options(connectivityCheckUrl) {
+        return {
+          connectivityCheckUrl: connectivityCheckUrl,
+          autoConnect: false,
+        };
+      }
+
+      it('succeeds with scheme', function (done) {
+        new helper.AblyRealtime(options(urlScheme + successUrl)).http.checkConnectivity(function (err, res) {
+          try {
+            expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
+          } catch (err) {
+            done(err);
+            return;
+          }
+          done();
+        });
+      });
+
+      it('fails with scheme', function (done) {
+        new helper.AblyRealtime(options(urlScheme + failUrl)).http.checkConnectivity(function (err, res) {
+          try {
+            expect(!res, 'Connectivity check expected to return false').to.be.ok;
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
+      });
+
+      it('succeeds with querystring', function (done) {
+        new helper.AblyRealtime(options(successUrl)).http.checkConnectivity(function (err, res) {
+          try {
+            expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
+      });
+
+      it('fails with querystring', function (done) {
+        new helper.AblyRealtime(options(failUrl)).http.checkConnectivity(function (err, res) {
+          try {
+            expect(!res, 'Connectivity check expected to return false').to.be.ok;
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
+      });
+
+      it('succeeds with plain url', function (done) {
+        new helper.AblyRealtime(options('sandbox-rest.ably.io/time')).http.checkConnectivity(function (err, res) {
+          try {
+            expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
+      });
+
+      it('fails with plain url', function (done) {
+        new helper.AblyRealtime(options('echo.ably.io')).http.checkConnectivity(function (err, res) {
+          try {
+            expect(!res, 'Connectivity check expected to return false').to.be.ok;
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
+      });
+    });
   });
 });

--- a/test/realtime/connectivity.test.js
+++ b/test/realtime/connectivity.test.js
@@ -113,5 +113,19 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         });
       });
     });
+
+    it('disable_connectivity_check', function (done) {
+      new helper.AblyRealtime({
+        connectivityCheckUrl: 'notarealhost',
+        disableConnectivityCheck: true,
+      }).http.checkConnectivity(function (err, res) {
+        try {
+          expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
Implementation is based on the one described by Lewis [here](https://github.com/ably/specification/issues/36). The only difference is that this implementation allows any success status code.

Includes some very basic URL parsing so that provided `internetAvailabilityUrl` can optionally contain a url scheme and/or query params.