### PR TITLE
Feature/subscription filters

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -987,6 +987,16 @@ declare namespace Types {
   }
 
   /**
+   * Passes additional properties to a {@link RealtimeChannelBase} name to produce a new derived channel
+   */
+  interface DeriveOptions {
+    /**
+     * The JMESPath Query filter string to be used to derive new channel.
+     */
+    filter?: string;
+  }
+
+  /**
    * The `RestHistoryParams` interface describes the parameters accepted by the following methods:
    *
    * - {@link PresenceCallbacks.history}
@@ -2752,6 +2762,16 @@ declare namespace Types {
      * @returns A {@link ChannelBase} or {@link RealtimeChannelBase} object.
      */
     get(name: string, channelOptions?: ChannelOptions): T;
+    /**
+     * Creates a new {@link ChannelBase} or {@link RealtimeChannelBase} object, with the specified channel {@link DeriveOptions}
+     * and {@link ChannelOptions}, or returns the existing channel object.
+     *
+     * @param name - The channel name.
+     * @param deriveOptions - A {@link DeriveOptions} object.
+     * @param channelOptions - A {@link ChannelOptions} object.
+     * @returns A {@link RealtimeChannelBase} object.
+     */
+    getDerived(name: string, deriveOptions: DeriveOptions, channelOptions?: ChannelOptions): T;
     /**
      * Releases a {@link ChannelBase} or {@link RealtimeChannelBase} object, deleting it, and enabling it to be garbage collected. It also removes any listeners associated with the channel. To release a channel, the {@link ChannelState} must be `INITIALIZED`, `DETACHED`, or `FAILED`.
      *

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -4,7 +4,6 @@ import Multicaster from '../util/multicaster';
 import ErrorInfo from '../types/errorinfo';
 import HmacSHA256 from 'crypto-js/build/hmac-sha256';
 import { stringify as stringifyBase64 } from 'crypto-js/build/enc-base64';
-import { parse as parseUtf8 } from 'crypto-js/build/enc-utf8';
 import { createHmac } from 'crypto';
 import { ErrnoException, RequestCallback, RequestParams } from '../../types/http';
 import * as API from '../../../../ably';
@@ -42,13 +41,6 @@ function normaliseAuthcallbackError(err: any) {
   }
   return err;
 }
-
-let toBase64 = (str: string): string => {
-  if (Platform.Config.createHmac) {
-    return Buffer.from(str, 'ascii').toString('base64');
-  }
-  return stringifyBase64(parseUtf8(str));
-};
 
 let hmac = (text: string, key: string): string => {
   if (Platform.Config.createHmac) {
@@ -886,7 +878,7 @@ class Auth {
         if (!tokenDetails) {
           throw new Error('Auth.getAuthParams(): _ensureValidAuthCredentials returned no error or tokenDetails');
         }
-        callback(null, { authorization: 'Bearer ' + toBase64(tokenDetails.token) });
+        callback(null, { authorization: 'Bearer ' + Utils.toBase64(tokenDetails.token) });
       });
     }
   }
@@ -916,7 +908,7 @@ class Auth {
   _saveBasicOptions(authOptions: API.Types.AuthOptions) {
     this.method = 'basic';
     this.key = authOptions.key;
-    this.basicKey = toBase64(authOptions.key as string);
+    this.basicKey = Utils.toBase64(authOptions.key as string);
     this.authOptions = authOptions || {};
     if ('clientId' in authOptions) {
       this._userSetClientId(authOptions.clientId);

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -161,6 +161,15 @@ class Channels extends EventEmitter {
     return channel;
   }
 
+  getDerived(name: string, deriveOptions: API.Types.DeriveOptions, channelOptions?: ChannelOptions) {
+    if (deriveOptions.filter) {
+      const filter = Utils.toBase64(deriveOptions.filter);
+      const match = Utils.matchDerivedChannel(name);
+      name = `[filter=${filter}${match.qualifierParam}]${match.channelName}`;
+    }
+    return this.get(name, channelOptions);
+  }
+
   /* Included to support certain niche use-cases; most users should ignore this.
    * Please do not use this unless you know what you're doing */
   release(name: string) {

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -1183,5 +1183,145 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
       });
     }
