### PR TITLE
Fix incorrect accessing of web’s `getRandomWordArray` and `getRandomValues`

### DIFF
--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -6,7 +6,7 @@ import Platform from '../../common/platform';
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
 // @ts-ignore
-import Crypto from '../web/lib/util/crypto';
+import CryptoFactory from '../web/lib/util/crypto';
 import Http from '../web/lib/util/http';
 // @ts-ignore
 import Config from './config';
@@ -18,6 +18,8 @@ import { getDefaults } from '../../common/lib/util/defaults';
 import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
+
+const Crypto = CryptoFactory(Config, BufferUtils);
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -6,7 +6,7 @@ import Platform from '../../common/platform';
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
 // @ts-ignore
-import Crypto from '../web/lib/util/crypto';
+import CryptoFactory from '../web/lib/util/crypto';
 import Http from '../web/lib/util/http';
 import Config from './config';
 // @ts-ignore
@@ -16,6 +16,8 @@ import { getDefaults } from '../../common/lib/util/defaults';
 import WebStorage from '../web/lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
+
+const Crypto = CryptoFactory(Config, BufferUtils);
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -6,7 +6,7 @@ import Platform from '../../common/platform';
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
 // @ts-ignore
-import Crypto from './lib/util/crypto';
+import CryptoFactory from './lib/util/crypto';
 import Http from './lib/util/http';
 import Config from './config';
 // @ts-ignore
@@ -16,6 +16,8 @@ import { getDefaults } from '../../common/lib/util/defaults';
 import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from './lib/util/defaults';
 import msgpack from './lib/util/msgpack';
+
+const Crypto = CryptoFactory(Config, BufferUtils);
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;

--- a/src/platform/web/lib/util/crypto.js
+++ b/src/platform/web/lib/util/crypto.js
@@ -1,10 +1,9 @@
 import WordArray from 'crypto-js/build/lib-typedarrays';
 import { parse as parseBase64 } from 'crypto-js/build/enc-base64';
 import CryptoJS from 'crypto-js/build';
-import Platform from '../../../../common/platform';
 import Logger from '../../../../common/lib/util/logger';
 
-var Crypto = (function () {
+var CryptoFactory = function (config, bufferUtils) {
   var DEFAULT_ALGORITHM = 'aes';
   var DEFAULT_KEYLENGTH = 256; // bits
   var DEFAULT_MODE = 'cbc';
@@ -19,16 +18,16 @@ var Crypto = (function () {
    * @param callback
    */
   var generateRandom;
-  if (Platform.getRandomWordArray) {
-    generateRandom = Platform.getRandomWordArray;
-  } else if (typeof Uint32Array !== 'undefined' && Platform.getRandomValues) {
+  if (config.getRandomWordArray) {
+    generateRandom = config.getRandomWordArray;
+  } else if (typeof Uint32Array !== 'undefined' && config.getRandomValues) {
     var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
     generateRandom = function (bytes, callback) {
       var words = bytes / 4,
         nativeArray = words == DEFAULT_BLOCKLENGTH_WORDS ? blockRandomArray : new Uint32Array(words);
-      Platform.getRandomValues(nativeArray, function (err) {
+      config.getRandomValues(nativeArray, function (err) {
         if (typeof callback !== 'undefined') {
-          callback(err, Platform.BufferUtils.toWordArray(nativeArray));
+          callback(err, bufferUtils.toWordArray(nativeArray));
         }
       });
     };
@@ -180,7 +179,7 @@ var Crypto = (function () {
     if (typeof params.key === 'string') {
       key = parseBase64(normaliseBase64(params.key));
     } else {
-      key = Platform.BufferUtils.toWordArray(params.key); // Expect key to be an Array, ArrayBuffer, or WordArray at this point
+      key = bufferUtils.toWordArray(params.key); // Expect key to be an Array, ArrayBuffer, or WordArray at this point
     }
 
     var cipherParams = new CipherParams();
@@ -230,16 +229,16 @@ var Crypto = (function () {
   function CBCCipher(params, blockLengthWords, iv) {
     this.algorithm = params.algorithm + '-' + String(params.keyLength) + '-' + params.mode;
     this.cjsAlgorithm = params.algorithm.toUpperCase().replace(/-\d+$/, '');
-    this.key = Platform.BufferUtils.toWordArray(params.key);
+    this.key = bufferUtils.toWordArray(params.key);
     if (iv) {
-      this.iv = Platform.BufferUtils.toWordArray(iv).clone();
+      this.iv = bufferUtils.toWordArray(iv).clone();
     }
     this.blockLengthWords = blockLengthWords;
   }
 
   CBCCipher.prototype.encrypt = function (plaintext, callback) {
     Logger.logAction(Logger.LOG_MICRO, 'CBCCipher.encrypt()', '');
-    plaintext = Platform.BufferUtils.toWordArray(plaintext);
+    plaintext = bufferUtils.toWordArray(plaintext);
     var plaintextLength = plaintext.sigBytes,
       paddedLength = getPaddedLength(plaintextLength),
       self = this;
@@ -278,7 +277,7 @@ var Crypto = (function () {
 
   CBCCipher.prototype.decrypt = function (ciphertext) {
     Logger.logAction(Logger.LOG_MICRO, 'CBCCipher.decrypt()', '');
-    ciphertext = Platform.BufferUtils.toWordArray(ciphertext);
+    ciphertext = bufferUtils.toWordArray(ciphertext);
     var blockLengthWords = this.blockLengthWords,
       ciphertextWords = ciphertext.words,
       iv = WordArray.create(ciphertextWords.slice(0, blockLengthWords)),
@@ -314,6 +313,6 @@ var Crypto = (function () {
   };
 
   return Crypto;
-})();
+};
 
-export default Crypto;
+export default CryptoFactory;


### PR DESCRIPTION
We were trying to access properties on `Platform` that actually exist on `Platform.Config`. This means that we always ended up falling back to using the non-cryptographically secure `Math.random`.

Resolves #1272.