### PR TITLE
Update outdated references to ES3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
    Note: don't commit files generated in `browser/static/*`, unless you are about to make a release.
 5. Ensure you have added suitable tests and the test suite is passing(`npm test`)
 6. Ensure the [type definitions](https://github.com/ably/ably-js/blob/main/ably.d.ts) have been updated if the public API has changed
-7. Ensure you stick to the version of JS used by the library (currently ES3). (The minfication task (`npm run grunt -- closureCompiler:ably.js`) will enforce that you stick to ES3 syntax, but will not enforce that you don't use, for example, new methods)
+7. Ensure you stick to the version of JS used by the library (currently ES5). (The minfication task (`npm run grunt -- closureCompiler:ably.js`) will enforce that you stick to ES5 syntax, but will not enforce that you don't use, for example, new methods)
 8. Push the branch (`git push origin my-new-feature`)
 9. Create a new Pull Request
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,8 +58,8 @@ module.exports = function (grunt) {
       compilerOpts: {
         compilation_level: 'SIMPLE_OPTIMIZATIONS',
         /* By default, the compiler assumes you're using es6 and transpiles to
-         * es3, adding various (unnecessary and undesired) polyfills. Specify
-         * both in and out to es3 to avoid transpilation */
+         * es5, adding various (unnecessary and undesired) polyfills. Specify
+         * both in and out to es5 to avoid transpilation */
         language_in: 'ECMASCRIPT5',
         language_out: 'ECMASCRIPT5',
         strict_mode_input: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-/**
- * Webpack v4 is used as Webpack v5 does not offer support for ES3 and creates issues for ES3 support such as discarding string literal keyword property names.
- */
 const path = require('path');
 const { BannerPlugin } = require('webpack');
 const banner = require('./src/fragments/license');


### PR DESCRIPTION
Whilst working on the webpack 5 upgrade, it wasn’t clear to me which version of ECMAScript we’re actually targeting. But f2014f7 ("Update to ES5") and #839 ("Now we no longer advertise support for IE8 (or ES3)") suggested that we’ve dropped ES3 support. Owen subsequently [confirmed this](https://github.com/ably/ably-js/pull/1201#issuecomment-1520018754). So let’s update the outdated references to ES3.