### PR TITLE
ci fixes

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -20,6 +20,10 @@ jobs:
         run: >
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
       - run: npm ci
       - name: Install playwright dependencies
         run: sudo npx playwright install-deps

--- a/test/rest/auth.test.js
+++ b/test/rest/auth.test.js
@@ -697,11 +697,11 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, as
         var rest = helper.AblyRest({ promises: true });
 
         var promise1 = rest.auth.requestToken();
-        var promise2 = rest.auth.requestToken({ ttl: 100 });
-        var promise3 = rest.auth.requestToken({ ttl: 100 }, { key: helper.getTestApp().keys[1].keyStr });
+        var promise2 = rest.auth.requestToken({ ttl: 200 });
+        var promise3 = rest.auth.requestToken({ ttl: 200 }, { key: helper.getTestApp().keys[1].keyStr });
         var promise4 = rest.auth.createTokenRequest();
-        var promise5 = rest.auth.createTokenRequest({ ttl: 100 });
-        var promise6 = rest.auth.requestToken({ ttl: 100 }, { key: 'bad' })['catch'](function (err) {
+        var promise5 = rest.auth.createTokenRequest({ ttl: 200 });
+        var promise6 = rest.auth.requestToken({ ttl: 200 }, { key: 'bad' })['catch'](function (err) {
           expect(true, 'Token attempt with bad key was rejected').to.be.ok;
         });
 


### PR DESCRIPTION
- pins node version for browser tests to 16.x (fixes problem with lib not building because node 18.x SSL changes)
- extends ttl in auth promise tests to fix a minor timing issue