### PR TITLE
Add workaround information for Chrome Manifest v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ const ablyRestPromiseExample = async () => {
   // Fetching the Ably service time
   const time = await client.time();
   console.log(`Ably service time: ${time}`);
-  
+
   client.close();
 };
 

--- a/README.md
+++ b/README.md
@@ -589,6 +589,11 @@ This library currently does not support being the [target of a push notification
 
 - ["Unable to parse request body" error when publishing large messages from old versions of Internet Explorer](https://support.ably.com/solution/articles/3000062360-ably-js-unable-to-parse-request-body-error-when-publishing-large-messages-from-old-browsers).
 
+#### Manifest v3 Chrome Extensions
+Chrome extensions built with manifest v3 require Service Workers instead of background pages.
+This is supported in Ably via the [Web Worker build](#supported-platforms), however [workarounds](docs/chrome-mv3.md) are required to ensure Chrome does not mark the Service Worker as inactive.
+
+
 ## Contributing
 
 For guidance on how to contribute to this project, see the [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -590,8 +590,8 @@ This library currently does not support being the [target of a push notification
 - ["Unable to parse request body" error when publishing large messages from old versions of Internet Explorer](https://support.ably.com/solution/articles/3000062360-ably-js-unable-to-parse-request-body-error-when-publishing-large-messages-from-old-browsers).
 
 #### Manifest v3 Chrome Extensions
-Chrome extensions built with manifest v3 require Service Workers instead of background pages.
-This is supported in Ably via the [Web Worker build](#supported-platforms), however [workarounds](docs/chrome-mv3.md) are required to ensure Chrome does not mark the Service Worker as inactive.
+Chrome extensions built with Manifest v3 require service workers instead of background pages.
+This is supported in Ably via the [Web Worker build](#supported-platforms), however [workarounds](docs/chrome-mv3.md) are required to ensure Chrome does not mark the service worker as inactive.
 
 
 ## Contributing

--- a/docs/chrome-mv3.md
+++ b/docs/chrome-mv3.md
@@ -1,6 +1,9 @@
 # Using Ably in a Chrome Extension with Manifest v3
 
-In Manifest V3, Chrome Extensions can [no longer use background pages in favour of Service Workers](https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/). Chrome will [mark a Service Worker as inactive even if an active websocket connection is made](https://bugs.chromium.org/p/chromium/issues/detail?id=1152255). This causes Ably to disconnect and new messages will not be received. Unfortunately, this appears to be intended design so workarounds are needed to keep the Service Worker alive in order to continue recieving messages. Multiple workarounds are available, depending on your use-case.
+In Manifest V3, Chrome Extensions can [no longer use background pages in favour of Service Workers](https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/).
+Chrome will [mark a Service Worker as inactive even if an active websocket connection is made](https://bugs.chromium.org/p/chromium/issues/detail?id=1152255).
+This causes Ably to disconnect and new messages will not be received.
+Unfortunately, this appears to be intended design so workarounds are needed to keep the Service Worker alive in order to continue receiving messages. Multiple workarounds are available, depending on your use-case.
 
 
 ### Using alarms

--- a/docs/chrome-mv3.md
+++ b/docs/chrome-mv3.md
@@ -1,7 +1,7 @@
 # Using Ably in a Chrome Extension with Manifest v3
 
 In Manifest V3, Chrome extensions can [no longer use background pages in favor of service workers](https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/).
-Chrome will [mark a service worker as inactive even if an active websocket connection is made](https://bugs.chromium.org/p/chromium/issues/detail?id=1152255).
+Chrome will [mark a service worker as inactive even if an active WebSocket connection is made](https://bugs.chromium.org/p/chromium/issues/detail?id=1152255).
 This causes Ably to disconnect and new messages will not be received.
 Unfortunately, this appears to be intended design so workarounds are needed to keep the service worker alive in order to continue receiving messages. Multiple workarounds are available, depending on your use-case.
 

--- a/docs/chrome-mv3.md
+++ b/docs/chrome-mv3.md
@@ -1,0 +1,103 @@
+# Using Ably in a Chrome Extension with Manifest v3
+
+In Manifest V3, Chrome Extensions can [no longer use background pages in favour of Service Workers](https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/). Chrome will [mark a Service Worker as inactive even if an active websocket connection is made](https://bugs.chromium.org/p/chromium/issues/detail?id=1152255). This causes Ably to disconnect and new messages will not be received. Unfortunately, this appears to be intended design so workarounds are needed to keep the Service Worker alive in order to continue recieving messages. Multiple workarounds are available, depending on your use-case.
+
+
+### Using alarms
+Alarms will extend the activity timer of a Service Worker or wake up an inactive Service Worker.
+Requires permission `alarms` to be added to manifest.json:
+```json
+{
+  // ...
+  "permissions": ["alarms"],
+}
+```
+
+```js
+chrome.alarms.create({ periodInMinutes: 0.3 })
+chrome.alarms.onAlarm.addListener(() => {
+	// This function will be called once the SW wakes up
+});
+```
+
+[More Info](https://developer.chrome.com/docs/extensions/reference/alarms/)
+
+
+### Connecting to a nativeMessaging host
+If your Chrome Extension connects to a native application, a Service Worker which is attached to a native application will not be marked as inactive as long as the native application is alive. To ensure that the native application exiting does not mark your Service Worker as inactive, make sure the connection can survive a restart of the native application.
+
+```js
+var port = chrome.runtime.connectNative('com.example.extension');
+port.onDisconnect.addListener(function() {
+  // Reconnect to avoid being marked as inactive
+});
+
+```
+
+[More Info](https://developer.chrome.com/docs/apps/nativeMessaging/)
+
+### Connecting to a tab
+If your Chrome Extension requires broad host permissions (e.g. `*://*/*`), connecting to a tab will keep your Service Worker active.
+Requires `scripting` permission to be added to manifest.json:
+```json
+{
+  // ...
+  "permissions": ["scripting"],
+}
+```
+
+```js
+findTab();
+chrome.runtime.onConnect.addListener(port => {
+  if (port.name === 'keepAlive') {
+    setTimeout(() => port.disconnect(), 250e3);
+    port.onDisconnect.addListener(() => findTab());
+  }
+});
+
+const onUpdate = (tabId, info, tab) => /^https?:/.test(info.url) && findTab([tab]);
+async function findTab(tabs) {
+  if (chrome.runtime.lastError) { /* tab was closed before setTimeout ran */ }
+  for (const {id: tabId} of tabs || await chrome.tabs.query({url: '*://*/*'})) {
+    try {
+      await chrome.scripting.executeScript({target: {tabId}, func: connect});
+      chrome.tabs.onUpdated.removeListener(onUpdate);
+      return;
+    } catch (e) {}
+  }
+  chrome.tabs.onUpdated.addListener(onUpdate);
+}
+function connect() {
+  chrome.runtime.connect({name: 'keepAlive'})
+    .onDisconnect.addListener(connect);
+}
+
+```
+
+### Connecting to a port
+If you connect to a port, the Service Worker's inactivity timer will be reset. However, the port must be reconnected at an interval less than 5 minutes or the SW will be marked as inactive.
+
+```js
+chrome.runtime.onConnect.addListener(port => {
+  if (port.name !== 'foo') return;
+  port.onMessage.addListener(()=>{});
+  port.onDisconnect.addListener(deleteTimer);
+  port._timer = setTimeout(forceReconnect, 250e3, port);
+});
+function forceReconnect(port) {
+  deleteTimer(port);
+  port.disconnect();
+}
+function deleteTimer(port) {
+  if (port._timer) {
+    clearTimeout(port._timer);
+    delete port._timer;
+  }
+}
+
+```
+
+[More Info](https://developer.chrome.com/docs/extensions/reference/runtime/#method-connect)
+
+### Enterprise Extensions
+[Enterprise extensions will continue to work on manifest v2 until January 2024](https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/). If your extension is installed as part of an enterprise policy, this means that you will have an extra year to continue using manifest v2.

--- a/docs/chrome-mv3.md
+++ b/docs/chrome-mv3.md
@@ -5,55 +5,57 @@ Chrome will [mark a service worker as inactive even if an active WebSocket conne
 This causes Ably to disconnect and new messages will not be received.
 Unfortunately, this appears to be intended design so workarounds are needed to keep the service worker alive in order to continue receiving messages. Multiple workarounds are available, depending on your use-case.
 
-
 ### Using alarms
+
 Alarms will reset the service worker's inactivity timer, or wake up an inactive service worker.
 The alarm must have a period of less than 5 minutes in order to keep a service worker active consistently.
 The minimum period required depends on the actions that your service worker performs, but it has to be at most 4.9 minutes.
 Requires permission `alarms` to be added to manifest.json:
+
 ```json
 {
   // ...
-  "permissions": ["alarms"],
+  "permissions": ["alarms"]
 }
 ```
 
 ```js
-chrome.alarms.create({ periodInMinutes: 0.3 })
+chrome.alarms.create({ periodInMinutes: 0.3 });
 chrome.alarms.onAlarm.addListener(() => {
-	// This function will be called once the SW wakes up
+  // This function will be called once the SW wakes up
 });
 ```
 
 [More Info](https://developer.chrome.com/docs/extensions/reference/alarms/)
 
-
 ### Connecting to a nativeMessaging host
+
 If your Chrome extension connects to a native application, a service worker which is attached to a native application will not be marked as inactive as long as the native application is alive. To ensure that the native application exiting does not mark your service worker as inactive, make sure the connection can survive a restart of the native application.
 
 ```js
 var port = chrome.runtime.connectNative('com.example.extension');
-port.onDisconnect.addListener(function() {
+port.onDisconnect.addListener(function () {
   // Reconnect to avoid being marked as inactive
 });
-
 ```
 
 [More Info](https://developer.chrome.com/docs/apps/nativeMessaging/)
 
 ### Connecting to a tab
+
 If your Chrome extension requires broad host permissions (e.g. `*://*/*`), connecting to a tab will keep your service worker active.
 Requires `scripting` permission to be added to manifest.json:
+
 ```json
 {
   // ...
-  "permissions": ["scripting"],
+  "permissions": ["scripting"]
 }
 ```
 
 ```js
 findTab();
-chrome.runtime.onConnect.addListener(port => {
+chrome.runtime.onConnect.addListener((port) => {
   if (port.name === 'keepAlive') {
     setTimeout(() => port.disconnect(), 250e3);
     port.onDisconnect.addListener(() => findTab());
@@ -62,10 +64,12 @@ chrome.runtime.onConnect.addListener(port => {
 
 const onUpdate = (tabId, info, tab) => /^https?:/.test(info.url) && findTab([tab]);
 async function findTab(tabs) {
-  if (chrome.runtime.lastError) { /* tab was closed before setTimeout ran */ }
-  for (const {id: tabId} of tabs || await chrome.tabs.query({url: '*://*/*'})) {
+  if (chrome.runtime.lastError) {
+    /* tab was closed before setTimeout ran */
+  }
+  for (const { id: tabId } of tabs || (await chrome.tabs.query({ url: '*://*/*' }))) {
     try {
-      await chrome.scripting.executeScript({target: {tabId}, func: connect});
+      await chrome.scripting.executeScript({ target: { tabId }, func: connect });
       chrome.tabs.onUpdated.removeListener(onUpdate);
       return;
     } catch (e) {}
@@ -73,20 +77,20 @@ async function findTab(tabs) {
   chrome.tabs.onUpdated.addListener(onUpdate);
 }
 function connect() {
-  chrome.runtime.connect({name: 'keepAlive'})
-    .onDisconnect.addListener(connect);
+  chrome.runtime.connect({ name: 'keepAlive' }).onDisconnect.addListener(connect);
 }
 ```
 
 [More Info](https://developer.chrome.com/docs/extensions/reference/scripting/)
 
 ### Connecting to a port
+
 If you connect to a port, the service worker's inactivity timer will be reset. However, the port must be reconnected at an interval less than 5 minutes or the SW will be marked as inactive.
 
 ```js
-chrome.runtime.onConnect.addListener(port => {
+chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== 'foo') return;
-  port.onMessage.addListener(()=>{});
+  port.onMessage.addListener(() => {});
   port.onDisconnect.addListener(deleteTimer);
   port._timer = setTimeout(forceReconnect, 250e3, port);
 });
@@ -100,11 +104,11 @@ function deleteTimer(port) {
     delete port._timer;
   }
 }
-
 ```
 
 [More Info](https://developer.chrome.com/docs/extensions/reference/runtime/#method-connect)
 
 ### Enterprise Extensions
+
 [Enterprise extensions will continue to work on manifest v2 until January 2024](https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/).
 If your extension is installed as part of an enterprise policy, this means that you will have until January 2024 to continue using manifest v2.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lint:fix": "eslint --fix .",
     "check-closure-compiler": "grunt check-closure-compiler",
     "prepare": "npm run build",
-    "format": "prettier --write --ignore-path .gitignore src test ably.d.ts webpack.config.js Gruntfile.js scripts/cdn_deploy.js",
+    "format": "prettier --write --ignore-path .gitignore src test ably.d.ts webpack.config.js Gruntfile.js scripts/cdn_deploy.js docs/chrome-mv3.md",
     "format:check": "prettier --check --ignore-path .gitignore src test ably.d.ts webpack.config.js Gruntfile.js scripts/cdn_deploy.js",
     "sourcemap": "source-map-explorer build/ably.min.js",
     "sourcemap:noencryption": "source-map-explorer build/ably.noencryption.min.js",


### PR DESCRIPTION
Adds some workaround suggestions for keeping a service worker alive on Chrome MV3 