### PR TITLE
Webworker patch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,5 +22,5 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm run check-closure-compiler
-      - run: npx tsc --noEmit ably.d.ts
+      - run: npx tsc --noEmit ably.d.ts build/ably-webworker.min.d.ts
       - run: npm audit --production

--- a/src/common/types/IPlatform.d.ts
+++ b/src/common/types/IPlatform.d.ts
@@ -49,4 +49,5 @@ export interface IPlatform {
     byteLength: number,
     callback: (err: Error, result: boolean | CryptoJS.lib.WordArray) => void
   ) => void;
+  isWebworker?: boolean;
 }

--- a/src/fragments/ably.d.ts
+++ b/src/fragments/ably.d.ts
@@ -1,2 +1,2 @@
-import Ably = require('../../../../ably');
+import Ably = require('../ably');
 export = Ably;

--- a/src/platform/web/index-webworker.ts
+++ b/src/platform/web/index-webworker.ts
@@ -1,0 +1,4 @@
+import './platform-webworker';
+import Ably from './index';
+
+export default Ably;

--- a/src/platform/web/lib/transport/fetchrequest.ts
+++ b/src/platform/web/lib/transport/fetchrequest.ts
@@ -39,13 +39,18 @@ export default function fetchRequest(
     rest ? rest.options.timeouts.httpRequestTimeout : Defaults.TIMEOUTS.httpRequestTimeout
   );
 
+  const requestInit: RequestInit = {
+    method: _method,
+    headers: fetchHeaders,
+    body: body as any,
+  };
+
+  if (!Platform.Config.isWebworker) {
+    requestInit.credentials = fetchHeaders.has('authorization') ? 'include' : 'same-origin';
+  }
+
   getGlobalObject()
-    .fetch(uri + '?' + new URLSearchParams(params || {}), {
-      method: _method,
-      headers: fetchHeaders,
-      body: body as any,
-      credentials: fetchHeaders.has('authorization') ? 'include' : 'same-origin',
-    })
+    .fetch(uri + '?' + new URLSearchParams(params || {}), requestInit)
     .then((res) => {
       clearTimeout(timeout);
       const contentType = res.headers.get('Content-Type');

--- a/src/platform/web/platform-webworker.ts
+++ b/src/platform/web/platform-webworker.ts
@@ -1,0 +1,5 @@
+import Platform from './platform';
+
+Platform.isWebworker = true;
+
+export default Platform;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -158,6 +158,9 @@ const browserMinConfig = {
 const webworkerConfig = {
   target: 'webworker',
   ...browserConfig,
+  entry: {
+    index: platformPath('web', 'index-webworker.ts'),
+  },
   output: {
     ...baseConfig.output,
     filename: 'ably-webworker.min.js',


### PR DESCRIPTION
Resolves #1127, #1112

- Omits `FetchInit.credentials` in webworker distribution
- Fixes typings for webworker bundle and adds a CI check to ensure no future regressions