### PR TITLE
Fix calling of Node `crypto.randomBytes`

### DIFF
--- a/src/platform/nodejs/lib/util/crypto.js
+++ b/src/platform/nodejs/lib/util/crypto.js
@@ -15,7 +15,7 @@ var Crypto = (function () {
    * @param callback (optional)
    */
   function generateRandom(bytes, callback) {
-    return crypto.randomBytes(bytes, callback);
+    return callback === undefined ? crypto.randomBytes(bytes) : crypto.randomBytes(bytes, callback);
   }
 
   /**


### PR DESCRIPTION
Preparation for converting the platform `crypto.js` files to TypeScript (#1252).

We are calling the `generateRandom` function both with and without a callback, and just passing the hence-potentially-`undefined` callback through to `crypto.randomBytes`. But that method’s TypeScript type signatures don’t accept an `undefined` callback.