### PR TITLE
fix: ensure ErrorInfo.message is included in JSON output

### DIFF
--- a/src/common/lib/types/errorinfo.ts
+++ b/src/common/lib/types/errorinfo.ts
@@ -40,6 +40,14 @@ export default class ErrorInfo extends Error implements IPartialErrorInfo, API.T
     return toString(this);
   }
 
+  toJSON(): Record<string, string | number> {
+    return {
+      message: this.message,
+      code: this.code,
+      statusCode: this.statusCode,
+    };
+  }
+
   static fromValues(values: Record<string, unknown> | ErrorInfo | Error): ErrorInfo {
     const { message, code, statusCode } = values as ErrorInfo;
     if (typeof message !== 'string' || typeof code !== 'number' || typeof statusCode !== 'number') {


### PR DESCRIPTION
fixes an issue where, in web browsers, `Platform.config.inspect(error)` (which is just JSON.stringify)  would not include the ErrorInfo.message since ErrorInfo extends Error for which message is not an enumerable property.