### PR TITLE
Fix Node’s `Crypto.getDefaultParams` with `ArrayBuffer` key

### DIFF
--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -4,6 +4,7 @@ export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, Compar
   base64CharSet: string;
   hexCharSet: string;
   isBuffer: (buffer: unknown) => buffer is Bufferlike;
+  isArrayBuffer: (buffer: unknown) => buffer is ArrayBuffer;
   // On browser this returns a Uint8Array, on node a Buffer
   toBuffer: (buffer: Bufferlike) => ToBufferOutput;
   toArrayBuffer: (buffer: Bufferlike) => ArrayBuffer;

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -36,7 +36,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Co
     return this.toBuffer(buffer).toString('hex');
   }
 
-  isArrayBuffer(ob: unknown) {
+  isArrayBuffer(ob: unknown): ob is ArrayBuffer {
     return ob !== null && ob !== undefined && (ob as ArrayBuffer).constructor === ArrayBuffer;
   }
 

--- a/src/platform/nodejs/lib/util/crypto.js
+++ b/src/platform/nodejs/lib/util/crypto.js
@@ -148,6 +148,8 @@ var Crypto = (function () {
 
     if (typeof params.key === 'string') {
       key = Platform.BufferUtils.base64Decode(normaliseBase64(params.key));
+    } else if (Platform.BufferUtils.isArrayBuffer(params.key)) {
+      key = Buffer.from(params.key);
     } else {
       key = params.key;
     }

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -166,6 +166,22 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
     });
 
+    it('getDefaultParams_ArrayBuffer_key', function (done) {
+      Crypto.generateRandomKey(function (err, key) {
+        if (err) {
+          done(err);
+        }
+        var arrayBufferKey = Ably.Realtime.Platform.BufferUtils.toArrayBuffer(key);
+        var params = Crypto.getDefaultParams({ key: arrayBufferKey });
+        try {
+          expect(BufferUtils.bufferCompare(params.key, key)).to.equal(0);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
+
     it('getDefaultParams_base64_key', function (done) {
       Crypto.generateRandomKey(function (err, key) {
         if (err) {


### PR DESCRIPTION
`getDefaultParams` is meant to take an argument of type `ably.d.ts`’s `Types.CipherParamOptions`, whose `key` property is of type `ArrayBuffer | Uint8Array | string`.

However, the test case that I’ve added here, which attempts to call `getDefaultParams` with a key of type `ArrayBuffer`, was failing due to the key length check in `validateCipherParams` failing.

But I believe then even beyond that, attempting to use the resulting `CipherParams` to encrypt or decrypt a message would fail on Node < 15, since support for passing Node’s `crypto.createCipheriv` a key of type `ArrayBuffer` was only added in Node 15.0.0.

Resolves #1278.