### PR TITLE
[CAP-49] no connection serials

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2989,7 +2989,7 @@ declare namespace Types {
     /**
      * The recovery key string can be used by another client to recover this connection's state in the recover client options property. See [connection state recover options](https://ably.com/docs/realtime/connection#connection-state-recover-options) for more information.
      */
-    recoveryKey: string;
+    recoveryKey: string | null;
     /**
      * The serial number of the last message to be received on this connection, used automatically by the library when recovering or resuming a connection. When recovering a connection explicitly, the `recoveryKey` is used in the recover client options as it contains both the key and the last message serial.
      */

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -63,7 +63,7 @@ class Channel extends EventEmitter {
     this.channelOptions = normaliseChannelOptions(channelOptions);
   }
 
-  setOptions(options: ChannelOptions): void {
+  setOptions(options?: ChannelOptions): void {
     this.channelOptions = normaliseChannelOptions(options);
   }
 

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -16,7 +16,6 @@ class Connection extends EventEmitter {
   state: string;
   key?: string;
   id?: string;
-  serial: undefined;
   errorReason: ErrorInfo | null;
 
   constructor(ably: Realtime, options: NormalisedClientOptions) {
@@ -26,7 +25,6 @@ class Connection extends EventEmitter {
     this.state = this.connectionManager.state.state;
     this.key = undefined;
     this.id = undefined;
-    this.serial = undefined;
     this.errorReason = null;
 
     this.connectionManager.on('connectionstate', (stateChange: ConnectionStateChange) => {

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -17,7 +17,6 @@ class Connection extends EventEmitter {
   key?: string;
   id?: string;
   serial: undefined;
-  recoveryKey?: string | null;
   errorReason: ErrorInfo | null;
 
   constructor(ably: Realtime, options: NormalisedClientOptions) {
@@ -28,7 +27,6 @@ class Connection extends EventEmitter {
     this.key = undefined;
     this.id = undefined;
     this.serial = undefined;
-    this.recoveryKey = undefined;
     this.errorReason = null;
 
     this.connectionManager.on('connectionstate', (stateChange: ConnectionStateChange) => {
@@ -73,6 +71,14 @@ class Connection extends EventEmitter {
   close(): void {
     Logger.logAction(Logger.LOG_MINOR, 'Connection.close()', 'connectionKey = ' + this.key);
     this.connectionManager.requestState({ state: 'closing' });
+  }
+
+  get recoveryKey(): string | null {
+    return this.createRecoveryKey();
+  }
+
+  createRecoveryKey(): string | null {
+    return this.connectionManager.createRecoveryKey();
   }
 }
 

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -100,6 +100,10 @@ class Channels extends EventEmitter {
         channel.checkPendingState();
       } else if (channel.state === 'suspended') {
         channel._attach(false, null);
+      } else if (channel.state === 'attached') {
+        // Note explicity request the state, channel.attach() would do nothing
+        // as its already attached.
+        channel.requestState('attaching');
       }
     }
   }

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -108,17 +108,6 @@ class Channels extends EventEmitter {
     }
   }
 
-  reattach(reason: ErrorInfo) {
-    for (const channelId in this.all) {
-      const channel = this.all[channelId];
-      /* NB this should not trigger for merely attaching channels, as they will
-       * be reattached anyway through the onTransportActive checkPendingState */
-      if (channel.state === 'attached') {
-        channel.requestState('attaching', reason);
-      }
-    }
-  }
-
   /* Connection interruptions (ie when the connection will no longer queue
    * events) imply connection state changes for any channel which is either
    * attached, pending, or will attempt to become attached in the future */

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -119,30 +119,6 @@ class Channels extends EventEmitter {
     }
   }
 
-  resetAttachedMsgIndicators() {
-    for (const channelId in this.all) {
-      const channel = this.all[channelId];
-      if (channel.state === 'attached') {
-        channel._attachedMsgIndicator = false;
-      }
-    }
-  }
-
-  checkAttachedMsgIndicators(connectionId: string) {
-    for (const channelId in this.all) {
-      const channel = this.all[channelId];
-      if (channel.state === 'attached' && channel._attachedMsgIndicator === false) {
-        const msg =
-          '30s after a resume, found channel which has not received an attached; channelId = ' +
-          channelId +
-          '; connectionId = ' +
-          connectionId;
-        Logger.logAction(Logger.LOG_ERROR, 'Channels.checkAttachedMsgIndicators()', msg);
-        channel.requestState('attaching');
-      }
-    }
-  }
-
   /* Connection interruptions (ie when the connection will no longer queue
    * events) imply connection state changes for any channel which is either
    * attached, pending, or will attempt to become attached in the future */

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -140,7 +140,7 @@ class Channels extends EventEmitter {
     }
   }
 
-  get(name: string, channelOptions: ChannelOptions) {
+  get(name: string, channelOptions?: ChannelOptions) {
     name = String(name);
     let channel = this.all[name];
     if (!channel) {

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -67,6 +67,17 @@ class Channels extends EventEmitter {
     });
   }
 
+  channelSerials(): { [name: string]: string } {
+    let serials: { [name: string]: string } = {};
+    for (const name of Utils.keysArray(this.all, true)) {
+      const channel = this.all[name];
+      if (channel.properties.channelSerial) {
+        serials[name] = channel.properties.channelSerial;
+      }
+    }
+    return serials;
+  }
+
   onChannelMessage(msg: ProtocolMessage) {
     const channelName = msg.channel;
     if (channelName === undefined) {

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -78,6 +78,14 @@ class Channels extends EventEmitter {
     return serials;
   }
 
+  // recoverChannels gets the given channels and sets their channel serials.
+  recoverChannels(channelSerials: { [name: string]: string }) {
+    for (const name of Utils.keysArray(channelSerials, true)) {
+      const channel = this.get(name);
+      channel.properties.channelSerial = channelSerials[name];
+    }
+  }
+
   onChannelMessage(msg: ProtocolMessage) {
     const channelName = msg.channel;
     if (channelName === undefined) {

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -26,8 +26,6 @@ interface RealtimeHistoryParams {
 
 const actions = ProtocolMessage.Action;
 const noop = function () {};
-const statechangeOp = 'statechange';
-const syncOp = 'sync';
 
 function validateChannelOptions(options?: API.Types.ChannelOptions) {
   if (options && 'params' in options && !Utils.isObject(options.params)) {
@@ -122,11 +120,6 @@ class RealtimeChannel extends Channel {
       message: 'Channel operation failed as channel state is ' + state,
     };
   }
-
-  static progressOps = {
-    statechange: statechangeOp,
-    sync: syncOp,
-  };
 
   static processListenerArgs(args: unknown[]): any[] {
     /* [event], listener, [callback] */
@@ -345,7 +338,6 @@ class RealtimeChannel extends Channel {
 
   attachImpl(): void {
     Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.attachImpl()', 'sending ATTACH message');
-    this.setInProgress(statechangeOp, true);
     const attachMsg = ProtocolMessage.fromValues({
       action: actions.ATTACH,
       channel: this.name,
@@ -422,7 +414,6 @@ class RealtimeChannel extends Channel {
       this.connectionManager.mostRecentMsg = null;
     }
     Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.detach()', 'sending DETACH message');
-    this.setInProgress(statechangeOp, true);
     const msg = ProtocolMessage.fromValues({ action: actions.DETACH, channel: this.name });
     this.sendMessage(msg, callback || noop);
   }
@@ -621,9 +612,6 @@ class RealtimeChannel extends Channel {
         const resumed = message.hasFlag('RESUMED');
         const hasPresence = message.hasFlag('HAS_PRESENCE');
         if (this.state === 'attached') {
-          /* attached operations to change options set the inprogress mutex, but leave
-           * channel in the attached state */
-          this.setInProgress(statechangeOp, false);
           if (!resumed) {
             /* On a loss of continuity, the presence set needs to be re-synced */
             this.presence.onAttached(hasPresence);
@@ -839,11 +827,6 @@ class RealtimeChannel extends Channel {
     /* Note: we don't set inProgress for pending states until the request is actually in progress */
     if (state === 'attached') {
       this.onAttached();
-      this.setInProgress(syncOp, hasPresence);
-      this.setInProgress(statechangeOp, false);
-    } else if (state === 'detached' || state === 'failed' || state === 'suspended') {
-      this.setInProgress(statechangeOp, false);
-      this.setInProgress(syncOp, false);
     }
 
     if (state === 'attached') {
@@ -963,10 +946,6 @@ class RealtimeChannel extends Channel {
       clearTimeout(this.retryTimer as NodeJS.Timeout);
       this.retryTimer = null;
     }
-  }
-
-  setInProgress(operation: string, value: unknown): void {
-    this.rest.channels.setInProgress(this, operation, value);
   }
 
   history = function (

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -410,9 +410,6 @@ class RealtimeChannel extends Channel {
   }
 
   detachImpl(callback?: ErrCallback): void {
-    if (this.connectionManager.mostRecentMsg && this.connectionManager.mostRecentMsg.channel === this.name) {
-      this.connectionManager.mostRecentMsg = null;
-    }
     Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.detach()', 'sending DETACH message');
     const msg = ProtocolMessage.fromValues({ action: actions.DETACH, channel: this.name });
     this.sendMessage(msg, callback || noop);

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -68,7 +68,6 @@ class RealtimeChannel extends Channel {
   errorReason: ErrorInfo | string | null;
   _requestedFlags: Array<API.Types.ChannelMode> | null;
   _mode?: null | number;
-  _attachedMsgIndicator: boolean;
   _attachResume: boolean;
   _decodingContext: { channelOptions: API.Types.ChannelOptions; plugins: any; baseEncodedPreviousPayload: undefined };
   _lastPayload: {
@@ -100,8 +99,6 @@ class RealtimeChannel extends Channel {
     this.errorReason = null;
     this._requestedFlags = null;
     this._mode = null;
-    /* Temporary; only used for the checkChannelsOnResume option */
-    this._attachedMsgIndicator = false;
     this._attachResume = false;
     this._decodingContext = {
       channelOptions: this.channelOptions,
@@ -616,7 +613,6 @@ class RealtimeChannel extends Channel {
       isSync = false;
     switch (message.action) {
       case actions.ATTACHED: {
-        this._attachedMsgIndicator = true;
         this.properties.attachSerial = message.channelSerial;
         this._mode = message.getMode();
         this.params = (message as any).params || {};

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -29,7 +29,7 @@ const noop = function () {};
 const statechangeOp = 'statechange';
 const syncOp = 'sync';
 
-function validateChannelOptions(options: API.Types.ChannelOptions) {
+function validateChannelOptions(options?: API.Types.ChannelOptions) {
   if (options && 'params' in options && !Utils.isObject(options.params)) {
     return new ErrorInfo('options.params must be an object', 40000, 400);
   }
@@ -82,7 +82,7 @@ class RealtimeChannel extends Channel {
   retryTimer?: number | NodeJS.Timeout | null;
   retryCount: number = 0;
 
-  constructor(realtime: Realtime, name: string, options: API.Types.ChannelOptions) {
+  constructor(realtime: Realtime, name: string, options?: API.Types.ChannelOptions) {
     super(realtime, name, options);
     Logger.logAction(Logger.LOG_MINOR, 'RealtimeChannel()', 'started; name = ' + name);
     this.realtime = realtime;
@@ -140,7 +140,7 @@ class RealtimeChannel extends Channel {
     return args;
   }
 
-  setOptions(options: API.Types.ChannelOptions, callback?: ErrCallback): void | Promise<void> {
+  setOptions(options?: API.Types.ChannelOptions, callback?: ErrCallback): void | Promise<void> {
     if (!callback) {
       if (this.rest.options.promises) {
         return Utils.promisify(this, 'setOptions', arguments);
@@ -184,8 +184,8 @@ class RealtimeChannel extends Channel {
     }
   }
 
-  _shouldReattachToSetOptions(options: API.Types.ChannelOptions) {
-    return (this.state === 'attached' || this.state === 'attaching') && (options.params || options.modes);
+  _shouldReattachToSetOptions(options?: API.Types.ChannelOptions) {
+    return (this.state === 'attached' || this.state === 'attaching') && (options?.params || options?.modes);
   }
 
   publish(...args: any[]): void | Promise<void> {

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -21,7 +21,7 @@ interface RealtimeHistoryParams {
   direction?: string;
   limit?: number;
   untilAttach?: boolean;
-  from_serial?: number;
+  from_serial?: string;
 }
 
 const actions = ProtocolMessage.Action;
@@ -60,8 +60,8 @@ class RealtimeChannel extends Channel {
     API.Types.messageCallback<Message>,
     Map<API.Types.MessageFilter, API.Types.messageCallback<Message>[]>
   >;
-  syncChannelSerial?: number | null;
-  properties: { attachSerial: number | null | undefined };
+  syncChannelSerial?: string | null;
+  properties: { attachSerial: string | null | undefined };
   errorReason: ErrorInfo | string | null;
   _requestedFlags: Array<API.Types.ChannelMode> | null;
   _mode?: null | number;
@@ -70,7 +70,7 @@ class RealtimeChannel extends Channel {
   _decodingContext: { channelOptions: API.Types.ChannelOptions; plugins: any; baseEncodedPreviousPayload: undefined };
   _lastPayload: {
     messageId?: string | null;
-    protocolMessageChannelSerial?: number | null;
+    protocolMessageChannelSerial?: string | null;
     decodeFailureRecoveryInProgress: null | boolean;
   };
   _allChannelChanges: EventEmitter;

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -61,7 +61,10 @@ class RealtimeChannel extends Channel {
     Map<API.Types.MessageFilter, API.Types.messageCallback<Message>[]>
   >;
   syncChannelSerial?: string | null;
-  properties: { attachSerial: string | null | undefined };
+  properties: {
+    attachSerial: string | null | undefined;
+    channelSerial: string | null | undefined;
+  };
   errorReason: ErrorInfo | string | null;
   _requestedFlags: Array<API.Types.ChannelMode> | null;
   _mode?: null | number;
@@ -91,6 +94,7 @@ class RealtimeChannel extends Channel {
     this.syncChannelSerial = undefined;
     this.properties = {
       attachSerial: undefined,
+      channelSerial: undefined,
     };
     this.setOptions(options);
     this.errorReason = null;
@@ -349,6 +353,9 @@ class RealtimeChannel extends Channel {
       action: actions.ATTACH,
       channel: this.name,
       params: this.channelOptions.params,
+      // RTL4c1: Includes the channel serial to resume from a previous message
+      // or attachment.
+      channelSerial: this.properties.channelSerial,
     });
     if (this._requestedFlags) {
       attachMsg.encodeModesToFlags(this._requestedFlags);
@@ -596,6 +603,15 @@ class RealtimeChannel extends Channel {
   }
 
   onMessage(message: ProtocolMessage): void {
+    if (
+      message.action === actions.ATTACHED ||
+      message.action === actions.MESSAGE ||
+      message.action === actions.PRESENCE
+    ) {
+      // RTL15b
+      this.setChannelSerial(message.channelSerial);
+    }
+
     let syncChannelSerial,
       isSync = false;
     switch (message.action) {
@@ -794,6 +810,11 @@ class RealtimeChannel extends Channel {
       'name = ' + this.name + ', current state = ' + this.state + ', notifying state ' + state
     );
     this.clearStateTimer();
+
+    // RTP5a1
+    if (Utils.arrIn(['detached', 'suspended', 'failed'], state)) {
+      this.properties.channelSerial = null;
+    }
 
     if (state === this.state) {
       return;
@@ -1009,6 +1030,20 @@ class RealtimeChannel extends Channel {
       90001,
       400
     );
+  }
+
+  setChannelSerial(channelSerial?: string | null): void {
+    Logger.logAction(
+      Logger.LOG_MICRO,
+      'RealtimeChannel.setChannelSerial()',
+      'Updating channel serial; serial = ' + channelSerial + '; previous = ' + this.properties.channelSerial
+    );
+
+    // RTP17h: Only update the channel serial if its present (it won't always
+    // be set).
+    if (channelSerial) {
+      this.properties.channelSerial = channelSerial;
+    }
   }
 }
 

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -468,8 +468,7 @@ class RealtimePresence extends Presence {
   }
 
   _ensureMyMembersPresent(): void {
-    const members = this.members,
-      myMembers = this._myMembers,
+    const myMembers = this._myMembers,
       reenterCb = (err?: ErrorInfo | null) => {
         if (err) {
           const msg = 'Presence auto-re-enter failed: ' + err.toString();
@@ -481,17 +480,15 @@ class RealtimePresence extends Presence {
       };
 
     for (const memberKey in myMembers.map) {
-      if (!(memberKey in members.map)) {
-        const entry = myMembers.map[memberKey];
-        Logger.logAction(
-          Logger.LOG_MICRO,
-          'RealtimePresence._ensureMyMembersPresent()',
-          'Auto-reentering clientId "' + entry.clientId + '" into the presence set'
-        );
-        // RTP17g: Send ENTER containing the member id, clientId and data
-        // attributes.
-        this._enterOrUpdateClient(entry.id, entry.clientId, entry.data, 'enter', reenterCb);
-      }
+      const entry = myMembers.map[memberKey];
+      Logger.logAction(
+        Logger.LOG_MICRO,
+        'RealtimePresence._ensureMyMembersPresent()',
+        'Auto-reentering clientId "' + entry.clientId + '" into the presence set'
+      );
+      // RTP17g: Send ENTER containing the member id, clientId and data
+      // attributes.
+      this._enterOrUpdateClient(entry.id, entry.clientId, entry.data, 'enter', reenterCb);
     }
   }
 

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -494,7 +494,6 @@ class RealtimePresence extends Presence {
         // RTP17g: Send ENTER containing the member id, clientId and data
         // attributes.
         this._enterOrUpdateClient(entry.id, entry.clientId, entry.data, 'enter', reenterCb);
-        delete myMembers.map[memberKey];
       }
     }
   }

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -381,8 +381,6 @@ class RealtimePresence extends Presence {
     /* if this is the last (or only) message in a sequence of sync updates, end the sync */
     if (isSync && !syncCursor) {
       members.endSync();
-      /* RTP5c2: re-enter our own members if they haven't shown up in the sync */
-      this._ensureMyMembersPresent();
       this.channel.setInProgress(RealtimeChannel.progressOps.sync, false);
       this.channel.syncChannelSerial = null;
     }
@@ -406,8 +404,10 @@ class RealtimePresence extends Presence {
     } else {
       this._synthesizeLeaves(this.members.values());
       this.members.clear();
-      this._ensureMyMembersPresent();
     }
+
+    // RTP17f: Re-enter own members when moving into the attached state.
+    this._ensureMyMembersPresent();
 
     /* NB this must be after the _ensureMyMembersPresent call, which may add items to pendingPresence */
     const pendingPresence = this.pendingPresence,

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -381,7 +381,6 @@ class RealtimePresence extends Presence {
     /* if this is the last (or only) message in a sequence of sync updates, end the sync */
     if (isSync && !syncCursor) {
       members.endSync();
-      this.channel.setInProgress(RealtimeChannel.progressOps.sync, false);
       this.channel.syncChannelSerial = null;
     }
 

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -23,7 +23,7 @@ interface RealtimeHistoryParams {
   direction?: string;
   limit?: number;
   untilAttach?: boolean;
-  from_serial?: number | null;
+  from_serial?: string | null;
 }
 
 const noop = function () {};

--- a/src/common/lib/transport/comettransport.ts
+++ b/src/common/lib/transport/comettransport.ts
@@ -207,7 +207,7 @@ abstract class CometTransport extends Transport {
 
     /* the connectionKey in a comet connected response is really
      * <instId>-<connectionKey> */
-    const connectionStr = message.connectionKey;
+    const connectionStr = message.connectionDetails?.connectionKey;
     Transport.prototype.onConnect.call(this, message);
 
     const baseConnectionUri = (this.baseUri as string) + connectionStr;

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1162,22 +1162,12 @@ class ConnectionManager extends EventEmitter {
       Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.setConnection()', 'Resetting msgSerial');
       this.msgSerial = 0;
     }
-    /* but do need to reattach channels, for channels that were previously in
-     * the attached state even though the connection mode was 'clean' due to a
-     * freshness check - see https://github.com/ably/ably-js/issues/394 */
     if (this.connectionId !== connectionId) {
       Logger.logAction(
         Logger.LOG_MINOR,
         'ConnectionManager.setConnection()',
         'New connectionId; reattaching any attached channels'
       );
-      /* Wait till next tick before reattaching channels, so that connection
-       * state will be updated and so that it will be applied after
-       * Channels#onTransportUpdate, else channels will not have an ATTACHED
-       * sent twice (once from this and once from that). */
-      Platform.Config.nextTick(() => {
-        this.realtime.channels.reattach();
-      });
     }
     this.realtime.connection.id = this.connectionId = connectionId;
     this.realtime.connection.key = this.connectionKey = connectionDetails.connectionKey;

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1183,6 +1183,19 @@ class ConnectionManager extends EventEmitter {
     this.unpersistConnection();
   }
 
+  createRecoveryKey(): string | null {
+    // RTN16g2.
+    if (!this.connectionKey) {
+      return null;
+    }
+
+    return JSON.stringify({
+      connectionKey: this.connectionKey,
+      msgSerial: this.msgSerial,
+      channelSerials: this.realtime.channels.channelSerials(),
+    });
+  }
+
   /* force: set the connectionSerial even if it's less than the current
    * connectionSerial. Used for new connections.
    * Returns true iff the message was rejected as a duplicate. */

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1059,6 +1059,9 @@ class ConnectionManager extends EventEmitter {
     if (connIdChanged || recoverFailure) {
       Logger.logAction(Logger.LOG_MINOR, 'ConnectionManager.setConnection()', 'Resetting msgSerial');
       this.msgSerial = 0;
+      // RTN19a2: In the event of a new connectionId, previous msgSerials are
+      // meaningless.
+      this.queuedMessages.resetSendAttempted();
     }
     if (this.connectionId !== connectionId) {
       Logger.logAction(

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -112,15 +112,11 @@ export class TransportParams {
         break;
       case 'resume':
         params.resume = this.connectionKey as string;
-        if (this.connectionSerial !== undefined) {
-          params.connectionSerial = this.connectionSerial;
-        }
         break;
       case 'recover': {
         const match = (options.recover as string).split(':');
         if (match) {
           params.recover = match[0];
-          params.connectionSerial = match[1];
         }
         break;
       }

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -680,7 +680,7 @@ class ConnectionManager extends EventEmitter {
     );
 
     const onReadyToUpgrade = (err?: ErrorInfo) => {
-      let oldProtocol: Protocol | null;
+      let oldProtocol: Protocol | null = null;
       if (err) {
         Logger.logAction(
           Logger.LOG_ERROR,
@@ -751,74 +751,66 @@ class ConnectionManager extends EventEmitter {
         'ConnectionManager.scheduleTransportActivation()',
         'Syncing transport; transport = ' + transport
       );
-      this.sync(transport, syncSerial, (syncErr: Error, connectionId: string, postSyncSerial: number) => {
-        /* If there's been some problem with syncing (and the connection hasn't
-         * closed or something in the meantime), we have a problem -- we can't
-         * just fall back on the old transport, as we don't know whether
-         * realtime got the sync -- if it did, the old transport is no longer
-         * valid. To be safe, we disconnect both and start again from scratch. */
-        if (syncErr) {
-          if (this.state === this.states.synchronizing) {
-            Logger.logAction(
-              Logger.LOG_ERROR,
-              'ConnectionManager.scheduleTransportActivation()',
-              'Unexpected error attempting to sync transport; transport = ' + transport + '; err = ' + syncErr
-            );
-            this.disconnectAllTransports();
-          }
-          return;
-        }
-        const finishUpgrade = () => {
+
+      const finishUpgrade = () => {
+        Logger.logAction(
+          Logger.LOG_MINOR,
+          'ConnectionManager.scheduleTransportActivation()',
+          'Activating transport; transport = ' + transport
+        );
+
+        // Send ACTIVATE to tell the server to make this transport the
+        // active transport, which suspends channels until we re-attach.
+        transport.send(
+          ProtocolMessage.fromValues({
+            action: actions.ACTIVATE,
+          })
+        );
+
+        this.activateTransport(error, transport, connectionId, connectionDetails, 0);
+        /* Restore pre-sync state. If state has changed in the meantime,
+         * don't touch it -- since the websocket transport waits a tick before
+         * disposing itself, it's possible for it to have happily synced
+         * without err while, unknown to it, the connection has closed in the
+         * meantime and the ws transport is scheduled for death */
+        if (this.state === this.states.synchronizing) {
+          Logger.logAction(
+            Logger.LOG_MICRO,
+            'ConnectionManager.scheduleTransportActivation()',
+            'Pre-upgrade protocol idle, sending queued messages on upgraded transport; transport = ' + transport
+          );
+          this.state = this.states.connected;
+        } else {
           Logger.logAction(
             Logger.LOG_MINOR,
             'ConnectionManager.scheduleTransportActivation()',
-            'Activating transport; transport = ' + transport
+            'Pre-upgrade protocol idle, but state is now ' + this.state.state + ', so leaving unchanged'
           );
-          this.activateTransport(error, transport, connectionId, connectionDetails, postSyncSerial);
-          /* Restore pre-sync state. If state has changed in the meantime,
-           * don't touch it -- since the websocket transport waits a tick before
-           * disposing itself, it's possible for it to have happily synced
-           * without err while, unknown to it, the connection has closed in the
-           * meantime and the ws transport is scheduled for death */
-          if (this.state === this.states.synchronizing) {
-            Logger.logAction(
-              Logger.LOG_MICRO,
-              'ConnectionManager.scheduleTransportActivation()',
-              'Pre-upgrade protocol idle, sending queued messages on upgraded transport; transport = ' + transport
-            );
-            this.state = this.states.connected;
-          } else {
-            Logger.logAction(
-              Logger.LOG_MINOR,
-              'ConnectionManager.scheduleTransportActivation()',
-              'Pre-upgrade protocol idle, but state is now ' + this.state.state + ', so leaving unchanged'
-            );
-          }
-          if (this.state.sendEvents) {
-            this.sendQueuedMessages();
-          }
-        };
-
-        /* Wait until sync is done and old transport is idle before activating new transport. This
-         * guarantees that messages arrive at realtime in the same order they are sent.
-         *
-         * If a message times out on the old transport, since it's still the active transport the
-         * message will be requeued. deactivateTransport will see the pending transport and notify
-         * the `connecting` state without starting a new connection, so the new transport can take
-         * over once deactivateTransport clears the old protocol's queue.
-         *
-         * If there is no old protocol, that meant that we weren't in the connected state at the
-         * beginning of the sync - likely the base transport died just before the sync. So can just
-         * finish the upgrade. If we're actually in closing/failed rather than connecting, that's
-         * fine, activatetransport will deal with that. */
-        if (oldProtocol) {
-          /* Most of the time this will be already true: the new-transport sync will have given
-           * enough time for in-flight messages on the old transport to complete. */
-          oldProtocol.onceIdle(finishUpgrade);
-        } else {
-          finishUpgrade();
         }
-      });
+        if (this.state.sendEvents) {
+          this.sendQueuedMessages();
+        }
+      };
+
+      /* Wait until sync is done and old transport is idle before activating new transport. This
+       * guarantees that messages arrive at realtime in the same order they are sent.
+       *
+       * If a message times out on the old transport, since it's still the active transport the
+       * message will be requeued. deactivateTransport will see the pending transport and notify
+       * the `connecting` state without starting a new connection, so the new transport can take
+       * over once deactivateTransport clears the old protocol's queue.
+       *
+       * If there is no old protocol, that meant that we weren't in the connected state at the
+       * beginning of the sync - likely the base transport died just before the sync. So can just
+       * finish the upgrade. If we're actually in closing/failed rather than connecting, that's
+       * fine, activatetransport will deal with that. */
+      if (oldProtocol) {
+        /* Most of the time this will be already true: the new-transport sync will have given
+         * enough time for in-flight messages on the old transport to complete. */
+        oldProtocol.onceIdle(finishUpgrade);
+      } else {
+        finishUpgrade();
+      }
     };
 
     // No point waiting for pending attaches if there's no active transport, just sync and
@@ -1128,33 +1120,6 @@ class ConnectionManager extends EventEmitter {
         return !transport.isConnected;
       })
     );
-  }
-
-  /**
-   * Called when activating a new transport, to ensure message delivery
-   * on the new transport synchronises with the messages already received
-   */
-  sync(transport: Transport, requestedSyncSerial: number, callback: Function): void {
-    const timeout = setTimeout(function () {
-      transport.off('sync');
-      callback(new ErrorInfo('Timeout waiting for sync response', 50000, 500));
-    }, this.options.timeouts.realtimeRequestTimeout);
-
-    /* send sync request */
-    const syncMessage = ProtocolMessage.fromValues({
-      action: actions.SYNC,
-      connectionKey: this.connectionKey,
-    });
-
-    if (requestedSyncSerial !== undefined) {
-      syncMessage.connectionSerial = requestedSyncSerial;
-    }
-    transport.send(syncMessage);
-
-    transport.once('sync', function (connectionId: string, syncSerial: number) {
-      clearTimeout(timeout);
-      callback(null, connectionId, syncSerial);
-    });
   }
 
   setConnection(

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1240,21 +1240,11 @@ class ConnectionManager extends EventEmitter {
         return true;
       }
       this.realtime.connection.serial = this.connectionSerial = connectionSerial;
-      this.setRecoveryKey();
     }
   }
 
   clearConnectionSerial(): void {
     this.realtime.connection.serial = this.connectionSerial = undefined;
-    this.clearRecoveryKey();
-  }
-
-  setRecoveryKey(): void {
-    this.realtime.connection.recoveryKey = this.connectionKey + ':' + this.connectionSerial + ':' + this.msgSerial;
-  }
-
-  clearRecoveryKey(): void {
-    this.realtime.connection.recoveryKey = null;
   }
 
   checkConnectionStateFreshness(): void {
@@ -1280,7 +1270,7 @@ class ConnectionManager extends EventEmitter {
    */
   persistConnection(): void {
     if (haveSessionStorage()) {
-      const recoveryKey = this.realtime.connection.recoveryKey;
+      const recoveryKey = this.createRecoveryKey();
       if (recoveryKey) {
         setSessionRecoverData({
           recoveryKey: recoveryKey,
@@ -2059,7 +2049,6 @@ class ConnectionManager extends EventEmitter {
      * so Ably can dedup if the previous send succeeded */
     if (pendingMessage.ackRequired && !pendingMessage.sendAttempted) {
       msg.msgSerial = this.msgSerial++;
-      this.setRecoveryKey();
     }
     try {
       (this.activeProtocol as Protocol).send(pendingMessage);

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -205,7 +205,6 @@ class ConnectionManager extends EventEmitter {
   mostRecentMsg: ProtocolMessage | null;
   forceFallbackHost: boolean;
   connectCounter: number;
-  channelResumeCheckTimer?: number | NodeJS.Timeout;
   transitionTimer?: number | NodeJS.Timeout | null;
   suspendTimer?: number | NodeJS.Timeout | null;
   retryTimer?: number | NodeJS.Timeout | null;
@@ -1042,7 +1041,6 @@ class ConnectionManager extends EventEmitter {
         (currentProtocol as Protocol).clearPendingMessages();
       });
       this.activeProtocol = this.host = null;
-      clearTimeout(this.channelResumeCheckTimer as number);
     }
 
     this.emit('transport.inactive', transport);
@@ -1180,22 +1178,6 @@ class ConnectionManager extends EventEmitter {
       Platform.Config.nextTick(() => {
         this.realtime.channels.reattach();
       });
-    } else if (this.options.checkChannelsOnResume) {
-      /* For attached channels, set the attached msg indicator variable to false,
-       * wait 30s, and check we got an attached for each one.
-       * 30s was chosen to be 5s longer than the transport idle timeout expire
-       * time, in an attempt to avoid false positives due to a transport
-       * silently failing immediately after a resume */
-      Logger.logAction(
-        Logger.LOG_MINOR,
-        'ConnectionManager.setConnection()',
-        'Same connectionId; checkChannelsOnResume is enabled'
-      );
-      clearTimeout(this.channelResumeCheckTimer as number);
-      this.realtime.channels.resetAttachedMsgIndicators();
-      this.channelResumeCheckTimer = setTimeout(() => {
-        this.realtime.channels.checkAttachedMsgIndicators(connectionId);
-      }, 30000);
     }
     this.realtime.connection.id = this.connectionId = connectionId;
     this.realtime.connection.key = this.connectionKey = connectionDetails.connectionKey;

--- a/src/common/lib/transport/messagequeue.ts
+++ b/src/common/lib/transport/messagequeue.ts
@@ -64,6 +64,12 @@ class MessageQueue extends EventEmitter {
     this.completeMessages(0, Number.MAX_SAFE_INTEGER || Number.MAX_VALUE, err);
   }
 
+  resetSendAttempted(): void {
+    for (let msg of this.messages) {
+      msg.sendAttempted = false;
+    }
+  }
+
   clear(): void {
     Logger.logAction(Logger.LOG_MICRO, 'MessageQueue.clear()', 'clearing ' + this.messages.length + ' messages');
     this.messages = [];

--- a/src/common/lib/transport/transport.ts
+++ b/src/common/lib/transport/transport.ts
@@ -33,7 +33,6 @@ const disconnectMessage = ProtocolMessage.fromValues({ action: actions.DISCONNEC
  * failed           error
  * disposed
  * connected        null error, connectionSerial, connectionId, connectionDetails
- * sync             connectionSerial, connectionId
  * event            channel message object
  */
 
@@ -154,13 +153,10 @@ abstract class Transport extends EventEmitter {
         this.emit('nack', message.msgSerial, message.count, message.error);
         break;
       case actions.SYNC:
-        if (message.connectionId !== undefined) {
-          /* a transport SYNC */
-          this.emit('sync', message.connectionId, message.connectionId);
-          break;
-        }
-        /* otherwise it's a channel SYNC, so handle it in the channel */
         this.connectionManager.onChannelMessage(message, this);
+        break;
+      case actions.ACTIVATE:
+        // Ignored.
         break;
       case actions.AUTH:
         this.auth.authorize(function (err: ErrorInfo) {

--- a/src/common/lib/types/presencemessage.ts
+++ b/src/common/lib/types/presencemessage.ts
@@ -47,6 +47,7 @@ class PresenceMessage {
    * @return {*}
    */
   toJSON(): {
+    id?: string;
     clientId?: string;
     action: number;
     data: string | Buffer | Uint8Array;
@@ -70,6 +71,7 @@ class PresenceMessage {
       }
     }
     return {
+      id: this.id,
       clientId: this.clientId,
       /* Convert presence action back to an int for sending to Ably */
       action: toActionValue(this.action as string),

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -57,8 +57,7 @@ function toStringArray(array?: any[]): string {
   return '[ ' + result.join(', ') + ' ]';
 }
 
-const simpleAttributes =
-  'id channel channelSerial connectionId connectionKey connectionSerial count msgSerial timestamp'.split(' ');
+const simpleAttributes = 'id channel channelSerial connectionId connectionKey count msgSerial timestamp'.split(' ');
 
 class ProtocolMessage {
   action?: number;
@@ -69,7 +68,6 @@ class ProtocolMessage {
   error?: ErrorInfo;
   connectionId?: string;
   connectionKey?: string;
-  connectionSerial?: number;
   channel?: string;
   channelSerial?: string | null;
   msgSerial?: number;

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -159,37 +159,6 @@ class ProtocolMessage {
     result += ']';
     return result;
   };
-
-  /* Only valid for channel messages */
-  static isDuplicate = function (a: any, b: any): boolean {
-    if (a && b) {
-      if (
-        (a.action === actions.MESSAGE || a.action === actions.PRESENCE) &&
-        a.action === b.action &&
-        a.channel === b.channel &&
-        a.id === b.id
-      ) {
-        if (a.action === actions.PRESENCE) {
-          return true;
-        } else if (a.messages.length === b.messages.length) {
-          for (let i = 0; i < a.messages.length; i++) {
-            const aMessage = a.messages[i];
-            const bMessage = b.messages[i];
-            if (
-              (aMessage.extras && aMessage.extras.delta && aMessage.extras.delta.format) !==
-              (bMessage.extras && bMessage.extras.delta && bMessage.extras.delta.format)
-            ) {
-              return false;
-            }
-          }
-
-          return true;
-        }
-      }
-    }
-
-    return false;
-  };
 }
 
 export default ProtocolMessage;

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -70,7 +70,7 @@ class ProtocolMessage {
   connectionKey?: string;
   connectionSerial?: number;
   channel?: string;
-  channelSerial?: number | null;
+  channelSerial?: string | null;
   msgSerial?: number;
   messages?: Message[];
   presence?: PresenceMessage[];

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -23,6 +23,7 @@ const actions = {
   MESSAGE: 15,
   SYNC: 16,
   AUTH: 17,
+  ACTIVATE: 18,
 };
 
 const ActionName: string[] = [];

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -76,7 +76,7 @@ const Defaults = {
   maxMessageSize: 65536,
 
   version,
-  apiVersion: '1.2',
+  apiVersion: '2',
   agent,
   getHost,
   getPort,

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -9,7 +9,6 @@ export type RestAgentOptions = {
 export default interface ClientOptions extends API.Types.ClientOptions {
   restAgentOptions?: RestAgentOptions;
   pushFullWait?: boolean;
-  checkChannelsOnResume?: boolean;
   agents?: string[];
 }
 

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -708,7 +708,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 },
                 function (cb) {
                   var channelUpdated = false;
-                  channel._allChannelChanges.on('update', function () {
+                  // attached or update: in case this is happening in parallel with
+                  // a transport upgrade, we might flip to attaching, meaning it'll come
+                  // through as attached not update
+                  channel._allChannelChanges.on(['attached', 'update'], function () {
                     channelUpdated = true;
                   });
 
@@ -737,7 +740,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 },
                 function (cb) {
                   var channelUpdated = false;
-                  channel._allChannelChanges.on('update', function () {
+                  channel._allChannelChanges.on(['attached', 'update'], function () {
                     channelUpdated = true;
                   });
 

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -134,11 +134,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime.connection.on('connected', function (stateChange) {
           try {
             expect(stateChange.reason.code).to.equal(
-              80008,
+              80018,
               'verify unrecoverable-connection error set in stateChange.reason'
             );
             expect(realtime.connection.errorReason.code).to.equal(
-              80008,
+              80018,
               'verify unrecoverable-connection error set in connection.errorReason'
             );
             expect(realtime.connection.connectionManager.msgSerial).to.equal(

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -68,15 +68,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime = helper.AblyRealtime({ log: { level: 4 } });
         realtime.connection.on('connected', function () {
           try {
-            expect(realtime.connection.serial).to.equal(-1, 'verify serial is -1 on connect');
-            expect(realtime.connection.recoveryKey).to.equal(
-              realtime.connection.key +
-                ':' +
-                realtime.connection.serial +
-                ':' +
-                realtime.connection.connectionManager.msgSerial,
-              'verify correct recovery key'
-            );
+            const recoveryContext = JSON.parse(realtime.connection.recoveryKey);
+            expect(recoveryContext.connectionKey).to.equal(realtime.connection.key);
+            expect(recoveryContext.msgSerial).to.equal(realtime.connection.connectionManager.msgSerial);
           } catch (err) {
             closeAndFinish(done, realtime, err);
             return;
@@ -93,34 +87,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 function (cb) {
                   channel.subscribe(function () {
                     setTimeout(function () {
-                      expect(realtime.connection.serial).to.equal(0, 'verify serial is 0 after message received');
-                      if (realtime.connection.serial !== 0) {
-                        var cm = realtime.connection.connectionManager;
-                        console.log(
-                          'connectionAttributes test: connection serial is ' +
-                            realtime.connection.serial +
-                            '; active transport' +
-                            (cm.activeProtocol && cm.activeProtocol.transport && cm.activeProtocol.transport.shortName)
-                        );
-                      }
-                      expect(realtime.connection.recoveryKey).to.equal(
-                        realtime.connection.key +
-                          ':' +
-                          realtime.connection.serial +
-                          ':' +
-                          realtime.connection.connectionManager.msgSerial,
-                        'verify recovery key still correct'
-                      );
+                      const recoveryContext = JSON.parse(realtime.connection.recoveryKey);
+                      expect(recoveryContext.connectionKey).to.equal(realtime.connection.key);
+                      expect(recoveryContext.msgSerial).to.equal(realtime.connection.connectionManager.msgSerial);
                       cb();
                     }, 0);
                   });
                 },
                 function (cb) {
                   channel.publish('name', 'data', cb);
-                  expect(realtime.connection.serial).to.equal(
-                    -1,
-                    'verify serial is -1 after publish begun but before message received'
-                  );
                 },
               ],
               function (err) {
@@ -148,8 +123,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     });
 
     it('unrecoverableConnection', function (done) {
-      var realtime,
-        fakeRecoveryKey = '_____!ablyjs_test_fake-key____:5:3';
+      var realtime;
+      const fakeRecoveryKey = JSON.stringify({
+        connectionKey: '_____!ablyjs_test_fake-key____',
+        msgSerial: 3,
+        channelSerials: {},
+      });
       try {
         realtime = helper.AblyRealtime({ recover: fakeRecoveryKey });
         realtime.connection.on('connected', function (stateChange) {
@@ -162,7 +141,6 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               80008,
               'verify unrecoverable-connection error set in connection.errorReason'
             );
-            expect(realtime.connection.serial).to.equal(-1, 'verify serial is -1 (new connection), not 5');
             expect(realtime.connection.connectionManager.msgSerial).to.equal(
               0,
               'verify msgSerial is 0 (new connection), not 3'

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -334,10 +334,6 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             try {
               if (message.action === 4) {
                 expect(message.connectionDetails.connectionKey).to.be.ok;
-                expect(message.connectionDetails.connectionKey).to.equal(
-                  message.connectionKey,
-                  'connection keys should match'
-                );
                 message.connectionDetails.connectionKey = 'importantConnectionKey';
                 message.connectionDetails.clientId = 'customClientId';
               }

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -34,7 +34,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             var transport = realtime.connection.connectionManager.activeProtocol.transport;
             var connectUri = helper.isWebsocket(transport) ? transport.uri : transport.recvRequest.uri;
             try {
-              expect(connectUri.indexOf('v=1.2') > -1, 'Check uri includes v=1.2').to.be.ok;
+              expect(connectUri.indexOf('v=2') > -1, 'Check uri includes v=2').to.be.ok;
             } catch (err) {
               closeAndFinish(done, realtime, err);
               return;

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -130,7 +130,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         realtime = helper.AblyRealtime({
           key: keyStr,
           useTokenAuth: true,
-          defaultTokenParams: { clientId: '*', ttl: 12345 },
+          defaultTokenParams: { clientId: '*', ttl: 123456 },
         });
         expect(realtime.auth.clientId).to.equal(undefined);
         realtime.connection.on('connected', function () {
@@ -138,7 +138,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             expect(realtime.auth.tokenDetails.clientId).to.equal('*');
             /* auth.clientId now does inherit the value '*' -- RSA7b4 */
             expect(realtime.auth.clientId).to.equal('*');
-            expect(realtime.auth.tokenDetails.expires - realtime.auth.tokenDetails.issued).to.equal(12345);
+            expect(realtime.auth.tokenDetails.expires - realtime.auth.tokenDetails.issued).to.equal(123456);
           } catch (err) {
             closeAndFinish(done, realtime, err);
             return;

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -619,53 +619,6 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       };
     });
 
-    it('duplicateMsgId', function (done) {
-      var realtime = helper.AblyRealtime({ log: { level: 4 } }),
-        channel = realtime.channels.get('duplicateMsgId'),
-        received = 0;
-
-      channel.subscribe(function (_msg) {
-        received++;
-      });
-      channel.once('attached', function () {
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 15,
-            channel: channel.name,
-            id: 'foo:0',
-            connectionSerial: 0,
-            messages: [{ name: null, data: null }],
-          })
-        );
-
-        /* add some nonmessage channel message inbetween */
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 11,
-            channel: channel.name,
-          })
-        );
-
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 15,
-            channel: channel.name,
-            id: 'foo:0',
-            connectionSerial: 1,
-            messages: [{ name: null, data: null }],
-          })
-        );
-
-        try {
-          expect(received).to.equal(1);
-        } catch (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        closeAndFinish(done, realtime);
-      });
-    });
-
     it('duplicateConnectionId', function (done) {
       var realtime = helper.AblyRealtime({ log: { level: 4 } }),
         channel = realtime.channels.get('duplicateConnectionId'),

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -619,45 +619,6 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       };
     });
 
-    it('duplicateConnectionId', function (done) {
-      var realtime = helper.AblyRealtime({ log: { level: 4 } }),
-        channel = realtime.channels.get('duplicateConnectionId'),
-        received = 0;
-
-      channel.subscribe(function (_msg) {
-        received++;
-      });
-      channel.once('attached', function () {
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 15,
-            channel: channel.name,
-            id: 'foo:0',
-            connectionSerial: 0,
-            messages: [{ name: null, data: null }],
-          })
-        );
-
-        realtime.connection.connectionManager.activeProtocol.getTransport().onProtocolMessage(
-          createPM({
-            action: 15,
-            channel: channel.name,
-            id: 'bar:0',
-            connectionSerial: 0,
-            messages: [{ name: null, data: null }],
-          })
-        );
-
-        try {
-          expect(received).to.equal(1);
-        } catch (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        closeAndFinish(done, realtime);
-      });
-    });
-
     /* Authenticate with a clientId and ensure that the clientId is not sent in the Message
 	   and is implicitly added when published */
     it('implicit_client_id_0', function (done) {

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -297,7 +297,6 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 /* Sabotage the resume */
                 (connection.connectionManager.connectionKey = '_____!ablyjs_test_fake-key____'),
                   (connection.connectionManager.connectionId = 'ablyjs_tes');
-                connection.connectionManager.connectionSerial = 17;
                 connection.connectionManager.msgSerial = 15;
                 connection.once('disconnected', function () {
                   cb();
@@ -308,16 +307,12 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 connection.once('connected', function (stateChange) {
                   try {
                     expect(stateChange.reason && stateChange.reason.code).to.equal(
-                      80008,
+                      80018,
                       'Unable to recover connection correctly set in the stateChange'
                     );
                     expect(attachedChannel.state).to.equal('attaching', 'Attached channel went into attaching');
                     expect(suspendedChannel.state).to.equal('attaching', 'Suspended channel went into attaching');
                     expect(connection.connectionManager.msgSerial).to.equal(0, 'Check msgSerial is reset to 0');
-                    expect(connection.connectionManager.connectionSerial).to.equal(
-                      -1,
-                      'Check connectionSerial is reset by the new CONNECTED'
-                    );
                     expect(
                       connection.connectionManager.connectionId !== 'ablyjs_tes',
                       'Check connectionId is set by the new CONNECTED'

--- a/test/realtime/upgrade.test.js
+++ b/test/realtime/upgrade.test.js
@@ -498,10 +498,10 @@ define(['shared_helper', 'async', 'chai', 'ably'], function (helper, async, chai
             /* on upgrade failure */
             realtime.connection.once('update', function (stateChange) {
               try {
-                expect(stateChange.reason.code).to.equal(80008, 'Check correct (unrecoverable connection) error');
+                expect(stateChange.reason.code).to.equal(80018, 'Check correct (unrecoverable connection) error');
                 expect(stateChange.current).to.equal('connected', 'Check current is connected');
                 expect(realtime.connection.errorReason.code).to.equal(
-                  80008,
+                  80018,
                   'Check error set in connection.errorReason'
                 );
                 expect(realtime.connection.state).to.equal('connected', 'Check still connected');

--- a/test/rest/http.test.js
+++ b/test/rest/http.test.js
@@ -50,8 +50,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         }
       }
 
-      var do_inner = Ably.Realtime.Platform.Http.do;
-      Ably.Rest.Platform.Http.do = testRequestHandler;
+      rest.http.do = testRequestHandler;
 
       // Call all methods that use rest http calls
       rest.auth.requestToken();
@@ -60,9 +59,6 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       var channel = rest.channels.get('http_test_channel');
       channel.publish('test', 'Testing http headers');
       channel.presence.get();
-
-      // Clean interceptors from Http.do
-      Ably.Rest.Platform.Http.do = do_inner;
 
       done();
     });

--- a/test/rest/http.test.js
+++ b/test/rest/http.test.js
@@ -30,7 +30,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
           // This test should not directly validate version against Defaults.version, as
           // ultimately the version header has been derived from that value.
-          expect(headers['X-Ably-Version']).to.equal('1.2', 'Verify current version number');
+          expect(headers['X-Ably-Version']).to.equal('2', 'Verify current version number');
           expect(headers['Ably-Agent'].indexOf('ably-js/' + Defaults.version) > -1, 'Verify agent').to.be.ok;
           expect(headers['Ably-Agent'].indexOf('custom-agent/0.1.2') > -1, 'Verify custom agent').to.be.ok;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es3",
+    "target": "es5",
     "module": "commonjs",
     "lib": ["ES5", "DOM", "webworker"],
     "strict": true,


### PR DESCRIPTION
Implements no connection serials as described by https://github.com/ably/specification/pull/88/files, and upgrade described by https://github.com/ably/realtime/issues/4216#issuecomment-1221407649.

## Changes
### Protocol version
Updates the ably protocol version to `2.0`

**Spec**
* RSC7a: replaces version string `1.2` with `2.0`

**Testing**
This is already tested by `rest/http.test.js` and `realtime/init.test.js` which check the query string and headers are correct.

### Resume with `ATTACH`
Each channel tracks the latest `channelSerial` its received. Unlike with connection serials we no longer check for duplicates by comparing serials. This was only needed for the old upgrade scheme which could potentially have duplicates. We wanted to keep the `channelSerial` format opaque rather than having to parse it to use for comparison (such as is could be a legacy serial or a time serial).

When resuming, instead of including a `connectionSerial` in the query (which leaves the realtime backend to look up the channel serial for each channel and resume), the client just re-attaches the channels including the `channelSerial` in the `ATTACH` message.

This also removes the `checkAttachedMsgIndicators` check, which will re-attach if the channel has not received an `ATTACHED` after reconnecting, which is now redundant given we always re-attach.

**Spec**
* RTN15c6/RTN15c7: The client already sends an `ATTACH` on the new connection for channels in the `ATTACHING` and `SUSPENDED` states - so this just moves channels in `ATTACHED` states back to `ATTACHING` when we get a new connection so they re-attach
* RTL4c1: Includes the tracked `channelSerial` in the `ATTACH` message
* RTL15b: Updates `RealtimeChannel.properties.channelSerial` when receive `MESSAGE`/`PRESENCE`/`ATTACHED` actions and `channelSerial` is defined
* RTP5a1: Clears `RealtimeChannel.properties.channelSerial` when the channel enters `DETACHED`/`SUSPENDED`/`FAILED` states
* RTN15b2: Removes the `connectionSerial` query param on resume

**Testing**
`realtime/resume.test.js` already tests resume works under a number of scenarios

### Presence Re-Enter

**Spec**
* RTP17h: Stores own members by `clientId` only (rather than member key)
* RTP17f: When the channel becomes attached `RealtimePresence.onAttached` is called (though not if already attached as its `RealtimeChannel` already checks `state === this.state`). When attached `_ensureMyMembersPresent` runs to perform re-entry
* RTP17g:
  * Adds the `member` `id` attribute to the re-entry
  * No longer removes the member from the internal presence map
  * No longer checks that member key is not already a member of the main presence map

**Testing**
* With the new presence model `presence_auto_reenter` now re-enters both members (even the member that was already in the presence set) and `channel.presence.get` returns the same member (`one`) twice with different connection IDs
  * @SimonWoolf I think when we talked about it before this is expected? (I guess before `one` wouldn't have been re-entered as it was in the main presence map?)

### Recovery
The recover now needs to store the `channelSerials` for each attached channel (since this state is no longer kept by the realtime backend), which is encoded as JSON for simplicity rather than some custom format. This adds a new method `createRecoveryKey` to create the key rather than recalculating each time (which could get expensive). To keep compatibility also adds a `recoveryKey` getter that returns `createRecoveryKey`, which required updating `tsconfig` to target `es5` (agreed in https://github.com/ably/specification/pull/88/files).

**Spec**
* RTN16f: Already does this so is updated to decode the new recovery key format
* RTN16j: `recoverChannels` sets the `channelSerial` for all channels in the recovery key before connecting
* RTN16k: Already does this so is updated to decode the new recovery key format
* RTN16g: Adds a `createRecoveryKey` which returns the `msgSerial`, `connectionKey` and `name` to `channelSerial` pairs for each channel, encoded as JSON
  * RTN16g2: Checks if it has a connection key, if not returns `null` (if `CLOSED`, `CLOSING`, `FAILED`, or `SUSPENDED`, `connectionKey` is cleared
* RTN16d: Adds `recover multiple channels` which tests the conn id stays the same but the conn key changes after recover

**Testing**
* Adds a `recover multiple channels`, which is similar to `resume_active` except uses recover rather than resume. This also tests the connection id stays the same but the connection key changes as described by RTN16d.

### Upgrade
Implements the new upgrade scheme as described in option 1 of https://github.com/ably/realtime/issues/4216#issuecomment-1221407649 (not in the spec as ably-js specific). Also rather than keeping the `SYNC` action, which is also used by presence which causes some confusion, upgrade instead now uses the `ACTIVATE` action to activate the new transport.

1. Before activating the new transport after an upgrade we send an empty `ACTIVATE` message to the server and assumes the transport is active immediately after sending (since we'll reattach so doesn't matter if we drop messages),
2. When receiving the `ACTIVATE` the server sets the active transport and suspends the connections channels (the same as if it got a resume request),
3. Since the SDK has activated a new transport it re-attaches all channels as it would on a normal resume

The SDK no longer waits for `channels.onceNopending` since we re-attach once the new connection is activated.

**Testing**
* Already has lots of upgrade testing
* Removes the `unresponsive_upgrade_sync` test as this no longer makes sense (since we don't wait for `SYNC`)

## Spec
- [x] G4
- [x] RSC7a
- [x] RTN8c
- [x] RTN9c
- [x] RTN10
  - [x] RTN10a
  - [x] RTN10b
- [x] RTN15g3
- [x] RTN15b
  - [x] RTN15b2
- [x] RTN15c
  - [x] RTN15c1
  - [x] RTN15c2
  - [x] RTN15c3
  - [x] RTN15c6
  - [x] RTN15c7
- [x] RTN15f
- [x] RTN16
  - [x] RTN16a
  - [x] RTN16b
  - [x] RTN16c
  - [x] RTN16d
  - [x] RTN16e
  - [x] RTN16f
  - [x] RTN16i
  - [x] RTN16j
  - [x] RTN16k
  - [x] RTN16g
    - [x] RTN16g1
    - [x] RTN16g2
  - [x] RTN16d
  - [x] RTN16l
- [x] RTN19
  - [x] RTN19a1
  - [x] RTN19a2
- [x] RTN25
- [x] RTL4c1
- [x] RTL15b
- [x] RTP17
  - [x] RTP17h
  - [x] RTP17f
  - [x] RTP17g
  - [x] RTP17c
  - [x] RTP17d
- [x] RTP5
  - [x] RTP5a1
- [x] TR4f
- [x] CP2a
- [x] CP2b
