### PR TITLE
Node/http: stop got from doing its own retries

### DIFF
--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -223,6 +223,10 @@ const Http: typeof IHttp = class {
 
     doOptions.url = uri;
     doOptions.timeout = { request: ((rest && rest.options.timeouts) || Defaults.TIMEOUTS).httpRequestTimeout };
+    // We have our own logic that retries appropriate statuscodes to fallback endpoints,
+    // with timeouts constructed appropriately. Don't want `got` doing its own retries to
+    // the same endpoint, inappropriately retrying 429s, etc
+    doOptions.retry = { limit: 0 };
 
     (got[method](doOptions) as CancelableRequest<Response>)
       .then((res: Response) => {


### PR DESCRIPTION
Got has an actually quite nice and configurable [retry API](https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md).

But so do we, and having both stacking is definitely undesirable. Got's defaults aren't great (retrying 429s?); that's fixable, but we in any case prefer ours because we want to have retries go to fallback endpoints / other datacenters, which got can't do. So this disables got retries.

(Might be worth scanning through got docs to see if it's doing anything else overly-helpfully which we want to disable in favour of our own existing mechanisms)