### PR TITLE
test: unset mutated client requestHeaders after test complete

### DIFF
--- a/test/rest/auth.test.js
+++ b/test/rest/auth.test.js
@@ -252,6 +252,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, as
         }
         rest.auth.authOptions.requestHeaders = authHeaders;
         rest.auth.requestToken(function (err, tokenDetails) {
+          delete rest.auth.authOptions.requestHeaders;
           if (err) {
             done(err);
             return;


### PR DESCRIPTION
Resolves #1336, although still begs the question of why this test was still passing with the Authorization header set until recently.