### PR TITLE
RTN20c: Retry connection attempt if 'online' while `CONNECTING`

### DIFF
--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -364,8 +364,18 @@ class ConnectionManager extends EventEmitter {
             'reattempting connection'
           );
           this.requestState({ state: 'connecting' });
+        } else if (this.state == this.states.connecting) {
+          // RTN20c: if 'online' event recieved while CONNECTING, abandon connection attempt and retry
+          this.pendingTransports.forEach(function (transport) {
+            // Detach transport listeners to avoid connection state side effects from calling dispose
+            transport.off();
+          });
+          this.disconnectAllTransports();
+
+          this.startConnect();
         }
       });
+
       addEventListener('offline', () => {
         if (this.state == this.states.connected) {
           Logger.logAction(

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -36,8 +36,8 @@ define([
     return result;
   }
 
-  function monitorConnection(done, realtime) {
-    utils.arrForEach(['failed', 'suspended'], function (state) {
+  function monitorConnection(done, realtime, states) {
+    utils.arrForEach(states || ['failed', 'suspended'], function (state) {
       realtime.connection.on(state, function () {
         done(new Error('Connection monitoring: state changed to ' + state + ', aborting test'));
         realtime.close();


### PR DESCRIPTION
See ably/specification#136

Upon an 'online' event, if the connectionmanager state is `CONNECTING`, this will silently dispose of all pending transports and call `startConnect` again. All listeners are detached from the transports before disposal in order to prevent connection state side effects (otherwise the state will temporarily become `DISCONNECTED`). 