### PR TITLE
Remove `ProtocolMessage.connectionKey`

### DIFF
--- a/src/common/lib/transport/comettransport.ts
+++ b/src/common/lib/transport/comettransport.ts
@@ -211,11 +211,7 @@ abstract class CometTransport extends Transport {
     Transport.prototype.onConnect.call(this, message);
 
     const baseConnectionUri = (this.baseUri as string) + connectionStr;
-    Logger.logAction(
-      Logger.LOG_MICRO,
-      'CometTransport.onConnect()',
-      'baseUri = ' + baseConnectionUri + '; connectionKey = ' + message.connectionKey
-    );
+    Logger.logAction(Logger.LOG_MICRO, 'CometTransport.onConnect()', 'baseUri = ' + baseConnectionUri);
     this.sendUri = baseConnectionUri + '/send';
     this.recvUri = baseConnectionUri + '/recv';
     this.closeUri = baseConnectionUri + '/close';

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -57,7 +57,7 @@ function toStringArray(array?: any[]): string {
   return '[ ' + result.join(', ') + ' ]';
 }
 
-const simpleAttributes = 'id channel channelSerial connectionId connectionKey count msgSerial timestamp'.split(' ');
+const simpleAttributes = 'id channel channelSerial connectionId count msgSerial timestamp'.split(' ');
 
 class ProtocolMessage {
   action?: number;
@@ -67,7 +67,6 @@ class ProtocolMessage {
   count?: number;
   error?: ErrorInfo;
   connectionId?: string;
-  connectionKey?: string;
   channel?: string;
   channelSerial?: string | null;
   msgSerial?: number;

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -321,7 +321,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       });
     }
 
-    /* Check that the connectionKey in ConnectionDetails takes precedence over connectionKey in ProtocolMessage,
+    /* Check that the connectionKey in ConnectionDetails updates the client connectionKey,
 	   and clientId in ConnectionDetails updates the client clientId */
     it('init_and_connection_details', function (done) {
       try {


### PR DESCRIPTION
The library no longer uses this property; rather, it uses the property of the same name on `ConnectionDetails`.

This property was removed from the features spec in https://github.com/ably/specification/commit/2d5462cd920614de046656379f79c69667eddbbf.

This work was scheduled as part of ably-js v2, but I believe we can remove it in v1 given that `ProtocolMessage` is not part of the public API of the library (i.e. it doesn’t appear in `ably.d.ts`).

Resolves #365.