### PR TITLE
Make `ErrorInfo` implement the public interface of same name

### DIFF
--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -1,7 +1,7 @@
 import Logger from '../util/logger';
 import * as Utils from '../util/utils';
 import Multicaster from '../util/multicaster';
-import ErrorInfo from '../types/errorinfo';
+import ErrorInfo, { IPartialErrorInfo } from '../types/errorinfo';
 import HmacSHA256 from 'crypto-js/build/hmac-sha256';
 import { stringify as stringifyBase64 } from 'crypto-js/build/enc-base64';
 import { parse as parseUtf8 } from 'crypto-js/build/enc-utf8';
@@ -25,9 +25,9 @@ function isRealtime(client: Rest | Realtime): client is Realtime {
   return !!(client as Realtime).connection;
 }
 
-/* A client auth callback may give errors in any number of formats; normalise to an errorinfo */
+/* A client auth callback may give errors in any number of formats; normalise to an ErrorInfo or PartialErrorInfo */
 function normaliseAuthcallbackError(err: any) {
-  if (!Utils.isErrorInfo(err)) {
+  if (!Utils.isErrorInfoOrPartialErrorInfo(err)) {
     return new ErrorInfo(Utils.inspectError(err), err.code || 40170, err.statusCode || 401);
   }
   /* network errors will not have an inherent error code */
@@ -1058,7 +1058,7 @@ class Auth {
     );
   }
 
-  static isTokenErr(error: ErrorInfo) {
+  static isTokenErr(error: IPartialErrorInfo) {
     return error.code && error.code >= 40140 && error.code < 40150;
   }
 }

--- a/src/common/lib/client/connectionstatechange.ts
+++ b/src/common/lib/client/connectionstatechange.ts
@@ -1,12 +1,12 @@
-import ErrorInfo from '../types/errorinfo';
+import { IPartialErrorInfo } from '../types/errorinfo';
 
 class ConnectionStateChange {
   previous?: string;
   current?: string;
   retryIn?: number;
-  reason?: ErrorInfo;
+  reason?: IPartialErrorInfo;
 
-  constructor(previous?: string, current?: string, retryIn?: number | null, reason?: ErrorInfo) {
+  constructor(previous?: string, current?: string, retryIn?: number | null, reason?: IPartialErrorInfo) {
     this.previous = previous;
     this.current = current;
     if (retryIn) this.retryIn = retryIn;

--- a/src/common/lib/client/paginatedresource.ts
+++ b/src/common/lib/client/paginatedresource.ts
@@ -1,7 +1,7 @@
 import * as Utils from '../util/utils';
 import Logger from '../util/logger';
 import Resource from './resource';
-import ErrorInfo from '../types/errorinfo';
+import ErrorInfo, { IPartialErrorInfo } from '../types/errorinfo';
 import { PaginatedResultCallback } from '../../types/utils';
 import Rest from './rest';
 
@@ -26,7 +26,7 @@ function parseRelLinks(linkHeader: string | Array<string>) {
   return relParams;
 }
 
-function returnErrOnly(err: ErrorInfo, body: unknown, useHPR?: boolean) {
+function returnErrOnly(err: IPartialErrorInfo, body: unknown, useHPR?: boolean) {
   /* If using httpPaginatedResponse, errors from Ably are returned as part of
    * the HPR, only do callback(err) for network errors etc. which don't
    * return a body and/or have no ably-originated error code (non-numeric
@@ -133,7 +133,7 @@ class PaginatedResource {
   }
 
   handlePage<T>(
-    err: ErrorInfo | null,
+    err: IPartialErrorInfo | null,
     body: unknown,
     headers: Record<string, string> | undefined,
     unpacked: boolean | undefined,
@@ -252,7 +252,7 @@ export class HttpPaginatedResponse<T> extends PaginatedResult<T> {
     headers: Record<string, string>,
     statusCode: number,
     relParams: any,
-    err: ErrorInfo | null
+    err: IPartialErrorInfo | null
   ) {
     super(resource, items, relParams);
     this.statusCode = statusCode;

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -6,7 +6,7 @@ import Logger from '../util/logger';
 import RealtimePresence from './realtimepresence';
 import Message, { CipherOptions } from '../types/message';
 import ChannelStateChange from './channelstatechange';
-import ErrorInfo from '../types/errorinfo';
+import ErrorInfo, { IPartialErrorInfo, PartialErrorInfo } from '../types/errorinfo';
 import PresenceMessage from '../types/presencemessage';
 import ConnectionErrors from '../transport/connectionerrors';
 import * as API from '../../../../ably';
@@ -142,7 +142,7 @@ class RealtimeChannel extends Channel {
     }
     const _callback =
       callback ||
-      function (err?: ErrorInfo | null) {
+      function (err?: IPartialErrorInfo | null) {
         if (err) {
           Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.setOptions()', 'Set options failed: ' + err.toString());
         }
@@ -563,7 +563,7 @@ class RealtimeChannel extends Channel {
       case 'initialized':
       case 'detaching':
       case 'detached':
-        throw new ErrorInfo('Unable to sync to channel; not attached', 40000);
+        throw new PartialErrorInfo('Unable to sync to channel; not attached', 40000);
       default:
     }
     const connectionManager = this.connectionManager;

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -3,7 +3,7 @@ import Presence from './presence';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
 import PresenceMessage from '../types/presencemessage';
-import ErrorInfo from '../types/errorinfo';
+import ErrorInfo, { IPartialErrorInfo, PartialErrorInfo } from '../types/errorinfo';
 import RealtimeChannel from './realtimechannel';
 import Multicaster from '../util/multicaster';
 import ChannelStateChange from './channelstatechange';
@@ -164,7 +164,7 @@ class RealtimePresence extends Presence {
       presence.clientId = clientId;
     }
 
-    PresenceMessage.encode(presence, channel.channelOptions as CipherOptions, (err: ErrorInfo) => {
+    PresenceMessage.encode(presence, channel.channelOptions as CipherOptions, (err: IPartialErrorInfo) => {
       if (err) {
         callback(err);
         return;
@@ -184,7 +184,10 @@ class RealtimePresence extends Presence {
           });
           break;
         default:
-          err = new ErrorInfo('Unable to ' + action + ' presence channel while in ' + channel.state + ' state', 90001);
+          err = new PartialErrorInfo(
+            'Unable to ' + action + ' presence channel while in ' + channel.state + ' state',
+            90001
+          );
           err.code = 90001;
           callback(err);
       }
@@ -244,7 +247,7 @@ class RealtimePresence extends Presence {
       case 'failed': {
         /* we're not attached; therefore we let any entered status
          * timeout by itself instead of attaching just in order to leave */
-        const err = new ErrorInfo('Unable to leave presence channel (incompatible state)', 90001);
+        const err = new PartialErrorInfo('Unable to leave presence channel (incompatible state)', 90001);
         callback?.(err);
         break;
       }

--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -3,7 +3,7 @@ import * as Utils from '../util/utils';
 import Logger from '../util/logger';
 import Auth from './auth';
 import HttpMethods from '../../constants/HttpMethods';
-import ErrorInfo from '../types/errorinfo';
+import ErrorInfo, { IPartialErrorInfo, PartialErrorInfo } from '../types/errorinfo';
 import Rest from './rest';
 import { ErrnoException } from '../../types/http';
 
@@ -38,17 +38,17 @@ function unenvelope<T>(callback: ResourceCallback<T>, format: Utils.Format | nul
       try {
         body = Utils.decodeBody(body, format);
       } catch (e) {
-        if (Utils.isErrorInfo(e)) {
+        if (Utils.isErrorInfoOrPartialErrorInfo(e)) {
           callback(e);
         } else {
-          callback(new ErrorInfo(Utils.inspectError(e), null));
+          callback(new PartialErrorInfo(Utils.inspectError(e), null));
         }
         return;
       }
     }
 
     if (!body) {
-      callback(new ErrorInfo('unenvelope(): Response body is missing', null));
+      callback(new PartialErrorInfo('unenvelope(): Response body is missing', null));
       return;
     }
 
@@ -123,7 +123,7 @@ function logResponseHandler<T>(
 }
 
 export type ResourceCallback<T = unknown> = (
-  err: ErrorInfo | null,
+  err: IPartialErrorInfo | null,
   body?: T,
   headers?: Record<string, string>,
   unpacked?: boolean,

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -8,7 +8,7 @@ import MessageQueue from './messagequeue';
 import Logger from '../util/logger';
 import ConnectionStateChange from 'common/lib/client/connectionstatechange';
 import ConnectionErrors, { isRetriable } from './connectionerrors';
-import ErrorInfo from 'common/lib/types/errorinfo';
+import ErrorInfo, { IPartialErrorInfo, PartialErrorInfo } from 'common/lib/types/errorinfo';
 import Auth from 'common/lib/client/auth';
 import Message from 'common/lib/types/message';
 import Multicaster, { MulticasterInstance } from 'common/lib/util/multicaster';
@@ -182,7 +182,7 @@ type ConnectionState = {
   retryDelay?: number;
   forceQueueEvents?: boolean;
   retryImmediately?: boolean;
-  error?: ErrorInfo;
+  error?: IPartialErrorInfo;
 };
 
 class ConnectionManager extends EventEmitter {
@@ -190,7 +190,7 @@ class ConnectionManager extends EventEmitter {
   options: ClientOptions;
   states: Record<string, ConnectionState>;
   state: ConnectionState;
-  errorReason: ErrorInfo | string | null;
+  errorReason: IPartialErrorInfo | string | null;
   queuedMessages: MessageQueue;
   msgSerial: number;
   connectionDetails?: Record<string, any>;
@@ -1151,7 +1151,7 @@ class ConnectionManager extends EventEmitter {
    * state management
    *********************/
 
-  getError(): ErrorInfo | string {
+  getError(): IPartialErrorInfo | string {
     return this.errorReason || this.getStateError();
   }
 
@@ -1596,7 +1596,7 @@ class ConnectionManager extends EventEmitter {
    * @param transportParams
    */
   connectBase(transportParams: TransportParams, connectCount?: number): void {
-    const giveUp = (err: ErrorInfo) => {
+    const giveUp = (err: IPartialErrorInfo) => {
       this.notifyState({ state: this.states.connecting.failState as string, error: err });
     };
     const candidateHosts = this.httpHosts.slice();
@@ -1634,7 +1634,7 @@ class ConnectionManager extends EventEmitter {
        * there is a problem with the ably host, or there is a general connectivity
        * problem */
       if (!this.realtime.http.checkConnectivity) {
-        giveUp(new ErrorInfo('Internal error: Http.checkConnectivity not set', null, 500));
+        giveUp(new PartialErrorInfo('Internal error: Http.checkConnectivity not set', null, 500));
         return;
       }
       this.realtime.http.checkConnectivity((err?: ErrorInfo | null, connectivity?: boolean) => {

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -1,6 +1,6 @@
 import Platform from 'common/platform';
 import Defaults, { getAgentString } from './defaults';
-import ErrorInfo from 'common/lib/types/errorinfo';
+import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
 import { NormalisedClientOptions } from 'common/types/ClientOptions';
 
 function randomPosn(arrOrStr: Array<unknown> | string) {
@@ -397,12 +397,20 @@ export const now =
     return new Date().getTime();
   };
 
-export function isErrorInfo(err: unknown): err is ErrorInfo {
-  return typeof err == 'object' && err !== null && err.constructor.name == 'ErrorInfo';
+export function isErrorInfoOrPartialErrorInfo(err: unknown): err is ErrorInfo | PartialErrorInfo {
+  return (
+    typeof err == 'object' &&
+    err !== null &&
+    (err.constructor.name == 'ErrorInfo' || err.constructor.name == 'PartialErrorInfo')
+  );
 }
 
 export function inspectError(err: unknown): string {
-  if (err instanceof Error || (err as ErrorInfo)?.constructor?.name === 'ErrorInfo')
+  if (
+    err instanceof Error ||
+    (err as ErrorInfo)?.constructor?.name === 'ErrorInfo' ||
+    (err as PartialErrorInfo)?.constructor?.name === 'PartialErrorInfo'
+  )
     return Platform.Config.inspect(err);
   return (err as Error).toString();
 }

--- a/src/common/types/http.d.ts
+++ b/src/common/types/http.d.ts
@@ -5,7 +5,7 @@ import { Agents } from 'got';
 
 export type PathParameter = string | ((host: string) => string);
 export type RequestCallback = (
-  error?: ErrnoException | ErrorInfo | null,
+  error?: ErrnoException | IPartialErrorInfo | null,
   body?: unknown,
   headers?: IncomingHttpHeaders,
   packed?: boolean,

--- a/src/platform/nodejs/lib/transport/nodecomettransport.js
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.js
@@ -2,7 +2,7 @@
 import CometTransport from '../../../../common/lib/transport/comettransport';
 import Logger from '../../../../common/lib/util/logger';
 import * as Utils from '../../../../common/lib/util/utils';
-import ErrorInfo from '../../../../common/lib/types/errorinfo';
+import ErrorInfo, { PartialErrorInfo } from '../../../../common/lib/types/errorinfo';
 import EventEmitter from '../../../../common/lib/util/eventemitter';
 import HttpStatusCodes from '../../../../common/constants/HttpStatusCodes';
 import XHRStates from '../../../../common/constants/XHRStates';
@@ -144,7 +144,7 @@ var NodeCometTransport = function (connectionManager) {
     req.on(
       'error',
       (this.onReqError = function (err) {
-        err = new ErrorInfo('Request error: ' + err.message, null, 400);
+        err = new PartialErrorInfo('Request error: ' + err.message, null, 400);
         clearTimeout(timer);
         self.timer = null;
         self.complete(err);
@@ -166,7 +166,7 @@ var NodeCometTransport = function (connectionManager) {
       res.on(
         'error',
         (self.onResError = function (err) {
-          err = new ErrorInfo('Response error: ' + err.message, null, 400);
+          err = new PartialErrorInfo('Response error: ' + err.message, null, 400);
           self.complete(err);
         })
       );
@@ -199,7 +199,7 @@ var NodeCometTransport = function (connectionManager) {
       } catch (e) {
         var msg = 'Malformed response body from server: ' + e.message;
         Logger.logAction(Logger.LOG_ERROR, 'NodeCometTransport.Request.readStream()', msg);
-        self.complete(new ErrorInfo(msg, null, 400));
+        self.complete(new PartialErrorInfo(msg, null, 400));
         return;
       }
       self.emit('data', chunk);
@@ -256,7 +256,7 @@ var NodeCometTransport = function (connectionManager) {
         } catch (e) {
           var msg = 'Malformed response body from server: ' + e.message;
           Logger.logAction(Logger.LOG_ERROR, 'NodeCometTransport.Request.readFully()', msg);
-          self.complete(new ErrorInfo(msg, null, 400));
+          self.complete(new PartialErrorInfo(msg, null, 400));
           return;
         }
 
@@ -271,7 +271,7 @@ var NodeCometTransport = function (connectionManager) {
 
         var err = body.error && ErrorInfo.fromValues(body.error);
         if (!err) {
-          err = new ErrorInfo(
+          err = new PartialErrorInfo(
             'Error response received from server: ' + statusCode + ', body was: ' + util.inspect(body),
             null,
             statusCode

--- a/src/platform/web/lib/transport/fetchrequest.ts
+++ b/src/platform/web/lib/transport/fetchrequest.ts
@@ -1,6 +1,6 @@
 import HttpMethods from 'common/constants/HttpMethods';
 import Rest from 'common/lib/client/rest';
-import ErrorInfo from 'common/lib/types/errorinfo';
+import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
 import { RequestCallback, RequestParams } from 'common/types/http';
 import Platform from 'common/platform';
 import Defaults from 'common/lib/util/defaults';
@@ -34,7 +34,7 @@ export default function fetchRequest(
   const timeout = setTimeout(
     () => {
       controller.abort();
-      callback(new ErrorInfo('Request timed out', null, 408));
+      callback(new PartialErrorInfo('Request timed out', null, 408));
     },
     rest ? rest.options.timeouts.httpRequestTimeout : Defaults.TIMEOUTS.httpRequestTimeout
   );
@@ -67,7 +67,7 @@ export default function fetchRequest(
         if (!res.ok) {
           const err =
             getAblyError(body, res.headers) ||
-            new ErrorInfo(
+            new PartialErrorInfo(
               'Error response received from server: ' + res.status + ' body was: ' + Platform.Config.inspect(body),
               null,
               res.status

--- a/src/platform/web/lib/transport/xhrrequest.ts
+++ b/src/platform/web/lib/transport/xhrrequest.ts
@@ -1,6 +1,6 @@
 import * as Utils from 'common/lib/util/utils';
 import EventEmitter from 'common/lib/util/eventemitter';
-import ErrorInfo from 'common/lib/types/errorinfo';
+import ErrorInfo, { IPartialErrorInfo, PartialErrorInfo } from 'common/lib/types/errorinfo';
 import Logger from 'common/lib/util/logger';
 import Defaults from 'common/lib/util/defaults';
 import HttpMethods from 'common/constants/HttpMethods';
@@ -129,7 +129,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
   }
 
   complete(
-    err?: ErrorInfo | null,
+    err?: IPartialErrorInfo | null,
     body?: unknown,
     headers?: Record<string, string> | null,
     unpacked?: boolean | null,
@@ -196,7 +196,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
       let errorMessage = message + ' (event type: ' + errorEvent.type + ')';
       if (this?.xhr?.statusText) errorMessage += ', current statusText is ' + this.xhr.statusText;
       Logger.logAction(Logger.LOG_ERROR, 'Request.on' + errorEvent.type + '()', errorMessage);
-      this.complete(new ErrorInfo(errorMessage, code, statusCode));
+      this.complete(new PartialErrorInfo(errorMessage, code, statusCode));
     };
     xhr.onerror = function (errorEvent) {
       errorHandler(errorEvent, 'XHR error occurred', null, 400);
@@ -265,7 +265,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
           headers = getHeadersAsObject(xhr);
         }
       } catch (e) {
-        this.complete(new ErrorInfo('Malformed response body from server: ' + (e as Error).message, null, 400));
+        this.complete(new PartialErrorInfo('Malformed response body from server: ' + (e as Error).message, null, 400));
         return;
       }
 
@@ -278,9 +278,9 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
         return;
       }
 
-      let err = getAblyError(parsedResponse, headers);
+      let err: IPartialErrorInfo | undefined = getAblyError(parsedResponse, headers);
       if (!err) {
-        err = new ErrorInfo(
+        err = new PartialErrorInfo(
           'Error response received from server: ' +
             statusCode +
             ' body was: ' +
@@ -307,7 +307,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
       try {
         chunk = JSON.parse(chunk);
       } catch (e) {
-        this.complete(new ErrorInfo('Malformed response body from server: ' + (e as Error).message, null, 400));
+        this.complete(new PartialErrorInfo('Malformed response body from server: ' + (e as Error).message, null, 400));
         return;
       }
       this.emit('data', chunk);

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -1,7 +1,7 @@
 import Platform from 'common/platform';
 import * as Utils from 'common/lib/util/utils';
 import Defaults from 'common/lib/util/defaults';
-import ErrorInfo from 'common/lib/types/errorinfo';
+import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
 import { ErrnoException, IHttp, RequestCallback, RequestParams } from 'common/types/http';
 import HttpMethods from 'common/constants/HttpMethods';
 import Rest from 'common/lib/client/rest';
@@ -198,7 +198,7 @@ const Http: typeof IHttp = class {
       };
     } else {
       this.Request = (method, rest, uri, headers, params, body, callback) => {
-        callback(new ErrorInfo('no supported HTTP transports available', null, 400), null);
+        callback(new PartialErrorInfo('no supported HTTP transports available', null, 400), null);
       };
     }
   }
@@ -225,7 +225,7 @@ const Http: typeof IHttp = class {
       if (currentFallback.validUntil > Utils.now()) {
         /* Use stored fallback */
         if (!this.Request) {
-          callback?.(new ErrorInfo('Request invoked before assigned to', null, 500));
+          callback?.(new PartialErrorInfo('Request invoked before assigned to', null, 500));
           return;
         }
         this.Request(
@@ -301,7 +301,7 @@ const Http: typeof IHttp = class {
     callback: RequestCallback
   ): void {
     if (!this.Request) {
-      callback(new ErrorInfo('Request invoked before assigned to', null, 500));
+      callback(new PartialErrorInfo('Request invoked before assigned to', null, 500));
       return;
     }
     this.Request(method, rest, uri, headers, params, body, callback);


### PR DESCRIPTION
This requires us to make its `code` and `statusCode` properties mandatory and non-nullable.

I initially attempted to implement this by simply adding the appropriate arguments (values pretty arbitrarily chosen) to all of the `ErrorInfo` constructor calls that didn’t currently have them. However, this caused the `authUrl_403_previously_active` test to stop receiving its expected status code, and looking into it, it seems like we are internally using an `ErrorInfo` with `code === null` to communicate something (?) which then gets picked up by `auth.ts`’s [`normaliseAuthcallbackError`](https://github.com/ably/ably-js/blob/d9573c2e5423f0ae15bd8d20a60d91dfe57f27a4/src/common/lib/client/auth.ts#L28-L44) function.

So I decided to change approach, introducing a new `PartialErrorInfo` class which behaves like the previous `ErrorInfo`, to be used when we don’t have a `code` or `statusCode` to provide. It was the lightest-touch approach I could think of.

Some current usage of the `ErrorInfo` type gets replaced with the `IPartialErrorInfo` interface, which is satisfied by `ErrorInfo` and `PartialErrorInfo`.

(The `setPrototypeOf` stuff in `PartialErrorInfo`’s constructor is just copied from that of `ErrorInfo` — I don’t really know what it does.)

Preparation for converting the platform `crypto.js` files to TypeScript (#1252).