### PR TITLE
Make representation of protocol version consistent with spec

### DIFF
--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -148,7 +148,7 @@ export class TransportParams {
     if (this.heartbeats !== undefined) {
       params.heartbeats = this.heartbeats;
     }
-    params.v = Defaults.apiVersion;
+    params.v = Defaults.protocolVersion;
     params.agent = encodeURIComponent(getAgentString(this.options));
     if (options.transportParams !== undefined) {
       Utils.mixin(params, options.transportParams);

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -30,7 +30,7 @@ type CompleteDefaults = IDefaults & {
   httpMaxRetryCount: number;
   maxMessageSize: number;
   version: string;
-  protocolVersion: string;
+  protocolVersion: number;
   agent: string;
   getHost(options: ClientOptions, host?: string | null, ws?: boolean): string;
   getPort(options: ClientOptions, tls?: boolean): number | undefined;
@@ -76,7 +76,7 @@ const Defaults = {
   maxMessageSize: 65536,
 
   version,
-  protocolVersion: '2',
+  protocolVersion: 2,
   agent,
   getHost,
   getPort,

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -30,7 +30,7 @@ type CompleteDefaults = IDefaults & {
   httpMaxRetryCount: number;
   maxMessageSize: number;
   version: string;
-  apiVersion: string;
+  protocolVersion: string;
   agent: string;
   getHost(options: ClientOptions, host?: string | null, ws?: boolean): string;
   getPort(options: ClientOptions, tls?: boolean): number | undefined;
@@ -76,7 +76,7 @@ const Defaults = {
   maxMessageSize: 65536,
 
   version,
-  apiVersion: '2',
+  protocolVersion: '2',
   agent,
   getHost,
   getPort,

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -351,7 +351,7 @@ export function defaultGetHeaders(options: NormalisedClientOptions, format?: For
   const accept = contentTypes[format || Format.json];
   return {
     accept: accept,
-    'X-Ably-Version': Defaults.apiVersion,
+    'X-Ably-Version': Defaults.protocolVersion,
     'Ably-Agent': getAgentString(options),
   };
 }
@@ -363,7 +363,7 @@ export function defaultPostHeaders(options: NormalisedClientOptions, format?: Fo
   return {
     accept: accept,
     'content-type': contentType,
-    'X-Ably-Version': Defaults.apiVersion,
+    'X-Ably-Version': Defaults.protocolVersion,
     'Ably-Agent': getAgentString(options),
   };
 }

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -351,7 +351,7 @@ export function defaultGetHeaders(options: NormalisedClientOptions, format?: For
   const accept = contentTypes[format || Format.json];
   return {
     accept: accept,
-    'X-Ably-Version': Defaults.protocolVersion,
+    'X-Ably-Version': Defaults.protocolVersion.toString(),
     'Ably-Agent': getAgentString(options),
   };
 }
@@ -363,7 +363,7 @@ export function defaultPostHeaders(options: NormalisedClientOptions, format?: Fo
   return {
     accept: accept,
     'content-type': contentType,
-    'X-Ably-Version': Defaults.protocolVersion,
+    'X-Ably-Version': Defaults.protocolVersion.toString(),
     'Ably-Agent': getAgentString(options),
   };
 }


### PR DESCRIPTION
This changes `Defaults`’s `apiVersion: string` to `protocolVersion: number`, for consistency with [`CSV2`](https://sdk.ably.com/builds/ably/specification/main/features/#CSV2). See commit messages for more details.