### PR TITLE
Make `IBufferUtils` generic

### DIFF
--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -4,7 +4,7 @@ import ErrorInfo from './errorinfo';
 import { ChannelOptions } from '../../types/channel';
 import PresenceMessage from './presencemessage';
 import * as Utils from '../util/utils';
-import { BrowserBufferlike } from '../../types/IBufferUtils';
+import { Bufferlike as BrowserBufferlike } from '../../../platform/web/lib/util/bufferutils';
 
 export type CipherOptions = {
   channelCipher: {

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -5,10 +5,24 @@ import IDefaults from './types/IDefaults';
 import IWebStorage from './types/IWebStorage';
 import IBufferUtils from './types/IBufferUtils';
 import Transport from './lib/transport/transport';
+import * as WebBufferUtils from '../platform/web/lib/util/bufferutils';
+import * as NodeBufferUtils from '../platform/nodejs/lib/util/bufferutils';
+
+type Bufferlike = WebBufferUtils.Bufferlike | NodeBufferUtils.Bufferlike;
+type BufferUtilsOutput = WebBufferUtils.Output | NodeBufferUtils.Output;
+type ToBufferOutput = WebBufferUtils.ToBufferOutput | NodeBufferUtils.ToBufferOutput;
+type ComparableBuffer = WebBufferUtils.ComparableBuffer | NodeBufferUtils.ComparableBuffer;
 
 export default class Platform {
   static Config: IPlatformConfig;
-  static BufferUtils: IBufferUtils;
+  /*
+     What we actually _want_ is for Platform to be a generic class
+     parameterised by Bufferlike etc, but that requires far-reaching changes to
+     components that make use of Platform. So instead we have to advertise a
+     BufferUtils object that accepts a broader range of data types than it
+     can in reality handle.
+   */
+  static BufferUtils: IBufferUtils<Bufferlike, BufferUtilsOutput, ToBufferOutput, ComparableBuffer>;
   static Crypto: any; //Not typed
   static Http: typeof IHttp;
   static Transports: Array<(connectionManager: typeof ConnectionManager) => Transport>;

--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -1,27 +1,19 @@
 import { TypedArray } from './IPlatformConfig';
-import WordArray from 'crypto-js/build/lib-typedarrays';
 
-export type NodeBufferlike = Buffer | ArrayBuffer | TypedArray;
-// As browsers don't support Buffer, ArrayBuffer is used if supported, and WordArray if not
-export type BrowserBufferlike = ArrayBuffer | WordArray;
-
-// A Buffer or a type which can be converted to a buffer
-export type Bufferlike = NodeBufferlike | BrowserBufferlike;
-
-export default interface IBufferUtils {
+export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, ComparableBuffer> {
   base64CharSet: string;
   hexCharSet: string;
   isBuffer: (buffer: unknown) => buffer is Bufferlike;
   // On browser this returns a Uint8Array, on node a Buffer
-  toBuffer: (buffer: Bufferlike) => Buffer | Uint8Array;
+  toBuffer: (buffer: Bufferlike) => ToBufferOutput;
   toArrayBuffer: (buffer: Bufferlike) => ArrayBuffer;
   base64Encode: (buffer: Bufferlike) => string;
-  base64Decode: (string: string) => Buffer | BrowserBufferlike;
+  base64Decode: (string: string) => Output;
   hexEncode: (buffer: Bufferlike) => string;
-  hexDecode: (string: string) => Buffer | BrowserBufferlike;
-  utf8Encode: (string: string) => Buffer | BrowserBufferlike;
+  hexDecode: (string: string) => Output;
+  utf8Encode: (string: string) => Output;
   utf8Decode: (buffer: Bufferlike) => string;
-  bufferCompare: (buffer1: Buffer, buffer2: Buffer) => number;
+  bufferCompare: (buffer1: ComparableBuffer, buffer2: ComparableBuffer) => number;
   byteLength: (buffer: Bufferlike) => number;
   typedArrayToBuffer: (typedArray: TypedArray) => Bufferlike;
 }

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -16,7 +16,7 @@ import { getDefaults } from '../../common/lib/util/defaults';
 import PlatformDefaults from './lib/util/defaults';
 
 Platform.Crypto = Crypto;
-Platform.BufferUtils = BufferUtils;
+Platform.BufferUtils = BufferUtils as typeof Platform.BufferUtils;
 Platform.Http = Http;
 Platform.Config = Config;
 Platform.Transports = Transports;

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -53,7 +53,7 @@ class BufferUtils implements IBufferUtils {
   }
 
   typedArrayToBuffer(typedArray: TypedArray): Buffer {
-    return this.toBuffer(typedArray.buffer as Buffer);
+    return this.toBuffer(typedArray.buffer);
   }
 
   utf8Decode(buffer: Bufferlike): string {

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -1,11 +1,16 @@
 import { TypedArray } from 'common/types/IPlatformConfig';
-import IBufferUtils, { Bufferlike, NodeBufferlike } from 'common/types/IBufferUtils';
+import IBufferUtils from 'common/types/IBufferUtils';
 
-class BufferUtils implements IBufferUtils {
+export type Bufferlike = Buffer | ArrayBuffer | TypedArray;
+export type Output = Buffer;
+export type ToBufferOutput = Buffer;
+export type ComparableBuffer = Buffer;
+
+class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, ComparableBuffer> {
   base64CharSet: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
   hexCharSet: string = '0123456789abcdef';
 
-  base64Decode(string: string): Buffer {
+  base64Decode(string: string): Output {
     return Buffer.from(string, 'base64');
   }
 
@@ -13,17 +18,17 @@ class BufferUtils implements IBufferUtils {
     return this.toBuffer(buffer).toString('base64');
   }
 
-  bufferCompare(buffer1: Buffer, buffer2: Buffer): number {
+  bufferCompare(buffer1: ComparableBuffer, buffer2: ComparableBuffer): number {
     if (!buffer1) return -1;
     if (!buffer2) return 1;
     return buffer1.compare(buffer2);
   }
 
   byteLength(buffer: Bufferlike): number {
-    return (buffer as NodeBufferlike).byteLength;
+    return buffer.byteLength;
   }
 
-  hexDecode(string: string): Buffer {
+  hexDecode(string: string): Output {
     return Buffer.from(string, 'hex');
   }
 
@@ -45,11 +50,11 @@ class BufferUtils implements IBufferUtils {
     return this.toBuffer(buffer).buffer;
   }
 
-  toBuffer(buffer: Bufferlike): Buffer {
+  toBuffer(buffer: Bufferlike): ToBufferOutput {
     if (Buffer.isBuffer(buffer)) {
       return buffer;
     }
-    return Buffer.from(buffer as TypedArray);
+    return Buffer.from(buffer);
   }
 
   typedArrayToBuffer(typedArray: TypedArray): Buffer {
@@ -63,7 +68,7 @@ class BufferUtils implements IBufferUtils {
     return this.toBuffer(buffer).toString('utf8');
   }
 
-  utf8Encode(string: string): Buffer {
+  utf8Encode(string: string): Output {
     return Buffer.from(string, 'utf8');
   }
 }

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -101,11 +101,11 @@ class BufferUtils implements IBufferUtils {
     }
 
     if (this.isArrayBuffer(buffer)) {
-      return new Uint8Array(buffer as ArrayBuffer);
+      return new Uint8Array(buffer);
     }
 
     if (this.isTypedArray(buffer)) {
-      return new Uint8Array((buffer as TypedArray).buffer);
+      return new Uint8Array(buffer.buffer);
     }
 
     if (this.isWordArray(buffer)) {
@@ -126,7 +126,7 @@ class BufferUtils implements IBufferUtils {
 
   toArrayBuffer(buffer: Bufferlike): ArrayBuffer {
     if (this.isArrayBuffer(buffer)) {
-      return buffer as ArrayBuffer;
+      return buffer;
     }
     return this.toBuffer(buffer).buffer;
   }
@@ -153,7 +153,7 @@ class BufferUtils implements IBufferUtils {
   }
 
   hexEncode(buffer: Bufferlike) {
-    return stringifyHex(this.toWordArray(buffer as ArrayBuffer));
+    return stringifyHex(this.toWordArray(buffer));
   }
 
   hexDecode(string: string) {

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -5,13 +5,17 @@ import WordArray from 'crypto-js/build/lib-typedarrays';
 import Platform from 'common/platform';
 import { TypedArray } from 'common/types/IPlatformConfig';
 import IBufferUtils from 'common/types/IBufferUtils';
-import { Bufferlike } from 'common/types/IBufferUtils';
 
 /* Most BufferUtils methods that return a binary object return an ArrayBuffer
  * if supported, else a CryptoJS WordArray. The exception is toBuffer, which
  * returns a Uint8Array (and won't work on browsers too old to support it) */
 
-class BufferUtils implements IBufferUtils {
+export type Bufferlike = WordArray | ArrayBuffer | TypedArray;
+export type Output = Bufferlike;
+export type ToBufferOutput = Uint8Array;
+export type ComparableBuffer = ArrayBuffer;
+
+class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, ComparableBuffer> {
   base64CharSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
   hexCharSet = '0123456789abcdef';
 
@@ -90,12 +94,12 @@ class BufferUtils implements IBufferUtils {
     return bytes.buffer;
   }
 
-  isBuffer(buffer: unknown): buffer is ArrayBuffer | WordArray | TypedArray {
+  isBuffer(buffer: unknown): buffer is Bufferlike {
     return this.isArrayBuffer(buffer) || this.isWordArray(buffer) || this.isTypedArray(buffer);
   }
 
   /* In browsers, returns a Uint8Array */
-  toBuffer(buffer: Bufferlike): Uint8Array {
+  toBuffer(buffer: Bufferlike): ToBufferOutput {
     if (!ArrayBuffer) {
       throw new Error("Can't convert to Buffer: browser does not support the necessary types");
     }
@@ -131,7 +135,7 @@ class BufferUtils implements IBufferUtils {
     return this.toBuffer(buffer).buffer;
   }
 
-  toWordArray(buffer: TypedArray | WordArray | number[] | ArrayBuffer) {
+  toWordArray(buffer: Bufferlike | number[]) {
     if (this.isTypedArray(buffer)) {
       buffer = buffer.buffer;
     }
@@ -145,7 +149,7 @@ class BufferUtils implements IBufferUtils {
     return this.uint8ViewToBase64(this.toBuffer(buffer));
   }
 
-  base64Decode(str: string): Buffer | ArrayBuffer | WordArray {
+  base64Decode(str: string): Output {
     if (ArrayBuffer && Platform.Config.atob) {
       return this.base64ToArrayBuffer(str);
     }
@@ -184,7 +188,7 @@ class BufferUtils implements IBufferUtils {
     return stringifyUtf8(buffer);
   }
 
-  bufferCompare(buffer1: TypedArray, buffer2: TypedArray) {
+  bufferCompare(buffer1: ComparableBuffer, buffer2: ComparableBuffer) {
     if (!buffer1) return -1;
     if (!buffer2) return 1;
     const wordArray1 = this.toWordArray(buffer1);


### PR DESCRIPTION
This makes the `IBufferUtils` interface generic, parameterised by the types of data it works with. The aim is to have access to more granular type information when I work on #1252. See commit messages for more details.