### PR TITLE
Use Web Crypto API for encrypting and decrypting

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2904,11 +2904,11 @@ declare namespace Types {
    */
   type CipherKeyParam = ArrayBuffer | Uint8Array | string; // if string must be base64-encoded
   /**
-   * Typed differently depending on platform. (`WordArray` in browser, `Buffer` in node)
+   * Typed differently depending on platform. (`ArrayBuffer` in browser, `Buffer` in node)
    *
    * @internal
    */
-  type CipherKey = unknown; // WordArray on browsers, Buffer on node, using unknown as
+  type CipherKey = unknown; // ArrayBuffer on browsers, Buffer on node, using unknown as
   // user should not be interacting with it - output of getDefaultParams should be used opaquely
 
   /**

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -975,7 +975,7 @@ declare namespace Types {
    */
   interface ChannelOptions {
     /**
-     * Requests encryption for this channel when not null, and specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See [an example](https://ably.com/docs/realtime/encryption#getting-started).
+     * Requests encryption for this channel when not null, and specifies encryption-related parameters (such as algorithm, chaining mode, key length and key). See [an example](https://ably.com/docs/realtime/encryption#getting-started). When running in a browser, encryption is only available when the current environment is a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
      */
     cipher?: CipherParamOptions | CipherParams;
     /**

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -275,7 +275,7 @@ class Message {
                 deltaBase = Platform.BufferUtils.toBuffer(deltaBase as Buffer);
                 data = Platform.BufferUtils.toBuffer(data);
 
-                data = Platform.BufferUtils.typedArrayToBuffer(context.plugins.vcdiff.decode(data, deltaBase));
+                data = Platform.BufferUtils.arrayBufferViewToBuffer(context.plugins.vcdiff.decode(data, deltaBase));
                 lastPayload = data;
               } catch (e) {
                 throw new ErrorInfo('Vcdiff delta decode failed with ' + e, 40018, 400);

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -269,9 +269,7 @@ class Message {
                   deltaBase = Platform.BufferUtils.utf8Encode(deltaBase);
                 }
 
-                /* vcdiff expects Uint8Arrays, can't copy with ArrayBuffers. (also, if we
-                 * don't have a TextDecoder, deltaBase might be a WordArray here, so need
-                 * to process it into a buffer anyway) */
+                // vcdiff expects Uint8Arrays, can't copy with ArrayBuffers.
                 deltaBase = Platform.BufferUtils.toBuffer(deltaBase as Buffer);
                 data = Platform.BufferUtils.toBuffer(data);
 

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -11,7 +11,6 @@ import * as NodeBufferUtils from '../platform/nodejs/lib/util/bufferutils';
 type Bufferlike = WebBufferUtils.Bufferlike | NodeBufferUtils.Bufferlike;
 type BufferUtilsOutput = WebBufferUtils.Output | NodeBufferUtils.Output;
 type ToBufferOutput = WebBufferUtils.ToBufferOutput | NodeBufferUtils.ToBufferOutput;
-type ComparableBuffer = WebBufferUtils.ComparableBuffer | NodeBufferUtils.ComparableBuffer;
 type WordArrayLike = WebBufferUtils.WordArrayLike | NodeBufferUtils.WordArrayLike;
 
 export default class Platform {
@@ -23,7 +22,7 @@ export default class Platform {
      BufferUtils object that accepts a broader range of data types than it
      can in reality handle.
    */
-  static BufferUtils: IBufferUtils<Bufferlike, BufferUtilsOutput, ToBufferOutput, ComparableBuffer, WordArrayLike>;
+  static BufferUtils: IBufferUtils<Bufferlike, BufferUtilsOutput, ToBufferOutput, WordArrayLike>;
   /*
      This should be a class whose static methods implement the ICryptoStatic
      interface, but (for the same reasons as described in the BufferUtils

--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -4,7 +4,6 @@ export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, WordAr
   base64CharSet: string;
   hexCharSet: string;
   isBuffer: (buffer: unknown) => buffer is Bufferlike;
-  isArrayBuffer: (buffer: unknown) => buffer is ArrayBuffer;
   isWordArray: (val: unknown) => val is WordArrayLike;
   // On browser this returns a Uint8Array, on node a Buffer
   toBuffer: (buffer: Bufferlike) => ToBufferOutput;

--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -5,7 +5,7 @@ export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, WordAr
   isWordArray: (val: unknown) => val is WordArrayLike;
   // On browser this returns a Uint8Array, on node a Buffer
   toBuffer: (buffer: Bufferlike) => ToBufferOutput;
-  toArrayBuffer: (buffer: Bufferlike) => ArrayBuffer;
+  toArrayBuffer: (buffer: Bufferlike | WordArrayLike) => ArrayBuffer;
   base64Encode: (buffer: Bufferlike) => string;
   base64Decode: (string: string) => Output;
   hexEncode: (buffer: Bufferlike) => string;

--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -12,7 +12,7 @@ export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, WordAr
   hexDecode: (string: string) => Output;
   utf8Encode: (string: string) => Output;
   utf8Decode: (buffer: Bufferlike) => string;
-  bufferCompare: (buffer1: Bufferlike, buffer2: Bufferlike) => number;
+  areBuffersEqual: (buffer1: Bufferlike, buffer2: Bufferlike) => boolean;
   byteLength: (buffer: Bufferlike) => number;
   arrayBufferViewToBuffer: (arrayBufferView: ArrayBufferView) => Bufferlike;
   toWordArray: (buffer: Bufferlike | number[]) => WordArrayLike;

--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -1,6 +1,6 @@
 import { TypedArray } from './IPlatformConfig';
 
-export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, ComparableBuffer, WordArrayLike> {
+export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, WordArrayLike> {
   base64CharSet: string;
   hexCharSet: string;
   isBuffer: (buffer: unknown) => buffer is Bufferlike;
@@ -15,7 +15,7 @@ export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, Compar
   hexDecode: (string: string) => Output;
   utf8Encode: (string: string) => Output;
   utf8Decode: (buffer: Bufferlike) => string;
-  bufferCompare: (buffer1: ComparableBuffer, buffer2: ComparableBuffer) => number;
+  bufferCompare: (buffer1: Bufferlike, buffer2: Bufferlike) => number;
   byteLength: (buffer: Bufferlike) => number;
   typedArrayToBuffer: (typedArray: TypedArray) => Bufferlike;
   toWordArray: (buffer: Bufferlike | number[]) => WordArrayLike;

--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -1,5 +1,3 @@
-import { TypedArray } from './IPlatformConfig';
-
 export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, WordArrayLike> {
   base64CharSet: string;
   hexCharSet: string;
@@ -16,6 +14,6 @@ export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput, WordAr
   utf8Decode: (buffer: Bufferlike) => string;
   bufferCompare: (buffer1: Bufferlike, buffer2: Bufferlike) => number;
   byteLength: (buffer: Bufferlike) => number;
-  typedArrayToBuffer: (typedArray: TypedArray) => Bufferlike;
+  arrayBufferViewToBuffer: (arrayBufferView: ArrayBufferView) => Bufferlike;
   toWordArray: (buffer: Bufferlike | number[]) => WordArrayLike;
 }

--- a/src/common/types/IPlatformConfig.d.ts
+++ b/src/common/types/IPlatformConfig.d.ts
@@ -33,9 +33,9 @@ export interface IPlatformConfig {
   atob?: typeof atob | null;
   TextEncoder?: typeof TextEncoder;
   TextDecoder?: typeof TextDecoder;
-  getRandomWordArray?: (
+  getRandomArrayBuffer?: (
     byteLength: number,
-    callback: (err: Error | null, result: CryptoJS.lib.WordArray | null) => void
+    callback: (err: Error | null, result: ArrayBuffer | null) => void
   ) => void;
   isWebworker?: boolean;
 }

--- a/src/common/types/IPlatformConfig.d.ts
+++ b/src/common/types/IPlatformConfig.d.ts
@@ -1,14 +1,3 @@
-export type TypedArray =
-  | Int8Array
-  | Uint8Array
-  | Int16Array
-  | Uint16Array
-  | Int32Array
-  | Uint32Array
-  | Uint8ClampedArray
-  | Float32Array
-  | Float64Array;
-
 interface MsgPack {
   encode(value: any, sparse?: boolean): Buffer | ArrayBuffer | undefined;
   decode(buffer: Buffer): any;
@@ -31,7 +20,7 @@ export interface IPlatformConfig {
   stringByteSize: Buffer.byteLength;
   addEventListener?: typeof window.addEventListener | typeof global.addEventListener | null;
   Promise: typeof Promise;
-  getRandomValues?: (arr: TypedArray, callback?: (error: Error | null) => void) => void;
+  getRandomValues?: (arr: ArrayBufferView, callback?: (error: Error | null) => void) => void;
   userAgent?: string | null;
   inherits?: typeof import('util').inherits;
   currentUrl?: string;

--- a/src/common/types/crypto-js.d.ts
+++ b/src/common/types/crypto-js.d.ts
@@ -10,12 +10,6 @@ declare module 'crypto-js/build/enc-base64' {
   export const stringify: typeof CryptoJS.enc.Base64.stringify;
 }
 
-declare module 'crypto-js/build/enc-hex' {
-  import CryptoJS from 'crypto-js';
-  export const parse: typeof CryptoJS.enc.Hex.parse;
-  export const stringify: typeof CryptoJS.enc.Hex.stringify;
-}
-
 declare module 'crypto-js/build/enc-utf8' {
   import CryptoJS from 'crypto-js';
   export const parse: typeof CryptoJS.enc.Utf8.parse;

--- a/src/platform/nodejs/config.ts
+++ b/src/platform/nodejs/config.ts
@@ -1,4 +1,4 @@
-import { TypedArray, IPlatformConfig } from '../../common/types/IPlatformConfig';
+import { IPlatformConfig } from '../../common/types/IPlatformConfig';
 import crypto from 'crypto';
 import WebSocket from 'ws';
 import util from 'util';
@@ -19,9 +19,14 @@ const Config: IPlatformConfig = {
   stringByteSize: Buffer.byteLength,
   inherits: util.inherits,
   addEventListener: null,
-  getRandomValues: function (arr: TypedArray, callback?: (err: Error | null) => void): void {
-    const bytes = crypto.randomBytes(arr.length);
-    arr.set(bytes);
+  getRandomValues: function (arr: ArrayBufferView, callback?: (err: Error | null) => void): void {
+    const bytes = crypto.randomBytes(arr.byteLength);
+    const dataView = new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
+
+    for (let i = 0; i < bytes.length; i++) {
+      dataView.setUint8(i, bytes[i]);
+    }
+
     if (callback) {
       callback(null);
     }

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -4,10 +4,9 @@ import IBufferUtils from 'common/types/IBufferUtils';
 export type Bufferlike = Buffer | ArrayBuffer | TypedArray;
 export type Output = Buffer;
 export type ToBufferOutput = Buffer;
-export type ComparableBuffer = Buffer;
 export type WordArrayLike = never;
 
-class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, ComparableBuffer, WordArrayLike> {
+class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, WordArrayLike> {
   base64CharSet: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
   hexCharSet: string = '0123456789abcdef';
 
@@ -19,10 +18,10 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Co
     return this.toBuffer(buffer).toString('base64');
   }
 
-  bufferCompare(buffer1: ComparableBuffer, buffer2: ComparableBuffer): number {
+  bufferCompare(buffer1: Bufferlike, buffer2: Bufferlike): number {
     if (!buffer1) return -1;
     if (!buffer2) return 1;
-    return buffer1.compare(buffer2);
+    return this.toBuffer(buffer1).compare(this.toBuffer(buffer2));
   }
 
   byteLength(buffer: Bufferlike): number {

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -17,10 +17,9 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
     return this.toBuffer(buffer).toString('base64');
   }
 
-  bufferCompare(buffer1: Bufferlike, buffer2: Bufferlike): number {
-    if (!buffer1) return -1;
-    if (!buffer2) return 1;
-    return this.toBuffer(buffer1).compare(this.toBuffer(buffer2));
+  areBuffersEqual(buffer1: Bufferlike, buffer2: Bufferlike): boolean {
+    if (!buffer1 || !buffer2) return false;
+    return this.toBuffer(buffer1).compare(this.toBuffer(buffer2)) == 0;
   }
 
   byteLength(buffer: Bufferlike): number {

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -41,7 +41,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
     return Buffer.isBuffer(buffer) || buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer);
   }
 
-  toArrayBuffer(buffer: Bufferlike): ArrayBuffer {
+  toArrayBuffer(buffer: Bufferlike | WordArrayLike): ArrayBuffer {
     const nodeBuffer = this.toBuffer(buffer);
     return nodeBuffer.buffer.slice(nodeBuffer.byteOffset, nodeBuffer.byteOffset + nodeBuffer.byteLength);
   }

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -1,7 +1,6 @@
-import { TypedArray } from 'common/types/IPlatformConfig';
 import IBufferUtils from 'common/types/IBufferUtils';
 
-export type Bufferlike = Buffer | ArrayBuffer | TypedArray;
+export type Bufferlike = Buffer | ArrayBuffer | ArrayBufferView;
 export type Output = Buffer;
 export type ToBufferOutput = Buffer;
 export type WordArrayLike = never;
@@ -51,11 +50,14 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
     if (Buffer.isBuffer(buffer)) {
       return buffer;
     }
-    return Buffer.from(buffer);
+    if (buffer instanceof ArrayBuffer) {
+      return Buffer.from(buffer);
+    }
+    return Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength);
   }
 
-  typedArrayToBuffer(typedArray: TypedArray): Buffer {
-    return this.toBuffer(typedArray.buffer);
+  arrayBufferViewToBuffer(arrayBufferView: ArrayBufferView): Buffer {
+    return this.toBuffer(arrayBufferView.buffer);
   }
 
   utf8Decode(buffer: Bufferlike): string {
@@ -70,7 +72,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-  toWordArray(buffer: TypedArray | WordArrayLike | number[] | ArrayBuffer): never {
+  toWordArray(buffer: ArrayBufferView | WordArrayLike | number[] | ArrayBuffer): never {
     throw new Error('Not implemented');
   }
 

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -36,14 +36,10 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
     return this.toBuffer(buffer).toString('hex');
   }
 
-  isArrayBuffer(ob: unknown): ob is ArrayBuffer {
-    return ob !== null && ob !== undefined && (ob as ArrayBuffer).constructor === ArrayBuffer;
-  }
-
   /* In node, BufferUtils methods that return binary objects return a Buffer
    * for historical reasons; the browser equivalents return ArrayBuffers */
   isBuffer(buffer: unknown): buffer is Bufferlike {
-    return Buffer.isBuffer(buffer) || this.isArrayBuffer(buffer) || ArrayBuffer.isView(buffer);
+    return Buffer.isBuffer(buffer) || buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer);
   }
 
   toArrayBuffer(buffer: Bufferlike): ArrayBuffer {

--- a/src/platform/nodejs/lib/util/crypto.ts
+++ b/src/platform/nodejs/lib/util/crypto.ts
@@ -147,9 +147,9 @@ var CryptoFactory = function (bufferUtils: typeof BufferUtils) {
      * in any not provided with default values, calculating a keyLength from
      * the supplied key, and validating the result.
      * @param params an object containing at a minimum a `key` key with value the
-     * key, as either a binary (ArrayBuffer, Array, WordArray) or a
-     * base64-encoded string. May optionally also contain: algorithm (defaults to
-     * AES), mode (defaults to 'cbc')
+     * key, as either a binary or a base64-encoded string.
+     * May optionally also contain: algorithm (defaults to AES),
+     * mode (defaults to 'cbc')
      */
     static getDefaultParams(params: API.Types.CipherParamOptions) {
       var key: NodeCipherKey;

--- a/src/platform/nodejs/lib/util/crypto.ts
+++ b/src/platform/nodejs/lib/util/crypto.ts
@@ -160,7 +160,7 @@ var CryptoFactory = function (bufferUtils: typeof BufferUtils) {
 
       if (typeof params.key === 'string') {
         key = bufferUtils.base64Decode(normaliseBase64(params.key));
-      } else if (bufferUtils.isArrayBuffer(params.key)) {
+      } else if (params.key instanceof ArrayBuffer) {
         key = Buffer.from(params.key);
       } else {
         key = params.key;

--- a/src/platform/react-native/config.ts
+++ b/src/platform/react-native/config.ts
@@ -2,47 +2,50 @@ import msgpack from '../web/lib/util/msgpack';
 import { parse as parseBase64 } from 'crypto-js/build/enc-base64';
 import { IPlatformConfig } from '../../common/types/IPlatformConfig';
 
-const Platform: IPlatformConfig = {
-  agent: 'reactnative',
-  logTimestamps: true,
-  noUpgrade: false,
-  binaryType: 'arraybuffer',
-  WebSocket: WebSocket,
-  xhrSupported: true,
-  allowComet: true,
-  streamingSupported: true,
-  useProtocolHeartbeats: true,
-  createHmac: null,
-  msgpack: msgpack,
-  supportsBinary: !!(typeof TextDecoder !== 'undefined' && TextDecoder),
-  preferBinary: false,
-  ArrayBuffer: typeof ArrayBuffer !== 'undefined' && ArrayBuffer,
-  atob: global.atob,
-  nextTick: function (f: Function) {
-    setTimeout(f, 0);
-  },
-  addEventListener: null,
-  inspect: JSON.stringify,
-  stringByteSize: function (str: string) {
-    /* str.length will be an underestimate for non-ascii strings. But if we're
-     * in a browser too old to support TextDecoder, not much we can do. Better
-     * to underestimate, so if we do go over-size, the server will reject the
-     * message */
-    return (typeof TextDecoder !== 'undefined' && new TextEncoder().encode(str).length) || str.length;
-  },
-  TextEncoder: global.TextEncoder,
-  TextDecoder: global.TextDecoder,
-  Promise: global.Promise,
-  getRandomWordArray: (function (RNRandomBytes) {
-    return function (byteLength: number, callback: (err: Error | null, result: CryptoJS.lib.WordArray | null) => void) {
-      RNRandomBytes.randomBytes(byteLength, function (err: Error | null, base64String: string | null) {
-        callback(err, base64String ? parseBase64(base64String) : null);
-      });
-    };
-    // Installing @types/react-native would fix this but conflicts with @types/node
-    // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15960
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-  })(require('react-native').NativeModules.RNRandomBytes),
-};
-
-export default Platform;
+export default function (): IPlatformConfig {
+  return {
+    agent: 'reactnative',
+    logTimestamps: true,
+    noUpgrade: false,
+    binaryType: 'arraybuffer',
+    WebSocket: WebSocket,
+    xhrSupported: true,
+    allowComet: true,
+    streamingSupported: true,
+    useProtocolHeartbeats: true,
+    createHmac: null,
+    msgpack: msgpack,
+    supportsBinary: !!(typeof TextDecoder !== 'undefined' && TextDecoder),
+    preferBinary: false,
+    ArrayBuffer: typeof ArrayBuffer !== 'undefined' && ArrayBuffer,
+    atob: global.atob,
+    nextTick: function (f: Function) {
+      setTimeout(f, 0);
+    },
+    addEventListener: null,
+    inspect: JSON.stringify,
+    stringByteSize: function (str: string) {
+      /* str.length will be an underestimate for non-ascii strings. But if we're
+       * in a browser too old to support TextDecoder, not much we can do. Better
+       * to underestimate, so if we do go over-size, the server will reject the
+       * message */
+      return (typeof TextDecoder !== 'undefined' && new TextEncoder().encode(str).length) || str.length;
+    },
+    TextEncoder: global.TextEncoder,
+    TextDecoder: global.TextDecoder,
+    Promise: global.Promise,
+    getRandomWordArray: (function (RNRandomBytes) {
+      return function (
+        byteLength: number,
+        callback: (err: Error | null, result: CryptoJS.lib.WordArray | null) => void
+      ) {
+        RNRandomBytes.randomBytes(byteLength, function (err: Error | null, base64String: string | null) {
+          callback(err, base64String ? parseBase64(base64String) : null);
+        });
+      };
+      // Installing @types/react-native would fix this but conflicts with @types/node
+      // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15960
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+    })(require('react-native').NativeModules.RNRandomBytes),
+  };
+}

--- a/src/platform/react-native/config.ts
+++ b/src/platform/react-native/config.ts
@@ -1,8 +1,8 @@
 import msgpack from '../web/lib/util/msgpack';
-import { parse as parseBase64 } from 'crypto-js/build/enc-base64';
 import { IPlatformConfig } from '../../common/types/IPlatformConfig';
+import BufferUtils from '../web/lib/util/bufferutils';
 
-export default function (): IPlatformConfig {
+export default function (bufferUtils: typeof BufferUtils): IPlatformConfig {
   return {
     agent: 'reactnative',
     logTimestamps: true,
@@ -34,13 +34,10 @@ export default function (): IPlatformConfig {
     TextEncoder: global.TextEncoder,
     TextDecoder: global.TextDecoder,
     Promise: global.Promise,
-    getRandomWordArray: (function (RNRandomBytes) {
-      return function (
-        byteLength: number,
-        callback: (err: Error | null, result: CryptoJS.lib.WordArray | null) => void
-      ) {
+    getRandomArrayBuffer: (function (RNRandomBytes) {
+      return function (byteLength: number, callback: (err: Error | null, result: ArrayBuffer | null) => void) {
         RNRandomBytes.randomBytes(byteLength, function (err: Error | null, base64String: string | null) {
-          callback(err, base64String ? parseBase64(base64String) : null);
+          callback(err, base64String ? bufferUtils.toArrayBuffer(bufferUtils.base64Decode(base64String)) : null);
         });
       };
       // Installing @types/react-native would fix this but conflicts with @types/node

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -8,7 +8,7 @@ import BufferUtils from '../web/lib/util/bufferutils';
 // @ts-ignore
 import CryptoFactory from '../web/lib/util/crypto';
 import Http from '../web/lib/util/http';
-import Config from './config';
+import configFactory from './config';
 // @ts-ignore
 import Transports from '../web/lib/transport';
 import Logger from '../../common/lib/util/logger';
@@ -16,6 +16,8 @@ import { getDefaults } from '../../common/lib/util/defaults';
 import WebStorage from '../web/lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
+
+const Config = configFactory();
 
 const Crypto = CryptoFactory(Config, BufferUtils);
 

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -17,7 +17,7 @@ import WebStorage from '../web/lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
 
-const Config = configFactory();
+const Config = configFactory(BufferUtils);
 
 const Crypto = CryptoFactory(Config, BufferUtils);
 

--- a/src/platform/web/config.ts
+++ b/src/platform/web/config.ts
@@ -1,5 +1,5 @@
 import msgpack from './lib/util/msgpack';
-import { IPlatformConfig, TypedArray } from '../../common/types/IPlatformConfig';
+import { IPlatformConfig } from '../../common/types/IPlatformConfig';
 import * as Utils from 'common/lib/util/utils';
 
 // Workaround for salesforce lightning locker compat
@@ -65,7 +65,7 @@ const Config: IPlatformConfig = {
     if (crypto === undefined) {
       return undefined;
     }
-    return function (arr: TypedArray, callback?: (error: Error | null) => void) {
+    return function (arr: ArrayBufferView, callback?: (error: Error | null) => void) {
       crypto.getRandomValues(arr);
       if (callback) {
         callback(null);

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -3,14 +3,13 @@ import { parse as parseUtf8, stringify as stringifyUtf8 } from 'crypto-js/build/
 import { parse as parseBase64, stringify as stringifyBase64 } from 'crypto-js/build/enc-base64';
 import WordArray from 'crypto-js/build/lib-typedarrays';
 import Platform from 'common/platform';
-import { TypedArray } from 'common/types/IPlatformConfig';
 import IBufferUtils from 'common/types/IBufferUtils';
 
 /* Most BufferUtils methods that return a binary object return an ArrayBuffer
  * if supported, else a CryptoJS WordArray. The exception is toBuffer, which
  * returns a Uint8Array (and won't work on browsers too old to support it) */
 
-export type Bufferlike = WordArray | ArrayBuffer | TypedArray;
+export type Bufferlike = WordArray | BufferSource;
 export type Output = Bufferlike;
 export type ToBufferOutput = Uint8Array;
 export type WordArrayLike = WordArray;
@@ -23,7 +22,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
     return ob !== null && ob !== undefined && (ob as WordArray).sigBytes !== undefined;
   }
 
-  isTypedArray(ob: unknown): ob is TypedArray {
+  isArrayBufferView(ob: unknown): ob is ArrayBufferView {
     return !!ArrayBuffer && ArrayBuffer.isView && ArrayBuffer.isView(ob);
   }
 
@@ -91,7 +90,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   isBuffer(buffer: unknown): buffer is Bufferlike {
-    return buffer instanceof ArrayBuffer || this.isWordArray(buffer) || this.isTypedArray(buffer);
+    return buffer instanceof ArrayBuffer || this.isWordArray(buffer) || this.isArrayBufferView(buffer);
   }
 
   /* In browsers, returns a Uint8Array */
@@ -104,7 +103,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
       return new Uint8Array(buffer);
     }
 
-    if (this.isTypedArray(buffer)) {
+    if (this.isArrayBufferView(buffer)) {
       return new Uint8Array(buffer.buffer);
     }
 
@@ -132,7 +131,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   toWordArray(buffer: Bufferlike | number[]) {
-    if (this.isTypedArray(buffer)) {
+    if (this.isArrayBufferView(buffer)) {
       buffer = buffer.buffer;
     }
     return this.isWordArray(buffer) ? buffer : WordArray.create(buffer as number[]);
@@ -204,7 +203,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   byteLength(buffer: Bufferlike) {
-    if (buffer instanceof ArrayBuffer || this.isTypedArray(buffer)) {
+    if (buffer instanceof ArrayBuffer || this.isArrayBufferView(buffer)) {
       return buffer.byteLength;
     } else if (this.isWordArray(buffer)) {
       return buffer.sigBytes;
@@ -213,8 +212,8 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   /* Returns ArrayBuffer on browser and Buffer on Node.js */
-  typedArrayToBuffer(typedArray: TypedArray) {
-    return typedArray.buffer;
+  arrayBufferViewToBuffer(arrayBufferView: ArrayBufferView) {
+    return arrayBufferView.buffer;
   }
 }
 

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -190,16 +190,16 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
 
   areBuffersEqual(buffer1: Bufferlike, buffer2: Bufferlike) {
     if (!buffer1 || !buffer2) return false;
-    const wordArray1 = this.toWordArray(buffer1);
-    const wordArray2 = this.toWordArray(buffer2);
-    wordArray1.clamp();
-    wordArray2.clamp();
+    const arrayBuffer1 = this.toArrayBuffer(buffer1);
+    const arrayBuffer2 = this.toArrayBuffer(buffer2);
 
-    if (wordArray1.sigBytes != wordArray2.sigBytes) return false;
-    const words1 = wordArray1.words;
-    const words2 = wordArray2.words;
-    for (var i = 0; i < words1.length; i++) {
-      if (words1[i] != words2[i]) return false;
+    if (arrayBuffer1.byteLength != arrayBuffer2.byteLength) return false;
+
+    const bytes1 = new Uint8Array(arrayBuffer1);
+    const bytes2 = new Uint8Array(arrayBuffer2);
+
+    for (var i = 0; i < bytes1.length; i++) {
+      if (bytes1[i] != bytes2[i]) return false;
     }
     return true;
   }

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -188,23 +188,20 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
     }
   }
 
-  bufferCompare(buffer1: Bufferlike, buffer2: Bufferlike) {
-    if (!buffer1) return -1;
-    if (!buffer2) return 1;
+  areBuffersEqual(buffer1: Bufferlike, buffer2: Bufferlike) {
+    if (!buffer1 || !buffer2) return false;
     const wordArray1 = this.toWordArray(buffer1);
     const wordArray2 = this.toWordArray(buffer2);
     wordArray1.clamp();
     wordArray2.clamp();
 
-    var cmp = wordArray1.sigBytes - wordArray2.sigBytes;
-    if (cmp != 0) return cmp;
+    if (wordArray1.sigBytes != wordArray2.sigBytes) return false;
     const words1 = wordArray1.words;
     const words2 = wordArray2.words;
     for (var i = 0; i < words1.length; i++) {
-      cmp = words1[i] - words2[i];
-      if (cmp != 0) return cmp;
+      if (words1[i] != words2[i]) return false;
     }
-    return 0;
+    return true;
   }
 
   byteLength(buffer: Bufferlike) {

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -23,10 +23,6 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
     return ob !== null && ob !== undefined && (ob as WordArray).sigBytes !== undefined;
   }
 
-  isArrayBuffer(ob: unknown): ob is ArrayBuffer {
-    return ob !== null && ob !== undefined && (ob as ArrayBuffer).constructor === ArrayBuffer;
-  }
-
   isTypedArray(ob: unknown): ob is TypedArray {
     return !!ArrayBuffer && ArrayBuffer.isView && ArrayBuffer.isView(ob);
   }
@@ -95,7 +91,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   isBuffer(buffer: unknown): buffer is Bufferlike {
-    return this.isArrayBuffer(buffer) || this.isWordArray(buffer) || this.isTypedArray(buffer);
+    return buffer instanceof ArrayBuffer || this.isWordArray(buffer) || this.isTypedArray(buffer);
   }
 
   /* In browsers, returns a Uint8Array */
@@ -104,7 +100,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
       throw new Error("Can't convert to Buffer: browser does not support the necessary types");
     }
 
-    if (this.isArrayBuffer(buffer)) {
+    if (buffer instanceof ArrayBuffer) {
       return new Uint8Array(buffer);
     }
 
@@ -129,7 +125,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   toArrayBuffer(buffer: Bufferlike): ArrayBuffer {
-    if (this.isArrayBuffer(buffer)) {
+    if (buffer instanceof ArrayBuffer) {
       return buffer;
     }
     return this.toBuffer(buffer).buffer;
@@ -208,7 +204,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   byteLength(buffer: Bufferlike) {
-    if (this.isArrayBuffer(buffer) || this.isTypedArray(buffer)) {
+    if (buffer instanceof ArrayBuffer || this.isTypedArray(buffer)) {
       return buffer.byteLength;
     } else if (this.isWordArray(buffer)) {
       return buffer.sigBytes;

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -13,10 +13,9 @@ import IBufferUtils from 'common/types/IBufferUtils';
 export type Bufferlike = WordArray | ArrayBuffer | TypedArray;
 export type Output = Bufferlike;
 export type ToBufferOutput = Uint8Array;
-export type ComparableBuffer = ArrayBuffer;
 export type WordArrayLike = WordArray;
 
-class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, ComparableBuffer, WordArrayLike> {
+class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, WordArrayLike> {
   base64CharSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
   hexCharSet = '0123456789abcdef';
 
@@ -189,7 +188,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Co
     return stringifyUtf8(buffer);
   }
 
-  bufferCompare(buffer1: ComparableBuffer, buffer2: ComparableBuffer) {
+  bufferCompare(buffer1: Bufferlike, buffer2: Bufferlike) {
     if (!buffer1) return -1;
     if (!buffer2) return 1;
     const wordArray1 = this.toWordArray(buffer1);

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -22,10 +22,6 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
     return ob !== null && ob !== undefined && (ob as WordArray).sigBytes !== undefined;
   }
 
-  isArrayBufferView(ob: unknown): ob is ArrayBufferView {
-    return !!ArrayBuffer && ArrayBuffer.isView && ArrayBuffer.isView(ob);
-  }
-
   // // https://gist.githubusercontent.com/jonleighton/958841/raw/f200e30dfe95212c0165ccf1ae000ca51e9de803/gistfile1.js
   uint8ViewToBase64(bytes: Uint8Array) {
     let base64 = '';
@@ -90,7 +86,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   isBuffer(buffer: unknown): buffer is Bufferlike {
-    return buffer instanceof ArrayBuffer || this.isWordArray(buffer) || this.isArrayBufferView(buffer);
+    return buffer instanceof ArrayBuffer || this.isWordArray(buffer) || ArrayBuffer.isView(buffer);
   }
 
   /* In browsers, returns a Uint8Array */
@@ -103,7 +99,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
       return new Uint8Array(buffer);
     }
 
-    if (this.isArrayBufferView(buffer)) {
+    if (ArrayBuffer.isView(buffer)) {
       return new Uint8Array(buffer.buffer);
     }
 
@@ -131,7 +127,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   toWordArray(buffer: Bufferlike | number[]) {
-    if (this.isArrayBufferView(buffer)) {
+    if (ArrayBuffer.isView(buffer)) {
       buffer = buffer.buffer;
     }
     return this.isWordArray(buffer) ? buffer : WordArray.create(buffer as number[]);
@@ -203,7 +199,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput, Wo
   }
 
   byteLength(buffer: Bufferlike) {
-    if (buffer instanceof ArrayBuffer || this.isArrayBufferView(buffer)) {
+    if (buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer)) {
       return buffer.byteLength;
     } else if (this.isWordArray(buffer)) {
       return buffer.sigBytes;

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -14,9 +14,9 @@ type MessagePackBinaryType = ArrayBuffer;
 
 type IV = CryptoDataTypes.IV<BufferUtilsOutput>;
 type InputPlaintext = CryptoDataTypes.InputPlaintext<Bufferlike, BufferUtilsOutput>;
-type OutputCiphertext = WordArray;
+type OutputCiphertext = ArrayBuffer;
 type InputCiphertext = CryptoDataTypes.InputCiphertext<MessagePackBinaryType, BufferUtilsOutput>;
-type OutputPlaintext = WordArray;
+type OutputPlaintext = ArrayBuffer;
 
 var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof BufferUtils) {
   var DEFAULT_ALGORITHM = 'aes';
@@ -287,7 +287,7 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
             plaintextWordArray.concat(pkcs5Padding[paddedLength - plaintextLength])
           );
           var ciphertext = iv!.concat(cipherOut);
-          callback(null, ciphertext);
+          callback(null, bufferUtils.toArrayBuffer(ciphertext));
         });
       };
 
@@ -325,7 +325,7 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
       var epilogue = decryptCipher.finalize();
       decryptCipher.reset();
       if (epilogue && epilogue.sigBytes) plaintext.concat(epilogue);
-      return plaintext;
+      return bufferUtils.toArrayBuffer(plaintext);
     }
 
     getIv(callback: (error: Error | null, iv: WordArray | null) => void) {

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -34,8 +34,12 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
    * @param callback
    */
   var generateRandom: (byteLength: number, callback: (error: Error | null, result: WordArray | null) => void) => void;
-  if (config.getRandomWordArray) {
-    generateRandom = config.getRandomWordArray;
+  if (config.getRandomArrayBuffer) {
+    generateRandom = (byteLength, callback) => {
+      config.getRandomArrayBuffer!(byteLength, (error, result) => {
+        callback(error, result ? bufferUtils.toWordArray(result) : null);
+      });
+    };
   } else if (typeof Uint32Array !== 'undefined' && config.getRandomValues) {
     var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
     generateRandom = function (bytes, callback) {

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -268,7 +268,7 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
       this.algorithm = params.algorithm + '-' + String(params.keyLength) + '-' + params.mode;
       // We trust that we can handle the algorithm specified by the user — this is the same as the pre-TypeScript behaviour.
       this.cjsAlgorithm = params.algorithm.toUpperCase().replace(/-\d+$/, '') as typeof this.cjsAlgorithm;
-      this.key = bufferUtils.toWordArray(params.key);
+      this.key = bufferUtils.isWordArray(params.key) ? params.key : bufferUtils.toWordArray(params.key);
       this.iv = iv ? bufferUtils.toWordArray(iv).clone() : null;
       this.blockLengthWords = blockLengthWords;
       this.encryptCipher = null;
@@ -317,9 +317,9 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
 
     async decrypt(ciphertext: InputCiphertext): Promise<OutputPlaintext> {
       Logger.logAction(Logger.LOG_MICRO, 'CBCCipher.decrypt()', '');
-      ciphertext = bufferUtils.toWordArray(ciphertext);
+      const ciphertextWordArray = bufferUtils.toWordArray(ciphertext);
       var blockLengthWords = this.blockLengthWords,
-        ciphertextWords = ciphertext.words,
+        ciphertextWords = ciphertextWordArray.words,
         iv = WordArray.create(ciphertextWords.slice(0, blockLengthWords)),
         ciphertextBody = WordArray.create(ciphertextWords.slice(blockLengthWords));
 

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -1,5 +1,3 @@
-import WordArray from 'crypto-js/build/lib-typedarrays';
-import CryptoJS from 'crypto-js/build';
 import Logger from '../../../../common/lib/util/logger';
 import ErrorInfo from 'common/lib/types/errorinfo';
 import * as API from '../../../../../ably';
@@ -27,7 +25,7 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
   var UINT32_SUP = 0x100000000;
 
   /**
-   * Internal: generate an array of secure random words corresponding to the given length of bytes
+   * Internal: generate an array of secure random data corresponding to the given length of bytes
    * @param bytes
    * @param callback
    */
@@ -63,16 +61,6 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
   }
 
   /**
-   * Internal: calculate the padded length of a given plaintext
-   * using PKCS5.
-   * @param plaintextLength
-   * @return
-   */
-  function getPaddedLength(plaintextLength: number) {
-    return (plaintextLength + DEFAULT_BLOCKLENGTH) & -DEFAULT_BLOCKLENGTH;
-  }
-
-  /**
    * Internal: checks that the cipherParams are a valid combination. Currently
    * just checks that the calculated keyLength is a valid one for aes-cbc
    */
@@ -93,29 +81,6 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
     /* url-safe base64 strings use _ and - instread of / and + */
     return string.replace('_', '/').replace('-', '+');
   }
-
-  /**
-   * Internal: obtain the pkcs5 padding string for a given padded length;
-   */
-  var pkcs5Padding = [
-    WordArray.create([0x10101010, 0x10101010, 0x10101010, 0x10101010], 16),
-    WordArray.create([0x01000000], 1),
-    WordArray.create([0x02020000], 2),
-    WordArray.create([0x03030300], 3),
-    WordArray.create([0x04040404], 4),
-    WordArray.create([0x05050505, 0x05000000], 5),
-    WordArray.create([0x06060606, 0x06060000], 6),
-    WordArray.create([0x07070707, 0x07070700], 7),
-    WordArray.create([0x08080808, 0x08080808], 8),
-    WordArray.create([0x09090909, 0x09090909, 0x09000000], 9),
-    WordArray.create([0x0a0a0a0a, 0x0a0a0a0a, 0x0a0a0000], 10),
-    WordArray.create([0x0b0b0b0b, 0x0b0b0b0b, 0x0b0b0b00], 11),
-    WordArray.create([0x0c0c0c0c, 0x0c0c0c0c, 0x0c0c0c0c], 12),
-    WordArray.create([0x0d0d0d0d, 0x0d0d0d0d, 0x0d0d0d0d, 0x0d000000], 13),
-    WordArray.create([0x0e0e0e0e, 0x0e0e0e0e, 0x0e0e0e0e, 0x0e0e0000], 14),
-    WordArray.create([0x0f0f0f0f, 0x0f0f0f0f, 0x0f0f0f0f, 0x0f0f0f0f], 15),
-    WordArray.create([0x10101010, 0x10101010, 0x10101010, 0x10101010], 16),
-  ];
 
   function isCipherParams(
     params: API.Types.CipherParams | API.Types.CipherParamOptions
@@ -175,9 +140,9 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
      * in any not provided with default values, calculating a keyLength from
      * the supplied key, and validating the result.
      * @param params an object containing at a minimum a `key` key with value the
-     * key, as either a binary (ArrayBuffer, Array, WordArray) or a
-     * base64-encoded string. May optionally also contain: algorithm (defaults to
-     * AES), mode (defaults to 'cbc')
+     * key, as either a binary or a base64-encoded string.
+     * May optionally also contain: algorithm (defaults to AES),
+     * mode (defaults to 'cbc')
      */
     static getDefaultParams(params: API.Types.CipherParamOptions) {
       var key: ArrayBuffer;
@@ -214,7 +179,7 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
 
     /**
      * Generate a random encryption key from the supplied keylength (or the
-     * default keyLength if none supplied) as a CryptoJS WordArray
+     * default keyLength if none supplied) as an ArrayBuffer
      * @param keyLength (optional) the required keyLength in bits
      * @param callback (optional) (err, key)
      */
@@ -248,84 +213,89 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
 
   Crypto satisfies ICryptoStatic<IV, InputPlaintext, OutputCiphertext, InputCiphertext, OutputPlaintext>;
 
-  // This is the only way I could think of to get a reference to the Cipher type, which doesn’t seem to be exported by CryptoJS’s type definitions file.
-  type CryptoJSCipher = ReturnType<typeof CryptoJS.algo.AES.createEncryptor>;
-
   class CBCCipher implements ICipher<InputPlaintext, OutputCiphertext, InputCiphertext, OutputPlaintext> {
     algorithm: string;
-    // All of the keys in the CryptoJS.algo namespace whose value is a CipherStatic.
-    cjsAlgorithm: 'AES' | 'DES' | 'TripleDES' | 'RC4' | 'RC4Drop' | 'Rabbit' | 'RabbitLegacy';
-    key: WordArray;
-    iv: WordArray | null;
-    encryptCipher: CryptoJSCipher | null;
+    webCryptoAlgorithm: string;
+    key: ArrayBuffer;
+    iv: ArrayBuffer | null;
 
     constructor(params: CipherParams, iv: IV | null) {
+      if (!crypto.subtle) {
+        if (isSecureContext) {
+          throw new Error(
+            'Crypto operations are not possible since the browser’s SubtleCrypto class is unavailable (reason unknown).'
+          );
+        } else {
+          throw new Error(
+            'Crypto operations are is not possible since the current environment is a non-secure context and hence the browser’s SubtleCrypto class is not available.'
+          );
+        }
+      }
+
       this.algorithm = params.algorithm + '-' + String(params.keyLength) + '-' + params.mode;
-      // We trust that we can handle the algorithm specified by the user — this is the same as the pre-TypeScript behaviour.
-      this.cjsAlgorithm = params.algorithm.toUpperCase().replace(/-\d+$/, '') as typeof this.cjsAlgorithm;
-      this.key = bufferUtils.isWordArray(params.key) ? params.key : bufferUtils.toWordArray(params.key);
-      this.iv = iv ? bufferUtils.toWordArray(iv).clone() : null;
-      this.encryptCipher = null;
+      this.webCryptoAlgorithm = params.algorithm + '-' + params.mode;
+      this.key = bufferUtils.toArrayBuffer(params.key);
+      this.iv = iv ? bufferUtils.toArrayBuffer(iv) : null;
+    }
+
+    private concat(buffer1: Bufferlike, buffer2: Bufferlike) {
+      const output = new ArrayBuffer(buffer1.byteLength + buffer2.byteLength);
+      const outputView = new DataView(output);
+
+      const buffer1View = new DataView(bufferUtils.toArrayBuffer(buffer1));
+      for (let i = 0; i < buffer1View.byteLength; i++) {
+        outputView.setInt8(i, buffer1View.getInt8(i));
+      }
+
+      const buffer2View = new DataView(bufferUtils.toArrayBuffer(buffer2));
+      for (let i = 0; i < buffer2View.byteLength; i++) {
+        outputView.setInt8(buffer1View.byteLength + i, buffer2View.getInt8(i));
+      }
+
+      return output;
     }
 
     encrypt(plaintext: InputPlaintext, callback: (error: Error | null, data: OutputCiphertext | null) => void) {
       Logger.logAction(Logger.LOG_MICRO, 'CBCCipher.encrypt()', '');
-      const plaintextWordArray = bufferUtils.toWordArray(plaintext);
-      var plaintextLength = plaintextWordArray.sigBytes,
-        paddedLength = getPaddedLength(plaintextLength),
-        self = this;
 
-      var then = function () {
-        self.getIv(function (err, iv) {
-          if (err) {
-            callback(err, null);
-            return;
-          }
-          var cipherOut = self.encryptCipher!.process(
-            plaintextWordArray.concat(pkcs5Padding[paddedLength - plaintextLength])
-          );
-          var ciphertext = iv!.concat(cipherOut);
-          callback(null, bufferUtils.toArrayBuffer(ciphertext));
+      const encryptAsync = async () => {
+        const iv = await new Promise((resolve: (iv: IV) => void, reject: (error: Error) => void) => {
+          this.getIv((error, iv) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(iv!);
+            }
+          });
         });
+
+        const cryptoKey = await crypto.subtle.importKey('raw', this.key, this.webCryptoAlgorithm, false, ['encrypt']);
+        const ciphertext = await crypto.subtle.encrypt({ name: this.webCryptoAlgorithm, iv }, cryptoKey, plaintext);
+
+        return this.concat(iv, ciphertext);
       };
 
-      if (!this.encryptCipher) {
-        if (this.iv) {
-          this.encryptCipher = CryptoJS.algo[this.cjsAlgorithm].createEncryptor(this.key, { iv: this.iv });
-          then();
-        } else {
-          generateRandom(DEFAULT_BLOCKLENGTH, function (err, iv) {
-            if (err) {
-              callback(err, null);
-              return;
-            }
-            const ivWordArray = bufferUtils.toWordArray(iv!);
-            self.encryptCipher = CryptoJS.algo[self.cjsAlgorithm].createEncryptor(self.key, { iv: ivWordArray });
-            self.iv = ivWordArray;
-            then();
-          });
-        }
-      } else {
-        then();
-      }
+      encryptAsync()
+        .then((ciphertext) => {
+          callback(null, ciphertext);
+        })
+        .catch((error) => {
+          callback(error, null);
+        });
     }
 
     async decrypt(ciphertext: InputCiphertext): Promise<OutputPlaintext> {
       Logger.logAction(Logger.LOG_MICRO, 'CBCCipher.decrypt()', '');
-      const ciphertextWordArray = bufferUtils.toWordArray(ciphertext);
-      var ciphertextWords = ciphertextWordArray.words,
-        iv = WordArray.create(ciphertextWords.slice(0, DEFAULT_BLOCKLENGTH_WORDS)),
-        ciphertextBody = WordArray.create(ciphertextWords.slice(DEFAULT_BLOCKLENGTH_WORDS));
 
-      var decryptCipher = CryptoJS.algo[this.cjsAlgorithm].createDecryptor(this.key, { iv: iv });
-      var plaintext = decryptCipher.process(ciphertextBody);
-      var epilogue = decryptCipher.finalize();
-      decryptCipher.reset();
-      if (epilogue && epilogue.sigBytes) plaintext.concat(epilogue);
-      return bufferUtils.toArrayBuffer(plaintext);
+      const ciphertextArrayBuffer = bufferUtils.toArrayBuffer(ciphertext);
+      const iv = ciphertextArrayBuffer.slice(0, DEFAULT_BLOCKLENGTH);
+      const ciphertextBody = ciphertextArrayBuffer.slice(DEFAULT_BLOCKLENGTH);
+
+      const cryptoKey = await crypto.subtle.importKey('raw', this.key, this.webCryptoAlgorithm, false, ['decrypt']);
+      return crypto.subtle.decrypt({ name: this.webCryptoAlgorithm, iv }, cryptoKey, ciphertextBody);
     }
 
-    getIv(callback: (error: Error | null, iv: WordArray | null) => void) {
+    getIv(callback: (error: Error | null, iv: ArrayBuffer | null) => void) {
       if (this.iv) {
         var iv = this.iv;
         this.iv = null;
@@ -336,14 +306,12 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
       /* Since the iv for a new block is the ciphertext of the last, this
        * sets a new iv (= aes(randomBlock XOR lastCipherText)) as well as
        * returning it */
-      var self = this;
       generateRandom(DEFAULT_BLOCKLENGTH, function (err, randomBlock) {
         if (err) {
           callback(err, null);
           return;
         }
-        const randomBlockWordArray = bufferUtils.toWordArray(randomBlock!);
-        callback(null, self.encryptCipher!.process(randomBlockWordArray));
+        callback(null, bufferUtils.toArrayBuffer(randomBlock!));
       });
     }
   }

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -124,8 +124,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           return;
         }
         try {
-          /* .length for a nodejs buffer, .sigbytes for a browser CryptoJS WordArray */
-          expect(key.length || key.sigBytes).to.equal(8, 'generated key is the correct length');
+          /* .length for a nodejs buffer, .byteLength for a browser ArrayBuffer */
+          expect(key.length || key.byteLength).to.equal(8, 'generated key is the correct length');
           done();
         } catch (err) {
           done(err);
@@ -141,7 +141,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           return;
         }
         try {
-          expect(key.length || key.sigBytes).to.equal(32, 'generated key is the default length');
+          expect(key.length || key.byteLength).to.equal(32, 'generated key is the default length');
           done();
         } catch (err) {
           done(err);

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -342,7 +342,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
               try {
                 /* Mainly testing that we're correctly encoding the direct output from
-                 * CryptoJS (a wordArray) into the msgpack binary type */
+                 * the platform's ICipher implementation into the msgpack binary type */
                 expect(BufferUtils.areBuffersEqual(msgpackFromEncoded, msgpackFromEncrypted)).to.equal(
                   true,
                   'verify msgpack encodings of newly-encrypted and preencrypted messages identical using areBuffersEqual'
@@ -376,7 +376,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
               try {
                 /* Mainly testing that we're correctly encoding the direct output from
-                 * CryptoJS (a wordArray) into the msgpack binary type */
+                 * the platform's ICipher implementation into the msgpack binary type */
                 expect(BufferUtils.areBuffersEqual(msgpackFromEncoded, msgpackFromEncrypted)).to.equal(
                   true,
                   'verify msgpack encodings of newly-encrypted and preencrypted messages identical using areBuffersEqual'

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -34,7 +34,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       }
 
       if (BufferUtils.isBuffer(one.data) && BufferUtils.isBuffer(two.data)) {
-        expect(BufferUtils.bufferCompare(one.data, two.data) === 0, 'Buffer data contents mismatch.').to.be.ok;
+        expect(BufferUtils.areBuffersEqual(one.data, two.data), 'Buffer data contents mismatch.').to.equal(true);
         return;
       }
 
@@ -174,7 +174,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var arrayBufferKey = Ably.Realtime.Platform.BufferUtils.toArrayBuffer(key);
         var params = Crypto.getDefaultParams({ key: arrayBufferKey });
         try {
-          expect(BufferUtils.bufferCompare(params.key, key)).to.equal(0);
+          expect(BufferUtils.areBuffersEqual(params.key, key)).to.equal(true);
           done();
         } catch (err) {
           done(err);
@@ -191,7 +191,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var b64key = Ably.Realtime.Platform.BufferUtils.base64Encode(key);
         var params = Crypto.getDefaultParams({ key: b64key });
         try {
-          expect(BufferUtils.bufferCompare(params.key, key)).to.equal(0);
+          expect(BufferUtils.areBuffersEqual(params.key, key)).to.equal(true);
           done();
         } catch (err) {
           done(err);
@@ -343,9 +343,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               try {
                 /* Mainly testing that we're correctly encoding the direct output from
                  * CryptoJS (a wordArray) into the msgpack binary type */
-                expect(BufferUtils.bufferCompare(msgpackFromEncoded, msgpackFromEncrypted)).to.equal(
-                  0,
-                  'verify msgpack encodings of newly-encrypted and preencrypted messages identical using bufferCompare'
+                expect(BufferUtils.areBuffersEqual(msgpackFromEncoded, msgpackFromEncrypted)).to.equal(
+                  true,
+                  'verify msgpack encodings of newly-encrypted and preencrypted messages identical using areBuffersEqual'
                 );
 
                 /* Can't compare msgpackFromEncoded with fixture data because can't
@@ -377,9 +377,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               try {
                 /* Mainly testing that we're correctly encoding the direct output from
                  * CryptoJS (a wordArray) into the msgpack binary type */
-                expect(BufferUtils.bufferCompare(msgpackFromEncoded, msgpackFromEncrypted)).to.equal(
-                  0,
-                  'verify msgpack encodings of newly-encrypted and preencrypted messages identical using bufferCompare'
+                expect(BufferUtils.areBuffersEqual(msgpackFromEncoded, msgpackFromEncrypted)).to.equal(
+                  true,
+                  'verify msgpack encodings of newly-encrypted and preencrypted messages identical using areBuffersEqual'
                 );
 
                 /* Can't compare msgpackFromEncoded with fixture data because can't

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -149,7 +149,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
     });
 
-    it('getDefaultParams_wordArray_key', function (done) {
+    it('getDefaultParams_withResultOfGenerateRandomKey', function (done) {
       Crypto.generateRandomKey(function (err, key) {
         if (err) {
           done(err);

--- a/test/rest/bufferutils.test.js
+++ b/test/rest/bufferutils.test.js
@@ -6,9 +6,6 @@ define(['ably', 'chai'], function (Ably, chai) {
   var testString = 'test';
   var testBase64 = 'dGVzdA==';
   var testHex = '74657374';
-  function isWordArray(ob) {
-    return ob !== null && ob !== undefined && ob.sigBytes !== undefined;
-  }
 
   describe('rest/bufferutils', function () {
     it('Basic encoding and decoding', function () {
@@ -31,7 +28,7 @@ define(['ably', 'chai'], function (Ably, chai) {
 
     /* In node it's idiomatic for most methods dealing with binary data to
      * return Buffers. In the browser it's more idiomatic to return
-     * ArrayBuffers (or in browser too old to support ArrayBuffer, wordarrays). */
+     * ArrayBuffers */
     it('BufferUtils return correct types', function () {
       if (typeof Buffer !== 'undefined') {
         /* node */
@@ -40,23 +37,13 @@ define(['ably', 'chai'], function (Ably, chai) {
         expect(BufferUtils.base64Decode(testBase64).constructor).to.equal(Buffer);
         expect(BufferUtils.toBuffer(BufferUtils.utf8Encode(testString)).constructor).to.equal(Buffer);
         expect(BufferUtils.toArrayBuffer(BufferUtils.utf8Encode(testString)).constructor).to.equal(ArrayBuffer);
-      } else if (typeof ArrayBuffer !== 'undefined') {
+      } else {
         /* modern browsers */
-        if (typeof TextDecoder !== 'undefined') {
-          expect(BufferUtils.utf8Encode(testString).constructor).to.equal(ArrayBuffer);
-        } else {
-          expect(isWordArray(BufferUtils.utf8Encode(testString))).to.be.ok;
-        }
+        expect(BufferUtils.utf8Encode(testString).constructor).to.equal(ArrayBuffer);
         expect(BufferUtils.hexDecode(testHex).constructor).to.equal(ArrayBuffer);
         expect(BufferUtils.base64Decode(testBase64).constructor).to.equal(ArrayBuffer);
         expect(BufferUtils.toBuffer(BufferUtils.utf8Encode(testString)).constructor).to.equal(Uint8Array);
         expect(BufferUtils.toArrayBuffer(BufferUtils.utf8Encode(testString)).constructor).to.equal(ArrayBuffer);
-      } else {
-        /* legacy browsers */
-        expect(isWordArray(BufferUtils.utf8Encode(testString))).to.be.ok;
-        expect(isWordArray(BufferUtils.hexDecode(testHex))).to.be.ok;
-        expect(isWordArray(BufferUtils.base64Decode(testBase64))).to.be.ok;
-        expect(isWordArray(BufferUtils.toWordArray(BufferUtils.utf8Encode(testString)))).to.be.ok;
       }
     });
   });

--- a/test/rest/bufferutils.test.js
+++ b/test/rest/bufferutils.test.js
@@ -19,11 +19,11 @@ define(['ably', 'chai'], function (Ably, chai) {
 
       /* compare */
       expect(
-        BufferUtils.bufferCompare(BufferUtils.utf8Encode(testString), BufferUtils.utf8Encode(testString))
-      ).to.equal(0);
+        BufferUtils.areBuffersEqual(BufferUtils.utf8Encode(testString), BufferUtils.utf8Encode(testString))
+      ).to.equal(true);
       expect(
-        BufferUtils.bufferCompare(BufferUtils.utf8Encode(testString), BufferUtils.utf8Encode('other'))
-      ).to.not.equal(0);
+        BufferUtils.areBuffersEqual(BufferUtils.utf8Encode(testString), BufferUtils.utf8Encode('other'))
+      ).to.not.equal(true);
     });
 
     /* In node it's idiomatic for most methods dealing with binary data to


### PR DESCRIPTION
**Note: This is based on top of #1311; please review that one first.**

This PR changes the web crypto code to use the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) instead of the CryptoJS library. See commit messages for more details.

Resolves #1292, resolves #1296, resolves #1300.