### PR TITLE
feat: add `ChannelStateChange.hasBacklog` and return state change to attach promise/callback

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2556,9 +2556,9 @@ declare namespace Types {
     /**
      * Attach to this channel ensuring the channel is created in the Ably system and all messages published on the channel are received by any channel listeners registered using {@link RealtimeChannelCallbacks.subscribe | `subscribe()`}. Any resulting channel state change will be emitted to any listeners registered using the {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`} methods. As a convenience, `attach()` is called implicitly if {@link RealtimeChannelCallbacks.subscribe | `subscribe()`} for the channel is called, or {@link RealtimePresenceCallbacks.enter | `enter()`} or {@link RealtimePresenceCallbacks.subscribe | `subscribe()`} are called on the {@link RealtimePresenceCallbacks} object for this channel.
      *
-     * @param callback - A function which will be called upon completion of the operation. If the operation succeeded, then the function will be called with `null`. If it failed, the function will be called with information about the error.
+     * @param callback - A function which will be called upon completion of the operation. If the operation succeeded and the channel became attached, then the function will be called with a {@link ChannelStateChange} object. If the channel was already attached the function will be called with `null`. If it failed, the function will be called with information about the error.
      */
-    attach(callback?: errorCallback): void;
+    attach(callback?: StandardCallback<ChannelStateChange | null>): void;
     /**
      * Detach from this channel. Any resulting channel state change is emitted to any listeners registered using the {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`} methods. Once all clients globally have detached from the channel, the channel will be released in the Ably service within two minutes.
      *
@@ -2590,32 +2590,44 @@ declare namespace Types {
      *
      * @param event - The event name.
      * @param listener - An event listener function.
-     * @param callbackWhenAttached - A function which will be called upon completion of the channel {@link RealtimeChannelCallbacks.attach | `attach()`} operation. If the operation succeeded, then the function will be called with `null`. If it failed, the function will be called with information about the error.
+     * @param callbackWhenAttached - A function which will be called upon completion of the channel {@link RealtimeChannelCallbacks.attach | `attach()`} operation. If the operation succeeded and the channel became attached, then the function will be called with a {@link ChannelStateChange} object. If the channel was already attached the function will be called with `null`. If it failed, the function will be called with information about the error.
      */
-    subscribe(event: string, listener?: messageCallback<Message>, callbackWhenAttached?: errorCallback): void;
+    subscribe(
+      event: string,
+      listener?: messageCallback<Message>,
+      callbackWhenAttached?: StandardCallback<ChannelStateChange | null>
+    ): void;
     /**
      * Registers a listener for messages on this channel for multiple event name values.
      *
      * @param events - An array of event names.
      * @param listener - An event listener function.
-     * @param callbackWhenAttached - A function which will be called upon completion of the channel {@link RealtimeChannelCallbacks.attach | `attach()`} operation. If the operation succeeded, then the function will be called with `null`. If it failed, the function will be called with information about the error.
+     * @param callbackWhenAttached - A function which will be called upon completion of the channel {@link RealtimeChannelCallbacks.attach | `attach()`} operation. If the operation succeeded and the channel became attached, then the function will be called with a {@link ChannelStateChange} object. If the channel was already attached the function will be called with `null`. If it failed, the function will be called with information about the error.
      */
-    subscribe(events: Array<string>, listener?: messageCallback<Message>, callbackWhenAttached?: errorCallback): void;
+    subscribe(
+      events: Array<string>,
+      listener?: messageCallback<Message>,
+      callbackWhenAttached?: StandardCallback<ChannelStateChange | null>
+    ): void;
     /**
      * Registers a listener for messages on this channel that match the supplied filter.
      *
      * @param filter - A {@link MessageFilter}.
      * @param listener - An event listener function.
-     * @param callbackWhenAttached - A function which will be called upon completion of the channel {@link RealtimeChannelCallbacks.attach | `attach()`} operation. If the operation succeeded, then the function will be called with `null`. If it failed, the function will be called with information about the error.
+     * @param callbackWhenAttached - A function which will be called upon completion of the channel {@link RealtimeChannelCallbacks.attach | `attach()`} operation. If the operation succeeded and the channel became attached, then the function will be called with a {@link ChannelStateChange} object. If the channel was already attached the function will be called with `null`. If it failed, the function will be called with information about the error.
      */
-    subscribe(filter: MessageFilter, listener?: messageCallback<Message>, callbackWhenAttached?: errorCallback): void;
+    subscribe(
+      filter: MessageFilter,
+      listener?: messageCallback<Message>,
+      callbackWhenAttached?: StandardCallback<ChannelStateChange | null>
+    ): void;
     /**
      * Registers a listener for messages on this channel. The caller supplies a listener function, which is called each time one or more messages arrives on the channel.
      *
      * @param listener - An event listener function.
-     * @param callbackWhenAttached - A function which will be called upon completion of the channel {@link RealtimeChannelCallbacks.attach | `attach()`} operation. If the operation succeeded, then the function will be called with `null`. If it failed, the function will be called with information about the error.
+     * @param callbackWhenAttached - A function which will be called upon completion of the channel {@link RealtimeChannelCallbacks.attach | `attach()`} operation. If the operation succeeded and the channel became attached, then the function will be called with a {@link ChannelStateChange} object. If the channel was already attached the function will be called with `null`. If it failed, the function will be called with information about the error.
      */
-    subscribe(listener: messageCallback<Message>, callbackWhenAttached?: errorCallback): void;
+    subscribe(listener: messageCallback<Message>, callbackWhenAttached?: StandardCallback<ChannelStateChange>): void;
     /**
      * Publishes a single message to the channel with the given event name and payload. When publish is called with this client library, it won't attempt to implicitly attach to the channel, so long as [transient publishing](https://ably.com/docs/realtime/channels#transient-publish) is available in the library. Otherwise, the client will implicitly attach.
      *
@@ -2666,9 +2678,9 @@ declare namespace Types {
     /**
      * Attach to this channel ensuring the channel is created in the Ably system and all messages published on the channel are received by any channel listeners registered using {@link RealtimeChannelPromise.subscribe | `subscribe()`}. Any resulting channel state change will be emitted to any listeners registered using the {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`} methods. As a convenience, `attach()` is called implicitly if {@link RealtimeChannelPromise.subscribe | `subscribe()`} for the channel is called, or {@link RealtimePresencePromise.enter | `enter()`} or {@link RealtimePresencePromise.subscribe | `subscribe()`} are called on the {@link RealtimePresencePromise} object for this channel.
      *
-     * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+     * @returns A promise which, upon success, if the channel became attached will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be fulfilled with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
      */
-    attach(): Promise<void>;
+    attach(): Promise<ChannelStateChange | null>;
     /**
      * Detach from this channel. Any resulting channel state change is emitted to any listeners registered using the {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`} methods. Once all clients globally have detached from the channel, the channel will be released in the Ably service within two minutes.
      *
@@ -2694,32 +2706,32 @@ declare namespace Types {
      *
      * @param event - The event name.
      * @param listener - An event listener function.
-     * @returns A promise which resolves upon success of the channel {@link RealtimeChannelPromise.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure.
+     * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
      */
-    subscribe(event: string, listener?: messageCallback<Message>): Promise<void>;
+    subscribe(event: string, listener?: messageCallback<Message>): Promise<ChannelStateChange | null>;
     /**
      * Registers a listener for messages on this channel for multiple event name values.
      *
      * @param events - An array of event names.
      * @param listener - An event listener function.
-     * @returns A promise which resolves upon success of the channel {@link RealtimeChannelPromise.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure.
+     * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
      */
-    subscribe(events: Array<string>, listener?: messageCallback<Message>): Promise<void>;
+    subscribe(events: Array<string>, listener?: messageCallback<Message>): Promise<ChannelStateChange | null>;
     /**
      * Registers a listener for messages on this channel that match the supplied filter.
      *
      * @param filter - A {@link MessageFilter}.
      * @param listener - An event listener function.
-     * @returns A promise which resolves upon success of the channel {@link RealtimeChannelPromise.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure.
+     * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
      */
-    subscribe(filter: MessageFilter, listener?: messageCallback<Message>): Promise<void>;
+    subscribe(filter: MessageFilter, listener?: messageCallback<Message>): Promise<ChannelStateChange | null>;
     /**
      * Registers a listener for messages on this channel. The caller supplies a listener function, which is called each time one or more messages arrives on the channel.
      *
      * @param callback - An event listener function.
-     * @returns A promise which resolves upon success of the channel {@link RealtimeChannelPromise.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure.
+     * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
      */
-    subscribe(callback: messageCallback<Message>): Promise<void>;
+    subscribe(callback: messageCallback<Message>): Promise<ChannelStateChange | null>;
     /**
      * Publishes a single message to the channel with the given event name and payload. When publish is called with this client library, it won't attempt to implicitly attach to the channel, so long as [transient publishing](https://ably.com/docs/realtime/channels#transient-publish) is available in the library. Otherwise, the client will implicitly attach.
      *

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -1149,6 +1149,10 @@ declare namespace Types {
      * Indicates whether message continuity on this channel is preserved, see [Nonfatal channel errors](https://ably.com/docs/realtime/channels#nonfatal-errors) for more info.
      */
     resumed: boolean;
+    /**
+     * Indicates whether the client can expect a backlog of messages from a rewind or resume.
+     */
+    hasBacklog?: boolean;
   }
 
   /**

--- a/src/common/lib/client/channelstatechange.ts
+++ b/src/common/lib/client/channelstatechange.ts
@@ -5,11 +5,21 @@ class ChannelStateChange {
   current: string;
   resumed?: boolean;
   reason?: string | Error | ErrorInfo;
+  hasBacklog?: boolean;
 
-  constructor(previous: string, current: string, resumed?: boolean, reason?: string | Error | ErrorInfo | null) {
+  constructor(
+    previous: string,
+    current: string,
+    resumed?: boolean,
+    hasBacklog?: boolean,
+    reason?: string | Error | ErrorInfo | null
+  ) {
     this.previous = previous;
     this.current = current;
-    if (current === 'attached') this.resumed = resumed;
+    if (current === 'attached') {
+      this.resumed = resumed;
+      this.hasBacklog = hasBacklog;
+    }
     if (reason) this.reason = reason;
   }
 }

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -477,7 +477,7 @@ class RealtimePresence extends Presence {
           const msg = 'Presence auto-re-enter failed: ' + err.toString();
           const wrappedErr = new ErrorInfo(msg, 91004, 400);
           Logger.logAction(Logger.LOG_ERROR, 'RealtimePresence._ensureMyMembersPresent()', msg);
-          const change = new ChannelStateChange(this.channel.state, this.channel.state, true, wrappedErr);
+          const change = new ChannelStateChange(this.channel.state, this.channel.state, true, false, wrappedErr);
           this.channel.emit('update', change);
         }
       };

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1630,5 +1630,59 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         }
       );
     });
+
+    it('rewind_has_backlog_0', function (done) {
+      var realtime = helper.AblyRealtime();
+      var channelName = 'rewind_has_backlog_0';
+      var channelOpts = { params: { rewind: '1' } };
+      var channel = realtime.channels.get(channelName, channelOpts);
+
+      // attach with rewind but no channel history - hasBacklog should be false
+      channel.attach(function (err, stateChange) {
+        if (err) {
+          closeAndFinish(done, realtime, err);
+          return;
+        }
+
+        try {
+          expect(!stateChange.hasBacklog).to.be.ok;
+        } catch (err) {
+          closeAndFinish(done, realtime, err);
+          return;
+        }
+        closeAndFinish(done, realtime);
+      });
+    });
+
+    it('rewind_has_backlog_1', function (done) {
+      var realtime = helper.AblyRealtime();
+      var rest = helper.AblyRest();
+      var channelName = 'rewind_has_backlog_1';
+      var channelOpts = { params: { rewind: '1' } };
+      var rtChannel = realtime.channels.get(channelName, channelOpts);
+      var restChannel = rest.channels.get(channelName);
+
+      // attach with rewind after publishing - hasBacklog should be true
+      restChannel.publish('foo', 'bar', function (err) {
+        if (err) {
+          closeAndFinish(done, realtime, err);
+          return;
+        }
+        rtChannel.attach(function (err, stateChange) {
+          if (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+
+          try {
+            expect(stateChange.hasBacklog).to.be.ok;
+          } catch (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          closeAndFinish(done, realtime);
+        });
+      });
+    });
   });
 });

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1569,5 +1569,66 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       channel.subscribe(subscriber);
     });
+
+    it('attach_returns_state_change', function (done) {
+      var realtime = helper.AblyRealtime();
+      var channelName = 'attach_returns_state_chnage';
+      var channel = realtime.channels.get(channelName);
+      channel.attach(function (err, stateChange) {
+        if (err) {
+          closeAndFinish(done, realtime, err);
+          return;
+        }
+
+        try {
+          expect(stateChange.current).to.equal('attached');
+          expect(stateChange.previous).to.equal('attaching');
+        } catch (err) {
+          closeAndFinish(done, realtime, err);
+          return;
+        }
+
+        // for an already-attached channel, null is returned
+        channel.attach(function (err, stateChange) {
+          if (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+
+          try {
+            expect(stateChange).to.equal(null);
+          } catch (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          closeAndFinish(done, realtime);
+        });
+      });
+    });
+
+    it('subscribe_returns_state_change', function (done) {
+      var realtime = helper.AblyRealtime();
+      var channelName = 'subscribe_returns_state_chnage';
+      var channel = realtime.channels.get(channelName);
+      channel.subscribe(
+        function () {}, // message listener
+        // attach callback
+        function (err, stateChange) {
+          if (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+
+          try {
+            expect(stateChange.current).to.equal('attached');
+            expect(stateChange.previous).to.equal('attaching');
+          } catch (err) {
+            closeAndFinish(done, realtime, err);
+            return;
+          }
+          closeAndFinish(done, realtime);
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
Resolves #1328 

See [corresponding spec PR](https://github.com/ably/specification/pull/152)

These features in combination will allow users to check whether to expect a backlog of messages once attached to a realtime channel. In particular, when using `rewind=1`, this will allow users to create a promise which resolves once a channel is attached and, if applicable, the rewind message has been received.