### PR TITLE
Make `Utils#inspectError` use `toString` for `Error`-like values

### DIFF
--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -413,8 +413,8 @@ export function inspectError(err: unknown): string {
     (err as ErrorInfo)?.constructor?.name === 'ErrorInfo' ||
     (err as PartialErrorInfo)?.constructor?.name === 'PartialErrorInfo'
   )
-    return Platform.Config.inspect(err);
-  return (err as Error).toString();
+    return (err as Error).toString();
+  return Platform.Config.inspect(err);
 }
 
 export function inspectBody(body: unknown): string {


### PR DESCRIPTION
This used to be the logic but was (presumably unintentionally) swapped in 1430d68.

Resolves #1390.