### PR TITLE
fix: align exposed type of ErrorInfo with internal type

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -730,7 +730,7 @@ declare namespace Types {
   /**
    * A generic Ably error object that contains an Ably-specific status code, and a generic status code. Errors returned from the Ably server are compatible with the `ErrorInfo` structure and should result in errors that inherit from `ErrorInfo`.
    */
-  interface ErrorInfo {
+  interface ErrorInfo extends Error {
     /**
      * Ably [error code](https://github.com/ably/ably-common/blob/main/protocol/errors.json).
      */


### PR DESCRIPTION
The type of the ErrorInfo class was incorrect when using the library, due to the `ably.d.ts` not being in sync with 

Not sure if I did this right -  is it okay to edit ably.d.ts manually?