### PR TITLE
Remove `DeprecatedClientOptions.timeouts` property

### DIFF
--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -21,7 +21,6 @@ export type DeprecatedClientOptions = Modify<
     promises?: boolean;
     headers?: Record<string, string>;
     maxMessageSize?: number;
-    timeouts?: Record<string, number>;
   }
 >;
 


### PR DESCRIPTION
The library never reads this property.

This work was scheduled as part of ably-js v2, but it appears safe to do it in v1.

Part of #1197.