### PR TITLE
Align `*Message.fromEncoded*` signatures with public API

### DIFF
--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -345,7 +345,6 @@ class Message {
   }
 
   static fromEncodedArray(encodedArray: Array<unknown>, options: CipherOptions): Message[] {
-    normalizeCipherOptions(options);
     return encodedArray.map(function (encoded) {
       return Message.fromEncoded(encoded, options);
     });

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -5,6 +5,7 @@ import { ChannelOptions } from '../../types/channel';
 import PresenceMessage from './presencemessage';
 import * as Utils from '../util/utils';
 import { Bufferlike as BrowserBufferlike } from '../../../platform/web/lib/util/bufferutils';
+import * as API from '../../../../ably';
 
 export type CipherOptions = {
   channelCipher: {
@@ -41,8 +42,8 @@ function normaliseContext(context: CipherOptions | EncodingDecodingContext | Cha
   return context as EncodingDecodingContext;
 }
 
-function normalizeCipherOptions(options: CipherOptions): CipherOptions {
-  if (options && options.cipher && !options.cipher.channelCipher) {
+function normalizeCipherOptions(options: API.Types.ChannelOptions | null): ChannelOptions {
+  if (options && options.cipher) {
     if (!Platform.Crypto) throw new Error('Encryption not enabled; use ably.encryption.js instead');
     const cipher = Platform.Crypto.getCipher(options.cipher);
     return {
@@ -50,7 +51,7 @@ function normalizeCipherOptions(options: CipherOptions): CipherOptions {
       channelCipher: cipher.cipher,
     };
   }
-  return options;
+  return options ?? {};
 }
 
 function getMessageSize(msg: Message) {
@@ -331,9 +332,9 @@ class Message {
     return result;
   }
 
-  static fromEncoded(encoded: unknown, inputOptions: CipherOptions): Message {
+  static fromEncoded(encoded: unknown, inputOptions?: API.Types.ChannelOptions): Message {
     const msg = Message.fromValues(encoded);
-    const options = normalizeCipherOptions(inputOptions);
+    const options = normalizeCipherOptions(inputOptions ?? null);
     /* if decoding fails at any point, catch and return the message decoded to
      * the fullest extent possible */
     try {
@@ -344,7 +345,7 @@ class Message {
     return msg;
   }
 
-  static fromEncodedArray(encodedArray: Array<unknown>, options: CipherOptions): Message[] {
+  static fromEncodedArray(encodedArray: Array<unknown>, options?: API.Types.ChannelOptions): Message[] {
     return encodedArray.map(function (encoded) {
       return Message.fromEncoded(encoded, options);
     });

--- a/src/common/lib/types/presencemessage.ts
+++ b/src/common/lib/types/presencemessage.ts
@@ -2,6 +2,7 @@ import Logger from '../util/logger';
 import Platform from 'common/platform';
 import Message, { CipherOptions } from './message';
 import * as Utils from '../util/utils';
+import * as API from '../../../../ably';
 
 function toActionValue(actionString: string) {
   return PresenceMessage.Actions.indexOf(actionString);
@@ -136,19 +137,19 @@ class PresenceMessage {
     return result;
   }
 
-  static fromEncoded(encoded: Record<string, unknown>, options: CipherOptions): PresenceMessage {
-    const msg = PresenceMessage.fromValues(encoded, true);
+  static fromEncoded(encoded: unknown, options?: API.Types.ChannelOptions): PresenceMessage {
+    const msg = PresenceMessage.fromValues(encoded as PresenceMessage | Record<string, unknown>, true);
     /* if decoding fails at any point, catch and return the message decoded to
      * the fullest extent possible */
     try {
-      PresenceMessage.decode(msg, options);
+      PresenceMessage.decode(msg, options ?? {});
     } catch (e) {
       Logger.logAction(Logger.LOG_ERROR, 'PresenceMessage.fromEncoded()', (e as Error).toString());
     }
     return msg;
   }
 
-  static fromEncodedArray(encodedArray: Record<string, unknown>[], options: CipherOptions): PresenceMessage[] {
+  static fromEncodedArray(encodedArray: unknown[], options?: API.Types.ChannelOptions): PresenceMessage[] {
     return encodedArray.map(function (encoded) {
       return PresenceMessage.fromEncoded(encoded, options);
     });


### PR DESCRIPTION
This aligns the internal signatures of the following methods with those in `ably.d.ts`:

- `Message.fromEncoded`
- `Message.fromEncodedArray`
- `PresenceMessage.fromEncoded`
- `PresenceMessage.fromEncodedArray`

See commit messages for more details.