### PR TITLE
Remove remaining deprecated APIs

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -439,11 +439,6 @@ declare namespace Types {
     fallbackHosts?: string[];
 
     /**
-     * @deprecated This property is deprecated and will be removed in a future version. Enables default fallback hosts to be used.
-     */
-    fallbackHostsUseDefault?: boolean;
-
-    /**
      * Set of configurable options to set on the HTTP(S) agent used for REST requests.
      *
      * See the [NodeJS docs](https://nodejs.org/api/http.html#new-agentoptions) for descriptions of these options.

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -284,19 +284,6 @@ class Auth {
       throw new ErrorInfo('Unable to update auth options with incompatible key', 40102, 401);
     }
 
-    if (_authOptions && 'force' in _authOptions) {
-      Logger.logAction(
-        Logger.LOG_ERROR,
-        'Auth.authorize',
-        'Deprecation warning: specifying {force: true} in authOptions is no longer necessary, authorize() now always gets a new token. Please remove this, as in version 1.0 and later, having a non-null authOptions will overwrite stored library authOptions, which may not be what you want'
-      );
-      /* Emulate the old behaviour: if 'force' was the only member of authOptions,
-       * set it to null so it doesn't overwrite stored. TODO: remove in version 1.0 */
-      if (Utils.isOnlyPropIn(_authOptions, 'force')) {
-        _authOptions = null;
-      }
-    }
-
     this._forceNewToken(
       tokenParams as API.Types.TokenParams,
       _authOptions,

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -313,11 +313,6 @@ class Auth {
     );
   }
 
-  authorise(tokenParams: API.Types.TokenParams | null, authOptions: API.Types.AuthOptions, callback: Function): void {
-    Logger.deprecated('Auth.authorise', 'Auth.authorize');
-    this.authorize(tokenParams, authOptions, callback);
-  }
-
   /* For internal use, eg by connectionManager - useful when want to call back
    * as soon as we have the new token, rather than waiting for it to take
    * effect on the connection as #authorize does */

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -272,14 +272,7 @@ class RealtimeChannel extends Channel {
     }
   }
 
