### PR TITLE
Describe the types of key returned by `generateRandomKey`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -716,7 +716,7 @@ declare namespace Types {
     /**
      * The private key used to encrypt and decrypt payloads. You should not set this value directly; rather, you should pass a `key` of type {@link Types.CipherKeyParam} to {@link Crypto.getDefaultParams}.
      */
-    key: CipherKey;
+    key: unknown;
     /**
      * The length of the key in bits; either 128 or 256.
      */
@@ -2904,12 +2904,9 @@ declare namespace Types {
    */
   type CipherKeyParam = ArrayBuffer | Uint8Array | string; // if string must be base64-encoded
   /**
-   * Typed differently depending on platform. (`ArrayBuffer` in browser, `Buffer` in node)
-   *
-   * @internal
+   * The type of the key returned by {@link Crypto.generateRandomKey}. Typed differently depending on platform (`Buffer` in Node.js, `ArrayBuffer` elsewhere).
    */
-  type CipherKey = unknown; // ArrayBuffer on browsers, Buffer on node, using unknown as
-  // user should not be interacting with it - output of getDefaultParams should be used opaquely
+  type CipherKey = ArrayBuffer | Buffer;
 
   /**
    * Contains the properties used to generate a {@link CipherParams} object.

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -191,7 +191,7 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
 
       generateRandom((keyLength || DEFAULT_KEYLENGTH) / 8, function (err, buf) {
         if (callback !== undefined) {
-          callback(err ? ErrorInfo.fromValues(err) : null, buf);
+          callback(err ? ErrorInfo.fromValues(err) : null, buf ?? undefined);
         }
       });
     }


### PR DESCRIPTION
My understanding of the intended use case of this method is that it allows a user to generate a key which they can then share with other parties through some side channel in order to establish encrypted communication with those parties. Hence, the output of `generateRandomKey` should not be an opaque value — the user needs to know how to interact with this value so that they can serialise it.

Resolves #1296 (this commit was originally included in #1299, why is why that PR claimed to resolve this issue, but I accidentally dropped this commit from that PR at some point).