### PR TITLE
[EDX-207] Add intro blurb to generated documentation

### DIFF
--- a/docs/landing-pages/choose-library.html
+++ b/docs/landing-pages/choose-library.html
@@ -2,14 +2,30 @@
 <html lang="en-US">
   <head>
     <meta charset="utf-8">
-    <title>Ably JavaScript client library documentation</title>
+    <title>Ably JavaScript Client Library SDK API Reference</title>
   </head>
   <body>
-    <h1>Ably JavaScript client library documentation</h1>
+    <h1>Ably JavaScript Client Library SDK API Reference</h1>
+
+    <p>
+    The JavaScript Client Library SDK supports a realtime and a REST interface. The JavaScript API references are generated from the <a href="https://github.com/ably/ably-js/">Ably JavaScript Client Library SDK source code</a> using <a href="https://jsdoc.app/">JSDoc</a> and structured by classes.
+    </p>
+
+    <p>
+    The realtime interface enables a client to maintain a persistent connection to Ably and publish, subscribe and be present on channels. The REST interface is stateless and typically implemented server-side. It is used to make requests such as retrieving statistics, token authentication and publishing to a channel.
+    </p>
+
+    <p>
+    There are two API variants of the Ably JavaScript Client Library SDK:
 
     <ul>
-      <li><a href="default/index.html">Default (callback-based) variant of library (<code>import * as Ably from 'ably'</code>)</a></li>
-      <li><a href="promises/index.html">Promise-based variant of library (<code>import * as Ably from 'ably/promises'</code>)</a></li>
+      <li><a href="default/index.html">Callback-based</a> (default)</li>
+      <li><a href="promises/index.html">Promise-based</a></li>
     </ul>
+    </p>
+
+    <p>
+    View the <a href="https://ably.com/docs/">Ably docs</a> for conceptual information on using Ably, and for API references featuring all languages. The combined <a href="https://ably.com/docs/api/">API references</a> are organized by features and split between the <a href="https://ably.com/docs/api/realtime-sdk">realtime</a> and <a href="https://ably.com/docs/api/rest-sdk">REST</a> interfaces.
+    </p>
   </body>
 </html>

--- a/docs/landing-pages/choose-library.html
+++ b/docs/landing-pages/choose-library.html
@@ -8,7 +8,7 @@
     <h1>Ably JavaScript Client Library SDK API Reference</h1>
 
     <p>
-    The JavaScript Client Library SDK supports a realtime and a REST interface. The JavaScript API references are generated from the <a href="https://github.com/ably/ably-js/">Ably JavaScript Client Library SDK source code</a> using <a href="https://jsdoc.app/">JSDoc</a> and structured by classes.
+    The JavaScript Client Library SDK supports a realtime and a REST interface. The JavaScript API references are generated from the <a href="https://github.com/ably/ably-js/">Ably JavaScript Client Library SDK source code</a> using <a href="https://typedoc.org">TypeDoc</a> and structured by classes.
     </p>
 
     <p>

--- a/docs/landing-pages/default.md
+++ b/docs/landing-pages/default.md
@@ -1,7 +1,7 @@
-# Hello there!
+# Ably JavaScript Client Library SDK API Reference for Callbacks
 
-This is the intro to the Ably SDK.
+You are currently viewing the callback-based variant of the Ably JavaScript Client Library SDK. View the promise-based variant [here](../promises/index.html).
 
-The entry points to this SDK are the [Rest](classes/Rest.html) and [Realtime](classes/Realtime.html) classes.
+The callback-based variant of the API implements the common Node.js error-first callback style. 
 
-**TODO proper content to come from tech writers (in [EDX-155](https://ably.atlassian.net/browse/EDX-155)) before this goes public**
+To get started with the Ably JavaScript Client Library SDK, follow the [Quickstart Guide](https://ably.com/docs/quick-start-guide) or view the introductions to the [realtime](https://ably.com/docs/realtime/usage) and [REST](https://ably.com/docs/rest/usage) interfaces.

--- a/docs/landing-pages/promises.md
+++ b/docs/landing-pages/promises.md
@@ -1,7 +1,7 @@
-# Hello there!
+# Ably JavaScript Client Library SDK API Reference for Promises
 
-This is the intro to the Promise-based variant of the Ably SDK.
+You are currently viewing the promise-based variant of the Ably JavaScript Client Library SDK. View the callback-based variant [here](../default/index.html).
 
-The entry points to this SDK are the [Rest](classes/Rest.html) and [Realtime](classes/Realtime.html) classes.
+Passing callbacks to methods when using the promise-based variant of the API is still possible, however, if a method does not receive a callback then it will instead return a promise.
 
-**TODO proper content to come from tech writers (in [EDX-155](https://ably.atlassian.net/browse/EDX-155)) before this goes public**
+To get started with the Ably JavaScript Client Library SDK, follow the [Quickstart Guide](https://ably.com/docs/quick-start-guide) or view the introductions to the [realtime](https://ably.com/docs/realtime/usage) and [REST](https://ably.com/docs/rest/usage) interfaces.


### PR DESCRIPTION
This adds (tech writer-written) intro blurbs to the top-level docs landing page and also to the home page of the two sets of documentation generated by TypeDoc.