### PR TITLE
Fix Node encryption of `ArrayBuffer` plaintext

### DIFF
--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -42,7 +42,8 @@ class BufferUtils implements IBufferUtils {
   }
 
   toArrayBuffer(buffer: Bufferlike): ArrayBuffer {
-    return this.toBuffer(buffer).buffer;
+    const nodeBuffer = this.toBuffer(buffer);
+    return nodeBuffer.buffer.slice(nodeBuffer.byteOffset, nodeBuffer.byteOffset + nodeBuffer.byteLength);
   }
 
   toBuffer(buffer: Bufferlike): Buffer {

--- a/src/platform/nodejs/lib/util/crypto.js
+++ b/src/platform/nodejs/lib/util/crypto.js
@@ -207,10 +207,13 @@ var Crypto = (function () {
 
   CBCCipher.prototype.encrypt = function (plaintext, callback) {
     Logger.logAction(Logger.LOG_MICRO, 'CBCCipher.encrypt()', '');
-    var plaintextLength = plaintext.length,
+    var plaintextBuffer = Platform.BufferUtils.toBuffer(plaintext);
+    var plaintextLength = plaintextBuffer.length,
       paddedLength = getPaddedLength(plaintextLength),
       iv = this.getIv();
-    var cipherOut = this.encryptCipher.update(Buffer.concat([plaintext, pkcs5Padding[paddedLength - plaintextLength]]));
+    var cipherOut = this.encryptCipher.update(
+      Buffer.concat([plaintextBuffer, pkcs5Padding[paddedLength - plaintextLength]])
+    );
     var ciphertext = Buffer.concat([iv, toBuffer(cipherOut)]);
     return callback(null, ciphertext);
   };


### PR DESCRIPTION
This fixes an error that is thrown in Node when attempting to encrypt a message whose `data` property is of type `ArrayBuffer`. See commit messages for more details.

Resolves #1281.