### PR TITLE
chore: bump features version

### DIFF
--- a/.ably/capabilities.yaml
+++ b/.ably/capabilities.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-common-version: 1.2.0
+common-version: 1.2.1
 compliance:
   Agent Identifier:
     Agents:


### PR DESCRIPTION
needed to support the new "OS Connectivity events" feature