### PR TITLE
Make `ICipher.decrypt` async

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2841,14 +2841,14 @@ declare namespace Types {
      * @param JsonObject - The deserialized `PresenceMessage`-like object to decode and decrypt.
      * @param channelOptions - A {@link ChannelOptions} object containing the cipher.
      */
-    static fromEncoded: (JsonObject: any, channelOptions?: ChannelOptions) => PresenceMessage;
+    static fromEncoded: (JsonObject: any, channelOptions?: ChannelOptions) => Promise<PresenceMessage>;
     /**
      * Decodes and decrypts an array of deserialized `PresenceMessage`-like object using the cipher in {@link ChannelOptions}. Any residual transforms that cannot be decoded or decrypted will be in the `encoding` property. Intended for users receiving messages from a source other than a REST or Realtime channel (for example a queue) to avoid having to parse the encoding string.
      *
      * @param JsonArray - An array of deserialized `PresenceMessage`-like objects to decode and decrypt.
      * @param channelOptions - A {@link ChannelOptions} object containing the cipher.
      */
-    static fromEncodedArray: (JsonArray: any[], channelOptions?: ChannelOptions) => PresenceMessage[];
+    static fromEncodedArray: (JsonArray: any[], channelOptions?: ChannelOptions) => Promise<PresenceMessage[]>;
     /**
      * The type of {@link PresenceAction} the `PresenceMessage` is for.
      */
@@ -2889,14 +2889,14 @@ declare namespace Types {
      * @param JsonObject - The deserialized `PresenceMessage`-like object to decode and decrypt.
      * @param channelOptions - A {@link ChannelOptions} object containing the cipher.
      */
-    fromEncoded: (JsonObject: any, channelOptions?: ChannelOptions) => PresenceMessage;
+    fromEncoded: (JsonObject: any, channelOptions?: ChannelOptions) => Promise<PresenceMessage>;
     /**
      * Decodes and decrypts an array of deserialized `PresenceMessage`-like object using the cipher in {@link ChannelOptions}. Any residual transforms that cannot be decoded or decrypted will be in the `encoding` property. Intended for users receiving messages from a source other than a REST or Realtime channel (for example a queue) to avoid having to parse the encoding string.
      *
      * @param JsonArray - An array of deserialized `PresenceMessage`-like objects to decode and decrypt.
      * @param channelOptions - A {@link ChannelOptions} object containing the cipher.
      */
-    fromEncodedArray: (JsonArray: any[], channelOptions?: ChannelOptions) => PresenceMessage[];
+    fromEncodedArray: (JsonArray: any[], channelOptions?: ChannelOptions) => Promise<PresenceMessage[]>;
   }
 
   /**

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2758,17 +2758,17 @@ declare namespace Types {
      *
      * @param JsonObject - A `Message`-like deserialized object.
      * @param channelOptions - A {@link ChannelOptions} object. If you have an encrypted channel, use this to allow the library to decrypt the data.
-     * @returns A `Message` object.
+     * @returns A promise which will be fulfilled with a `Message` object.
      */
-    static fromEncoded: (JsonObject: any, channelOptions?: ChannelOptions) => Message;
+    static fromEncoded: (JsonObject: any, channelOptions?: ChannelOptions) => Promise<Message>;
     /**
      * A static factory method to create an array of `Message` objects from an array of deserialized Message-like object encoded using Ably's wire protocol.
      *
      * @param JsonArray - An array of `Message`-like deserialized objects.
      * @param channelOptions - A {@link ChannelOptions} object. If you have an encrypted channel, use this to allow the library to decrypt the data.
-     * @returns An array of {@link Message} objects.
+     * @returns A promise which will be fulfilled with an array of {@link Message} objects.
      */
-    static fromEncodedArray: (JsonArray: any[], channelOptions?: ChannelOptions) => Message[];
+    static fromEncodedArray: (JsonArray: any[], channelOptions?: ChannelOptions) => Promise<Message[]>;
     /**
      * The client ID of the publisher of this message.
      */
@@ -2812,17 +2812,17 @@ declare namespace Types {
      *
      * @param JsonObject - A `Message`-like deserialized object.
      * @param channelOptions - A {@link ChannelOptions} object. If you have an encrypted channel, use this to allow the library to decrypt the data.
-     * @returns A `Message` object.
+     * @returns A promise which will be fulfilled with a `Message` object.
      */
-    fromEncoded: (JsonObject: any, channelOptions?: ChannelOptions) => Message;
+    fromEncoded: (JsonObject: any, channelOptions?: ChannelOptions) => Promise<Message>;
     /**
      * A static factory method to create an array of `Message` objects from an array of deserialized Message-like object encoded using Ably's wire protocol.
      *
      * @param JsonArray - An array of `Message`-like deserialized objects.
      * @param channelOptions - A {@link ChannelOptions} object. If you have an encrypted channel, use this to allow the library to decrypt the data.
-     * @returns An array of {@link Message} objects.
+     * @returns A promise which will be fulfilled with an array of {@link Message} objects.
      */
-    fromEncodedArray: (JsonArray: any[], channelOptions?: ChannelOptions) => Message[];
+    fromEncodedArray: (JsonArray: any[], channelOptions?: ChannelOptions) => Promise<Message[]>;
   }
 
   /**

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -102,7 +102,7 @@ class Channel extends EventEmitter {
       headers: Record<string, string>,
       unpacked?: boolean
     ) {
-      return Message.fromResponseBody(body, options, unpacked ? undefined : format);
+      return await Message.fromResponseBody(body, options, unpacked ? undefined : format);
     }).get(params as Record<string, unknown>, callback);
   }
 

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -97,7 +97,7 @@ class Channel extends EventEmitter {
     Utils.mixin(headers, rest.options.headers);
 
     const options = this.channelOptions;
-    new PaginatedResource(rest, this.basePath + '/messages', headers, envelope, function (
+    new PaginatedResource(rest, this.basePath + '/messages', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean

--- a/src/common/lib/client/presence.ts
+++ b/src/common/lib/client/presence.ts
@@ -42,7 +42,7 @@ class Presence extends EventEmitter {
     Utils.mixin(headers, rest.options.headers);
 
     const options = this.channel.channelOptions;
-    new PaginatedResource(rest, this.basePath, headers, envelope, function (
+    new PaginatedResource(rest, this.basePath, headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -84,7 +84,7 @@ class Presence extends EventEmitter {
     Utils.mixin(headers, rest.options.headers);
 
     const options = this.channel.channelOptions;
-    new PaginatedResource(rest, this.basePath + '/history', headers, envelope, function (
+    new PaginatedResource(rest, this.basePath + '/history', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean

--- a/src/common/lib/client/presence.ts
+++ b/src/common/lib/client/presence.ts
@@ -47,7 +47,7 @@ class Presence extends EventEmitter {
       headers: Record<string, string>,
       unpacked?: boolean
     ) {
-      return PresenceMessage.fromResponseBody(body, options as CipherOptions, unpacked ? undefined : format);
+      return await PresenceMessage.fromResponseBody(body, options as CipherOptions, unpacked ? undefined : format);
     }).get(params, callback);
   }
 
@@ -89,7 +89,7 @@ class Presence extends EventEmitter {
       headers: Record<string, string>,
       unpacked?: boolean
     ) {
-      return PresenceMessage.fromResponseBody(body, options as CipherOptions, unpacked ? undefined : format);
+      return await PresenceMessage.fromResponseBody(body, options as CipherOptions, unpacked ? undefined : format);
     }).get(params, callback);
   }
 }

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -161,7 +161,7 @@ class DeviceRegistrations {
 
     Utils.mixin(headers, rest.options.headers);
 
-    new PaginatedResource(rest, '/push/deviceRegistrations', headers, envelope, function (
+    new PaginatedResource(rest, '/push/deviceRegistrations', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -286,7 +286,7 @@ class ChannelSubscriptions {
 
     Utils.mixin(headers, rest.options.headers);
 
-    new PaginatedResource(rest, '/push/channelSubscriptions', headers, envelope, function (
+    new PaginatedResource(rest, '/push/channelSubscriptions', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -334,7 +334,7 @@ class ChannelSubscriptions {
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
-    new PaginatedResource(rest, '/push/channels', headers, envelope, function (
+    new PaginatedResource(rest, '/push/channels', headers, envelope, async function (
       body: unknown,
       headers: Record<string, string>,
       unpacked?: boolean

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -83,12 +83,12 @@ class Channels extends EventEmitter {
     }
   }
 
-  onChannelMessage(msg: ProtocolMessage) {
+  processChannelMessage(msg: ProtocolMessage) {
     const channelName = msg.channel;
     if (channelName === undefined) {
       Logger.logAction(
         Logger.LOG_ERROR,
-        'Channels.onChannelMessage()',
+        'Channels.processChannelMessage()',
         'received event unspecified channel, action = ' + msg.action
       );
       return;
@@ -97,7 +97,7 @@ class Channels extends EventEmitter {
     if (!channel) {
       Logger.logAction(
         Logger.LOG_ERROR,
-        'Channels.onChannelMessage()',
+        'Channels.processChannelMessage()',
         'received event for non-existent channel: ' + channelName
       );
       return;

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -83,7 +83,8 @@ class Channels extends EventEmitter {
     }
   }
 
-  processChannelMessage(msg: ProtocolMessage) {
+  // Access to this method is synchronised by ConnectionManager#processChannelMessage.
+  async processChannelMessage(msg: ProtocolMessage) {
     const channelName = msg.channel;
     if (channelName === undefined) {
       Logger.logAction(

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -102,7 +102,7 @@ class Channels extends EventEmitter {
       );
       return;
     }
-    channel.onMessage(msg);
+    channel.processMessage(msg);
   }
 
   /* called when a transport becomes connected; reattempt attach/detach

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -103,7 +103,7 @@ class Channels extends EventEmitter {
       );
       return;
     }
-    channel.processMessage(msg);
+    await channel.processMessage(msg);
   }
 
   /* called when a transport becomes connected; reattempt attach/detach

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -582,7 +582,8 @@ class RealtimeChannel extends Channel {
     this.sendMessage(msg, callback);
   }
 
-  processMessage(message: ProtocolMessage): void {
+  // Access to this method is synchronised by ConnectionManager#processChannelMessage, in order to synchronise access to the state stored in _decodingContext.
+  async processMessage(message: ProtocolMessage): Promise<void> {
     if (
       message.action === actions.ATTACHED ||
       message.action === actions.MESSAGE ||

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -582,7 +582,7 @@ class RealtimeChannel extends Channel {
     this.sendMessage(msg, callback);
   }
 
-  onMessage(message: ProtocolMessage): void {
+  processMessage(message: ProtocolMessage): void {
     if (
       message.action === actions.ATTACHED ||
       message.action === actions.MESSAGE ||
@@ -661,7 +661,7 @@ class RealtimeChannel extends Channel {
             if (!presenceMsg.timestamp) presenceMsg.timestamp = timestamp;
             if (!presenceMsg.id) presenceMsg.id = id + ':' + i;
           } catch (e) {
-            Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.onMessage()', (e as Error).toString());
+            Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.processMessage()', (e as Error).toString());
           }
         }
         this.presence.setPresence(presence, isSync, syncChannelSerial as any);
@@ -672,7 +672,7 @@ class RealtimeChannel extends Channel {
         if (this.state !== 'attached') {
           Logger.logAction(
             Logger.LOG_MAJOR,
-            'RealtimeChannel.onMessage()',
+            'RealtimeChannel.processMessage()',
             'Message "' +
               message.id +
               '" skipped as this channel "' +
@@ -702,7 +702,7 @@ class RealtimeChannel extends Channel {
             '" on this channel "' +
             this.name +
             '".';
-          Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.onMessage()', msg);
+          Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.processMessage()', msg);
           this._startDecodeFailureRecovery(new ErrorInfo(msg, 40018, 400));
           break;
         }
@@ -713,7 +713,7 @@ class RealtimeChannel extends Channel {
             Message.decode(msg, this._decodingContext);
           } catch (e) {
             /* decrypt failed .. the most likely cause is that we have the wrong key */
-            Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.onMessage()', (e as Error).toString());
+            Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.processMessage()', (e as Error).toString());
             switch ((e as ErrorInfo).code) {
               case 40018:
                 /* decode failure */
@@ -753,7 +753,7 @@ class RealtimeChannel extends Channel {
       default:
         Logger.logAction(
           Logger.LOG_ERROR,
-          'RealtimeChannel.onMessage()',
+          'RealtimeChannel.processMessage()',
           'Fatal protocol error: unrecognised action (' + message.action + ')'
         );
         this.connectionManager.abort(ConnectionErrors.unknownChannelErr());
@@ -762,7 +762,11 @@ class RealtimeChannel extends Channel {
 
   _startDecodeFailureRecovery(reason: ErrorInfo): void {
     if (!this._lastPayload.decodeFailureRecoveryInProgress) {
-      Logger.logAction(Logger.LOG_MAJOR, 'RealtimeChannel.onMessage()', 'Starting decode failure recovery process.');
+      Logger.logAction(
+        Logger.LOG_MAJOR,
+        'RealtimeChannel.processMessage()',
+        'Starting decode failure recovery process.'
+      );
       this._lastPayload.decodeFailureRecoveryInProgress = true;
       this._attach(true, reason, () => {
         this._lastPayload.decodeFailureRecoveryInProgress = false;

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -657,7 +657,7 @@ class RealtimeChannel extends Channel {
         for (let i = 0; i < presence.length; i++) {
           try {
             presenceMsg = presence[i];
-            PresenceMessage.decode(presenceMsg, options);
+            await PresenceMessage.decode(presenceMsg, options);
             if (!presenceMsg.connectionId) presenceMsg.connectionId = connectionId;
             if (!presenceMsg.timestamp) presenceMsg.timestamp = timestamp;
             if (!presenceMsg.id) presenceMsg.id = id + ':' + i;
@@ -711,7 +711,7 @@ class RealtimeChannel extends Channel {
         for (let i = 0; i < messages.length; i++) {
           const msg = messages[i];
           try {
-            Message.decode(msg, this._decodingContext);
+            await Message.decode(msg, this._decodingContext);
           } catch (e) {
             /* decrypt failed .. the most likely cause is that we have the wrong key */
             Logger.logAction(Logger.LOG_ERROR, 'RealtimeChannel.processMessage()', (e as Error).toString());

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -207,7 +207,7 @@ class Rest {
       path,
       headers,
       envelope,
-      function (resbody: unknown, headers: Record<string, string>, unpacked?: boolean) {
+      async function (resbody: unknown, headers: Record<string, string>, unpacked?: boolean) {
         return Utils.ensureArray(unpacked ? resbody : decoder(resbody as string & Buffer));
       },
       /* useHttpPaginatedResponse: */ true

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1973,13 +1973,13 @@ class ConnectionManager extends EventEmitter {
      * before it's become active (while waiting for the old one to become
      * idle), message can validly arrive on it even though it isn't active */
     if (onActiveTransport || onUpgradeTransport) {
-      this.realtime.channels.onChannelMessage(message);
+      this.realtime.channels.processChannelMessage(message);
     } else {
       // Message came in on a defunct transport. Allow only acks, nacks, & errors for outstanding
       // messages,  no new messages (as sync has been sent on new transport so new messages will
       // be resent there, or connection has been closed so don't want new messages)
       if (Utils.arrIndexOf([actions.ACK, actions.NACK, actions.ERROR], message.action) > -1) {
-        this.realtime.channels.onChannelMessage(message);
+        this.realtime.channels.processChannelMessage(message);
       } else {
         Logger.logAction(
           Logger.LOG_MICRO,

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -2007,13 +2007,13 @@ class ConnectionManager extends EventEmitter {
      * before it's become active (while waiting for the old one to become
      * idle), message can validly arrive on it even though it isn't active */
     if (onActiveTransport || onUpgradeTransport) {
-      this.realtime.channels.processChannelMessage(message);
+      await this.realtime.channels.processChannelMessage(message);
     } else {
       // Message came in on a defunct transport. Allow only acks, nacks, & errors for outstanding
       // messages,  no new messages (as sync has been sent on new transport so new messages will
       // be resent there, or connection has been closed so don't want new messages)
       if (Utils.arrIndexOf([actions.ACK, actions.NACK, actions.ERROR], message.action) > -1) {
-        this.realtime.channels.processChannelMessage(message);
+        await this.realtime.channels.processChannelMessage(message);
       } else {
         Logger.logAction(
           Logger.LOG_MICRO,

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -243,7 +243,7 @@ class Message {
                 if (xformAlgorithm != cipher.algorithm) {
                   throw new Error('Unable to decrypt message with given cipher; incompatible cipher params');
                 }
-                data = cipher.decrypt(data);
+                data = await cipher.decrypt(data);
                 continue;
               } else {
                 throw new Error('Unable to decrypt message; not an encrypted channel');

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -301,11 +301,11 @@ class Message {
     context.baseEncodedPreviousPayload = lastPayload;
   }
 
-  static fromResponseBody(
+  static async fromResponseBody(
     body: Array<Message>,
     options: ChannelOptions | EncodingDecodingContext,
     format?: Utils.Format
-  ): Message[] {
+  ): Promise<Message[]> {
     if (format) {
       body = Utils.decodeBody(body, format);
     }

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -332,7 +332,7 @@ class Message {
     return result;
   }
 
-  static fromEncoded(encoded: unknown, inputOptions?: API.Types.ChannelOptions): Message {
+  static async fromEncoded(encoded: unknown, inputOptions?: API.Types.ChannelOptions): Promise<Message> {
     const msg = Message.fromValues(encoded);
     const options = normalizeCipherOptions(inputOptions ?? null);
     /* if decoding fails at any point, catch and return the message decoded to
@@ -345,10 +345,12 @@ class Message {
     return msg;
   }
 
-  static fromEncodedArray(encodedArray: Array<unknown>, options?: API.Types.ChannelOptions): Message[] {
-    return encodedArray.map(function (encoded) {
-      return Message.fromEncoded(encoded, options);
-    });
+  static async fromEncodedArray(encodedArray: Array<unknown>, options?: API.Types.ChannelOptions): Promise<Message[]> {
+    return Promise.all(
+      encodedArray.map(function (encoded) {
+        return Message.fromEncoded(encoded, options);
+      })
+    );
   }
 
   /* This should be called on encode()d (and encrypt()d) Messages (as it

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -197,10 +197,10 @@ class Message {
 
   static serialize = Utils.encodeBody;
 
-  static decode(
+  static async decode(
     message: Message | PresenceMessage,
     inputContext: CipherOptions | EncodingDecodingContext | ChannelOptions
-  ): void {
+  ): Promise<void> {
     const context = normaliseContext(inputContext);
 
     let lastPayload = message.data;
@@ -313,7 +313,7 @@ class Message {
     for (let i = 0; i < body.length; i++) {
       const msg = (body[i] = Message.fromValues(body[i]));
       try {
-        Message.decode(msg, options);
+        await Message.decode(msg, options);
       } catch (e) {
         Logger.logAction(Logger.LOG_ERROR, 'Message.fromResponseBody()', (e as Error).toString());
       }
@@ -338,7 +338,7 @@ class Message {
     /* if decoding fails at any point, catch and return the message decoded to
      * the fullest extent possible */
     try {
-      Message.decode(msg, options);
+      await Message.decode(msg, options);
     } catch (e) {
       Logger.logAction(Logger.LOG_ERROR, 'Message.fromEncoded()', (e as Error).toString());
     }

--- a/src/common/lib/types/presencemessage.ts
+++ b/src/common/lib/types/presencemessage.ts
@@ -102,11 +102,11 @@ class PresenceMessage {
   static encode = Message.encode;
   static decode = Message.decode;
 
-  static fromResponseBody(
+  static async fromResponseBody(
     body: Record<string, unknown>[],
     options: CipherOptions,
     format?: Utils.Format
-  ): PresenceMessage[] {
+  ): Promise<PresenceMessage[]> {
     const messages: PresenceMessage[] = [];
     if (format) {
       body = Utils.decodeBody(body, format);

--- a/src/common/lib/types/presencemessage.ts
+++ b/src/common/lib/types/presencemessage.ts
@@ -137,7 +137,7 @@ class PresenceMessage {
     return result;
   }
 
-  static fromEncoded(encoded: unknown, options?: API.Types.ChannelOptions): PresenceMessage {
+  static async fromEncoded(encoded: unknown, options?: API.Types.ChannelOptions): Promise<PresenceMessage> {
     const msg = PresenceMessage.fromValues(encoded as PresenceMessage | Record<string, unknown>, true);
     /* if decoding fails at any point, catch and return the message decoded to
      * the fullest extent possible */
@@ -149,10 +149,15 @@ class PresenceMessage {
     return msg;
   }
 
-  static fromEncodedArray(encodedArray: unknown[], options?: API.Types.ChannelOptions): PresenceMessage[] {
-    return encodedArray.map(function (encoded) {
-      return PresenceMessage.fromEncoded(encoded, options);
-    });
+  static async fromEncodedArray(
+    encodedArray: unknown[],
+    options?: API.Types.ChannelOptions
+  ): Promise<PresenceMessage[]> {
+    return Promise.all(
+      encodedArray.map(function (encoded) {
+        return PresenceMessage.fromEncoded(encoded, options);
+      })
+    );
   }
 
   static getMessagesSize = Message.getMessagesSize;

--- a/src/common/lib/types/presencemessage.ts
+++ b/src/common/lib/types/presencemessage.ts
@@ -115,7 +115,7 @@ class PresenceMessage {
     for (let i = 0; i < body.length; i++) {
       const msg = (messages[i] = PresenceMessage.fromValues(body[i], true));
       try {
-        PresenceMessage.decode(msg, options);
+        await PresenceMessage.decode(msg, options);
       } catch (e) {
         Logger.logAction(Logger.LOG_ERROR, 'PresenceMessage.fromResponseBody()', (e as Error).toString());
       }
@@ -142,7 +142,7 @@ class PresenceMessage {
     /* if decoding fails at any point, catch and return the message decoded to
      * the fullest extent possible */
     try {
-      PresenceMessage.decode(msg, options ?? {});
+      await PresenceMessage.decode(msg, options ?? {});
     } catch (e) {
       Logger.logAction(Logger.LOG_ERROR, 'PresenceMessage.fromEncoded()', (e as Error).toString());
     }

--- a/src/common/types/ICipher.ts
+++ b/src/common/types/ICipher.ts
@@ -1,5 +1,5 @@
 export default interface ICipher<InputPlaintext, OutputCiphertext, InputCiphertext, OutputPlaintext> {
   algorithm: string;
   encrypt: (plaintext: InputPlaintext, callback: (error: Error | null, data: OutputCiphertext | null) => void) => void;
-  decrypt: (ciphertext: InputCiphertext) => OutputPlaintext;
+  decrypt: (ciphertext: InputCiphertext) => Promise<OutputPlaintext>;
 }

--- a/src/platform/nodejs/lib/util/crypto.ts
+++ b/src/platform/nodejs/lib/util/crypto.ts
@@ -249,7 +249,7 @@ var CryptoFactory = function (bufferUtils: typeof BufferUtils) {
       return callback(null, ciphertext);
     }
 
-    decrypt(ciphertext: InputCiphertext) {
+    async decrypt(ciphertext: InputCiphertext): Promise<OutputPlaintext> {
       var blockLength = this.blockLength,
         decryptCipher = crypto.createDecipheriv(this.algorithm, this.key, ciphertext.slice(0, blockLength)),
         plaintext = toBuffer(decryptCipher.update(ciphertext.slice(blockLength))),

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -315,7 +315,7 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
       }
     }
 
-    decrypt(ciphertext: InputCiphertext) {
+    async decrypt(ciphertext: InputCiphertext): Promise<OutputPlaintext> {
       Logger.logAction(Logger.LOG_MICRO, 'CBCCipher.decrypt()', '');
       ciphertext = bufferUtils.toWordArray(ciphertext);
       var blockLengthWords = this.blockLengthWords,

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -274,9 +274,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         'decrypt_message_128',
         2,
         false,
-        function (channelOpts, testMessage, encryptedMessage) {
+        async function (channelOpts, testMessage, encryptedMessage) {
           /* decrypt encrypted message; decode() also to handle data that is not string or buffer */
-          Message.decode(encryptedMessage, channelOpts);
+          await Message.decode(encryptedMessage, channelOpts);
           /* compare */
           testMessageEquality(done, testMessage, encryptedMessage);
         }
@@ -290,9 +290,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         'decrypt_message_256',
         2,
         false,
-        function (channelOpts, testMessage, encryptedMessage) {
+        async function (channelOpts, testMessage, encryptedMessage) {
           /* decrypt encrypted message; decode() also to handle data that is not string or buffer */
-          Message.decode(encryptedMessage, channelOpts);
+          await Message.decode(encryptedMessage, channelOpts);
           /* compare */
           testMessageEquality(done, testMessage, encryptedMessage);
         }

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -56,7 +56,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       return;
     }
 
-    loadTestData(testResourcesPath + filename, function (err, testData) {
+    loadTestData(testResourcesPath + filename, async function (err, testData) {
       if (err) {
         done(new Error('Unable to get test assets; err = ' + displayError(err)));
         return;
@@ -71,11 +71,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           var item = testData.items[i];
 
           /* read messages from test data and decode (ie remove any base64 encoding). */
-          var createTestMessage = function () {
-            return Message.fromEncoded(item.encoded);
+          var createTestMessage = async function () {
+            return await Message.fromEncoded(item.encoded);
           };
 
-          var encryptedMessage = Message.fromEncoded(item.encrypted);
+          var encryptedMessage = await Message.fromEncoded(item.encrypted);
 
           var runTest = function (testMessage) {
             /* reset channel cipher, to ensure it uses the given iv */
@@ -84,13 +84,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           };
 
           // Run the test with the message’s data as-is.
-          runTest(createTestMessage());
+          runTest(await createTestMessage());
 
           if (testPlaintextVariants) {
-            var testMessage = createTestMessage();
+            var testMessage = await createTestMessage();
             if (BufferUtils.isBuffer(testMessage.data) && !(testMessage.data instanceof ArrayBuffer)) {
               // Now, check that we can also handle an ArrayBuffer plaintext.
-              var testMessageWithArrayBufferData = createTestMessage();
+              var testMessageWithArrayBufferData = await createTestMessage();
               testMessageWithArrayBufferData.data = BufferUtils.toArrayBuffer(testMessageWithArrayBufferData.data);
               runTest(testMessageWithArrayBufferData);
             }
@@ -305,7 +305,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         return;
       }
 
-      loadTestData(testResourcesPath + 'crypto-data-256.json', function (err, testData) {
+      loadTestData(testResourcesPath + 'crypto-data-256.json', async function (err, testData) {
         if (err) {
           done(err);
           return;
@@ -315,8 +315,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         for (var i = 0; i < testData.items.length; i++) {
           var item = testData.items[i];
-          var testMessage = Message.fromEncoded(item.encoded);
-          var decryptedMessage = Message.fromEncoded(item.encrypted, { cipher: { key: key, iv: iv } });
+          var testMessage = await Message.fromEncoded(item.encoded);
+          var decryptedMessage = await Message.fromEncoded(item.encrypted, { cipher: { key: key, iv: iv } });
           testMessageEquality(done, testMessage, decryptedMessage);
         }
         done();

--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -329,11 +329,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channel = realtime.channels.get('failed_attach'),
         originalProcessMessage = channel.processMessage.bind(channel);
 
-      channel.processMessage = function (message) {
+      channel.processMessage = async function (message) {
         if (message.action === 11) {
           return;
         }
-        originalProcessMessage(message);
+        await originalProcessMessage(message);
       };
 
       realtime.connection.once('connected', function () {
@@ -371,12 +371,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         var performance = isBrowser ? window.performance : require('perf_hooks').performance;
 
-        channel.processMessage = function (message) {
+        channel.processMessage = async function (message) {
           // Ignore ATTACHED messages
           if (message.action === 11) {
             return;
           }
-          originalProcessMessage(message);
+          await originalProcessMessage(message);
         };
 
         realtime.connection.on('connected', function () {

--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -327,13 +327,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('attach_timeout', function (done) {
       var realtime = helper.AblyRealtime({ realtimeRequestTimeout: 2000, channelRetryTimeout: 1000 }),
         channel = realtime.channels.get('failed_attach'),
-        originalOnMessage = channel.onMessage.bind(channel);
+        originalProcessMessage = channel.processMessage.bind(channel);
 
-      channel.onMessage = function (message) {
+      channel.processMessage = function (message) {
         if (message.action === 11) {
           return;
         }
-        originalOnMessage(message);
+        originalProcessMessage(message);
       };
 
       realtime.connection.once('connected', function () {
@@ -366,17 +366,17 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             transports: [transport],
           }),
           channel = realtime.channels.get('failed_attach'),
-          originalOnMessage = channel.onMessage.bind(channel),
+          originalProcessMessage = channel.processMessage.bind(channel),
           retryCount = 0;
 
         var performance = isBrowser ? window.performance : require('perf_hooks').performance;
 
-        channel.onMessage = function (message) {
+        channel.processMessage = function (message) {
           // Ignore ATTACHED messages
           if (message.action === 11) {
             return;
           }
-          originalOnMessage(message);
+          originalProcessMessage(message);
         };
 
         realtime.connection.on('connected', function () {

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1732,18 +1732,27 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
           function (cb) {
             /* Inject an additional member locally */
-            channel.processMessage({
-              action: 14,
-              id: 'messageid:0',
-              connectionId: 'connid',
-              timestamp: utils.now(),
-              presence: [
-                {
-                  clientId: goneClientId,
-                  action: 'enter',
-                },
-              ],
-            });
+            channel
+              .processMessage({
+                action: 14,
+                id: 'messageid:0',
+                connectionId: 'connid',
+                timestamp: utils.now(),
+                presence: [
+                  {
+                    clientId: goneClientId,
+                    action: 'enter',
+                  },
+                ],
+              })
+              .then(function () {
+                cb(null);
+              })
+              .catch(function (err) {
+                cb(err);
+              });
+          },
+          function (cb) {
             channel.presence.get(function (err, members) {
               try {
                 expect(members && members.length).to.equal(2, 'Check two members present');
@@ -1812,18 +1821,27 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
           function (cb) {
             /* Inject a member locally */
-            channel.processMessage({
-              action: 14,
-              id: 'messageid:0',
-              connectionId: 'connid',
-              timestamp: utils.now(),
-              presence: [
-                {
-                  clientId: fakeClientId,
-                  action: 'enter',
-                },
-              ],
-            });
+            channel
+              .processMessage({
+                action: 14,
+                id: 'messageid:0',
+                connectionId: 'connid',
+                timestamp: utils.now(),
+                presence: [
+                  {
+                    clientId: fakeClientId,
+                    action: 'enter',
+                  },
+                ],
+              })
+              .then(function () {
+                cb();
+              })
+              .catch(function () {
+                cb(err);
+              });
+          },
+          function (cb) {
             channel.presence.get(function (err, members) {
               try {
                 expect(members && members.length).to.equal(1, 'Check one member present');

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1732,7 +1732,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
           function (cb) {
             /* Inject an additional member locally */
-            channel.onMessage({
+            channel.processMessage({
               action: 14,
               id: 'messageid:0',
               connectionId: 'connid',
@@ -1812,7 +1812,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
           function (cb) {
             /* Inject a member locally */
-            channel.onMessage({
+            channel.processMessage({
               action: 14,
               id: 'messageid:0',
               connectionId: 'connid',
@@ -1846,7 +1846,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               cb();
             });
             /* Inject an ATTACHED with RESUMED and HAS_PRESENCE both false */
-            channel.onMessage(
+            channel.processMessage(
               createPM({
                 action: 11,
                 channelSerial: channel.properties.attachSerial,

--- a/test/realtime/sync.test.js
+++ b/test/realtime/sync.test.js
@@ -47,7 +47,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'syncexistingset',
         channel = realtime.channels.get(channelName);
 
-      channel.processMessage(
+      await channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -63,27 +63,33 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         async.series(
           [
             function (cb) {
-              channel.processMessage({
-                action: 16,
-                channel: channelName,
-                presence: [
-                  {
-                    action: 'present',
-                    clientId: 'one',
-                    connectionId: 'one_connid',
-                    id: 'one_connid:0:0',
-                    timestamp: 1e12,
-                  },
-                  {
-                    action: 'present',
-                    clientId: 'two',
-                    connectionId: 'two_connid',
-                    id: 'two_connid:0:0',
-                    timestamp: 1e12,
-                  },
-                ],
-              });
-              cb();
+              channel
+                .processMessage({
+                  action: 16,
+                  channel: channelName,
+                  presence: [
+                    {
+                      action: 'present',
+                      clientId: 'one',
+                      connectionId: 'one_connid',
+                      id: 'one_connid:0:0',
+                      timestamp: 1e12,
+                    },
+                    {
+                      action: 'present',
+                      clientId: 'two',
+                      connectionId: 'two_connid',
+                      id: 'two_connid:0:0',
+                      timestamp: 1e12,
+                    },
+                  ],
+                })
+                .then(function () {
+                  cb();
+                })
+                .catch(function (err) {
+                  cb(err);
+                });
             },
             function (cb) {
               channel.presence.get(function (err, results) {
@@ -100,27 +106,33 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             },
             function (cb) {
               /* Trigger another sync. Two has gone without so much as a `leave` message! */
-              channel.processMessage({
-                action: 16,
-                channel: channelName,
-                presence: [
-                  {
-                    action: 'present',
-                    clientId: 'one',
-                    connectionId: 'one_connid',
-                    id: 'one_connid:0:0',
-                    timestamp: 1e12,
-                  },
-                  {
-                    action: 'present',
-                    clientId: 'three',
-                    connectionId: 'three_connid',
-                    id: 'three_connid:0:0',
-                    timestamp: 1e12,
-                  },
-                ],
-              });
-              cb();
+              channel
+                .processMessage({
+                  action: 16,
+                  channel: channelName,
+                  presence: [
+                    {
+                      action: 'present',
+                      clientId: 'one',
+                      connectionId: 'one_connid',
+                      id: 'one_connid:0:0',
+                      timestamp: 1e12,
+                    },
+                    {
+                      action: 'present',
+                      clientId: 'three',
+                      connectionId: 'three_connid',
+                      id: 'three_connid:0:0',
+                      timestamp: 1e12,
+                    },
+                  ],
+                })
+                .then(function () {
+                  cb();
+                })
+                .catch(function (err) {
+                  cb(err);
+                });
             },
             function (cb) {
               channel.presence.get(function (err, results) {
@@ -155,7 +167,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'sync_member_arrives_in_middle',
         channel = realtime.channels.get(channelName);
 
-      channel.processMessage(
+      await channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -164,7 +176,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       );
 
       /* First sync */
-      channel.processMessage({
+      await channel.processMessage({
         action: 16,
         channel: channelName,
         presence: [
@@ -179,7 +191,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* A second sync, this time in multiple parts, with a presence message in the middle */
-      channel.processMessage({
+      await channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:cursor',
@@ -194,7 +206,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         presence: [
@@ -208,7 +220,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.processMessage({
+      await channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:',
@@ -257,7 +269,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'sync_member_arrives_normally_after_came_in_sync',
         channel = realtime.channels.get(channelName);
 
-      channel.processMessage(
+      await channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -265,7 +277,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         })
       );
 
-      channel.processMessage({
+      await channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:cursor',
@@ -280,7 +292,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         presence: [
@@ -294,7 +306,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.processMessage({
+      await channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:',
@@ -340,7 +352,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'sync_member_arrives_normally_before_comes_in_sync',
         channel = realtime.channels.get(channelName);
 
-      channel.processMessage(
+      await channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -348,7 +360,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         })
       );
 
-      channel.processMessage({
+      await channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:cursor',
@@ -363,7 +375,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         presence: [
@@ -377,7 +389,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.processMessage({
+      await channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:',
@@ -424,7 +436,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'sync_ordering',
         channel = realtime.channels.get(channelName);
 
-      channel.processMessage(
+      await channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -432,7 +444,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       );
 
       /* One enters */
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         id: 'one_connid:1',
@@ -447,7 +459,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* An earlier leave from one (should be ignored) */
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'one_connid',
@@ -462,7 +474,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* One adds some data in a newer msgSerial */
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'one_connid',
@@ -478,7 +490,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* Two enters */
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'two_connid',
@@ -493,7 +505,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* Two updates twice in the same message */
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'two_connid',
@@ -514,7 +526,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* Three enters */
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'three_connid',
@@ -530,7 +542,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       /* Synthesized leave for three (with earlier msgSerial, incompatible id,
        * and later timestamp) */
-      channel.processMessage({
+      await channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'synthesized',
@@ -614,12 +626,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
           function (cb) {
             var originalProcessMessage = syncerChannel.processMessage;
-            syncerChannel.processMessage = function (message) {
-              originalProcessMessage.apply(this, arguments);
+            syncerChannel.processMessage = async function (message) {
+              await originalProcessMessage.apply(this, arguments);
               /* Inject an additional presence message after the first sync */
               if (message.action === 16) {
                 syncerChannel.processMessage = originalProcessMessage;
-                syncerChannel.processMessage({
+                await syncerChannel.processMessage({
                   action: 14,
                   id: 'messageid:0',
                   connectionId: 'connid',

--- a/test/realtime/sync.test.js
+++ b/test/realtime/sync.test.js
@@ -47,7 +47,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'syncexistingset',
         channel = realtime.channels.get(channelName);
 
-      channel.onMessage(
+      channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -58,7 +58,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       async.series(
         [
           function (cb) {
-            channel.onMessage({
+            channel.processMessage({
               action: 16,
               channel: channelName,
               presence: [
@@ -95,7 +95,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
           function (cb) {
             /* Trigger another sync. Two has gone without so much as a `leave` message! */
-            channel.onMessage({
+            channel.processMessage({
               action: 16,
               channel: channelName,
               presence: [
@@ -149,7 +149,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'sync_member_arrives_in_middle',
         channel = realtime.channels.get(channelName);
 
-      channel.onMessage(
+      channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -158,7 +158,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       );
 
       /* First sync */
-      channel.onMessage({
+      channel.processMessage({
         action: 16,
         channel: channelName,
         presence: [
@@ -173,7 +173,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* A second sync, this time in multiple parts, with a presence message in the middle */
-      channel.onMessage({
+      channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:cursor',
@@ -188,7 +188,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         presence: [
@@ -202,7 +202,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.onMessage({
+      channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:',
@@ -242,7 +242,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'sync_member_arrives_normally_after_came_in_sync',
         channel = realtime.channels.get(channelName);
 
-      channel.onMessage(
+      channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -250,7 +250,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         })
       );
 
-      channel.onMessage({
+      channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:cursor',
@@ -265,7 +265,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         presence: [
@@ -279,7 +279,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.onMessage({
+      channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:',
@@ -319,7 +319,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'sync_member_arrives_normally_before_comes_in_sync',
         channel = realtime.channels.get(channelName);
 
-      channel.onMessage(
+      channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -327,7 +327,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         })
       );
 
-      channel.onMessage({
+      channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:cursor',
@@ -342,7 +342,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         presence: [
@@ -356,7 +356,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.onMessage({
+      channel.processMessage({
         action: 16,
         channel: channelName,
         channelSerial: 'serial:',
@@ -397,7 +397,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'sync_ordering',
         channel = realtime.channels.get(channelName);
 
-      channel.onMessage(
+      channel.processMessage(
         createPM({
           action: 11,
           channel: channelName,
@@ -405,7 +405,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       );
 
       /* One enters */
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         id: 'one_connid:1',
@@ -420,7 +420,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* An earlier leave from one (should be ignored) */
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'one_connid',
@@ -435,7 +435,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* One adds some data in a newer msgSerial */
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'one_connid',
@@ -451,7 +451,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* Two enters */
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'two_connid',
@@ -466,7 +466,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* Two updates twice in the same message */
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'two_connid',
@@ -487,7 +487,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       });
 
       /* Three enters */
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'three_connid',
@@ -503,7 +503,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       /* Synthesized leave for three (with earlier msgSerial, incompatible id,
        * and later timestamp) */
-      channel.onMessage({
+      channel.processMessage({
         action: 14,
         channel: channelName,
         connectionId: 'synthesized',
@@ -581,13 +581,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             );
           },
           function (cb) {
-            var originalOnMessage = syncerChannel.onMessage;
-            syncerChannel.onMessage = function (message) {
-              originalOnMessage.apply(this, arguments);
+            var originalProcessMessage = syncerChannel.processMessage;
+            syncerChannel.processMessage = function (message) {
+              originalProcessMessage.apply(this, arguments);
               /* Inject an additional presence message after the first sync */
               if (message.action === 16) {
-                syncerChannel.onMessage = originalOnMessage;
-                syncerChannel.onMessage({
+                syncerChannel.processMessage = originalProcessMessage;
+                syncerChannel.processMessage({
                   action: 14,
                   id: 'messageid:0',
                   connectionId: 'connid',

--- a/test/realtime/sync.test.js
+++ b/test/realtime/sync.test.js
@@ -42,7 +42,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * sync in progress, then do one sync, then a second with a slightly
      * different presence set
      */
-    it('sync_existing_set', function (done) {
+    it('sync_existing_set', async function () {
       var realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'syncexistingset',
         channel = realtime.channels.get(channelName);
@@ -55,96 +55,102 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         })
       );
 
-      async.series(
-        [
-          function (cb) {
-            channel.processMessage({
-              action: 16,
-              channel: channelName,
-              presence: [
-                {
-                  action: 'present',
-                  clientId: 'one',
-                  connectionId: 'one_connid',
-                  id: 'one_connid:0:0',
-                  timestamp: 1e12,
-                },
-                {
-                  action: 'present',
-                  clientId: 'two',
-                  connectionId: 'two_connid',
-                  id: 'two_connid:0:0',
-                  timestamp: 1e12,
-                },
-              ],
-            });
-            cb();
-          },
-          function (cb) {
-            channel.presence.get(function (err, results) {
-              try {
-                expect(results.length).to.equal(2, 'Check correct number of results');
-                expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
-                expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check correct members');
-              } catch (err) {
+      await new Promise(function (resolve, reject) {
+        var done = function (err) {
+          err ? reject(err) : resolve();
+        };
+
+        async.series(
+          [
+            function (cb) {
+              channel.processMessage({
+                action: 16,
+                channel: channelName,
+                presence: [
+                  {
+                    action: 'present',
+                    clientId: 'one',
+                    connectionId: 'one_connid',
+                    id: 'one_connid:0:0',
+                    timestamp: 1e12,
+                  },
+                  {
+                    action: 'present',
+                    clientId: 'two',
+                    connectionId: 'two_connid',
+                    id: 'two_connid:0:0',
+                    timestamp: 1e12,
+                  },
+                ],
+              });
+              cb();
+            },
+            function (cb) {
+              channel.presence.get(function (err, results) {
+                try {
+                  expect(results.length).to.equal(2, 'Check correct number of results');
+                  expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
+                  expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check correct members');
+                } catch (err) {
+                  cb(err);
+                  return;
+                }
                 cb(err);
-                return;
-              }
-              cb(err);
-            });
-          },
-          function (cb) {
-            /* Trigger another sync. Two has gone without so much as a `leave` message! */
-            channel.processMessage({
-              action: 16,
-              channel: channelName,
-              presence: [
-                {
-                  action: 'present',
-                  clientId: 'one',
-                  connectionId: 'one_connid',
-                  id: 'one_connid:0:0',
-                  timestamp: 1e12,
-                },
-                {
-                  action: 'present',
-                  clientId: 'three',
-                  connectionId: 'three_connid',
-                  id: 'three_connid:0:0',
-                  timestamp: 1e12,
-                },
-              ],
-            });
-            cb();
-          },
-          function (cb) {
-            channel.presence.get(function (err, results) {
-              try {
-                expect(results.length).to.equal(2, 'Check correct number of results');
-                expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
-                expect(extractClientIds(results)).to.deep.equal(
-                  ['one', 'three'],
-                  'check two has gone and three is there'
-                );
-              } catch (err) {
+              });
+            },
+            function (cb) {
+              /* Trigger another sync. Two has gone without so much as a `leave` message! */
+              channel.processMessage({
+                action: 16,
+                channel: channelName,
+                presence: [
+                  {
+                    action: 'present',
+                    clientId: 'one',
+                    connectionId: 'one_connid',
+                    id: 'one_connid:0:0',
+                    timestamp: 1e12,
+                  },
+                  {
+                    action: 'present',
+                    clientId: 'three',
+                    connectionId: 'three_connid',
+                    id: 'three_connid:0:0',
+                    timestamp: 1e12,
+                  },
+                ],
+              });
+              cb();
+            },
+            function (cb) {
+              channel.presence.get(function (err, results) {
+                try {
+                  expect(results.length).to.equal(2, 'Check correct number of results');
+                  expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
+                  expect(extractClientIds(results)).to.deep.equal(
+                    ['one', 'three'],
+                    'check two has gone and three is there'
+                  );
+                } catch (err) {
+                  cb(err);
+                  return;
+                }
                 cb(err);
-                return;
-              }
-              cb(err);
-            });
-          },
-        ],
-        function (err) {
-          closeAndFinish(done, realtime, err);
-        }
-      );
+              });
+            },
+          ],
+          function (err) {
+            closeAndFinish(done, realtime, err);
+          }
+        );
+      });
     });
 
     /*
      * Sync with an existing presence set and a presence member added in the
      * middle of the sync should should discard the former, but not the latter
      * */
-    it('sync_member_arrives_in_middle', function (done) {
+    it('sync_member_arrives_in_middle', async function () {
       var realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'sync_member_arrives_in_middle',
         channel = realtime.channels.get(channelName);
@@ -217,27 +223,36 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.presence.get(function (err, results) {
-        if (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        try {
-          expect(results.length).to.equal(3, 'Check correct number of results');
-          expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
-          expect(extractClientIds(results)).to.deep.equal(['four', 'three', 'two'], 'check expected presence members');
-        } catch (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        closeAndFinish(done, realtime);
+      await new Promise(function (resolve, reject) {
+        var done = function (err) {
+          err ? reject(err) : resolve();
+        };
+
+        channel.presence.get(function (err, results) {
+          if (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          try {
+            expect(results.length).to.equal(3, 'Check correct number of results');
+            expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
+            expect(extractClientIds(results)).to.deep.equal(
+              ['four', 'three', 'two'],
+              'check expected presence members'
+            );
+          } catch (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          closeAndFinish(done, realtime);
+        });
       });
     });
 
     /*
      * Presence message that was in the sync arrives again as a normal message, after it's come in the sync
      */
-    it('sync_member_arrives_normally_after_came_in_sync', function (done) {
+    it('sync_member_arrives_normally_after_came_in_sync', async function () {
       var realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'sync_member_arrives_normally_after_came_in_sync',
         channel = realtime.channels.get(channelName);
@@ -294,27 +309,33 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.presence.get(function (err, results) {
-        if (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        try {
-          expect(results.length).to.equal(2, 'Check correct number of results');
-          expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
-          expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check expected presence members');
-        } catch (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        closeAndFinish(done, realtime);
+      await new Promise(function (resolve, reject) {
+        var done = function (err) {
+          err ? reject(err) : resolve();
+        };
+
+        channel.presence.get(function (err, results) {
+          if (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          try {
+            expect(results.length).to.equal(2, 'Check correct number of results');
+            expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
+            expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check expected presence members');
+          } catch (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          closeAndFinish(done, realtime);
+        });
       });
     });
 
     /*
      * Presence message that will be in the sync arrives as a normal message, before it comes in the sync
      */
-    it('sync_member_arrives_normally_before_comes_in_sync', function (done) {
+    it('sync_member_arrives_normally_before_comes_in_sync', async function () {
       var realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'sync_member_arrives_normally_before_comes_in_sync',
         channel = realtime.channels.get(channelName);
@@ -371,20 +392,26 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.presence.get(function (err, results) {
-        if (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        try {
-          expect(results.length).to.equal(2, 'Check correct number of results');
-          expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
-          expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check expected presence members');
-        } catch (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        closeAndFinish(done, realtime);
+      await new Promise(function (resolve, reject) {
+        var done = function (err) {
+          err ? reject(err) : resolve();
+        };
+
+        channel.presence.get(function (err, results) {
+          if (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          try {
+            expect(results.length).to.equal(2, 'Check correct number of results');
+            expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
+            expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check expected presence members');
+          } catch (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          closeAndFinish(done, realtime);
+        });
       });
     });
 
@@ -392,7 +419,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * Get several presence messages with various combinations of msgserial,
      * index, and synthesized leaves, check that the end result is correct
      */
-    it('presence_ordering', function (done) {
+    it('presence_ordering', async function () {
       var realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'sync_ordering',
         channel = realtime.channels.get(channelName);
@@ -518,22 +545,27 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
       });
 
-      channel.presence.get(function (err, results) {
-        if (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        try {
-          expect(results.length).to.equal(2, 'Check correct number of results');
-          expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
-          expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check expected presence members');
-          expect(extractMember(results, 'one').data).to.equal('onedata', 'check correct data on one');
-          expect(extractMember(results, 'two').data).to.equal('twodata', 'check correct data on two');
-        } catch (err) {
-          closeAndFinish(done, realtime, err);
-          return;
-        }
-        closeAndFinish(done, realtime);
+      await new Promise(function (resolve, reject) {
+        var done = function (err) {
+          err ? reject(err) : resolve();
+        };
+        channel.presence.get(function (err, results) {
+          if (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          try {
+            expect(results.length).to.equal(2, 'Check correct number of results');
+            expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
+            expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check expected presence members');
+            expect(extractMember(results, 'one').data).to.equal('onedata', 'check correct data on one');
+            expect(extractMember(results, 'two').data).to.equal('twodata', 'check correct data on two');
+          } catch (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          closeAndFinish(done, realtime);
+        });
       });
     });
 


### PR DESCRIPTION
**Note: This is based on top of #1246; please review that one first.**

This makes `ICipher.decrypt` async, in preparation for using the (async-only) `SubtleCrypto.decrypt` method in #1292.

The changes of note are:

- making `RealtimeChannel#processMessage` async — involves adding a queue to synchronise access to this method
- making the public `{Message, PresenceMessage}#{fromEncoded, fromEncodedArray}` methods async

See commit messages for more details.

Resolves #1293.