### PR TITLE
[SDK-3717] Add tree-shakable BaseClient and Rest exports

### DIFF
--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -37,3 +37,4 @@ jobs:
           sourcePath: bundle-reports
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           artifactName: bundle-report
+      - run: npm run modulereport

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,6 +111,17 @@ module.exports = function (grunt) {
       target: 'es6',
     };
 
+    var modulesConfig = {
+      ...baseConfig,
+      entryPoints: ['src/platform/web/modules.ts'],
+      outfile: 'build/modules/index.js',
+      format: 'esm',
+      plugins: [],
+    };
+
+    // For reasons I don't understand this build fails when run asynchronously
+    esbuild.buildSync(modulesConfig);
+
     Promise.all([
       esbuild.build(baseConfig),
       esbuild.build({

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts webpack.config.js Gruntfile.js scripts/cdn_deploy.js",
     "sourcemap": "source-map-explorer build/ably.min.js",
     "sourcemap:noencryption": "source-map-explorer build/ably.noencryption.min.js",
+    "modulereport": "node scripts/moduleReport.js",
     "docs": "typedoc --entryPoints ably.d.ts --out docs/generated --readme docs/landing-page.md"
   }
 }

--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -1,0 +1,37 @@
+const esbuild = require('esbuild');
+
+// List of all modules accepted in ModulesMap
+const moduleNames = ['Rest'];
+
+function formatBytes(bytes) {
+  const kb = bytes / 1024;
+  const formatted = kb.toFixed(2);
+  return `${formatted}kb`;
+}
+
+// Gets the bundled size of an array of named exports from 'ably/modules' formatted as a string
+function getImportSize(modules) {
+  const outfile = modules.join('');
+  const result = esbuild.buildSync({
+    stdin: {
+      contents: `export { ${modules.join(', ')} } from './build/modules'`,
+      resolveDir: '.',
+    },
+    metafile: true,
+    minify: true,
+    bundle: true,
+    outfile,
+    write: false,
+  });
+
+  return formatBytes(result.metafile.outputs[outfile].bytes);
+}
+
+// First display the size of the BaseClient
+console.log(`BaseClient: ${getImportSize(['BaseClient'])}`);
+
+// Then display the size of each module together with the BaseClient
+moduleNames.forEach((moduleName) => {
+  const sizeInBytes = getImportSize(['BaseClient', moduleName]);
+  console.log(`BaseClient + ${moduleName}: ${sizeInBytes}`);
+});

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -5,11 +5,10 @@ import ErrorInfo, { IPartialErrorInfo } from '../types/errorinfo';
 import { ErrnoException, RequestCallback, RequestParams } from '../../types/http';
 import * as API from '../../../../ably';
 import { StandardCallback } from '../../types/utils';
-import Rest from './rest';
-import Realtime from './realtime';
 import ClientOptions from '../../types/ClientOptions';
 import HttpMethods from '../../constants/HttpMethods';
 import Platform from '../../platform';
+import { BaseClient } from './baseclient';
 import Defaults from '../util/defaults';
 
 const MAX_TOKEN_LENGTH = Math.pow(2, 17);
@@ -101,7 +100,7 @@ function getTokenRequestId() {
 }
 
 class Auth {
-  client: Rest | Realtime;
+  client: BaseClient;
   tokenParams: API.Types.TokenParams;
   currentTokenRequestId: number | null;
   waitingForTokenRequest: ReturnType<typeof Multicaster.create> | null;
@@ -113,7 +112,7 @@ class Auth {
   basicKey?: string;
   clientId?: string | null;
 
-  constructor(client: Rest | Realtime, options: ClientOptions) {
+  constructor(client: BaseClient, options: ClientOptions) {
     this.client = client;
     this.tokenParams = options.defaultTokenParams || {};
     /* The id of the current token request if one is in progress, else null */
@@ -274,7 +273,7 @@ class Auth {
             /* We interpret RSA4d as including requests made by a client lib to
              * authenticate triggered by an explicit authorize() or an AUTH received from
              * ably, not just connect-sequence-triggered token fetches */
-            (this.client as Realtime).connection.connectionManager.actOnErrorFromAuthorize(err);
+            this.client.connection.connectionManager.actOnErrorFromAuthorize(err);
           }
           callback?.(err);
           return;

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -18,10 +18,6 @@ function random() {
   return ('000000' + Math.floor(Math.random() * 1e16)).slice(-16);
 }
 
-function isRealtime(client: Rest | Realtime): client is Realtime {
-  return !!(client as Realtime).connection;
-}
-
 /* A client auth callback may give errors in any number of formats; normalise to an ErrorInfo or PartialErrorInfo */
 function normaliseAuthcallbackError(err: any) {
   if (!Utils.isErrorInfoOrPartialErrorInfo(err)) {
@@ -274,7 +270,7 @@ class Auth {
       _authOptions,
       (err: ErrorInfo, tokenDetails: API.Types.TokenDetails) => {
         if (err) {
-          if ((this.client as Realtime).connection) {
+          if (Utils.isRealtime(this.client)) {
             /* We interpret RSA4d as including requests made by a client lib to
              * authenticate triggered by an explicit authorize() or an AUTH received from
              * ably, not just connect-sequence-triggered token fetches */
@@ -289,7 +285,7 @@ class Auth {
          * don't call back till new token has taken effect.
          * - Use this.client.connection as a proxy for (this.client instanceof Realtime),
          * which doesn't work in node as Realtime isn't part of the vm context for Rest clients */
-        if (isRealtime(this.client)) {
+        if (Utils.isRealtime(this.client)) {
           this.client.connection.connectionManager.onAuthUpdated(tokenDetails, callback || noop);
         } else {
           callback?.(null, tokenDetails);

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -10,6 +10,7 @@ import Realtime from './realtime';
 import ClientOptions from '../../types/ClientOptions';
 import HttpMethods from '../../constants/HttpMethods';
 import Platform from '../../platform';
+import Defaults from '../util/defaults';
 
 const MAX_TOKEN_LENGTH = Math.pow(2, 17);
 function noop() {}
@@ -575,7 +576,7 @@ class Auth {
           return client.baseUri(host) + path;
         };
 
-      const requestHeaders = Utils.defaultPostHeaders(this.client.options);
+      const requestHeaders = Defaults.defaultPostHeaders(this.client.options);
       if (authOptions.requestHeaders) Utils.mixin(requestHeaders, authOptions.requestHeaders);
       Logger.logAction(
         Logger.LOG_MICRO,

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -75,7 +75,7 @@ class BaseClient {
     this.http = new Platform.Http(normalOptions);
     this.auth = new Auth(this, normalOptions);
 
-    if (modules?.Rest) {
+    if (modules.Rest) {
       this._rest = new modules.Rest(this);
     }
   }

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -1,0 +1,128 @@
+import Logger, { LoggerOptions } from '../util/logger';
+import Defaults from '../util/defaults';
+import Auth from './auth';
+import ErrorInfo from '../types/errorinfo';
+import Stats from '../types/stats';
+import { StandardCallback } from '../../types/utils';
+import { IHttp, RequestParams } from '../../types/http';
+import ClientOptions, { NormalisedClientOptions } from '../../types/ClientOptions';
+
+import Platform from '../../platform';
+import Rest from './rest';
+import { HttpPaginatedResponse, PaginatedResult } from './paginatedresource';
+
+interface ModulesMap {
+  Rest?: typeof Rest;
+}
+
+class BaseClient {
+  options: NormalisedClientOptions;
+  baseUri: (host: string) => string;
+  authority: (host: string) => string;
+  _currentFallback: null | {
+    host: string;
+    validUntil: number;
+  };
+  serverTimeOffset: number | null;
+  http: IHttp;
+  auth: Auth;
+  _rest?: Rest;
+
+  constructor(options: ClientOptions | string, modules: ModulesMap) {
+    if (!options) {
+      const msg = 'no options provided';
+      Logger.logAction(Logger.LOG_ERROR, 'Rest()', msg);
+      throw new Error(msg);
+    }
+    const optionsObj = Defaults.objectifyOptions(options);
+
+    Logger.setLog(optionsObj.logLevel, optionsObj.logHandler);
+    Logger.logAction(Logger.LOG_MICRO, 'Rest()', 'initialized with clientOptions ' + Platform.Config.inspect(options));
+
+    const normalOptions = (this.options = Defaults.normaliseOptions(optionsObj));
+
+    /* process options */
+    if (normalOptions.key) {
+      const keyMatch = normalOptions.key.match(/^([^:\s]+):([^:.\s]+)$/);
+      if (!keyMatch) {
+        const msg = 'invalid key parameter';
+        Logger.logAction(Logger.LOG_ERROR, 'Rest()', msg);
+        throw new ErrorInfo(msg, 40400, 404);
+      }
+      normalOptions.keyName = keyMatch[1];
+      normalOptions.keySecret = keyMatch[2];
+    }
+
+    if ('clientId' in normalOptions) {
+      if (!(typeof normalOptions.clientId === 'string' || normalOptions.clientId === null))
+        throw new ErrorInfo('clientId must be either a string or null', 40012, 400);
+      else if (normalOptions.clientId === '*')
+        throw new ErrorInfo(
+          'Can’t use "*" as a clientId as that string is reserved. (To change the default token request behaviour to use a wildcard clientId, use {defaultTokenParams: {clientId: "*"}})',
+          40012,
+          400
+        );
+    }
+
+    Logger.logAction(Logger.LOG_MINOR, 'Rest()', 'started; version = ' + Defaults.version);
+
+    this.baseUri = this.authority = function (host) {
+      return Defaults.getHttpScheme(normalOptions) + host + ':' + Defaults.getPort(normalOptions, false);
+    };
+    this._currentFallback = null;
+
+    this.serverTimeOffset = null;
+    this.http = new Platform.Http(normalOptions);
+    this.auth = new Auth(this, normalOptions);
+
+    if (modules?.Rest) {
+      this._rest = new modules.Rest(this);
+    }
+  }
+
+  private get rest(): Rest {
+    if (!this._rest) {
+      throw new ErrorInfo('Rest module not provided', 400, 40000);
+    }
+    return this._rest;
+  }
+
+  get channels() {
+    return this.rest.channels;
+  }
+
+  get push() {
+    return this.rest.push;
+  }
+
+  stats(
+    params: RequestParams,
+    callback: StandardCallback<PaginatedResult<Stats>>
+  ): Promise<PaginatedResult<Stats>> | void {
+    return this.rest.stats(params, callback);
+  }
+
+  time(params?: RequestParams | StandardCallback<number>, callback?: StandardCallback<number>): Promise<number> | void {
+    return this.rest.time(params, callback);
+  }
+
+  request(
+    method: string,
+    path: string,
+    version: number,
+    params: RequestParams,
+    body: unknown,
+    customHeaders: Record<string, string>,
+    callback: StandardCallback<HttpPaginatedResponse<unknown>>
+  ): Promise<HttpPaginatedResponse<unknown>> | void {
+    return this.rest.request(method, path, version, params, body, customHeaders, callback);
+  }
+
+  setLog(logOptions: LoggerOptions): void {
+    Logger.setLog(logOptions.level, logOptions.handler);
+  }
+
+  static Platform = Platform;
+}
+
+export { BaseClient };

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -12,6 +12,7 @@ import Rest from './rest';
 import Realtime from './realtime';
 import * as API from '../../../../ably';
 import Platform from 'common/platform';
+import Defaults from '../util/defaults';
 
 interface RestHistoryParams {
   start?: number;
@@ -89,7 +90,7 @@ class Channel extends EventEmitter {
     const rest = this.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+      headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     Utils.mixin(headers, rest.options.headers);
 
@@ -142,7 +143,7 @@ class Channel extends EventEmitter {
       options = rest.options,
       format = options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       idempotentRestPublishing = rest.options.idempotentRestPublishing,
-      headers = Utils.defaultPostHeaders(rest.options, { format });
+      headers = Defaults.defaultPostHeaders(rest.options, { format });
 
     Utils.mixin(headers, options.headers);
 
@@ -191,7 +192,7 @@ class Channel extends EventEmitter {
     }
 
     const format = this.rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json;
-    const headers = Utils.defaultPostHeaders(this.rest.options, { format });
+    const headers = Defaults.defaultPostHeaders(this.rest.options, { format });
 
     Resource.get<API.Types.ChannelDetails>(this.rest, this.basePath, headers, {}, format, callback || noop);
   }

--- a/src/common/lib/client/defaultrest.ts
+++ b/src/common/lib/client/defaultrest.ts
@@ -1,0 +1,24 @@
+import Platform from 'common/platform';
+import ClientOptions from 'common/types/ClientOptions';
+import Message from '../types/message';
+import PresenceMessage from '../types/presencemessage';
+import { BaseClient } from './baseclient';
+import Rest from './rest';
+
+/**
+ * Preloaded BaseClient with all REST features, used as the default non-treeshakeable Rest export
+ */
+class DefaultRest extends BaseClient {
+  constructor(options: string | ClientOptions) {
+    super(options, {
+      Rest,
+    });
+  }
+
+  static Platform = Platform;
+  static Crypto?: typeof Platform.Crypto;
+  static Message = Message;
+  static PresenceMessage = PresenceMessage;
+}
+
+export { DefaultRest };

--- a/src/common/lib/client/defaultrest.ts
+++ b/src/common/lib/client/defaultrest.ts
@@ -15,7 +15,6 @@ class DefaultRest extends BaseClient {
     });
   }
 
-  static Platform = Platform;
   static Crypto?: typeof Platform.Crypto;
   static Message = Message;
   static PresenceMessage = PresenceMessage;

--- a/src/common/lib/client/paginatedresource.ts
+++ b/src/common/lib/client/paginatedresource.ts
@@ -3,7 +3,7 @@ import Logger from '../util/logger';
 import Resource from './resource';
 import ErrorInfo, { IPartialErrorInfo } from '../types/errorinfo';
 import { PaginatedResultCallback } from '../../types/utils';
-import Rest from './rest';
+import { BaseClient } from './baseclient';
 
 export type BodyHandler = (body: unknown, headers: Record<string, string>, packed?: boolean) => Promise<any>;
 
@@ -35,7 +35,7 @@ function returnErrOnly(err: IPartialErrorInfo, body: unknown, useHPR?: boolean) 
 }
 
 class PaginatedResource {
-  rest: Rest;
+  client: BaseClient;
   path: string;
   headers: Record<string, string>;
   envelope: Utils.Format | null;
@@ -43,14 +43,14 @@ class PaginatedResource {
   useHttpPaginatedResponse: boolean;
 
   constructor(
-    rest: Rest,
+    client: BaseClient,
     path: string,
     headers: Record<string, string>,
     envelope: Utils.Format | undefined,
     bodyHandler: BodyHandler,
     useHttpPaginatedResponse?: boolean
   ) {
-    this.rest = rest;
+    this.client = client;
     this.path = path;
     this.headers = headers;
     this.envelope = envelope ?? null;
@@ -60,7 +60,7 @@ class PaginatedResource {
 
   get<T1, T2>(params: Record<string, T2>, callback: PaginatedResultCallback<T1>): void {
     Resource.get(
-      this.rest,
+      this.client,
       this.path,
       this.headers,
       params,
@@ -73,7 +73,7 @@ class PaginatedResource {
 
   delete<T1, T2>(params: Record<string, T2>, callback: PaginatedResultCallback<T1>): void {
     Resource.delete(
-      this.rest,
+      this.client,
       this.path,
       this.headers,
       params,
@@ -86,7 +86,7 @@ class PaginatedResource {
 
   post<T1, T2>(params: Record<string, T2>, body: unknown, callback: PaginatedResultCallback<T1>): void {
     Resource.post(
-      this.rest,
+      this.client,
       this.path,
       body,
       this.headers,
@@ -102,7 +102,7 @@ class PaginatedResource {
 
   put<T1, T2>(params: Record<string, T2>, body: unknown, callback: PaginatedResultCallback<T1>): void {
     Resource.put(
-      this.rest,
+      this.client,
       this.path,
       body,
       this.headers,
@@ -118,7 +118,7 @@ class PaginatedResource {
 
   patch<T1, T2>(params: Record<string, T2>, body: unknown, callback: PaginatedResultCallback<T1>): void {
     Resource.patch(
-      this.rest,
+      this.client,
       this.path,
       body,
       this.headers,
@@ -234,7 +234,7 @@ export class PaginatedResult<T> {
   get(params: any, callback: PaginatedResultCallback<T>): void {
     const res = this.resource;
     Resource.get(
-      res.rest,
+      res.client,
       res.path,
       res.headers,
       params,

--- a/src/common/lib/client/presence.ts
+++ b/src/common/lib/client/presence.ts
@@ -30,15 +30,15 @@ class Presence extends EventEmitter {
         return Utils.promisify(this, 'get', arguments);
       }
     }
-    const rest = this.channel.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.channel.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Defaults.defaultGetHeaders(rest.options, { format });
+    const client = this.channel.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.channel.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
     const options = this.channel.channelOptions;
-    new PaginatedResource(rest, this.basePath, headers, envelope, async function (
+    new PaginatedResource(client, this.basePath, headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -69,9 +69,9 @@ class Presence extends EventEmitter {
       }
     }
 
-    const rest = this.channel.rest,
+    const rest = this.channel.client,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.channel.rest.http.supportsLinkHeaders ? undefined : format,
+      envelope = this.channel.client.http.supportsLinkHeaders ? undefined : format,
       headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     Utils.mixin(headers, rest.options.headers);

--- a/src/common/lib/client/presence.ts
+++ b/src/common/lib/client/presence.ts
@@ -7,6 +7,7 @@ import { CipherOptions } from '../types/message';
 import { PaginatedResultCallback } from '../../types/utils';
 import Channel from './channel';
 import RealtimeChannel from './realtimechannel';
+import Defaults from '../util/defaults';
 
 class Presence extends EventEmitter {
   channel: RealtimeChannel | Channel;
@@ -32,7 +33,7 @@ class Presence extends EventEmitter {
     const rest = this.channel.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.channel.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+      headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     Utils.mixin(headers, rest.options.headers);
 
@@ -71,7 +72,7 @@ class Presence extends EventEmitter {
     const rest = this.channel.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.channel.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+      headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     Utils.mixin(headers, rest.options.headers);
 

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -6,6 +6,7 @@ import ErrorInfo from '../types/errorinfo';
 import PushChannelSubscription from '../types/pushchannelsubscription';
 import { ErrCallback, PaginatedResultCallback, StandardCallback } from '../../types/utils';
 import Rest from './rest';
+import Defaults from '../util/defaults';
 
 class Push {
   rest: Rest;
@@ -31,7 +32,7 @@ class Admin {
   publish(recipient: any, payload: any, callback: ErrCallback) {
     const rest = this.rest;
     const format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(rest.options, { format }),
+      headers = Defaults.defaultPostHeaders(rest.options, { format }),
       params = {};
     const body = Utils.mixin({ recipient: recipient }, payload);
 
@@ -59,7 +60,7 @@ class DeviceRegistrations {
     const rest = this.rest;
     const body = DeviceDetails.fromValues(device);
     const format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(rest.options, { format }),
+      headers = Defaults.defaultPostHeaders(rest.options, { format }),
       params = {};
 
     if (typeof callback !== 'function') {
@@ -95,7 +96,7 @@ class DeviceRegistrations {
   get(deviceIdOrDetails: any, callback: StandardCallback<DeviceDetails>) {
     const rest = this.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(rest.options, { format }),
+      headers = Defaults.defaultGetHeaders(rest.options, { format }),
       deviceId = deviceIdOrDetails.id || deviceIdOrDetails;
 
     if (typeof callback !== 'function') {
@@ -139,7 +140,7 @@ class DeviceRegistrations {
     const rest = this.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+      headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'list', arguments);
@@ -159,7 +160,7 @@ class DeviceRegistrations {
   remove(deviceIdOrDetails: any, callback: ErrCallback) {
     const rest = this.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(rest.options, { format }),
+      headers = Defaults.defaultGetHeaders(rest.options, { format }),
       params = {},
       deviceId = deviceIdOrDetails.id || deviceIdOrDetails;
 
@@ -195,7 +196,7 @@ class DeviceRegistrations {
   removeWhere(params: any, callback: ErrCallback) {
     const rest = this.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+      headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'removeWhere', arguments);
@@ -220,7 +221,7 @@ class ChannelSubscriptions {
     const rest = this.rest;
     const body = PushChannelSubscription.fromValues(subscription);
     const format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(rest.options, { format }),
+      headers = Defaults.defaultPostHeaders(rest.options, { format }),
       params = {};
 
     if (typeof callback !== 'function') {
@@ -252,7 +253,7 @@ class ChannelSubscriptions {
     const rest = this.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+      headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'list', arguments);
@@ -272,7 +273,7 @@ class ChannelSubscriptions {
   removeWhere(params: any, callback: PaginatedResultCallback<unknown>) {
     const rest = this.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+      headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'removeWhere', arguments);
@@ -292,7 +293,7 @@ class ChannelSubscriptions {
     const rest = this.rest,
       format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+      headers = Defaults.defaultGetHeaders(rest.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'listChannels', arguments);

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -45,7 +45,7 @@ class Admin {
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
     const requestBody = Utils.encodeBody(body, format);
-    Resource.post(rest, '/push/publish', requestBody, headers, params, null, (err) => callback(err));
+    Resource.post(rest.client, '/push/publish', requestBody, headers, params, null, (err) => callback(err));
   }
 }
 
@@ -73,7 +73,7 @@ class DeviceRegistrations {
 
     const requestBody = Utils.encodeBody(body, format);
     Resource.put(
-      rest,
+      rest.client,
       '/push/deviceRegistrations/' + encodeURIComponent(device.id),
       requestBody,
       headers,
@@ -117,7 +117,7 @@ class DeviceRegistrations {
     Utils.mixin(headers, rest.options.headers);
 
     Resource.get(
-      rest,
+      rest.client,
       '/push/deviceRegistrations/' + encodeURIComponent(deviceId),
       headers,
       {},
@@ -148,7 +148,7 @@ class DeviceRegistrations {
 
     Utils.mixin(headers, rest.options.headers);
 
-    new PaginatedResource(rest, '/push/deviceRegistrations', headers, envelope, async function (
+    new PaginatedResource(rest.client, '/push/deviceRegistrations', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -184,7 +184,7 @@ class DeviceRegistrations {
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
     Resource['delete'](
-      rest,
+      rest.client,
       '/push/deviceRegistrations/' + encodeURIComponent(deviceId),
       headers,
       params,
@@ -206,7 +206,7 @@ class DeviceRegistrations {
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
-    Resource['delete'](rest, '/push/deviceRegistrations', headers, params, null, (err) => callback(err));
+    Resource['delete'](rest.client, '/push/deviceRegistrations', headers, params, null, (err) => callback(err));
   }
 }
 
@@ -234,7 +234,7 @@ class ChannelSubscriptions {
 
     const requestBody = Utils.encodeBody(body, format);
     Resource.post(
-      rest,
+      rest.client,
       '/push/channelSubscriptions',
       requestBody,
       headers,
@@ -261,7 +261,7 @@ class ChannelSubscriptions {
 
     Utils.mixin(headers, rest.options.headers);
 
-    new PaginatedResource(rest, '/push/channelSubscriptions', headers, envelope, async function (
+    new PaginatedResource(rest.client, '/push/channelSubscriptions', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -283,7 +283,7 @@ class ChannelSubscriptions {
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
-    Resource['delete'](rest, '/push/channelSubscriptions', headers, params, null, (err) => callback(err));
+    Resource['delete'](rest.client, '/push/channelSubscriptions', headers, params, null, (err) => callback(err));
   }
 
   /* ChannelSubscriptions have no unique id; removing one is equivalent to removeWhere by its properties */
@@ -303,7 +303,7 @@ class ChannelSubscriptions {
 
     if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
-    new PaginatedResource(rest, '/push/channels', headers, envelope, async function (
+    new PaginatedResource(rest.client, '/push/channels', headers, envelope, async function (
       body: unknown,
       headers: Record<string, string>,
       unpacked?: boolean

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -1,5 +1,5 @@
 import * as Utils from '../util/utils';
-import Rest from './rest';
+import { DefaultRest as Rest } from './defaultrest';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
 import Connection from './connection';
@@ -14,15 +14,19 @@ import Platform from 'common/platform';
 import Message from '../types/message';
 
 class Realtime extends Rest {
-  channels: any;
+  _channels: any;
   connection: Connection;
 
   constructor(options: ClientOptions) {
     super(options);
     Logger.logAction(Logger.LOG_MINOR, 'Realtime()', '');
     this.connection = new Connection(this, this.options);
-    this.channels = new Channels(this);
+    this._channels = new Channels(this);
     if (options.autoConnect !== false) this.connect();
+  }
+
+  get channels() {
+    return this._channels;
   }
 
   connect(): void {

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -1,7 +1,5 @@
 import * as Utils from '../util/utils';
 import Logger, { LoggerOptions } from '../util/logger';
-import Defaults from '../util/defaults';
-import Auth from './auth';
 import Push from './push';
 import PaginatedResource, { HttpPaginatedResponse, PaginatedResult } from './paginatedresource';
 import Channel from './channel';
@@ -15,7 +13,7 @@ import ClientOptions, { NormalisedClientOptions } from '../../types/ClientOption
 
 import Platform from '../../platform';
 import Message from '../types/message';
-import PresenceMessage from '../types/presencemessage';
+import Defaults from '../util/defaults';
 
 const noop = function () {};
 class Rest {
@@ -95,7 +93,7 @@ class Rest {
         return Utils.promisify(this, 'stats', [params]) as Promise<PaginatedResult<Stats>>;
       }
     }
-    const headers = Utils.defaultGetHeaders(this.options),
+    const headers = Defaults.defaultGetHeaders(this.options),
       format = this.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.http.supportsLinkHeaders ? undefined : format;
 
@@ -125,7 +123,7 @@ class Rest {
 
     const _callback = callback || noop;
 
-    const headers = Utils.defaultGetHeaders(this.options);
+    const headers = Defaults.defaultGetHeaders(this.options);
     if (this.options.headers) Utils.mixin(headers, this.options.headers);
     const timeUri = (host: string) => {
       return this.authority(host) + '/time';
@@ -178,8 +176,8 @@ class Rest {
     const _method = method.toLowerCase() as HttpMethods;
     const headers =
       _method == 'get'
-        ? Utils.defaultGetHeaders(this.options, { format, protocolVersion: version })
-        : Utils.defaultPostHeaders(this.options, { format, protocolVersion: version });
+        ? Defaults.defaultGetHeaders(this.options, { format, protocolVersion: version })
+        : Defaults.defaultPostHeaders(this.options, { format, protocolVersion: version });
 
     if (callback === undefined) {
       return Utils.promisify(this, 'request', [method, path, version, params, body, customHeaders]) as Promise<

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -42,6 +42,8 @@ type CompleteDefaults = IDefaults & {
   getRealtimeHost(options: ClientOptions, production: boolean, environment: string): string;
   objectifyOptions(options: ClientOptions | string): ClientOptions;
   normaliseOptions(options: InternalClientOptions): NormalisedClientOptions;
+  defaultGetHeaders(options: NormalisedClientOptions, headersOptions?: HeadersOptions): Record<string, string>;
+  defaultPostHeaders(options: NormalisedClientOptions, headersOptions?: HeadersOptions): Record<string, string>;
 };
 
 const Defaults = {
@@ -87,6 +89,8 @@ const Defaults = {
   checkHost,
   objectifyOptions,
   normaliseOptions,
+  defaultGetHeaders,
+  defaultPostHeaders,
 };
 
 export function getHost(options: ClientOptions, host?: string | null, ws?: boolean): string {
@@ -257,6 +261,56 @@ export function normaliseOptions(options: InternalClientOptions): NormalisedClie
     connectivityCheckParams,
     connectivityCheckUrl,
     headers,
+  };
+}
+
+const contentTypes = {
+  json: 'application/json',
+  xml: 'application/xml',
+  html: 'text/html',
+  msgpack: 'application/x-msgpack',
+};
+
+export interface HeadersOptions {
+  format?: Utils.Format;
+  protocolVersion?: number;
+}
+
+const defaultHeadersOptions: Required<HeadersOptions> = {
+  format: Utils.Format.json,
+  protocolVersion: Defaults.protocolVersion,
+};
+
+export function defaultGetHeaders(
+  options: NormalisedClientOptions,
+  {
+    format = defaultHeadersOptions.format,
+    protocolVersion = defaultHeadersOptions.protocolVersion,
+  }: HeadersOptions = {}
+): Record<string, string> {
+  const accept = contentTypes[format];
+  return {
+    accept: accept,
+    'X-Ably-Version': protocolVersion.toString(),
+    'Ably-Agent': getAgentString(options),
+  };
+}
+
+export function defaultPostHeaders(
+  options: NormalisedClientOptions,
+  {
+    format = defaultHeadersOptions.format,
+    protocolVersion = defaultHeadersOptions.protocolVersion,
+  }: HeadersOptions = {}
+): Record<string, string> {
+  let contentType;
+  const accept = (contentType = contentTypes[format]);
+
+  return {
+    accept: accept,
+    'content-type': contentType,
+    'X-Ably-Version': protocolVersion.toString(),
+    'Ably-Agent': getAgentString(options),
   };
 }
 

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -1,7 +1,7 @@
 import Platform from 'common/platform';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
 import Realtime from '../client/realtime';
-import Rest from '../client/rest';
+import { BaseClient } from '../client/baseclient';
 
 function randomPosn(arrOrStr: Array<unknown> | string) {
   return Math.floor(Math.random() * arrOrStr.length);
@@ -531,6 +531,6 @@ export function toBase64(str: string) {
   return bufferUtils.base64Encode(textBuffer);
 }
 
-export function isRealtime(client: Rest | Realtime): client is Realtime {
+export function isRealtime(client: BaseClient): client is Realtime {
   return !!(client as Realtime).connection;
 }

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -1,5 +1,7 @@
 import Platform from 'common/platform';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
+import Realtime from '../client/realtime';
+import Rest from '../client/rest';
 
 function randomPosn(arrOrStr: Array<unknown> | string) {
   return Math.floor(Math.random() * arrOrStr.length);
@@ -527,4 +529,8 @@ export function toBase64(str: string) {
   const bufferUtils = Platform.BufferUtils;
   const textBuffer = bufferUtils.utf8Encode(str);
   return bufferUtils.base64Encode(textBuffer);
+}
+
+export function isRealtime(client: Rest | Realtime): client is Realtime {
+  return !!(client as Realtime).connection;
 }

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -1,7 +1,5 @@
 import Platform from 'common/platform';
-import Defaults, { getAgentString } from './defaults';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
-import { NormalisedClientOptions } from 'common/types/ClientOptions';
 
 function randomPosn(arrOrStr: Array<unknown> | string) {
   return Math.floor(Math.random() * arrOrStr.length);
@@ -330,59 +328,9 @@ export function allSame(arr: Array<Record<string, unknown>>, prop: string): bool
   });
 }
 
-const contentTypes = {
-  json: 'application/json',
-  xml: 'application/xml',
-  html: 'text/html',
-  msgpack: 'application/x-msgpack',
-};
-
 export enum Format {
   msgpack = 'msgpack',
   json = 'json',
-}
-
-export interface HeadersOptions {
-  format?: Format;
-  protocolVersion?: number;
-}
-
-const defaultHeadersOptions: Required<HeadersOptions> = {
-  format: Format.json,
-  protocolVersion: Defaults.protocolVersion,
-};
-
-export function defaultGetHeaders(
-  options: NormalisedClientOptions,
-  {
-    format = defaultHeadersOptions.format,
-    protocolVersion = defaultHeadersOptions.protocolVersion,
-  }: HeadersOptions = {}
-): Record<string, string> {
-  const accept = contentTypes[format];
-  return {
-    accept: accept,
-    'X-Ably-Version': protocolVersion.toString(),
-    'Ably-Agent': getAgentString(options),
-  };
-}
-
-export function defaultPostHeaders(
-  options: NormalisedClientOptions,
-  {
-    format = defaultHeadersOptions.format,
-    protocolVersion = defaultHeadersOptions.protocolVersion,
-  }: HeadersOptions = {}
-): Record<string, string> {
-  let contentType;
-  const accept = (contentType = contentTypes[format]);
-
-  return {
-    accept: accept,
-    'content-type': contentType,
-    'X-Ably-Version': protocolVersion.toString(),
-    'Ably-Agent': getAgentString(options),
-  };
 }
 
 export function arrPopRandomElement<T>(arr: Array<T>): T {

--- a/src/common/types/http.d.ts
+++ b/src/common/types/http.d.ts
@@ -2,6 +2,7 @@ import HttpMethods from '../constants/HttpMethods';
 import Rest from '../lib/client/rest';
 import ErrorInfo from '../lib/types/errorinfo';
 import { Agents } from 'got';
+import { BaseClient } from 'common/lib/client/baseclient';
 
 export type PathParameter = string | ((host: string) => string);
 export type RequestCallback = (
@@ -25,7 +26,7 @@ export declare class IHttp {
 
   Request?: (
     method: HttpMethods,
-    rest: Rest | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     params: RequestParams,
@@ -35,7 +36,7 @@ export declare class IHttp {
   _getHosts: (client: Rest | Realtime) => string[];
   do(
     method: HttpMethods,
-    rest: Rest | null,
+    client: BaseClient | null,
     path: PathParameter,
     headers: Record<string, string> | null,
     body: unknown,
@@ -44,7 +45,7 @@ export declare class IHttp {
   ): void;
   doUri(
     method: HttpMethods,
-    rest: Rest | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     body: unknown,

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -1,5 +1,5 @@
 // Common
-import Rest from '../../common/lib/client/rest';
+import { DefaultRest as Rest } from '../../common/lib/client/defaultrest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
 

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -1,5 +1,5 @@
 // Common
-import Rest from '../../common/lib/client/rest';
+import { DefaultRest as Rest } from '../../common/lib/client/defaultrest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
 

--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -6,11 +6,10 @@ import HttpMethods from '../../../../common/constants/HttpMethods';
 import got, { Response, Options, CancelableRequest, Agents } from 'got';
 import http from 'http';
 import https from 'https';
-import Rest from 'common/lib/client/rest';
-import Realtime from 'common/lib/client/realtime';
 import { NormalisedClientOptions, RestAgentOptions } from 'common/types/ClientOptions';
 import { isSuccessCode } from 'common/constants/HttpStatusCodes';
 import { shallowEquals, isRealtime } from 'common/lib/util/utils';
+import { BaseClient } from 'common/lib/client/baseclient';
 
 /***************************************************
  *
@@ -74,7 +73,7 @@ function shouldFallback(err: ErrnoException) {
   );
 }
 
-function getHosts(client: Rest | Realtime): string[] {
+function getHosts(client: BaseClient): string[] {
   /* If we're a connected realtime client, try the endpoint we're connected
    * to first -- but still have fallbacks, being connected is not an absolute
    * guarantee that a datacenter has free capacity to service REST requests. */
@@ -105,7 +104,7 @@ const Http: typeof IHttp = class {
   /* Unlike for doUri, the 'rest' param here is mandatory, as it's used to generate the hosts */
   do(
     method: HttpMethods,
-    rest: Rest,
+    client: BaseClient,
     path: PathParameter,
     headers: Record<string, string> | null,
     body: unknown,
@@ -116,16 +115,16 @@ const Http: typeof IHttp = class {
       typeof path === 'function'
         ? path
         : function (host: string) {
-            return rest.baseUri(host) + path;
+            return client.baseUri(host) + path;
           };
 
-    const currentFallback = rest._currentFallback;
+    const currentFallback = client._currentFallback;
     if (currentFallback) {
       if (currentFallback.validUntil > Date.now()) {
         /* Use stored fallback */
         this.doUri(
           method,
-          rest,
+          client,
           uriFromHost(currentFallback.host),
           headers,
           body,
@@ -133,8 +132,8 @@ const Http: typeof IHttp = class {
           (err?: ErrnoException | ErrorInfo | null, ...args: unknown[]) => {
             if (err && shouldFallback(err as ErrnoException)) {
               /* unstore the fallback and start from the top with the default sequence */
-              rest._currentFallback = null;
-              this.do(method, rest, path, headers, body, params, callback);
+              client._currentFallback = null;
+              this.do(method, client, path, headers, body, params, callback);
               return;
             }
             callback(err, ...args);
@@ -143,15 +142,15 @@ const Http: typeof IHttp = class {
         return;
       } else {
         /* Fallback expired; remove it and fallthrough to normal sequence */
-        rest._currentFallback = null;
+        client._currentFallback = null;
       }
     }
 
-    const hosts = getHosts(rest);
+    const hosts = getHosts(client);
 
     /* see if we have one or more than one host */
     if (hosts.length === 1) {
-      this.doUri(method, rest, uriFromHost(hosts[0]), headers, body, params, callback);
+      this.doUri(method, client, uriFromHost(hosts[0]), headers, body, params, callback);
       return;
     }
 
@@ -159,7 +158,7 @@ const Http: typeof IHttp = class {
       const host = candidateHosts.shift();
       this.doUri(
         method,
-        rest,
+        client,
         uriFromHost(host as string),
         headers,
         body,
@@ -171,9 +170,9 @@ const Http: typeof IHttp = class {
           }
           if (persistOnSuccess) {
             /* RSC15f */
-            rest._currentFallback = {
+            client._currentFallback = {
               host: host as string,
-              validUntil: Date.now() + rest.options.timeouts.fallbackRetryTimeout,
+              validUntil: Date.now() + client.options.timeouts.fallbackRetryTimeout,
             };
           }
           callback(err, ...args);
@@ -185,7 +184,7 @@ const Http: typeof IHttp = class {
 
   doUri(
     method: HttpMethods,
-    rest: Rest,
+    client: BaseClient,
     uri: string,
     headers: Record<string, string> | null,
     body: unknown,
@@ -195,7 +194,7 @@ const Http: typeof IHttp = class {
     /* Will generally be making requests to one or two servers exclusively
      * (Ably and perhaps an auth server), so for efficiency, use the
      * foreverAgent to keep the TCP stream alive between requests where possible */
-    const agentOptions = (rest && rest.options.restAgentOptions) || (Defaults.restAgentOptions as RestAgentOptions);
+    const agentOptions = (client && client.options.restAgentOptions) || (Defaults.restAgentOptions as RestAgentOptions);
     const doOptions: Options = { headers: headers || undefined, responseType: 'buffer' };
 
     if (!this.agent) {
@@ -222,7 +221,7 @@ const Http: typeof IHttp = class {
     doOptions.agent = this.agent;
 
     doOptions.url = uri;
-    doOptions.timeout = { request: ((rest && rest.options.timeouts) || Defaults.TIMEOUTS).httpRequestTimeout };
+    doOptions.timeout = { request: ((client && client.options.timeouts) || Defaults.TIMEOUTS).httpRequestTimeout };
     // We have our own logic that retries appropriate statuscodes to fallback endpoints,
     // with timeouts constructed appropriately. Don't want `got` doing its own retries to
     // the same endpoint, inappropriately retrying 429s, etc
@@ -275,7 +274,7 @@ const Http: typeof IHttp = class {
 
   Request?: (
     method: HttpMethods,
-    rest: Rest | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     params: RequestParams,

--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -10,7 +10,7 @@ import Rest from 'common/lib/client/rest';
 import Realtime from 'common/lib/client/realtime';
 import { NormalisedClientOptions, RestAgentOptions } from 'common/types/ClientOptions';
 import { isSuccessCode } from 'common/constants/HttpStatusCodes';
-import { shallowEquals } from 'common/lib/util/utils';
+import { shallowEquals, isRealtime } from 'common/lib/util/utils';
 
 /***************************************************
  *
@@ -78,11 +78,11 @@ function getHosts(client: Rest | Realtime): string[] {
   /* If we're a connected realtime client, try the endpoint we're connected
    * to first -- but still have fallbacks, being connected is not an absolute
    * guarantee that a datacenter has free capacity to service REST requests. */
-  const connection = (client as Realtime).connection;
-  const connectionHost = connection && connection.connectionManager.host;
-
-  if (connectionHost) {
-    return [connectionHost].concat(Defaults.getFallbackHosts(client.options));
+  if (isRealtime(client)) {
+    const connectionHost = client.connection.connectionManager.host;
+    if (connectionHost) {
+      return [connectionHost].concat(Defaults.getFallbackHosts(client.options));
+    }
   }
 
   return Defaults.getHosts(client.options);

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -1,5 +1,5 @@
 // Common
-import Rest from '../../common/lib/client/rest';
+import { DefaultRest as Rest } from '../../common/lib/client/defaultrest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
 

--- a/src/platform/web-noencryption/index.ts
+++ b/src/platform/web-noencryption/index.ts
@@ -1,5 +1,5 @@
 // Common
-import Rest from '../../common/lib/client/rest';
+import { DefaultRest as Rest } from '../../common/lib/client/defaultrest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
 

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -1,5 +1,5 @@
 // Common
-import Rest from '../../common/lib/client/rest';
+import { DefaultRest as Rest } from '../../common/lib/client/defaultrest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
 

--- a/src/platform/web/lib/transport/fetchrequest.ts
+++ b/src/platform/web/lib/transport/fetchrequest.ts
@@ -1,11 +1,11 @@
 import HttpMethods from 'common/constants/HttpMethods';
-import Rest from 'common/lib/client/rest';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
 import { RequestCallback, RequestParams } from 'common/types/http';
 import Platform from 'common/platform';
 import Defaults from 'common/lib/util/defaults';
 import * as Utils from 'common/lib/util/utils';
 import { getGlobalObject } from 'common/lib/util/utils';
+import { BaseClient } from 'common/lib/client/baseclient';
 
 function isAblyError(responseBody: unknown, headers: Headers): responseBody is { error?: ErrorInfo } {
   return !!headers.get('x-ably-errorcode');
@@ -19,7 +19,7 @@ function getAblyError(responseBody: unknown, headers: Headers) {
 
 export default function fetchRequest(
   method: HttpMethods,
-  rest: Rest | null,
+  client: BaseClient | null,
   uri: string,
   headers: Record<string, string> | null,
   params: RequestParams,
@@ -36,7 +36,7 @@ export default function fetchRequest(
       controller.abort();
       callback(new PartialErrorInfo('Request timed out', null, 408));
     },
-    rest ? rest.options.timeouts.httpRequestTimeout : Defaults.TIMEOUTS.httpRequestTimeout
+    client ? client.options.timeouts.httpRequestTimeout : Defaults.TIMEOUTS.httpRequestTimeout
   );
 
   const requestInit: RequestInit = {

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -30,11 +30,11 @@ function getHosts(client: Rest | Realtime): string[] {
   /* If we're a connected realtime client, try the endpoint we're connected
    * to first -- but still have fallbacks, being connected is not an absolute
    * guarantee that a datacenter has free capacity to service REST requests. */
-  const connection = (client as Realtime).connection,
-    connectionHost = connection && connection.connectionManager.host;
-
-  if (connectionHost) {
-    return [connectionHost].concat(Defaults.getFallbackHosts(client.options));
+  if (Utils.isRealtime(client)) {
+    const connectionHost = client.connection.connectionManager.host;
+    if (connectionHost) {
+      return [connectionHost].concat(Defaults.getFallbackHosts(client.options));
+    }
   }
 
   return Defaults.getHosts(client.options);

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -4,8 +4,6 @@ import Defaults from 'common/lib/util/defaults';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
 import { ErrnoException, IHttp, RequestCallback, RequestParams } from 'common/types/http';
 import HttpMethods from 'common/constants/HttpMethods';
-import Rest from 'common/lib/client/rest';
-import Realtime from 'common/lib/client/realtime';
 import XHRRequest from '../transport/xhrrequest';
 import XHRStates from 'common/constants/XHRStates';
 import Logger from 'common/lib/util/logger';
@@ -13,6 +11,7 @@ import { StandardCallback } from 'common/types/utils';
 import fetchRequest from '../transport/fetchrequest';
 import { NormalisedClientOptions } from 'common/types/ClientOptions';
 import { isSuccessCode } from 'common/constants/HttpStatusCodes';
+import { BaseClient } from 'common/lib/client/baseclient';
 
 function shouldFallback(errorInfo: ErrorInfo) {
   const statusCode = errorInfo.statusCode as number;
@@ -26,7 +25,7 @@ function shouldFallback(errorInfo: ErrorInfo) {
   );
 }
 
-function getHosts(client: Rest | Realtime): string[] {
+function getHosts(client: BaseClient): string[] {
   /* If we're a connected realtime client, try the endpoint we're connected
    * to first -- but still have fallbacks, being connected is not an absolute
    * guarantee that a datacenter has free capacity to service REST requests. */
@@ -57,7 +56,7 @@ const Http: typeof IHttp = class {
       this.supportsAuthHeaders = true;
       this.Request = function (
         method: HttpMethods,
-        rest: Rest | null,
+        client: BaseClient | null,
         uri: string,
         headers: Record<string, string> | null,
         params: RequestParams,
@@ -70,7 +69,7 @@ const Http: typeof IHttp = class {
           params,
           body,
           XHRStates.REQ_SEND,
-          rest && rest.options.timeouts,
+          client && client.options.timeouts,
           method
         );
         req.once('complete', callback);
@@ -143,7 +142,7 @@ const Http: typeof IHttp = class {
   /* Unlike for doUri, the 'rest' param here is mandatory, as it's used to generate the hosts */
   do(
     method: HttpMethods,
-    rest: Rest,
+    client: BaseClient,
     path: string,
     headers: Record<string, string> | null,
     body: unknown,
@@ -154,10 +153,10 @@ const Http: typeof IHttp = class {
       typeof path == 'function'
         ? path
         : function (host: string) {
-            return rest.baseUri(host) + path;
+            return client.baseUri(host) + path;
           };
 
-    const currentFallback = rest._currentFallback;
+    const currentFallback = client._currentFallback;
     if (currentFallback) {
       if (currentFallback.validUntil > Utils.now()) {
         /* Use stored fallback */
@@ -167,7 +166,7 @@ const Http: typeof IHttp = class {
         }
         this.Request(
           method,
-          rest,
+          client,
           uriFromHost(currentFallback.host),
           headers,
           params,
@@ -176,8 +175,8 @@ const Http: typeof IHttp = class {
             // This typecast is safe because ErrnoExceptions are only thrown in NodeJS
             if (err && shouldFallback(err as ErrorInfo)) {
               /* unstore the fallback and start from the top with the default sequence */
-              rest._currentFallback = null;
-              this.do(method, rest, path, headers, body, params, callback);
+              client._currentFallback = null;
+              this.do(method, client, path, headers, body, params, callback);
               return;
             }
             callback?.(err, ...args);
@@ -186,15 +185,15 @@ const Http: typeof IHttp = class {
         return;
       } else {
         /* Fallback expired; remove it and fallthrough to normal sequence */
-        rest._currentFallback = null;
+        client._currentFallback = null;
       }
     }
 
-    const hosts = getHosts(rest);
+    const hosts = getHosts(client);
 
     /* if there is only one host do it */
     if (hosts.length === 1) {
-      this.doUri(method, rest, uriFromHost(hosts[0]), headers, body, params, callback as RequestCallback);
+      this.doUri(method, client, uriFromHost(hosts[0]), headers, body, params, callback as RequestCallback);
       return;
     }
 
@@ -203,7 +202,7 @@ const Http: typeof IHttp = class {
       const host = candidateHosts.shift();
       this.doUri(
         method,
-        rest,
+        client,
         uriFromHost(host as string),
         headers,
         body,
@@ -216,9 +215,9 @@ const Http: typeof IHttp = class {
           }
           if (persistOnSuccess) {
             /* RSC15f */
-            rest._currentFallback = {
+            client._currentFallback = {
               host: host as string,
-              validUntil: Utils.now() + rest.options.timeouts.fallbackRetryTimeout,
+              validUntil: Utils.now() + client.options.timeouts.fallbackRetryTimeout,
             };
           }
           callback?.(err, ...args);
@@ -230,7 +229,7 @@ const Http: typeof IHttp = class {
 
   doUri(
     method: HttpMethods,
-    rest: Rest | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     body: unknown,
@@ -241,12 +240,12 @@ const Http: typeof IHttp = class {
       callback(new PartialErrorInfo('Request invoked before assigned to', null, 500));
       return;
     }
-    this.Request(method, rest, uri, headers, params, body, callback);
+    this.Request(method, client, uri, headers, params, body, callback);
   }
 
   Request?: (
     method: HttpMethods,
-    rest: Rest | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     params: RequestParams,

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -1,0 +1,43 @@
+// Common
+import { BaseClient } from '../../common/lib/client/baseclient';
+import Rest from '../../common/lib/client/rest';
+import Platform from '../../common/platform';
+
+// Platform Specific
+import BufferUtils from './lib/util/bufferutils';
+// @ts-ignore
+import CryptoFactory from './lib/util/crypto';
+import Http from './lib/util/http';
+import Config from './config';
+// @ts-ignore
+import Logger from '../../common/lib/util/logger';
+import { getDefaults } from '../../common/lib/util/defaults';
+import WebStorage from './lib/util/webstorage';
+import PlatformDefaults from './lib/util/defaults';
+
+const Crypto = CryptoFactory(Config, BufferUtils);
+
+Platform.Crypto = Crypto;
+Platform.BufferUtils = BufferUtils;
+Platform.Http = Http;
+Platform.Config = Config;
+Platform.WebStorage = WebStorage;
+
+Logger.initLogHandlers();
+
+Platform.Defaults = getDefaults(PlatformDefaults);
+
+if (Platform.Config.agent) {
+  // @ts-ignore
+  Platform.Defaults.agent += ' ' + Platform.Config.agent;
+}
+
+/* If using IE8, don't attempt to upgrade from xhr_polling to xhr_streaming -
+ * while it can do streaming, the low max http-connections-per-host limit means
+ * that the polling transport is crippled during the upgrade process. So just
+ * leave it at the base transport */
+if (Platform.Config.noUpgrade) {
+  Platform.Defaults.upgradeTransports = [];
+}
+
+export { BaseClient, Rest, Crypto };

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -1,0 +1,32 @@
+import { BaseClient, Rest } from '../../build/modules/index.js';
+
+describe('browser/modules', function () {
+  this.timeout(10 * 1000);
+  let key;
+
+  before(function (done) {
+    window.ablyHelpers.setupApp(function () {
+      key = window.AblyTestApp.keys[0].keyStr;
+      done();
+    });
+  });
+
+  it('baseclient_with_rest', async function () {
+    const client = new BaseClient({ key }, { Rest });
+    const time = await client.time();
+    if (typeof time !== 'number') {
+      throw new Error('client.time returned wrong type');
+    }
+  });
+
+  it('baseclient_without_rest', function (done) {
+    const client = new BaseClient({ key }, {});
+    try {
+      client.time();
+    } catch (err) {
+      done();
+      return;
+    }
+    done(new Error('Expected client.time to throw'));
+  });
+});

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -218,7 +218,7 @@ define([
         return res;
       };
 
-  return (module.exports = {
+  var exports = {
     setupApp: testAppModule.setup,
     tearDownApp: testAppModule.tearDown,
     createStats: testAppModule.createStatsFixtureData,
@@ -249,5 +249,11 @@ define([
     arrFind: arrFind,
     arrFilter: arrFilter,
     whenPromiseSettles: whenPromiseSettles,
-  });
+  };
+
+  if (typeof window !== 'undefined') {
+    window.ablyHelpers = exports;
+  }
+
+  return (module.exports = exports);
 });

--- a/test/mocha.html
+++ b/test/mocha.html
@@ -22,6 +22,7 @@
     <script type="text/javascript" src="support/modules_helper.js"></script>
     <script type="text/javascript" src="support/test_helper.js"></script>
     <script type="text/javascript" src="support/browser_file_list.js"></script>
+    <script type="module" src="test/browser/modules.test.js"></script>
     <script type="text/javascript" src="support/browser_setup.js"></script>
   </body>
 </html>

--- a/test/playwright.html
+++ b/test/playwright.html
@@ -20,6 +20,7 @@
     <script type="text/javascript" src="support/modules_helper.js"></script>
     <script type="text/javascript" src="support/test_helper.js"></script>
     <script type="text/javascript" src="support/browser_file_list.js"></script>
+    <script type="module" src="test/browser/modules.test.js"></script>
     <script type="text/javascript" src="support/browser_setup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Resolves #1374 

Refactors the existing `Rest` class into `BaseClient` and an encapsulated `Rest` class which can be passed in to the `BaseClient` constructor to allow access to the rest interface.

The tree-shakable modules are currently available as an esm module from 'ably/modules', example usage:
```ts
import { BaseClient, Rest } from 'ably/modules';

const client = new BaseClient(options, { Rest });
```

A new npm script (`npm run modulereport`) is added which displays information about the size of each module in the bundle-report workflow. Currently ([76d2ab0](https://github.com/ably/ably-js/pull/1400/commits/76d2ab0eb9237cc0f0f863a5b0a500b9a5ad50b7)) the output shows:

```
BaseClient: 61.63kb
BaseClient + Rest: 78.56kb
```

These numbers will be lower after we encapsulate further functionality into tree-shakable modules.