### PR TITLE
fix: `ErrorInfo` extends `Error`

### DIFF
--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -114,11 +114,7 @@ class RealtimeChannel extends Channel {
   }
 
   static invalidStateError(state: string): ErrorInfo {
-    return {
-      statusCode: 400,
-      code: 90001,
-      message: 'Channel operation failed as channel state is ' + state,
-    };
+    return new ErrorInfo('Channel operation failed as channel state is ' + state, 90001, 400);
   }
 
   static processListenerArgs(args: unknown[]): any[] {

--- a/src/common/lib/types/errorinfo.ts
+++ b/src/common/lib/types/errorinfo.ts
@@ -9,6 +9,9 @@ export default class ErrorInfo extends Error {
 
   constructor(message: string, code: number | null, statusCode?: number, cause?: string | Error | ErrorInfo) {
     super(message);
+    if (typeof Object.setPrototypeOf !== 'undefined') {
+      Object.setPrototypeOf(this, ErrorInfo.prototype);
+    }
     this.code = code;
     this.statusCode = statusCode;
     this.cause = cause;

--- a/src/common/lib/types/errorinfo.ts
+++ b/src/common/lib/types/errorinfo.ts
@@ -1,15 +1,14 @@
 import Platform from 'common/platform';
 import * as Utils from '../util/utils';
 
-export default class ErrorInfo {
-  message: string;
+export default class ErrorInfo extends Error {
   code: number | null;
   statusCode?: number;
   cause?: string | Error | ErrorInfo;
   href?: string;
 
   constructor(message: string, code: number | null, statusCode?: number, cause?: string | Error | ErrorInfo) {
-    this.message = message;
+    super(message);
     this.code = code;
     this.statusCode = statusCode;
     this.cause = cause;


### PR DESCRIPTION
[TypeScript doesn't properly let you extend builtin classes](https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work), hence the call to `Object.setPrototypeOf`. This has the very minor caveat that `ErrorInfo.code` may not be set correctly for authUrl 403 responses in IE < 11, but I think that's insignificant enough to not block this change.