### PR TITLE
Rename `IPlatform` to `IPlatformConfig`

### DIFF
--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -1,4 +1,4 @@
-import { IPlatform } from './types/IPlatform';
+import { IPlatformConfig } from './types/IPlatformConfig';
 import { IHttp } from './types/http';
 import ConnectionManager from './lib/transport/connectionmanager';
 import IDefaults from './types/IDefaults';
@@ -7,7 +7,7 @@ import IBufferUtils from './types/IBufferUtils';
 import Transport from './lib/transport/transport';
 
 export default class Platform {
-  static Config: IPlatform;
+  static Config: IPlatformConfig;
   static BufferUtils: IBufferUtils;
   static Crypto: any; //Not typed
   static Http: typeof IHttp;

--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -1,4 +1,4 @@
-import { TypedArray } from './IPlatform';
+import { TypedArray } from './IPlatformConfig';
 import WordArray from 'crypto-js/build/lib-typedarrays';
 
 export type NodeBufferlike = Buffer | ArrayBuffer | TypedArray;

--- a/src/common/types/IPlatformConfig.d.ts
+++ b/src/common/types/IPlatformConfig.d.ts
@@ -14,7 +14,7 @@ interface MsgPack {
   decode(buffer: Buffer): any;
 }
 
-export interface IPlatform {
+export interface IPlatformConfig {
   agent: string;
   logTimestamps: boolean;
   binaryType: BinaryType;

--- a/src/platform/nativescript/config.js
+++ b/src/platform/nativescript/config.js
@@ -18,7 +18,7 @@ if (global.android) {
   };
 }
 
-var Platform = {
+var Config = {
   agent: 'nativescript',
   logTimestamps: true,
   noUpgrade: false,
@@ -61,4 +61,4 @@ var Platform = {
   },
 };
 
-export default Platform;
+export default Config;

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -9,7 +9,7 @@ import BufferUtils from '../web/lib/util/bufferutils';
 import Crypto from '../web/lib/util/crypto';
 import Http from '../web/lib/util/http';
 // @ts-ignore
-import Config from './platform';
+import Config from './config';
 // @ts-ignore
 import Transports from '../web/lib/transport';
 import Logger from '../../common/lib/util/logger';

--- a/src/platform/nodejs/config.ts
+++ b/src/platform/nodejs/config.ts
@@ -1,9 +1,9 @@
-import { TypedArray, IPlatform } from '../../common/types/IPlatform';
+import { TypedArray, IPlatformConfig } from '../../common/types/IPlatformConfig';
 import crypto from 'crypto';
 import WebSocket from 'ws';
 import util from 'util';
 
-const Platform: IPlatform = {
+const Config: IPlatformConfig = {
   agent: 'nodejs/' + process.versions.node,
   logTimestamps: true,
   userAgent: null,
@@ -29,4 +29,4 @@ const Platform: IPlatform = {
   Promise: global && global.Promise,
 };
 
-export default Platform;
+export default Config;

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -8,7 +8,7 @@ import BufferUtils from './lib/util/bufferutils';
 // @ts-ignore
 import Crypto from './lib/util/crypto';
 import Http from './lib/util/http';
-import Config from './platform';
+import Config from './config';
 // @ts-ignore
 import Transports from './lib/transport';
 import Logger from '../../common/lib/util/logger';

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -1,4 +1,4 @@
-import { TypedArray } from 'common/types/IPlatform';
+import { TypedArray } from 'common/types/IPlatformConfig';
 import IBufferUtils, { Bufferlike, NodeBufferlike } from 'common/types/IBufferUtils';
 
 class BufferUtils implements IBufferUtils {

--- a/src/platform/react-native/config.ts
+++ b/src/platform/react-native/config.ts
@@ -1,8 +1,8 @@
 import msgpack from '../web/lib/util/msgpack';
 import { parse as parseBase64 } from 'crypto-js/build/enc-base64';
-import { IPlatform } from '../../common/types/IPlatform';
+import { IPlatformConfig } from '../../common/types/IPlatformConfig';
 
-const Platform: IPlatform = {
+const Platform: IPlatformConfig = {
   agent: 'reactnative',
   logTimestamps: true,
   noUpgrade: false,

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -8,7 +8,7 @@ import BufferUtils from '../web/lib/util/bufferutils';
 // @ts-ignore
 import Crypto from '../web/lib/util/crypto';
 import Http from '../web/lib/util/http';
-import Config from './platform';
+import Config from './config';
 // @ts-ignore
 import Transports from '../web/lib/transport';
 import Logger from '../../common/lib/util/logger';

--- a/src/platform/web-noencryption/index.ts
+++ b/src/platform/web-noencryption/index.ts
@@ -7,7 +7,7 @@ import Platform from '../../common/platform';
 import BufferUtils from '../web/lib/util/bufferutils';
 // @ts-ignore
 import Http from '../web/lib/util/http';
-import Config from '../web/platform';
+import Config from '../web/config';
 // @ts-ignore
 import Transports from '../web/lib/transport';
 import Logger from '../../common/lib/util/logger';

--- a/src/platform/web/config-webworker.ts
+++ b/src/platform/web/config-webworker.ts
@@ -1,0 +1,5 @@
+import Config from './config';
+
+Config.isWebworker = true;
+
+export default Config;

--- a/src/platform/web/config.ts
+++ b/src/platform/web/config.ts
@@ -1,5 +1,5 @@
 import msgpack from './lib/util/msgpack';
-import { IPlatform, TypedArray } from '../../common/types/IPlatform';
+import { IPlatformConfig, TypedArray } from '../../common/types/IPlatformConfig';
 import * as Utils from 'common/lib/util/utils';
 
 // Workaround for salesforce lightning locker compat
@@ -24,7 +24,7 @@ function allowComet() {
 const userAgent = globalObject.navigator && globalObject.navigator.userAgent.toString();
 const currentUrl = globalObject.location && globalObject.location.href;
 
-const Platform: IPlatform = {
+const Config: IPlatformConfig = {
   agent: 'browser',
   logTimestamps: true,
   userAgent: userAgent,
@@ -75,4 +75,4 @@ const Platform: IPlatform = {
   })(globalObject.crypto || msCrypto),
 };
 
-export default Platform;
+export default Config;

--- a/src/platform/web/index-webworker.ts
+++ b/src/platform/web/index-webworker.ts
@@ -1,4 +1,4 @@
-import './platform-webworker';
+import './config-webworker';
 import Ably from './index';
 
 export default Ably;

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -8,7 +8,7 @@ import BufferUtils from './lib/util/bufferutils';
 // @ts-ignore
 import Crypto from './lib/util/crypto';
 import Http from './lib/util/http';
-import Config from './platform';
+import Config from './config';
 // @ts-ignore
 import Transports from './lib/transport';
 import Logger from '../../common/lib/util/logger';

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -3,7 +3,7 @@ import { parse as parseUtf8, stringify as stringifyUtf8 } from 'crypto-js/build/
 import { parse as parseBase64, stringify as stringifyBase64 } from 'crypto-js/build/enc-base64';
 import WordArray from 'crypto-js/build/lib-typedarrays';
 import Platform from 'common/platform';
-import { TypedArray } from 'common/types/IPlatform';
+import { TypedArray } from 'common/types/IPlatformConfig';
 import IBufferUtils from 'common/types/IBufferUtils';
 import { Bufferlike } from 'common/types/IBufferUtils';
 

--- a/src/platform/web/platform-webworker.ts
+++ b/src/platform/web/platform-webworker.ts
@@ -1,5 +1,0 @@
-import Platform from './platform';
-
-Platform.isWebworker = true;
-
-export default Platform;


### PR DESCRIPTION
Whilst trying to understand how the platform configuration mechanism works I noticed that we have multiple things called `Platform` and found it rather confusing.

The new naming matches how these objects are being used in the platforms’ `index.ts` files — that is, imported as `Config` and used as the value of `Platform.Config`.