### PR TITLE
Rename some misnamed parameters

### DIFF
--- a/src/common/lib/client/paginatedresource.ts
+++ b/src/common/lib/client/paginatedresource.ts
@@ -5,7 +5,7 @@ import ErrorInfo, { IPartialErrorInfo } from '../types/errorinfo';
 import { PaginatedResultCallback } from '../../types/utils';
 import Rest from './rest';
 
-export type BodyHandler = (body: unknown, headers: Record<string, string>, packed?: boolean) => any;
+export type BodyHandler = (body: unknown, headers: Record<string, string>, unpacked?: boolean) => any;
 
 function getRelParams(linkUrl: string) {
   const urlMatch = linkUrl.match(/^\.\/(\w+)\?(.*)$/);

--- a/src/common/types/http.d.ts
+++ b/src/common/types/http.d.ts
@@ -8,7 +8,7 @@ export type RequestCallback = (
   error?: ErrnoException | IPartialErrorInfo | null,
   body?: unknown,
   headers?: IncomingHttpHeaders,
-  packed?: boolean,
+  unpacked?: boolean,
   statusCode?: number
 ) => void;
 export type RequestParams = Record<string, string> | null;

--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -261,7 +261,7 @@ const Http: typeof IHttp = class {
         err?: ErrnoException | ErrorInfo | null,
         responseText?: unknown,
         headers?: any,
-        packed?: boolean,
+        unpacked?: boolean,
         statusCode?: number
       ) {
         if (!err && !connectivityUrlIsDefault) {

--- a/src/platform/web/lib/transport/fetchrequest.ts
+++ b/src/platform/web/lib/transport/fetchrequest.ts
@@ -63,7 +63,7 @@ export default function fetchRequest(
         prom = res.text();
       }
       prom.then((body) => {
-        const packed = !!contentType && contentType.indexOf('application/x-msgpack') === -1;
+        const unpacked = !!contentType && contentType.indexOf('application/x-msgpack') === -1;
         if (!res.ok) {
           const err =
             getAblyError(body, res.headers) ||
@@ -72,9 +72,9 @@ export default function fetchRequest(
               null,
               res.status
             );
-          callback(err, body, res.headers, packed, res.status);
+          callback(err, body, res.headers, unpacked, res.status);
         } else {
-          callback(null, body, res.headers, packed, res.status);
+          callback(null, body, res.headers, unpacked, res.status);
         }
       });
     })

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -100,7 +100,7 @@ const Http: typeof IHttp = class {
               err?: ErrorInfo | ErrnoException | null,
               responseText?: unknown,
               headers?: any,
-              packed?: boolean,
+              unpacked?: boolean,
               statusCode?: number
             ) {
               let result = false;


### PR DESCRIPTION
This renames a couple of parameters that seem to be misnamed and whose names confused me whilst I was trying to figure out how to make a REST request from inside the codebase. See commit messages for more details.