### PR TITLE
fix(typings): optional `Message.connectionId`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2793,7 +2793,7 @@ declare namespace Types {
     /**
      * The connection ID of the publisher of this message.
      */
-    connectionId: string;
+    connectionId?: string;
     /**
      * The message payload, if provided.
      */


### PR DESCRIPTION
Resolves #1301

nb: this is a possibly breaking change - although since it would only break builds and should be simple to resolve I think it's acceptable to do this in 1.2.x