### PR TITLE
Rename `IBufferUtils.toBuffer` to `toUint8Array`

### DIFF
--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -98,10 +98,10 @@ class Message {
         encoding = encoding ? encoding + '/base64' : 'base64';
         data = Platform.BufferUtils.base64Encode(data);
       } else {
-        /* Called by msgpack. toBuffer returns a datatype understandable by
+        /* Called by msgpack. toUint8Array returns a datatype understandable by
          * that platform's msgpack implementation (Buffer in node, Uint8Array
          * in browsers) */
-        data = Platform.BufferUtils.toBuffer(data);
+        data = Platform.BufferUtils.toUint8Array(data);
       }
     }
     return {
@@ -271,8 +271,8 @@ class Message {
                 /* vcdiff expects Uint8Arrays, can't copy with ArrayBuffers. (also, if we
                  * don't have a TextDecoder, deltaBase might be a WordArray here, so need
                  * to process it into a buffer anyway) */
-                deltaBase = Platform.BufferUtils.toBuffer(deltaBase as Buffer);
-                data = Platform.BufferUtils.toBuffer(data);
+                deltaBase = Platform.BufferUtils.toUint8Array(deltaBase as Buffer);
+                data = Platform.BufferUtils.toUint8Array(data);
 
                 data = Platform.BufferUtils.typedArrayToBuffer(context.plugins.vcdiff.decode(data, deltaBase));
                 lastPayload = data;

--- a/src/common/lib/types/presencemessage.ts
+++ b/src/common/lib/types/presencemessage.ts
@@ -64,10 +64,8 @@ class PresenceMessage {
         encoding = encoding ? encoding + '/base64' : 'base64';
         data = Platform.BufferUtils.base64Encode(data);
       } else {
-        /* Called by msgpack. toBuffer returns a datatype understandable by
-         * that platform's msgpack implementation (Buffer in node, Uint8Array
-         * in browsers) */
-        data = Platform.BufferUtils.toBuffer(data);
+        /* Called by msgpack. */
+        data = Platform.BufferUtils.toUint8Array(data);
       }
     }
     return {

--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -12,8 +12,7 @@ export default interface IBufferUtils {
   base64CharSet: string;
   hexCharSet: string;
   isBuffer: (buffer: unknown) => buffer is Bufferlike;
-  // On browser this returns a Uint8Array, on node a Buffer
-  toBuffer: (buffer: Bufferlike) => Buffer | Uint8Array;
+  toUint8Array: (buffer: Bufferlike) => Uint8Array;
   toArrayBuffer: (buffer: Bufferlike) => ArrayBuffer;
   base64Encode: (buffer: Bufferlike) => string;
   base64Decode: (string: string) => Buffer | BrowserBufferlike;

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -10,7 +10,7 @@ class BufferUtils implements IBufferUtils {
   }
 
   base64Encode(buffer: Bufferlike): string {
-    return this.toBuffer(buffer).toString('base64');
+    return this.toUint8Array(buffer).toString('base64');
   }
 
   bufferCompare(buffer1: Buffer, buffer2: Buffer): number {
@@ -28,7 +28,7 @@ class BufferUtils implements IBufferUtils {
   }
 
   hexEncode(buffer: Bufferlike): string {
-    return this.toBuffer(buffer).toString('hex');
+    return this.toUint8Array(buffer).toString('hex');
   }
 
   isArrayBuffer(ob: unknown) {
@@ -42,10 +42,10 @@ class BufferUtils implements IBufferUtils {
   }
 
   toArrayBuffer(buffer: Bufferlike): ArrayBuffer {
-    return this.toBuffer(buffer).buffer;
+    return this.toUint8Array(buffer).buffer;
   }
 
-  toBuffer(buffer: Bufferlike): Buffer {
+  toUint8Array(buffer: Bufferlike): Buffer {
     if (Buffer.isBuffer(buffer)) {
       return buffer;
     }
@@ -53,14 +53,14 @@ class BufferUtils implements IBufferUtils {
   }
 
   typedArrayToBuffer(typedArray: TypedArray): Buffer {
-    return this.toBuffer(typedArray.buffer as Buffer);
+    return this.toUint8Array(typedArray.buffer as Buffer);
   }
 
   utf8Decode(buffer: Bufferlike): string {
     if (!this.isBuffer(buffer)) {
       throw new Error('Expected input of utf8Decode to be a buffer, arraybuffer, or view');
     }
-    return this.toBuffer(buffer).toString('utf8');
+    return this.toUint8Array(buffer).toString('utf8');
   }
 
   utf8Encode(string: string): Buffer {

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -8,7 +8,7 @@ import IBufferUtils from 'common/types/IBufferUtils';
 import { Bufferlike } from 'common/types/IBufferUtils';
 
 /* Most BufferUtils methods that return a binary object return an ArrayBuffer
- * if supported, else a CryptoJS WordArray. The exception is toBuffer, which
+ * if supported, else a CryptoJS WordArray. The exception is toUint8Array, which
  * returns a Uint8Array (and won't work on browsers too old to support it) */
 
 class BufferUtils implements IBufferUtils {
@@ -95,7 +95,7 @@ class BufferUtils implements IBufferUtils {
   }
 
   /* In browsers, returns a Uint8Array */
-  toBuffer(buffer: Bufferlike): Uint8Array {
+  toUint8Array(buffer: Bufferlike): Uint8Array {
     if (!ArrayBuffer) {
       throw new Error("Can't convert to Buffer: browser does not support the necessary types");
     }
@@ -121,14 +121,14 @@ class BufferUtils implements IBufferUtils {
       return uint8View;
     }
 
-    throw new Error('BufferUtils.toBuffer expected an arraybuffer, typed array, or CryptoJS wordarray');
+    throw new Error('BufferUtils.toUint8Array expected an arraybuffer, typed array, or CryptoJS wordarray');
   }
 
   toArrayBuffer(buffer: Bufferlike): ArrayBuffer {
     if (this.isArrayBuffer(buffer)) {
       return buffer as ArrayBuffer;
     }
-    return this.toBuffer(buffer).buffer;
+    return this.toUint8Array(buffer).buffer;
   }
 
   toWordArray(buffer: TypedArray | WordArray | number[] | ArrayBuffer) {
@@ -142,7 +142,7 @@ class BufferUtils implements IBufferUtils {
     if (this.isWordArray(buffer)) {
       return stringifyBase64(buffer);
     }
-    return this.uint8ViewToBase64(this.toBuffer(buffer));
+    return this.uint8ViewToBase64(this.toUint8Array(buffer));
   }
 
   base64Decode(str: string): Buffer | ArrayBuffer | WordArray {

--- a/test/rest/bufferutils.test.js
+++ b/test/rest/bufferutils.test.js
@@ -38,7 +38,7 @@ define(['ably', 'chai'], function (Ably, chai) {
         expect(BufferUtils.utf8Encode(testString).constructor).to.equal(Buffer);
         expect(BufferUtils.hexDecode(testHex).constructor).to.equal(Buffer);
         expect(BufferUtils.base64Decode(testBase64).constructor).to.equal(Buffer);
-        expect(BufferUtils.toBuffer(BufferUtils.utf8Encode(testString)).constructor).to.equal(Buffer);
+        expect(BufferUtils.toUint8Array(BufferUtils.utf8Encode(testString)).constructor).to.equal(Buffer);
         expect(BufferUtils.toArrayBuffer(BufferUtils.utf8Encode(testString)).constructor).to.equal(ArrayBuffer);
       } else if (typeof ArrayBuffer !== 'undefined') {
         /* modern browsers */
@@ -49,7 +49,7 @@ define(['ably', 'chai'], function (Ably, chai) {
         }
         expect(BufferUtils.hexDecode(testHex).constructor).to.equal(ArrayBuffer);
         expect(BufferUtils.base64Decode(testBase64).constructor).to.equal(ArrayBuffer);
-        expect(BufferUtils.toBuffer(BufferUtils.utf8Encode(testString)).constructor).to.equal(Uint8Array);
+        expect(BufferUtils.toUint8Array(BufferUtils.utf8Encode(testString)).constructor).to.equal(Uint8Array);
         expect(BufferUtils.toArrayBuffer(BufferUtils.utf8Encode(testString)).constructor).to.equal(ArrayBuffer);
       } else {
         /* legacy browsers */


### PR DESCRIPTION
And change its signature to just return a `Uint8Array` ([`Buffer` inherits from `Uint8Array` since Node 3.0.0]( https://nodejs.org/api/buffer.html#buffers-and-typedarrays)).