### PR TITLE
INT-2325 upload to correct cdn bucket

### DIFF
--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           node-version: 14.x
       - run: npm ci
-      - run: node scripts/cdn_deploy.js --bucket cdn.ably.com --skipCheckout --tag=${{ github.event.inputs.version }}
+      - run: node scripts/cdn_deploy.js --bucket prod-cdn.ably.com --skipCheckout --tag=${{ github.event.inputs.version }}


### PR DESCRIPTION
In previous PR, I have accidentally used incorrect bucket name. This PR is fixing that. I have verified that the prod-cdn.ably.com S3 bucket does exist in the correct account.