### PR TITLE
Fix nullability of `ErrorInfo` class’s properties

### DIFF
--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -563,7 +563,7 @@ class RealtimeChannel extends Channel {
       case 'initialized':
       case 'detaching':
       case 'detached':
-        throw new ErrorInfo('Unable to sync to channel; not attached', 40000);
+        throw new ErrorInfo('Unable to sync to channel; not attached', 40000, 500);
       default:
     }
     const connectionManager = this.connectionManager;

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -184,7 +184,11 @@ class RealtimePresence extends Presence {
           });
           break;
         default:
-          err = new ErrorInfo('Unable to ' + action + ' presence channel while in ' + channel.state + ' state', 90001);
+          err = new ErrorInfo(
+            'Unable to ' + action + ' presence channel while in ' + channel.state + ' state',
+            90001,
+            500
+          );
           err.code = 90001;
           callback(err);
       }
@@ -244,7 +248,7 @@ class RealtimePresence extends Presence {
       case 'failed': {
         /* we're not attached; therefore we let any entered status
          * timeout by itself instead of attaching just in order to leave */
-        const err = new ErrorInfo('Unable to leave presence channel (incompatible state)', 90001);
+        const err = new ErrorInfo('Unable to leave presence channel (incompatible state)', 90001, 500);
         callback?.(err);
         break;
       }

--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -41,14 +41,14 @@ function unenvelope<T>(callback: ResourceCallback<T>, format: Utils.Format | nul
         if (Utils.isErrorInfo(e)) {
           callback(e);
         } else {
-          callback(new ErrorInfo(Utils.inspectError(e), 50000));
+          callback(new ErrorInfo(Utils.inspectError(e), 50000, 500));
         }
         return;
       }
     }
 
     if (!body) {
-      callback(new ErrorInfo('unenvelope(): Response body is missing', 50000));
+      callback(new ErrorInfo('unenvelope(): Response body is missing', 50000, 500));
       return;
     }
 

