### PR TITLE
fix(WebSocketTransport): encode all query string params

### DIFF
--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -33,12 +33,8 @@ class WebSocketTransport extends Transport {
   }
 
   createWebSocket(uri: string, connectParams: Record<string, string>) {
-    let paramCount = 0;
-    if (connectParams) {
-      for (const key in connectParams) uri += (paramCount++ ? '&' : '?') + key + '=' + connectParams[key];
-    }
-    this.uri = uri;
-    return new Platform.Config.WebSocket(uri);
+    this.uri = uri + Utils.toQueryString(connectParams);
+    return new Platform.Config.WebSocket(this.uri);
   }
 
   toString() {


### PR DESCRIPTION
Resolves #1262 

Resolves an issue where the react-native websocket constructor crashes due to space characters being included in the ws url (in web and nodejs the websocket constructor will just url encode it automatically).