-  attach(flags?: API.Types.ChannelMode[] | ErrCallback, callback?: ErrCallback): void | Promise<void> {
-    let _flags: API.Types.ChannelMode[] | null | undefined;
-    if (typeof flags === 'function') {
-      callback = flags;
-      _flags = null;
-    } else {
-      _flags = flags;
-    }
+  attach(callback?: ErrCallback): void | Promise<void> {
     if (!callback) {
       if (this.realtime.options.promises) {
         return Utils.promisify(this, 'attach', arguments);
@@ -290,12 +283,7 @@ class RealtimeChannel extends Channel {
         }
       };
     }
-    if (_flags) {
-      Logger.deprecated('channel.attach() with flags', 'channel.setOptions() with channelOptions.params');
-      /* If flags requested, always do a re-attach. TODO only do this if
-       * current mode differs from requested mode */
-      this._requestedFlags = _flags as API.Types.ChannelMode[];
-    } else if (this.state === 'attached') {
+    if (this.state === 'attached') {
       callback();
       return;
     }

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -507,18 +507,6 @@ class RealtimePresence extends Presence {
     });
   }
 
-  /* Deprecated */
-  on(...args: unknown[]): void {
-    Logger.deprecated('presence.on', 'presence.subscribe');
-    this.subscribe(...args);
-  }
-
-  /* Deprecated */
-  off(...args: unknown[]): void {
-    Logger.deprecated('presence.off', 'presence.unsubscribe');
-    this.unsubscribe(...args);
-  }
-
   subscribe(..._args: unknown[] /* [event], listener, [callback] */): void | Promise<void> {
     const args = RealtimeChannel.processListenerArgs(_args);
     const event = args[0];

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -182,35 +182,6 @@ export function objectifyOptions(options: ClientOptions | string): ClientOptions
 }
 
 export function normaliseOptions(options: InternalClientOptions): NormalisedClientOptions {
-  if (options.fallbackHostsUseDefault) {
-    /* fallbackHostsUseDefault and fallbackHosts are mutually exclusive as per TO3k7 */
-    if (options.fallbackHosts) {
-      const msg = 'fallbackHosts and fallbackHostsUseDefault cannot both be set';
-      Logger.logAction(Logger.LOG_ERROR, 'Defaults.normaliseOptions', msg);
-      throw new ErrorInfo(msg, 40000, 400);
-    }
-
-    /* default fallbacks can't be used with custom ports */
-    if (options.port || options.tlsPort) {
-      const msg = 'fallbackHostsUseDefault cannot be set when port or tlsPort are set';
-      Logger.logAction(Logger.LOG_ERROR, 'Defaults.normaliseOptions', msg);
-      throw new ErrorInfo(msg, 40000, 400);
-    }
-
-    /* emit an appropriate deprecation warning */
-    if (options.environment) {
-      Logger.deprecatedWithMsg(
-        'fallbackHostsUseDefault',
-        'There is no longer a need to set this when the environment option is also set since the library will now generate the correct fallback hosts using the environment option.'
-      );
-    } else {
-      Logger.deprecated('fallbackHostsUseDefault', 'fallbackHosts: Ably.Defaults.FALLBACK_HOSTS');
-    }
-
-    /* use the default fallback hosts as requested */
-    options.fallbackHosts = Defaults.FALLBACK_HOSTS;
-  }
-
   /* options.recover as a boolean is deprecated, and therefore is not part of the public typing */
   if ((options.recover as any) === true) {
     Logger.deprecated('{recover: true}', '{recover: function(lastConnectionDetails, cb) { cb(true); }}');

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -197,12 +197,6 @@ export function normaliseOptions(options: InternalClientOptions): NormalisedClie
     options.closeOnUnload = !options.recover;
   }
 
-  if (options.transports && Utils.arrIn(options.transports, 'xhr')) {
-    Logger.deprecated('transports: ["xhr"]', 'transports: ["xhr_streaming"]');
-    Utils.arrDeleteValue(options.transports, 'xhr');
-    options.transports.push('xhr_streaming');
-  }
-
   if (!('queueMessages' in options)) options.queueMessages = true;
 
   /* infer hosts and fallbacks based on the configured environment */

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -182,14 +182,6 @@ export function objectifyOptions(options: ClientOptions | string): ClientOptions
 }
 
 export function normaliseOptions(options: InternalClientOptions): NormalisedClientOptions {
-  /* options.recover as a boolean is deprecated, and therefore is not part of the public typing */
-  if ((options.recover as any) === true) {
-    Logger.deprecated('{recover: true}', '{recover: function(lastConnectionDetails, cb) { cb(true); }}');
-    options.recover = function (lastConnectionDetails: unknown, cb: (shouldRecover: boolean) => void) {
-      cb(true);
-    };
-  }
-
   if (typeof options.recover === 'function' && options.closeOnUnload === true) {
     Logger.logAction(
       Logger.LOG_ERROR,

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -104,18 +104,6 @@ class Logger {
     }
   };
 
-  static deprecated = function (original: string, replacement: string) {
-    Logger.deprecatedWithMsg(original, "Please use '" + replacement + "' instead.");
-  };
-
-  static deprecatedWithMsg = (funcName: string, msg: string) => {
-    if (Logger.shouldLog(LogLevels.Error)) {
-      Logger.logErrorHandler(
-        "Ably: Deprecation warning - '" + funcName + "' is deprecated and will be removed from a future version. " + msg
-      );
-    }
-  };
-
   /* Where a logging operation is expensive, such as serialisation of data, use shouldLog will prevent
 	   the object being serialised if the log level will not output the message */
   static shouldLog = (level: LogLevels) => {

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -81,15 +81,6 @@ export function isEmpty(ob: Record<string, unknown> | unknown[]): boolean {
   return true;
 }
 
-export function isOnlyPropIn(ob: Record<string, unknown>, property: string): boolean {
-  for (const prop in ob) {
-    if (prop !== property) {
-      return false;
-    }
-  }
-  return true;
-}
-
 /*
  * Determine whether or not an argument to an overloaded function is
  * undefined (missing) or null.

--- a/src/platform/nodejs/lib/util/crypto.js
+++ b/src/platform/nodejs/lib/util/crypto.js
@@ -126,20 +126,6 @@ var Crypto = (function () {
    */
   Crypto.getDefaultParams = function (params) {
     var key;
-    /* Backward compatibility */
-    if (typeof params === 'function' || typeof params === 'string') {
-      Logger.deprecated('Crypto.getDefaultParams(key, callback)', 'Crypto.getDefaultParams({key: key})');
-      if (typeof params === 'function') {
-        Crypto.generateRandomKey(function (key) {
-          params(null, Crypto.getDefaultParams({ key: key }));
-        });
-      } else if (typeof arguments[1] === 'function') {
-        arguments[1](null, Crypto.getDefaultParams({ key: params }));
-      } else {
-        throw new Error('Invalid arguments for Crypto.getDefaultParams');
-      }
-      return;
-    }
 
     if (!params.key) {
       throw new Error('Crypto.getDefaultParams: a key is required');

--- a/src/platform/web/lib/util/crypto.js
+++ b/src/platform/web/lib/util/crypto.js
@@ -158,20 +158,6 @@ var Crypto = (function () {
    */
   Crypto.getDefaultParams = function (params) {
     var key;
-    /* Backward compatibility */
-    if (typeof params === 'function' || typeof params === 'string') {
-      Logger.deprecated('Crypto.getDefaultParams(key, callback)', 'Crypto.getDefaultParams({key: key})');
-      if (typeof params === 'function') {
-        Crypto.generateRandomKey(function (key) {
-          params(null, Crypto.getDefaultParams({ key: key }));
-        });
-      } else if (typeof arguments[1] === 'function') {
-        arguments[1](null, Crypto.getDefaultParams({ key: params }));
-      } else {
-        throw new Error('Invalid arguments for Crypto.getDefaultParams');
-      }
-      return;
-    }
 
     if (!params.key) {
       throw new Error('Crypto.getDefaultParams: a key is required');

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -972,14 +972,6 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           'Check authorize completely replaces stored authOptions with passed in ones'
         );
 
-        /* TODO remove for lib version 1.0 */
-        realtime.auth.authorize(null, { authUrl: 'http://invalid' });
-        realtime.auth.authorize(null, { force: true });
-        expect(realtime.auth.authOptions.authUrl).to.equal(
-          'http://invalid',
-          'Check authorize does *not* replace stored authOptions when the only option is "force" in 0.9, for compatibility with 0.8'
-        );
-
         closeAndFinish(done, realtime);
       } catch (err) {
         closeAndFinish(done, realtime, err);

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1119,39 +1119,6 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     });
 
     /*
-     * Check that old deprecated on/off methods still work
-     */
-    it('presenceOn', function (done) {
-      var channelName = 'enterOn';
-      var testData = 'some data';
-      var eventListener = function (channel, callback) {
-        var presenceHandler = function () {
-          callback();
-        };
-        channel.presence.on(presenceHandler);
-      };
-      var enterOn = function (cb) {
-        var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
-        clientRealtime.connection.on('connected', function () {
-          /* get channel, attach, and enter */
-          var clientChannel = clientRealtime.channels.get(channelName);
-          clientChannel.attach(function (err) {
-            if (err) {
-              cb(err, clientRealtime);
-              return;
-            }
-            clientChannel.presence.enter(testData, function (err) {
-              cb(err, clientRealtime);
-            });
-          });
-        });
-        monitorConnection(done, clientRealtime);
-      };
-
-      runTestWithEventListener(done, channelName, eventListener, enterOn);
-    });
-
-    /*
      * Check that encodable presence messages are encoded correctly
      */
     it('presenceEncoding', function (done) {

--- a/test/rest/defaults.test.js
+++ b/test/rest/defaults.test.js
@@ -61,27 +61,6 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
     });
 
-    /* will emit a deprecation warning */
-    it('Init with given environment and default fallbacks', function () {
-      var normalisedOptions = Defaults.normaliseOptions({ environment: 'sandbox', fallbackHostsUseDefault: true });
-
-      expect(normalisedOptions.restHost).to.equal('sandbox-rest.ably.io');
-      expect(normalisedOptions.realtimeHost).to.equal('sandbox-realtime.ably.io');
-      expect(normalisedOptions.port).to.equal(80);
-      expect(normalisedOptions.tlsPort).to.equal(443);
-      expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.FALLBACK_HOSTS.sort());
-      expect(normalisedOptions.tls).to.equal(true);
-
-      expect(Defaults.getHosts(normalisedOptions).length).to.deep.equal(4);
-      expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
-      expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', false)).to.deep.equal('sandbox-rest.ably.io');
-      expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', true)).to.deep.equal(
-        'sandbox-realtime.ably.io'
-      );
-
-      expect(Defaults.getPort(normalisedOptions)).to.equal(443);
-    });
-
     it('Init with local environment and non-default ports', function () {
       var normalisedOptions = Defaults.normaliseOptions({ environment: 'local', port: 8080, tlsPort: 8081 });
 
@@ -132,34 +111,6 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(Defaults.getHost(normalisedOptions, 'test.org', true)).to.deep.equal('ws.test.org');
 
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
-    });
-
-    /* init with given restHost and realtimeHost, using the default fallback hosts */
-    it('Init with given restHost and realtimeHost, using the default fallback hosts', function () {
-      var normalisedOptions = Defaults.normaliseOptions({
-        restHost: 'test.org',
-        realtimeHost: 'ws.test.org',
-        fallbackHostsUseDefault: true,
-      });
-
-      expect(normalisedOptions.restHost).to.equal('test.org');
-      expect(normalisedOptions.realtimeHost).to.equal('ws.test.org');
-      expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.FALLBACK_HOSTS.sort());
-    });
-
-    it('Throws an error when initiated with fallbackHosts and fallbackHostsUseDefault', function () {
-      expect(function () {
-        Defaults.normaliseOptions({ fallbackHosts: ['a.example.com', 'b.example.com'], fallbackHostsUseDefault: true });
-      }, "Check fallbackHosts and fallbackHostsUseDefault can't both be set").to.throw();
-    });
-
-    it('Throws an error with initiated with fallbackHostsUseDefault and port or tlsPort set', function () {
-      expect(function () {
-        Defaults.normaliseOptions({ fallbackHostsUseDefault: true, port: 8080 });
-      }, "Check fallbackHostsUseDefault and port can't both be set").to.throw;
-      expect(function () {
-        Defaults.normaliseOptions({ fallbackHostsUseDefault: true, tlsPort: 8081 });
-      }, "Check fallbackHostsUseDefault and tlsPort can't both be set").to.throw;
     });
 
     it('Init with no endpoint-related options and given default environment', function () {


### PR DESCRIPTION
**Note: This PR is based on top of #1221. Please review that one first.**

This removes the remaining deprecated APIs in the SDK. See commit messages for more details.

Resolves #1197.