### PR TITLE
refactor: avoid early initialisation of connection errors

### DIFF
--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -768,7 +768,7 @@ class RealtimeChannel extends Channel {
           'RealtimeChannel.onMessage()',
           'Fatal protocol error: unrecognised action (' + message.action + ')'
         );
-        this.connectionManager.abort(ConnectionErrors.unknownChannelErr);
+        this.connectionManager.abort(ConnectionErrors.unknownChannelErr());
     }
   }
 

--- a/src/common/lib/transport/comettransport.ts
+++ b/src/common/lib/transport/comettransport.ts
@@ -192,7 +192,7 @@ abstract class CometTransport extends Transport {
       }
       /* In almost all cases the transport will be finished before it's
        * disposed. Finish here just to make sure. */
-      this.finish('disconnected', ConnectionErrors.disconnected);
+      this.finish('disconnected', ConnectionErrors.disconnected());
       Platform.Config.nextTick(() => {
         this.emit('disposed');
       });

--- a/src/common/lib/transport/connectionerrors.ts
+++ b/src/common/lib/transport/connectionerrors.ts
@@ -1,54 +1,65 @@
 import ErrorInfo from '../types/errorinfo';
 
+const ConnectionErrorCodes = {
+  DISCONNECTED: 80003,
+  SUSPENDED: 80002,
+  FAILED: 80000,
+  CLOSING: 80017,
+  CLOSED: 80017,
+  UNKNOWN_CONNECTION_ERR: 50002,
+  UNKNOWN_CHANNEL_ERR: 50001,
+};
+
 const ConnectionErrors = {
-  disconnected: ErrorInfo.fromValues({
-    statusCode: 400,
-    code: 80003,
-    message: 'Connection to server temporarily unavailable',
-  }),
-  suspended: ErrorInfo.fromValues({
-    statusCode: 400,
-    code: 80002,
-    message: 'Connection to server unavailable',
-  }),
-  failed: ErrorInfo.fromValues({
-    statusCode: 400,
-    code: 80000,
-    message: 'Connection failed or disconnected by server',
-  }),
-  closing: ErrorInfo.fromValues({
-    statusCode: 400,
-    code: 80017,
-    message: 'Connection closing',
-  }),
-  closed: ErrorInfo.fromValues({
-    statusCode: 400,
-    code: 80017,
-    message: 'Connection closed',
-  }),
-  unknownConnectionErr: ErrorInfo.fromValues({
-    statusCode: 500,
-    code: 50002,
-    message: 'Internal connection error',
-  }),
-  unknownChannelErr: ErrorInfo.fromValues({
-    statusCode: 500,
-    code: 50001,
-    message: 'Internal channel error',
-  }),
+  disconnected: () =>
+    ErrorInfo.fromValues({
+      statusCode: 400,
+      code: ConnectionErrorCodes.DISCONNECTED,
+      message: 'Connection to server temporarily unavailable',
+    }),
+  suspended: () =>
+    ErrorInfo.fromValues({
+      statusCode: 400,
+      code: ConnectionErrorCodes.SUSPENDED,
+      message: 'Connection to server unavailable',
+    }),
+  failed: () =>
+    ErrorInfo.fromValues({
+      statusCode: 400,
+      code: ConnectionErrorCodes.FAILED,
+      message: 'Connection failed or disconnected by server',
+    }),
+  closing: () =>
+    ErrorInfo.fromValues({
+      statusCode: 400,
+      code: ConnectionErrorCodes.CLOSING,
+      message: 'Connection closing',
+    }),
+  closed: () =>
+    ErrorInfo.fromValues({
+      statusCode: 400,
+      code: ConnectionErrorCodes.CLOSED,
+      message: 'Connection closed',
+    }),
+  unknownConnectionErr: () =>
+    ErrorInfo.fromValues({
+      statusCode: 500,
+      code: ConnectionErrorCodes.UNKNOWN_CONNECTION_ERR,
+      message: 'Internal connection error',
+    }),
+  unknownChannelErr: () =>
+    ErrorInfo.fromValues({
+      statusCode: 500,
+      code: ConnectionErrorCodes.UNKNOWN_CONNECTION_ERR,
+      message: 'Internal channel error',
+    }),
 };
 
 export function isRetriable(err: ErrorInfo) {
   if (!err.statusCode || !err.code || err.statusCode >= 500) {
     return true;
   }
-  let retriable = false;
-  Object.values(ConnectionErrors).forEach(function (connErr) {
-    if (connErr.code && connErr.code == err.code) {
-      retriable = true;
-    }
-  });
-  return retriable;
+  return Object.values(ConnectionErrorCodes).includes(err.code);
 }
 
 export default ConnectionErrors;

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1156,7 +1156,7 @@ class ConnectionManager extends EventEmitter {
   }
 
   getStateError(): ErrorInfo {
-    return (ConnectionErrors as Record<string, ErrorInfo>)[this.state.state];
+    return (ConnectionErrors as Record<string, () => ErrorInfo>)[this.state.state]?.();
   }
 
   activeState(): boolean | void {
@@ -1330,7 +1330,7 @@ class ConnectionManager extends EventEmitter {
       this.state.state,
       newState.state,
       retryDelay,
-      indicated.error || (ConnectionErrors as Record<string, ErrorInfo>)[newState.state]
+      indicated.error || (ConnectionErrors as Partial<Record<string, () => ErrorInfo>>)[newState.state]?.()
     );
 
     if (retryImmediately) {
@@ -1411,7 +1411,7 @@ class ConnectionManager extends EventEmitter {
         this.state.state,
         newState.state,
         null,
-        request.error || (ConnectionErrors as Record<string, ErrorInfo>)[newState.state]
+        request.error || (ConnectionErrors as Partial<Record<string, () => ErrorInfo>>)[newState.state]?.()
       );
 
     this.enactStateChange(change);

--- a/src/common/lib/transport/transport.ts
+++ b/src/common/lib/transport/transport.ts
@@ -78,7 +78,7 @@ abstract class Transport extends EventEmitter {
     if (this.isConnected) {
       this.requestClose();
     }
-    this.finish('closed', ConnectionErrors.closed);
+    this.finish('closed', ConnectionErrors.closed());
   }
 
   disconnect(err?: Error | ErrorInfo): void {
@@ -87,7 +87,7 @@ abstract class Transport extends EventEmitter {
     if (this.isConnected) {
       this.requestDisconnect();
     }
-    this.finish('disconnected', err || ConnectionErrors.disconnected);
+    this.finish('disconnected', err || ConnectionErrors.disconnected());
   }
 
   fail(err: ErrorInfo): void {
@@ -95,7 +95,7 @@ abstract class Transport extends EventEmitter {
     if (this.isConnected) {
       this.requestDisconnect();
     }
-    this.finish('failed', err || ConnectionErrors.failed);
+    this.finish('failed', err || ConnectionErrors.failed());
   }
 
   finish(event: string, err?: Error | ErrorInfo): void {


### PR DESCRIPTION
Resolves #1202 

Fixes an issue where reusable connection errors would have a stack trace showing where they were initialised, ie upon module import, rather than where they are thrown