### PR TITLE
Remove mention of `Platform` from `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ When a 128 bit or 256 bit key is provided to the library, the `data` attributes 
 ```javascript
 // Generate a random 256-bit key for demonstration purposes (in
 // practice you need to create one and distribute it to clients yourselves)
-Ably.Realtime.Platform.Crypto.generateRandomKey(function (err, key) {
+Ably.Realtime.Crypto.generateRandomKey(function (err, key) {
   var channel = client.channels.get('channelName', { cipher: { key: key } });
 
   channel.subscribe(function (message) {


### PR DESCRIPTION
It’s not part of the public API of the SDK (e.g. doesn’t appear in `ably.d.ts`). That does now lead to a question — now that it’s been accidentally documented, do we need to remember to maintain the `Ably.Realtime.Platform.Crypto` property or are we at liberty to rename / change as we see fit without considering it a breaking change?