### PR TITLE
Fix the flag for running a single test file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,9 @@ Run the Mocha test suite
 
     npm run test:node
 
-Or run just one or more test files
+Or run just one test file
 
-    npm run test:node -- --test=test/realtime/auth.test.js
+    npm run test:node -- --file=test/realtime/auth.test.js
 
 ### Debugging the mocha tests locally with a debugger
 

--- a/test/tasks/grunt-mocha.js
+++ b/test/tasks/grunt-mocha.js
@@ -6,7 +6,7 @@ var fs = require('fs'),
   kexec = require('kexec');
 
 module.exports = function (grunt) {
-  var test = grunt.option('test'),
+  var file = grunt.option('file'),
     debug = grunt.option('debug'),
     inspector = grunt.option('inspector'),
     fgrep = grunt.option('fgrep'),
@@ -32,13 +32,13 @@ module.exports = function (grunt) {
 
   grunt.registerTask(
     'mocha',
-    'Run the Mocha test suite.\nOptions:\n  --test [tests] e.g. --test test/rest/auth.test.js\n  --debug will debug using standard node debugger\n  --inspector will start with node inspector',
+    'Run the Mocha test suite.\nOptions:\n  --file=<file> e.g. --file=test/rest/auth.test.js\n  --debug will debug using standard node debugger\n  --inspector will start with node inspector',
     function () {
       var runTests = getRelativePath(helpers).concat(['test/realtime/*.test.js', 'test/rest/*.test.js']).join(' ');
-      grunt.log.writeln('Running Mocha test suite against ' + (test ? test : 'all tests'));
+      grunt.log.writeln('Running Mocha test suite against ' + (file ? file : 'all tests'));
 
-      if (test) {
-        runTests = getRelativePath(helpers).concat(resolveTests(test)).join(' ');
+      if (file) {
+        runTests = getRelativePath(helpers).concat(resolveTests(file)).join(' ');
       }
 
       if (fgrep) {


### PR DESCRIPTION
`--test` clashes with the [flag of the same name](https://nodejs.org/docs/v16.17.0/api/cli.html#--test) introduced in Node 16.17.0, so rename it to `--file`.

I’ve also:

- removed the mention of running multiple test files, because there’s no indication of how you’re actually meant to do this, and from a brief glance at the code it’s not clear whether you can;
- fixed the invocation in the task description (missing necessary `=`)