### PR TITLE
refactor: fix ClientOptions.agents typing

### DIFF
--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -9,7 +9,7 @@ export type RestAgentOptions = {
 export default interface ClientOptions extends API.Types.ClientOptions {
   restAgentOptions?: RestAgentOptions;
   pushFullWait?: boolean;
-  agents?: string[];
+  agents?: Record<string, string | undefined>;
 }
 
 export type DeprecatedClientOptions = Modify<


### PR DESCRIPTION
This was always parsed as a `Record<string, string>` but for some reason was typed as a `string[]`. I guess it was like that from the original implementation and typescript didn't complain since you can do a `for in` loop on an array.