### PR TITLE
fix(WebSocketTransport): use encodeURI for react-native

### DIFF
--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -37,7 +37,7 @@ class WebSocketTransport extends Transport {
     if (connectParams) {
       for (const key in connectParams) uri += (paramCount++ ? '&' : '?') + key + '=' + connectParams[key];
     }
-    this.uri = uri;
+    this.uri = Platform.Config.encodeWsUri ? Platform.Config.encodeWsUri(uri) : uri;
     return new Platform.Config.WebSocket(uri);
   }
 

--- a/src/common/types/IPlatformConfig.d.ts
+++ b/src/common/types/IPlatformConfig.d.ts
@@ -50,4 +50,5 @@ export interface IPlatformConfig {
     callback: (err: Error, result: boolean | CryptoJS.lib.WordArray) => void
   ) => void;
   isWebworker?: boolean;
+  encodeWsUri?: (uri: string) => string;
 }

--- a/src/platform/react-native/config.ts
+++ b/src/platform/react-native/config.ts
@@ -31,6 +31,7 @@ const Platform: IPlatformConfig = {
      * message */
     return (typeof TextDecoder !== 'undefined' && new TextEncoder().encode(str).length) || str.length;
   },
+  encodeWsUri: global.encodeURI,
   TextEncoder: global.TextEncoder,
   TextDecoder: global.TextDecoder,
   Promise: global.Promise,


### PR DESCRIPTION
Resolves #1262

Based on https://stackoverflow.com/questions/47486413/passing-parameter-in-websocket-uri-on-react-native-is-not-working