### PR TITLE
Remove the `DeprecatedClientOptions` type

### DIFF
--- a/promises.js
+++ b/promises.js
@@ -3,7 +3,11 @@ function promisifyOptions(options) {
   if (typeof options == 'string') {
     options = options.indexOf(':') == -1 ? { token: options } : { key: options };
   }
-  options.promises = true;
+  if (options.internal === undefined) {
+    options.internal = { promises: true }
+  } else {
+    options.internal.promises = true
+  }
   return options;
 }
 

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -94,7 +94,7 @@ class Channel extends EventEmitter {
       envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
       headers = Utils.defaultGetHeaders(rest.options, format);
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     const options = this.channelOptions;
     new PaginatedResource(rest, this.basePath + '/messages', headers, envelope, function (
@@ -150,7 +150,7 @@ class Channel extends EventEmitter {
       idempotentRestPublishing = rest.options.idempotentRestPublishing,
       headers = Utils.defaultPostHeaders(rest.options, format);
 
-    if (options.headers) Utils.mixin(headers, options.headers);
+    Utils.mixin(headers, options.headers);
 
     if (idempotentRestPublishing && allEmptyIds(messages)) {
       const msgIdBase = Utils.randomString(MSG_ID_ENTROPY_BYTES);

--- a/src/common/lib/client/presence.ts
+++ b/src/common/lib/client/presence.ts
@@ -39,7 +39,7 @@ class Presence extends EventEmitter {
       envelope = this.channel.rest.http.supportsLinkHeaders ? undefined : format,
       headers = Utils.defaultGetHeaders(rest.options, format);
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     const options = this.channel.channelOptions;
     new PaginatedResource(rest, this.basePath, headers, envelope, function (
@@ -81,7 +81,7 @@ class Presence extends EventEmitter {
       envelope = this.channel.rest.http.supportsLinkHeaders ? undefined : format,
       headers = Utils.defaultGetHeaders(rest.options, format);
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     const options = this.channel.channelOptions;
     new PaginatedResource(rest, this.basePath + '/history', headers, envelope, function (

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -44,7 +44,7 @@ class Admin {
       callback = noop;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
@@ -74,7 +74,7 @@ class DeviceRegistrations {
       callback = noop;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
@@ -124,7 +124,7 @@ class DeviceRegistrations {
       return;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     Resource.get(
       rest,
@@ -159,7 +159,7 @@ class DeviceRegistrations {
       callback = noop;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     new PaginatedResource(rest, '/push/deviceRegistrations', headers, envelope, function (
       body: any,
@@ -195,7 +195,7 @@ class DeviceRegistrations {
       return;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
@@ -221,7 +221,7 @@ class DeviceRegistrations {
       callback = noop;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
@@ -250,7 +250,7 @@ class ChannelSubscriptions {
       callback = noop;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
@@ -284,7 +284,7 @@ class ChannelSubscriptions {
       callback = noop;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     new PaginatedResource(rest, '/push/channelSubscriptions', headers, envelope, function (
       body: any,
@@ -307,7 +307,7 @@ class ChannelSubscriptions {
       callback = noop;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
@@ -330,7 +330,7 @@ class ChannelSubscriptions {
       callback = noop;
     }
 
-    if (rest.options.headers) Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, rest.options.headers);
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -8,7 +8,7 @@ import Defaults from '../util/defaults';
 import ErrorInfo from '../types/errorinfo';
 import ProtocolMessage from '../types/protocolmessage';
 import { ChannelOptions } from '../../types/channel';
-import ClientOptions, { DeprecatedClientOptions } from '../../types/ClientOptions';
+import ClientOptions, { InternalClientOptions } from '../../types/ClientOptions';
 import * as API from '../../../../ably';
 import ConnectionManager from '../transport/connectionmanager';
 import Platform from 'common/platform';
@@ -36,9 +36,9 @@ class Realtime extends Rest {
     this.connection.close();
   }
 
-  static Promise = function (options: DeprecatedClientOptions): Realtime {
+  static Promise = function (options: InternalClientOptions): Realtime {
     options = Defaults.objectifyOptions(options);
-    options.promises = true;
+    options.internal = { ...options.internal, promises: true };
     return new Realtime(options);
   };
 

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -102,7 +102,7 @@ class Rest {
       format = this.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.http.supportsLinkHeaders ? undefined : format;
 
-    if (this.options.headers) Utils.mixin(headers, this.options.headers);
+    Utils.mixin(headers, this.options.headers);
 
     new PaginatedResource(this, '/stats', headers, envelope, function (
       body: unknown,
@@ -195,9 +195,7 @@ class Rest {
     if (typeof body !== 'string') {
       body = encoder(body);
     }
-    if (this.options.headers) {
-      Utils.mixin(headers, this.options.headers);
-    }
+    Utils.mixin(headers, this.options.headers);
     if (customHeaders) {
       Utils.mixin(headers, customHeaders);
     }

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -11,7 +11,7 @@ import HttpMethods from '../../constants/HttpMethods';
 import { ChannelOptions } from '../../types/channel';
 import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
 import { ErrnoException, IHttp, RequestParams } from '../../types/http';
-import ClientOptions, { DeprecatedClientOptions, NormalisedClientOptions } from '../../types/ClientOptions';
+import ClientOptions, { InternalClientOptions, NormalisedClientOptions } from '../../types/ClientOptions';
 
 import Platform from '../../platform';
 import Message from '../types/message';
@@ -228,9 +228,9 @@ class Rest {
     Logger.setLog(logOptions.level, logOptions.handler);
   }
 
-  static Promise = function (options: DeprecatedClientOptions): Rest {
+  static Promise = function (options: InternalClientOptions): Rest {
     options = Defaults.objectifyOptions(options);
-    options.promises = true;
+    options.internal = { ...options.internal, promises: true };
     return new Rest(options);
   };
 

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -183,10 +183,6 @@ export function objectifyOptions(options: ClientOptions | string): ClientOptions
 
 export function normaliseOptions(options: DeprecatedClientOptions): NormalisedClientOptions {
   /* Deprecated options */
-  if (options.wsHost) {
-    Logger.deprecated('wsHost', 'realtimeHost');
-    options.realtimeHost = options.wsHost;
-  }
   if (options.queueEvents) {
     Logger.deprecated('queueEvents', 'queueMessages');
     options.queueMessages = options.queueEvents;

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -267,8 +267,8 @@ export function normaliseOptions(options: DeprecatedClientOptions): NormalisedCl
     options.useBinaryProtocol = Platform.Config.preferBinary;
   }
 
+  const headers: Record<string, string> = {};
   if (options.clientId) {
-    const headers = (options.headers = options.headers || {});
     headers['X-Ably-ClientId'] = Platform.BufferUtils.base64Encode(Platform.BufferUtils.utf8Encode(options.clientId));
   }
 
@@ -308,6 +308,7 @@ export function normaliseOptions(options: DeprecatedClientOptions): NormalisedCl
     timeouts,
     connectivityCheckParams,
     connectivityCheckUrl,
+    headers,
   };
 }
 

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -3,7 +3,7 @@ import * as Utils from './utils';
 import Logger from './logger';
 import ErrorInfo from 'common/lib/types/errorinfo';
 import { version } from '../../../../package.json';
-import ClientOptions, { DeprecatedClientOptions, NormalisedClientOptions } from 'common/types/ClientOptions';
+import ClientOptions, { InternalClientOptions, NormalisedClientOptions } from 'common/types/ClientOptions';
 import IDefaults from '../../types/IDefaults';
 
 let agent = 'ably-js/' + version;
@@ -41,7 +41,7 @@ type CompleteDefaults = IDefaults & {
   checkHost(host: string): void;
   getRealtimeHost(options: ClientOptions, production: boolean, environment: string): string;
   objectifyOptions(options: ClientOptions | string): ClientOptions;
-  normaliseOptions(options: DeprecatedClientOptions): NormalisedClientOptions;
+  normaliseOptions(options: InternalClientOptions): NormalisedClientOptions;
 };
 
 const Defaults = {
@@ -181,7 +181,7 @@ export function objectifyOptions(options: ClientOptions | string): ClientOptions
   return options;
 }
 
-export function normaliseOptions(options: DeprecatedClientOptions): NormalisedClientOptions {
+export function normaliseOptions(options: InternalClientOptions): NormalisedClientOptions {
   if (options.fallbackHostsUseDefault) {
     /* fallbackHostsUseDefault and fallbackHosts are mutually exclusive as per TO3k7 */
     if (options.fallbackHosts) {
@@ -276,13 +276,13 @@ export function normaliseOptions(options: DeprecatedClientOptions): NormalisedCl
     options.idempotentRestPublishing = true;
   }
 
-  if (options.promises && !Platform.Config.Promise) {
+  if (options.internal?.promises && !Platform.Config.Promise) {
     Logger.logAction(
       Logger.LOG_ERROR,
       'Defaults.normaliseOptions',
       '{promises: true} was specified, but no Promise constructor found; disabling promises'
     );
-    options.promises = false;
+    options.internal.promises = false;
   }
 
   let connectivityCheckParams = null;
@@ -304,11 +304,12 @@ export function normaliseOptions(options: DeprecatedClientOptions): NormalisedCl
         : Platform.Config.preferBinary,
     realtimeHost,
     restHost,
-    maxMessageSize: options.maxMessageSize || Defaults.maxMessageSize,
+    maxMessageSize: options.internal?.maxMessageSize || Defaults.maxMessageSize,
     timeouts,
     connectivityCheckParams,
     connectivityCheckUrl,
     headers,
+    promises: options.internal?.promises ?? false,
   };
 }
 

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -182,12 +182,6 @@ export function objectifyOptions(options: ClientOptions | string): ClientOptions
 }
 
 export function normaliseOptions(options: DeprecatedClientOptions): NormalisedClientOptions {
-  /* Deprecated options */
-  if (options.queueEvents) {
-    Logger.deprecated('queueEvents', 'queueMessages');
-    options.queueMessages = options.queueEvents;
-  }
-
   if (options.fallbackHostsUseDefault) {
     /* fallbackHostsUseDefault and fallbackHosts are mutually exclusive as per TO3k7 */
     if (options.fallbackHosts) {

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -183,10 +183,6 @@ export function objectifyOptions(options: ClientOptions | string): ClientOptions
 
 export function normaliseOptions(options: DeprecatedClientOptions): NormalisedClientOptions {
   /* Deprecated options */
-  if (options.host) {
-    Logger.deprecated('host', 'restHost');
-    options.restHost = options.host;
-  }
   if (options.wsHost) {
     Logger.deprecated('wsHost', 'realtimeHost');
     options.realtimeHost = options.wsHost;

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -15,7 +15,6 @@ export default interface ClientOptions extends API.Types.ClientOptions {
 export type DeprecatedClientOptions = Modify<
   ClientOptions,
   {
-    wsHost?: string;
     queueEvents?: boolean;
     promises?: boolean;
     headers?: Record<string, string>;

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -15,7 +15,6 @@ export default interface ClientOptions extends API.Types.ClientOptions {
 export type DeprecatedClientOptions = Modify<
   ClientOptions,
   {
-    queueEvents?: boolean;
     promises?: boolean;
     headers?: Record<string, string>;
     maxMessageSize?: number;

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -15,7 +15,6 @@ export default interface ClientOptions extends API.Types.ClientOptions {
 export type DeprecatedClientOptions = Modify<
   ClientOptions,
   {
-    host?: string;
     wsHost?: string;
     queueEvents?: boolean;
     promises?: boolean;

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -12,16 +12,21 @@ export default interface ClientOptions extends API.Types.ClientOptions {
   agents?: string[];
 }
 
-export type DeprecatedClientOptions = Modify<
+/**
+ * Properties which internal and test code wish to be able to pass to the public constructor of `Rest` and `Realtime` in order to modify the behaviour of those classes.
+ */
+export type InternalClientOptions = Modify<
   ClientOptions,
   {
-    promises?: boolean;
-    maxMessageSize?: number;
+    internal?: {
+      promises?: boolean;
+      maxMessageSize?: number;
+    };
   }
 >;
 
 export type NormalisedClientOptions = Modify<
-  DeprecatedClientOptions,
+  InternalClientOptions,
   {
     realtimeHost: string;
     restHost: string;
@@ -31,5 +36,6 @@ export type NormalisedClientOptions = Modify<
     maxMessageSize: number;
     connectivityCheckParams: Record<string, string> | null;
     headers: Record<string, string>;
+    promises: boolean;
   }
 >;

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -16,7 +16,6 @@ export type DeprecatedClientOptions = Modify<
   ClientOptions,
   {
     promises?: boolean;
-    headers?: Record<string, string>;
     maxMessageSize?: number;
   }
 >;
@@ -31,5 +30,6 @@ export type NormalisedClientOptions = Modify<
     timeouts: Record<string, number>;
     maxMessageSize: number;
     connectivityCheckParams: Record<string, string> | null;
+    headers: Record<string, string>;
   }
 >;

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -286,7 +286,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     if (typeof Promise !== 'undefined') {
       describe('connection_promise', function () {
         it('ping', function (done) {
-          var client = helper.AblyRealtime({ promises: true });
+          var client = helper.AblyRealtime({ internal: { promises: true } });
 
           client.connection
             .once('connected')

--- a/test/realtime/event_emitter.test.js
+++ b/test/realtime/event_emitter.test.js
@@ -442,7 +442,7 @@ define(['shared_helper', 'chai'], function (helper, chai) {
     if (typeof Promise !== 'undefined') {
       describe('event_emitter_promise', function () {
         it('whenState', function (done) {
-          var realtime = helper.AblyRealtime({ promises: true });
+          var realtime = helper.AblyRealtime({ internal: { promises: true } });
           var eventEmitter = realtime.connection;
 
           eventEmitter
@@ -456,7 +456,7 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         });
 
         it('once', function (done) {
-          var realtime = helper.AblyRealtime({ promises: true });
+          var realtime = helper.AblyRealtime({ internal: { promises: true } });
           var eventEmitter = realtime.connection;
 
           eventEmitter

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -1141,7 +1141,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     if (typeof Promise !== 'undefined') {
       it('publishpromise', function (done) {
-        var realtime = helper.AblyRealtime({ promises: true });
+        var realtime = helper.AblyRealtime({ internal: { promises: true } });
         var channel = realtime.channels.get('publishpromise');
 
         var publishPromise = realtime.connection

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -2089,7 +2089,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     if (typeof Promise !== 'undefined') {
       describe('presence_promise', function () {
-        var options = { clientId: testClientId, promises: true };
+        var options = { clientId: testClientId, internal: { promises: true } };
 
         it('enter_get', function (done) {
           var client = helper.AblyRealtime(options);

--- a/test/rest/auth.test.js
+++ b/test/rest/auth.test.js
@@ -694,7 +694,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, as
 
     if (typeof Promise !== 'undefined') {
       it('Promise based auth', function (done) {
-        var rest = helper.AblyRest({ promises: true });
+        var rest = helper.AblyRest({ internal: { promises: true } });
 
         var promise1 = rest.auth.requestToken();
         var promise2 = rest.auth.requestToken({ ttl: 200 });

--- a/test/rest/defaults.test.js
+++ b/test/rest/defaults.test.js
@@ -162,22 +162,6 @@ define(['ably', 'chai'], function (Ably, chai) {
       }, "Check fallbackHostsUseDefault and tlsPort can't both be set").to.throw;
     });
 
-    /* will emit a warning */
-    it('Init with deprecated wsHost option', function () {
-      var normalisedOptions = Defaults.normaliseOptions({ wsHost: 'ws.test.org' });
-
-      expect(normalisedOptions.realtimeHost).to.equal('ws.test.org');
-      expect(normalisedOptions.port).to.equal(80);
-      expect(normalisedOptions.tlsPort).to.equal(443);
-      expect(normalisedOptions.fallbackHosts).to.equal(undefined);
-      expect(normalisedOptions.tls).to.equal(true);
-
-      expect(Defaults.getHosts(normalisedOptions)).to.deep.equal([normalisedOptions.restHost]);
-      expect(Defaults.getHost(normalisedOptions, 'test.org', false)).to.deep.equal('test.org');
-
-      expect(Defaults.getPort(normalisedOptions)).to.equal(443);
-    });
-
     it('Init with no endpoint-related options and given default environment', function () {
       Defaults.ENVIRONMENT = 'sandbox';
       var normalisedOptions = Defaults.normaliseOptions({});

--- a/test/rest/defaults.test.js
+++ b/test/rest/defaults.test.js
@@ -163,10 +163,9 @@ define(['ably', 'chai'], function (Ably, chai) {
     });
 
     /* will emit a warning */
-    it('Init with deprecated host and wsHost options', function () {
-      var normalisedOptions = Defaults.normaliseOptions({ host: 'test.org', wsHost: 'ws.test.org' });
+    it('Init with deprecated wsHost option', function () {
+      var normalisedOptions = Defaults.normaliseOptions({ wsHost: 'ws.test.org' });
 
-      expect(normalisedOptions.restHost).to.equal('test.org');
       expect(normalisedOptions.realtimeHost).to.equal('ws.test.org');
       expect(normalisedOptions.port).to.equal(80);
       expect(normalisedOptions.tlsPort).to.equal(443);
@@ -175,7 +174,6 @@ define(['ably', 'chai'], function (Ably, chai) {
 
       expect(Defaults.getHosts(normalisedOptions)).to.deep.equal([normalisedOptions.restHost]);
       expect(Defaults.getHost(normalisedOptions, 'test.org', false)).to.deep.equal('test.org');
-      expect(Defaults.getHost(normalisedOptions, 'test.org', true)).to.deep.equal('ws.test.org');
 
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
     });

--- a/test/rest/history.test.js
+++ b/test/rest/history.test.js
@@ -446,7 +446,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
     if (typeof Promise !== 'undefined') {
       it('historyPromise', function (done) {
-        var rest = helper.AblyRest({ promises: true });
+        var rest = helper.AblyRest({ internal: { promises: true } });
         var testchannel = rest.channels.get('persisted:history_promise');
 
         testchannel

--- a/test/rest/message.test.js
+++ b/test/rest/message.test.js
@@ -160,7 +160,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     /* TO3l8; CD2C; RSL1i */
     it('Should error when publishing message larger than maxMessageSize', function (done) {
       /* No connectionDetails mechanism for REST, so just pass the override into the constructor */
-      var realtime = helper.AblyRest({ maxMessageSize: 64 }),
+      var realtime = helper.AblyRest({ internal: { maxMessageSize: 64 } }),
         channel = realtime.channels.get('maxMessageSize');
 
       channel.publish('foo', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', function (err) {
@@ -292,7 +292,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     if (typeof Promise !== undefined) {
       it('Rest publish promise', function (done) {
-        var rest = helper.AblyRest({ promises: true });
+        var rest = helper.AblyRest({ internal: { promises: true } });
         var channel = rest.channels.get('publishpromise');
 
         channel

--- a/test/rest/presence.test.js
+++ b/test/rest/presence.test.js
@@ -148,7 +148,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     if (typeof Promise !== 'undefined') {
       it('presencePromise', function (done) {
-        var rest = helper.AblyRest({ promises: true });
+        var rest = helper.AblyRest({ internal: { promises: true } });
         var channel = rest.channels.get('some_channel');
 
         channel.presence

--- a/test/rest/push.test.js
+++ b/test/rest/push.test.js
@@ -139,7 +139,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     if (typeof Promise !== 'undefined') {
       it('Publish promise', function (done) {
-        var realtime = helper.AblyRealtime({ promises: true });
+        var realtime = helper.AblyRealtime({ internal: { promises: true } });
         var channelName = 'pushenabled:publish_promise';
         var channel = realtime.channels.get(channelName);
         channel.attach(function (err) {
@@ -368,7 +368,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     if (typeof Promise !== undefined) {
       it('deviceRegistrations promise', function (done) {
-        var rest = helper.AblyRest({ promises: true });
+        var rest = helper.AblyRest({ internal: { promises: true } });
 
         /* save */
         rest.push.admin.deviceRegistrations
@@ -566,7 +566,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     if (typeof Promise !== 'undefined') {
       it('channelSubscriptions promise', function (done) {
-        var rest = helper.AblyRest({ promises: true });
+        var rest = helper.AblyRest({ internal: { promises: true } });
         var channelId = 'pushenabled:channelsubscriptions_promise';
         var subscription = { clientId: 'testClient', channel: channelId };
 

--- a/test/rest/request.test.js
+++ b/test/rest/request.test.js
@@ -240,7 +240,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
     if (typeof Promise !== 'undefined') {
       it('request_promise', function (done) {
-        var client = helper.AblyRest({ promises: true });
+        var client = helper.AblyRest({ internal: { promises: true } });
 
         client
           .request('get', '/time', null, null, null)

--- a/test/rest/stats.test.js
+++ b/test/rest/stats.test.js
@@ -602,7 +602,7 @@ define(['shared_helper', 'chai'], function (helper, chai) {
 
     if (typeof Promise !== 'undefined') {
       it('stats_promise', function (done) {
-        var client = helper.AblyRest({ promises: true });
+        var client = helper.AblyRest({ internal: { promises: true } });
 
         client
           .stats()

--- a/test/rest/status.test.js
+++ b/test/rest/status.test.js
@@ -42,7 +42,7 @@ define(['shared_helper', 'chai'], function (helper, chai) {
 
     if (typeof Promise !== 'undefined') {
       it('statusPromise', function (done) {
-        var rest = helper.AblyRest({ promises: true });
+        var rest = helper.AblyRest({ internal: { promises: true } });
         var channel = rest.channels.get('statusPromise');
         channel
           .status()

--- a/test/rest/time.test.js
+++ b/test/rest/time.test.js
@@ -38,7 +38,7 @@ define(['shared_helper', 'chai'], function (helper, chai) {
 
     if (typeof Promise !== 'undefined') {
       it('timePromise', function (done) {
-        var rest = helper.AblyRest({ promises: true });
+        var rest = helper.AblyRest({ internal: { promises: true } });
         rest
           .time()
           .then(function () {


### PR DESCRIPTION
This is part of #1197 (removing deprecated APIs for v2). See commit messages for more details. Would be good to hear opinions on the approach of the final commit and whether it's safe.