### PR TITLE
Conform to spec for logging configuration

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -392,9 +392,16 @@ declare namespace Types {
     environment?: string;
 
     /**
-     * Parameters to control the log output of the library, such as the log handler and log level.
+     * Controls the verbosity of the logs output from the library. Valid values are: 0 (no logs), 1 (errors only), 2 (errors plus connection and channel state changes), 3 (high-level debug output), and 4 (full debug output).
      */
-    log?: LogInfo;
+    logLevel?: number;
+
+    /**
+     * Controls the log output of the library. This is a function to handle each line of log output. If you do not set this value, then `console.log` will be used.
+     *
+     * @param msg - The log message emitted by the library.
+     */
+    logHandler?: (msg: string) => void;
 
     /**
      * Enables a non-default Ably port to be specified. For development environments only. The default value is 80.
@@ -1100,23 +1107,6 @@ declare namespace Types {
      * When `true`, ensures message history is up until the point of the channel being attached. See [continuous history](https://ably.com/docs/realtime/history#continuous-history) for more info. Requires the `direction` to be `backwards`. If the channel is not attached, or if `direction` is set to `forwards`, this option results in an error.
      */
     untilAttach?: boolean;
-  }
-
-  /**
-   * Settings which control the log output of the library.
-   */
-  interface LogInfo {
-    /**
-     * Controls the verbosity of the logs output from the library. Valid values are: 0 (no logs), 1 (errors only), 2 (errors plus connection and channel state changes), 3 (high-level debug output), and 4 (full debug output).
-     */
-    level?: number;
-
-    /**
-     * Controls the log output of the library. This is a function to handle each line of log output. If you do not set this value, then `console.log` will be used.
-     *
-     * @param msg - The log message emitted by the library.
-     */
-    handler?: (msg: string) => void;
   }
 
   /**

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -40,9 +40,7 @@ class Rest {
     }
     const optionsObj = Defaults.objectifyOptions(options);
 
-    if (optionsObj.log) {
-      Logger.setLog(optionsObj.log.level, optionsObj.log.handler);
-    }
+    Logger.setLog(optionsObj.logLevel, optionsObj.logHandler);
     Logger.logAction(Logger.LOG_MICRO, 'Rest()', 'initialized with clientOptions ' + Platform.Config.inspect(options));
 
     const normalOptions = (this.options = Defaults.normaliseOptions(optionsObj));

--- a/test/common/globals/environment.js
+++ b/test/common/globals/environment.js
@@ -41,15 +41,13 @@ define(function (require) {
     port: port,
     tlsPort: tlsPort,
     tls: tls,
-    log: {
-      level: logLevel,
-      handler: function (msg) {
-        var time = new Date();
-        console.log(
-          time.getHours() + ':' + time.getMinutes() + ':' + time.getSeconds() + '.' + time.getMilliseconds(),
-          msg
-        );
-      },
+    logLevel: logLevel,
+    logHandler: function (msg) {
+      var time = new Date();
+      console.log(
+        time.getHours() + ':' + time.getMinutes() + ':' + time.getSeconds() + '.' + time.getMilliseconds(),
+        msg
+      );
     },
   });
 });

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -1337,7 +1337,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     /* Check that only the last authorize matters */
     it('multiple_concurrent_authorize', function (done) {
       var realtime = helper.AblyRealtime({
-        log: { level: 4 },
+        logLevel: 4,
         useTokenAuth: true,
         defaultTokenParams: { capability: { wrong: ['*'] } },
       });

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -65,7 +65,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('connectionAttributes', function (done) {
       var realtime;
       try {
-        realtime = helper.AblyRealtime({ log: { level: 4 } });
+        realtime = helper.AblyRealtime({ logLevel: 4 });
         realtime.connection.on('connected', function () {
           try {
             const recoveryContext = JSON.parse(realtime.connection.recoveryKey);

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1910,9 +1910,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * and only members that changed between ATTACHED states should result in
      * presence events */
     it('suspended_preserves_presence', function (done) {
-      var mainRealtime = helper.AblyRealtime({ clientId: 'main', log: { level: 4 } }),
-        continuousRealtime = helper.AblyRealtime({ clientId: 'continuous', log: { level: 4 } }),
-        leavesRealtime = helper.AblyRealtime({ clientId: 'leaves', log: { level: 4 } }),
+      var mainRealtime = helper.AblyRealtime({ clientId: 'main', logLevel: 4 }),
+        continuousRealtime = helper.AblyRealtime({ clientId: 'continuous', logLevel: 4 }),
+        leavesRealtime = helper.AblyRealtime({ clientId: 'leaves', logLevel: 4 }),
         channelName = 'suspended_preserves_presence',
         mainChannel = mainRealtime.channels.get(channelName);
 

--- a/test/rest/fallbacks.test.js
+++ b/test/rest/fallbacks.test.js
@@ -25,7 +25,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
         restHost: helper.unroutableHost,
         fallbackHosts: [goodHost],
         httpRequestTimeout: 3000,
-        log: { level: 4 },
+        logLevel: 4,
       });
       var validUntil;
       async.series(


### PR DESCRIPTION
Replace the `ClientOptions.log` property with separate `logLevel` and `logHandler` properties, to conform with [`TO3b`](https://sdk.ably.com/builds/ably/specification/main/features/#TO3b) and [`TO3c`](https://sdk.ably.com/builds/ably/specification/main/features/#TO3c).

Resolves #642.