### PR TITLE
channel: move suspended channel to attaching state on reconnect

### DIFF
--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -99,7 +99,7 @@ class Channels extends EventEmitter {
       if (channel.state === 'attaching' || channel.state === 'detaching') {
         channel.checkPendingState();
       } else if (channel.state === 'suspended') {
-        channel.attach();
+        channel._attach(false, null);
       }
     }
   }


### PR DESCRIPTION
Fix for an small issue found using `ably/promises` when updating realtime tests to async/await
1. channel becomes `suspended`
2. when the channel gets a new transport `Realtime.onTransportActive` which calls `RealtimeChannel.attach` with a callback of `undefined`
3. `RealtimeChannel.attach` sees callback is `undefined` and `options.promises` is true so returns `Utils.promisify` - even though the returned promise is never handled
4. if the reattach fails, as the returned promise by `RealtimeChannel.attach` is never handled, ends up with a `UnhandledPromiseRejectionWarning` (which in our case is causing some tests to fail)

The redundant `Utils.promisify` can be avoided by calling `_attach` directly (which given `attach` is called with no arguments I don't think it makes a difference) - not sure if we care about the error log in this case or if `this.requestState('attaching')` is better?