### PR TITLE
ci: log failed tests at end of playwright suite

### DIFF
--- a/test/support/playwrightSetup.js
+++ b/test/support/playwrightSetup.js
@@ -6,6 +6,7 @@ class CustomEventReporter extends Mocha.reporters.HTML {
   constructor(runner) {
     super(runner);
     this.indents = 0;
+    this.failedTests = [];
 
     runner
       .on(EVENT_SUITE_BEGIN, (suite) => {
@@ -22,9 +23,13 @@ class CustomEventReporter extends Mocha.reporters.HTML {
       })
       .on(EVENT_TEST_FAIL, (test, err) => {
         this.logToNodeConsole(`${failSymbol}: ${test.title} - error: ${err.message}`);
+        this.failedTests.push(test.title);
       })
       .once(EVENT_RUN_END, () => {
         this.indents = 0;
+        if (this.failedTests.length > 0) {
+          this.logToNodeConsole('\nfailed tests: \n' + this.failedTests.map((x) => ' - ' + x).join('\n') + '\n');
+        }
         runner.stats &&
           window.dispatchEvent(
             new CustomEvent('testResult', {


### PR DESCRIPTION
updates the playwright automated browser testing setup to log the name of all failed tests at the end of the run.

example output:
<img width="565" alt="image" src="https://github.com/ably/ably-js/assets/48608556/28bd58cc-79bf-4f28-b681-f1d9ad918dac">
