### PR TITLE
Fix mis-accessing of `util.inspect` method

### DIFF
--- a/src/platform/nodejs/lib/transport/nodecomettransport.js
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.js
@@ -272,7 +272,7 @@ var NodeCometTransport = function (connectionManager) {
         var err = body.error && ErrorInfo.fromValues(body.error);
         if (!err) {
           err = new ErrorInfo(
-            'Error response received from server: ' + statusCode + ', body was: ' + Utils.inspect(body),
+            'Error response received from server: ' + statusCode + ', body was: ' + util.inspect(body),
             null,
             statusCode
           );


### PR DESCRIPTION
This was pointed out by webpack 5 whilst doing the upgrade for #1184.