### PR TITLE
Fix type of error emitted by `Crypto.generateRandomKey`

### DIFF
--- a/src/platform/nodejs/lib/util/crypto.js
+++ b/src/platform/nodejs/lib/util/crypto.js
@@ -2,6 +2,7 @@
 import Logger from '../../../../common/lib/util/logger';
 import Platform from '../../../../common/platform';
 import crypto from 'crypto';
+import ErrorInfo from '../../../../common/lib/types/errorinfo';
 
 var Crypto = (function () {
   var DEFAULT_ALGORITHM = 'aes';
@@ -181,7 +182,12 @@ var Crypto = (function () {
       callback = keyLength;
       keyLength = undefined;
     }
-    generateRandom((keyLength || DEFAULT_KEYLENGTH) / 8, callback);
+
+    generateRandom((keyLength || DEFAULT_KEYLENGTH) / 8, function (err, buf) {
+      if (callback !== undefined) {
+        callback(err ? ErrorInfo.fromValues(err) : null, buf);
+      }
+    });
   };
 
   /**

--- a/src/platform/web/lib/util/crypto.js
+++ b/src/platform/web/lib/util/crypto.js
@@ -3,6 +3,7 @@ import { parse as parseBase64 } from 'crypto-js/build/enc-base64';
 import CryptoJS from 'crypto-js/build';
 import Platform from '../../../../common/platform';
 import Logger from '../../../../common/lib/util/logger';
+import ErrorInfo from 'common/lib/types/errorinfo';
 
 var Crypto = (function () {
   var DEFAULT_ALGORITHM = 'aes';
@@ -213,7 +214,12 @@ var Crypto = (function () {
       callback = keyLength;
       keyLength = undefined;
     }
-    generateRandom((keyLength || DEFAULT_KEYLENGTH) / 8, callback);
+
+    generateRandom((keyLength || DEFAULT_KEYLENGTH) / 8, function (err, buf) {
+      if (callback !== undefined) {
+        callback(err ? ErrorInfo.fromValues(err) : null, buf);
+      }
+    });
   };
 
   /**


### PR DESCRIPTION
Make sure we emit an `ErrorInfo`, to satisfy the signature in `ably.d.ts`. See commit messages for more details.