### PR TITLE
[SDK-3549] Remove `ably-commonjs*.js` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For usage, jump to [Using the Realtime API](#using-the-realtime-api) or [Using t
 
 WebPack will search your `node_modules` folder by default, so if you include `ably` in your `package.json` file, when running Webpack the following will allow you to `require('ably')` (or if using typescript or ES6 modules, `import * as Ably from 'ably';`). If your webpack target is set to 'browser', this will automatically use the browser commonjs distribution.
 
-If that doesn't work for some reason (e.g. you are using a custom webpack target), you can reference the `ably-commonjs.js` static file directly: `require('ably/build/ably-commonjs.js');` (or `import * as Ably from 'ably/build/ably-commonjs.js'` for typescript / ES6 modules).
+If that doesn't work for some reason (e.g. you are using a custom webpack target), you can reference the `ably.js` static file directly: `require('ably/build/ably.js');` (or `import * as Ably from 'ably/build/ably.js'` for typescript / ES6 modules).
 
 ### TypeScript
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "./build/ably-node.js": "./build/ably-reactnative.js"
   },
   "browser": {
-    "./build/ably-node.js": "./build/ably-commonjs.js"
+    "./build/ably-node.js": "./build/ably.js"
   },
   "files": [
     "build/**",

--- a/test/support/browser_file_list.js
+++ b/test/support/browser_file_list.js
@@ -1,7 +1,5 @@
 window.__testFiles__ = { base: '../' };
 window.__testFiles__.files = {
-  'build/ably-commonjs.js': true,
-  'build/ably-commonjs.noencryption.js': true,
   'build/ably-nativescript.js': true,
   'build/ably-node.js': true,
   'build/ably-reactnative.js': true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -207,23 +207,6 @@ const noEncryptionMinConfig = {
   devtool: 'source-map',
 };
 
-// We are using UMD in ably.js now so there is no need to build separately for CommonJS. These files are still being distributed to avoid breaking changes but should no longer be used.
-const commonJsConfig = {
-  ...browserConfig,
-  output: {
-    ...baseConfig.output,
-    filename: 'ably-commonjs.js',
-  },
-};
-
-const commonJsNoEncryptionConfig = {
-  ...noEncryptionConfig,
-  output: {
-    ...baseConfig.output,
-    filename: 'ably-commonjs.noencryption.js',
-  },
-};
-
 module.exports = {
   node: nodeConfig,
   browser: browserConfig,
@@ -233,6 +216,4 @@ module.exports = {
   reactNative: reactNativeConfig,
   noEncryption: noEncryptionConfig,
   noEncryptionMin: noEncryptionMinConfig,
-  commonJs: commonJsConfig,
-  commonJsNoEncryption: commonJsNoEncryptionConfig,
 };


### PR DESCRIPTION
These files are identical to `ably.js` and `ably.noencryption.js`. We only maintained them in v1 for backwards compatibility.

Resolves #1200.