### PR TITLE
Make `ErrorInfo.fromValues`’s signature correspond to its expectations

### DIFF
--- a/src/common/lib/types/devicedetails.ts
+++ b/src/common/lib/types/devicedetails.ts
@@ -1,5 +1,5 @@
 import * as Utils from '../util/utils';
-import ErrorInfo from './errorinfo';
+import ErrorInfo, { IConvertibleToErrorInfo } from './errorinfo';
 
 enum DeviceFormFactor {
   Phone = 'phone',
@@ -88,7 +88,7 @@ class DeviceDetails {
   }
 
   static fromValues(values: Record<string, unknown>): DeviceDetails {
-    values.error = values.error && ErrorInfo.fromValues(values.error as Error);
+    values.error = values.error && ErrorInfo.fromValues(values.error as IConvertibleToErrorInfo);
     return Object.assign(new DeviceDetails(), values);
   }
 

--- a/src/common/lib/types/errorinfo.ts
+++ b/src/common/lib/types/errorinfo.ts
@@ -20,6 +20,12 @@ function toString(err: ErrorInfo | PartialErrorInfo) {
   return result;
 }
 
+export interface IConvertibleToErrorInfo {
+  message: string;
+  code: number;
+  statusCode: number;
+}
+
 export default class ErrorInfo extends Error implements IPartialErrorInfo, API.Types.ErrorInfo {
   code: number;
   statusCode: number;
@@ -40,8 +46,8 @@ export default class ErrorInfo extends Error implements IPartialErrorInfo, API.T
     return toString(this);
   }
 
-  static fromValues(values: Record<string, unknown> | ErrorInfo | Error): ErrorInfo {
-    const { message, code, statusCode } = values as ErrorInfo;
+  static fromValues(values: IConvertibleToErrorInfo): ErrorInfo {
+    const { message, code, statusCode } = values;
     if (typeof message !== 'string' || typeof code !== 'number' || typeof statusCode !== 'number') {
       throw new Error('ErrorInfo.fromValues(): invalid values: ' + Platform.Config.inspect(values));
     }

--- a/src/platform/nodejs/lib/util/crypto.ts
+++ b/src/platform/nodejs/lib/util/crypto.ts
@@ -198,7 +198,10 @@ var CryptoFactory = function (bufferUtils: typeof BufferUtils) {
 
       generateRandom((keyLength || DEFAULT_KEYLENGTH) / 8, function (err, buf) {
         if (callback !== undefined) {
-          callback(err ? ErrorInfo.fromValues(err) : null, buf);
+          const errorInfo = err
+            ? new ErrorInfo('Failed to generate random key: ' + err.message, 500, 50000, err)
+            : null;
+          callback(errorInfo, buf);
         }
       });
     }

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -191,7 +191,10 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
 
       generateRandom((keyLength || DEFAULT_KEYLENGTH) / 8, function (err, buf) {
         if (callback !== undefined) {
-          callback(err ? ErrorInfo.fromValues(err) : null, buf ?? undefined);
+          const errorInfo = err
+            ? new ErrorInfo('Failed to generate random key: ' + err.message, 400, 50000, err)
+            : null;
+          callback(errorInfo, buf ?? undefined);
         }
       });
     }


### PR DESCRIPTION
It expects the received object to have certain keys of certain types, and throws an error if not. So, get the compiler’s help in enforcing this.