--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -41,14 +41,14 @@ function unenvelope<T>(callback: ResourceCallback<T>, format: Utils.Format | nul
         if (Utils.isErrorInfo(e)) {
           callback(e);
         } else {
-          callback(new ErrorInfo(Utils.inspectError(e), null));
+          callback(new ErrorInfo(Utils.inspectError(e), 50000));
         }
         return;
       }
     }
 
     if (!body) {
-      callback(new ErrorInfo('unenvelope(): Response body is missing', null));
+      callback(new ErrorInfo('unenvelope(): Response body is missing', 50000));
       return;
     }
 

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1634,7 +1634,7 @@ class ConnectionManager extends EventEmitter {
        * there is a problem with the ably host, or there is a general connectivity
        * problem */
       if (!this.realtime.http.checkConnectivity) {
-        giveUp(new ErrorInfo('Internal error: Http.checkConnectivity not set', null, 500));
+        giveUp(new ErrorInfo('Internal error: Http.checkConnectivity not set', 50000, 500));
         return;
       }
       this.realtime.http.checkConnectivity((err?: ErrorInfo | null, connectivity?: boolean) => {

--- a/src/common/lib/types/errorinfo.ts
+++ b/src/common/lib/types/errorinfo.ts
@@ -3,11 +3,11 @@ import * as Utils from '../util/utils';
 
 export default class ErrorInfo extends Error {
   code: number;
-  statusCode?: number;
+  statusCode: number;
   cause?: string | Error | ErrorInfo;
   href?: string;
 
-  constructor(message: string, code: number, statusCode?: number, cause?: string | Error | ErrorInfo) {
+  constructor(message: string, code: number, statusCode: number, cause?: string | Error | ErrorInfo) {
     super(message);
     if (typeof Object.setPrototypeOf !== 'undefined') {
       Object.setPrototypeOf(this, ErrorInfo.prototype);

--- a/src/common/lib/types/errorinfo.ts
+++ b/src/common/lib/types/errorinfo.ts
@@ -2,12 +2,12 @@ import Platform from 'common/platform';
 import * as Utils from '../util/utils';
 
 export default class ErrorInfo extends Error {
-  code: number | null;
+  code: number;
   statusCode?: number;
   cause?: string | Error | ErrorInfo;
   href?: string;
 
-  constructor(message: string, code: number | null, statusCode?: number, cause?: string | Error | ErrorInfo) {
+  constructor(message: string, code: number, statusCode?: number, cause?: string | Error | ErrorInfo) {
     super(message);
     if (typeof Object.setPrototypeOf !== 'undefined') {
       Object.setPrototypeOf(this, ErrorInfo.prototype);

--- a/src/common/lib/types/errorinfo.ts
+++ b/src/common/lib/types/errorinfo.ts
@@ -1,7 +1,8 @@
 import Platform from 'common/platform';
 import * as Utils from '../util/utils';
+import * as API from '../../../../ably';
 
-export default class ErrorInfo extends Error {
+export default class ErrorInfo extends Error implements API.Types.ErrorInfo {
   code: number;
   statusCode: number;
   cause?: string | Error | ErrorInfo;

--- a/src/platform/nodejs/lib/transport/nodecomettransport.js
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.js
@@ -144,7 +144,7 @@ var NodeCometTransport = function (connectionManager) {
     req.on(
       'error',
       (this.onReqError = function (err) {
-        err = new ErrorInfo('Request error: ' + err.message, null, 400);
+        err = new ErrorInfo('Request error: ' + err.message, 50000, 400);
         clearTimeout(timer);
         self.timer = null;
         self.complete(err);
@@ -166,7 +166,7 @@ var NodeCometTransport = function (connectionManager) {
       res.on(
         'error',
         (self.onResError = function (err) {
-          err = new ErrorInfo('Response error: ' + err.message, null, 400);
+          err = new ErrorInfo('Response error: ' + err.message, 50000, 400);
           self.complete(err);
         })
       );
@@ -199,7 +199,7 @@ var NodeCometTransport = function (connectionManager) {
       } catch (e) {
         var msg = 'Malformed response body from server: ' + e.message;
         Logger.logAction(Logger.LOG_ERROR, 'NodeCometTransport.Request.readStream()', msg);
-        self.complete(new ErrorInfo(msg, null, 400));
+        self.complete(new ErrorInfo(msg, 50000, 400));
         return;
       }
       self.emit('data', chunk);
@@ -256,7 +256,7 @@ var NodeCometTransport = function (connectionManager) {
         } catch (e) {
           var msg = 'Malformed response body from server: ' + e.message;
           Logger.logAction(Logger.LOG_ERROR, 'NodeCometTransport.Request.readFully()', msg);
-          self.complete(new ErrorInfo(msg, null, 400));
+          self.complete(new ErrorInfo(msg, 50000, 400));
           return;
         }
 
@@ -273,7 +273,7 @@ var NodeCometTransport = function (connectionManager) {
         if (!err) {
           err = new ErrorInfo(
             'Error response received from server: ' + statusCode + ', body was: ' + util.inspect(body),
-            null,
+            50000,
             statusCode
           );
         }

--- a/src/platform/web/lib/transport/fetchrequest.ts
+++ b/src/platform/web/lib/transport/fetchrequest.ts
@@ -34,7 +34,7 @@ export default function fetchRequest(
   const timeout = setTimeout(
     () => {
       controller.abort();
-      callback(new ErrorInfo('Request timed out', null, 408));
+      callback(new ErrorInfo('Request timed out', 50003, 408));
     },
     rest ? rest.options.timeouts.httpRequestTimeout : Defaults.TIMEOUTS.httpRequestTimeout
   );
@@ -69,7 +69,7 @@ export default function fetchRequest(
             getAblyError(body, res.headers) ||
             new ErrorInfo(
               'Error response received from server: ' + res.status + ' body was: ' + Platform.Config.inspect(body),
-              null,
+              50000,
               res.status
             );
           callback(err, body, res.headers, packed, res.status);

--- a/src/platform/web/lib/transport/jsonptransport.ts
+++ b/src/platform/web/lib/transport/jsonptransport.ts
@@ -164,7 +164,7 @@ export class Request extends EventEmitter {
     script.type = 'text/javascript';
     script.charset = 'UTF-8';
     script.onerror = (err: string | Event) => {
-      this.complete(new ErrorInfo('JSONP script error (event: ' + Platform.Config.inspect(err) + ')', null, 400));
+      this.complete(new ErrorInfo('JSONP script error (event: ' + Platform.Config.inspect(err) + ')', 50000, 400));
     };
 
     type JSONPResponse = {
@@ -182,7 +182,7 @@ export class Request extends EventEmitter {
         if (message.statusCode == 204) {
           this.complete(null, null, null, message.statusCode);
         } else if (!response) {
-          this.complete(new ErrorInfo('Invalid server response: no envelope detected', null, 500));
+          this.complete(new ErrorInfo('Invalid server response: no envelope detected', 50000, 500));
         } else if (message.statusCode < 400 || Utils.isArray(response)) {
           /* If response is an array, it's an array of protocol messages -- even if
            * it contains an error action (hence the nonsuccess statuscode), we can
@@ -190,7 +190,7 @@ export class Request extends EventEmitter {
            * onProtocolMessage to decide what to do */
           this.complete(null, response, message.headers, message.statusCode);
         } else {
-          const err = response.error || new ErrorInfo('Error response received from server', null, message.statusCode);
+          const err = response.error || new ErrorInfo('Error response received from server', 50000, message.statusCode);
           this.complete(err);
         }
       } else {

--- a/src/platform/web/lib/transport/xhrrequest.ts
+++ b/src/platform/web/lib/transport/xhrrequest.ts
@@ -196,7 +196,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
       let errorMessage = message + ' (event type: ' + errorEvent.type + ')';
       if (this?.xhr?.statusText) errorMessage += ', current statusText is ' + this.xhr.statusText;
       Logger.logAction(Logger.LOG_ERROR, 'Request.on' + errorEvent.type + '()', errorMessage);
-      this.complete(new ErrorInfo(errorMessage, code, statusCode));
+      this.complete(new ErrorInfo(errorMessage, code ?? 50000, statusCode));
     };
     xhr.onerror = function (errorEvent) {
       errorHandler(errorEvent, 'XHR error occurred', null, 400);
@@ -265,7 +265,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
           headers = getHeadersAsObject(xhr);
         }
       } catch (e) {
-        this.complete(new ErrorInfo('Malformed response body from server: ' + (e as Error).message, null, 400));
+        this.complete(new ErrorInfo('Malformed response body from server: ' + (e as Error).message, 50000, 400));
         return;
       }
 
@@ -285,7 +285,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
             statusCode +
             ' body was: ' +
             Platform.Config.inspect(parsedResponse),
-          null,
+          50000,
           statusCode
         );
       }
@@ -307,7 +307,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
       try {
         chunk = JSON.parse(chunk);
       } catch (e) {
-        this.complete(new ErrorInfo('Malformed response body from server: ' + (e as Error).message, null, 400));
+        this.complete(new ErrorInfo('Malformed response body from server: ' + (e as Error).message, 50000, 400));
         return;
       }
       this.emit('data', chunk);

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -198,7 +198,7 @@ const Http: typeof IHttp = class {
       };
     } else {
       this.Request = (method, rest, uri, headers, params, body, callback) => {
-        callback(new ErrorInfo('no supported HTTP transports available', null, 400), null);
+        callback(new ErrorInfo('no supported HTTP transports available', 50000, 400), null);
       };
     }
   }
@@ -225,7 +225,7 @@ const Http: typeof IHttp = class {
       if (currentFallback.validUntil > Utils.now()) {
         /* Use stored fallback */
         if (!this.Request) {
-          callback?.(new ErrorInfo('Request invoked before assigned to', null, 500));
+          callback?.(new ErrorInfo('Request invoked before assigned to', 50000, 500));
           return;
         }
         this.Request(
@@ -301,7 +301,7 @@ const Http: typeof IHttp = class {
     callback: RequestCallback
   ): void {
     if (!this.Request) {
-      callback(new ErrorInfo('Request invoked before assigned to', null, 500));
+      callback(new ErrorInfo('Request invoked before assigned to', 50000, 500));
       return;
     }
     this.Request(method, rest, uri, headers, params, body, callback);


### PR DESCRIPTION
This brings the nullability of the `code` and `statusCode` properties in line with that expressed in the public API. See commit messages for more details.

Preparation for #1252.