+
+    it('subscribes to filtered channel', function (done) {
+      var testData = [
+        {
+          name: 'filtered',
+          data: 'These headers match the JMESPath expression so this message should not be filtered',
+          extras: {
+            headers: {
+              name: 'Lorem Choo',
+              number: 26095,
+              bool: true,
+            },
+          },
+        },
+        {
+          name: 'filtered',
+          data: 'Random data with no extras for filter',
+        },
+        {
+          name: 'filtered',
+          data: 'This message should also not be filtered',
+          extras: {
+            headers: {
+              name: 'John Bull',
+              number: 26095,
+              bool: false,
+            },
+          },
+        },
+        {
+          name: 'filtered',
+          data: 'No header on message',
+        },
+        {
+          name: 'filtered',
+          data: 'Can be filtered because it does not meet filter condition on headers.number',
+          extras: {
+            headers: {
+              name: 'John Bull',
+              number: 12345,
+              bool: false,
+            },
+          },
+        },
+        {
+          name: 'end',
+          data: 'last message check',
+        },
+      ];
+
+      var filterOption = {
+        filter: 'name == `"filtered"` && headers.number == `26095`',
+      };
+
+      try {
+        /* set up realtime */
+        var realtime = helper.AblyRealtime({ key: helper.getTestApp().keys[5].keyStr });
+        var rest = helper.AblyRest();
+
+        realtime.connection.on('connected', function () {
+          var rtFilteredChannel = realtime.channels.getDerived('chan', filterOption);
+          var rtUnfilteredChannel = realtime.channels.get('chan');
+
+          var filteredMessages = [];
+          var unFilteredMessages = [];
+          /* subscribe to event */
+          rtFilteredChannel.attach(function (err) {
+            if (err) {
+              closeAndFinish(done, realtime, err);
+              return;
+            }
+            rtFilteredChannel.subscribe(function (msg) {
+              try {
+                // Push received filtered messages into an array
+                filteredMessages.push(msg);
+              } catch (err) {
+                closeAndFinish(done, realtime, err);
+                return;
+              }
+            });
+
+            rtUnfilteredChannel.attach(function (err) {
+              if (err) {
+                closeAndFinish(done, realtime, err);
+                return;
+              }
+
+              rtUnfilteredChannel.subscribe(function (msg) {
+                try {
+                  // Push received unfiltered messages into an array
+                  unFilteredMessages.push(msg);
+                } catch (err) {
+                  closeAndFinish(done, realtime, err);
+                  return;
+                }
+              });
+
+              // Subscription to check all messages were received as expected
+              rtUnfilteredChannel.subscribe('end', function (msg) {
+                try {
+                  expect(msg.data).to.equal(testData[testData.length - 1].data, 'Unexpected msg data received');
+
+                  // Check that we receive expected messages on filtered channel
+                  expect(filteredMessages.length).to.equal(2, 'Expect only two filtered message to be received');
+                  expect(filteredMessages[0].data).to.equal(testData[0].data, 'Unexpected data received');
+                  expect(filteredMessages[1].data).to.equal(testData[2].data, 'Unexpected data received');
+                  expect(filteredMessages[0].extras.headers.name).to.equal(
+                    testData[0].extras.headers.name,
+                    'Unexpected header value received'
+                  );
+                  expect(filteredMessages[1].extras.headers.name).to.equal(
+                    testData[2].extras.headers.name,
+                    'Unexpected header value received'
+                  );
+                  // Check that message with header that doesn't meet filtering condition is not received.
+                  for (msg of filteredMessages) {
+                    expect(msg.extras.headers.number).to.equal(26095, 'Unexpected header filtering value received');
+                  }
+
+                  // Check that we receive expected messages on unfiltered channel, including the `end` event message
+                  expect(unFilteredMessages.length).to.equal(6, 'Expect only 6 unfiltered message to be received');
+                  for (var i = 0; i < unFilteredMessages.length; i++) {
+                    expect(unFilteredMessages[i].data).to.equal(testData[i].data, 'Unexpected data received');
+                  }
+                } catch (err) {
+                  closeAndFinish(done, realtime, err);
+                  return;
+                }
+                closeAndFinish(done, realtime);
+              });
+              var restChannel = rest.channels.get('chan');
+              restChannel.publish(testData);
+            });
+          });
+        });
+        monitorConnection(done, realtime);
+      } catch (err) {
+        closeAndFinish(done, realtime, err);
+      }
+    });
   });
 });


### PR DESCRIPTION
We are creating a new method called getDerived so we can create derived/synthetic channels. Presently, we only have filter as an option. The filter option lets us implement filtered subscription on a channel.
DR can be found [here](https://ably.atlassian.net/wiki/spaces/product/pages/2560098305/DR2+Filtered+Subscription+SDK+Implementation+Decision)
Ticket: [DSC-54](https://ably.atlassian.net/browse/DSC-54)

Recreating this PR originally merged in https://github.com/ably/ably-js/pull/1185 and reverted in https://github.com/ably/ably-js/pull/1259 to apply these changes on an integration branch.

[DSC-54]: https://ably.atlassian.net/browse/DSC-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