### PR TITLE
DRAFT: Changes the default hash function from md4 to sha-256

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ const baseConfig = {
   },
   output: {
     path: path.resolve(__dirname, 'build'),
+    hashFunction: 'sha-256',
     library: 'Ably',
     libraryTarget: 'umd',
     libraryExport: 'default',


### PR DESCRIPTION
MD4 is a legacy algorithm and therefore not supported by node 18. This simple fix ensures that node 18 can work with the codebase but does not fully fix the issue, taking `npm install` from 10% to 24% completion at the `webpack:all` stage.

There seems to be another issue somewhere in the codebase, I thought maybe ably-common but could not find any other issues there.

Info taken from:
[Stack Overflow on initial error message](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported) - best answer is #3.
[OpenSSL Legacy Algorithms](https://wiki.openssl.org/index.php/OpenSSL_3.0#Legacy_Algorithms)