### PR TITLE
Fix the type definition of `Crypto.getDefaultParams`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2970,9 +2970,9 @@ declare namespace Types {
      * Returns a {@link CipherParams} object, using the default values for any fields not supplied by the {@link CipherParamOptions} object.
      *
      * @param params - A {@link CipherParamOptions} object.
-     * @param callback - A function which, upon success, will be called with a {@link CipherParams} object, using the default values for any fields not supplied. Upon failure, the function will be called with information about the error.
+     * @returns A {@link CipherParams} object, using the default values for any fields not supplied.
      */
-    getDefaultParams(params: CipherParamOptions, callback: Types.StandardCallback<CipherParams>): void;
+    getDefaultParams(params: CipherParamOptions): CipherParams;
   }
 
   /**


### PR DESCRIPTION
The implementations of this method return their result synchronously, as does the feature spec IDL.

I’m not sure why the compiler didn’t catch this.

Resolves #1350.