### PR TITLE
[SDK-3768] Add tree-shakable `Base*` and `Rest` exports 

### DIFF
--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -37,4 +37,5 @@ jobs:
           sourcePath: bundle-reports
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           artifactName: bundle-report
+      # This step performs some validation and may fail, so it should come after the steps that we want to always execute.
       - run: npm run modulereport

--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -37,3 +37,4 @@ jobs:
           sourcePath: bundle-reports
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           artifactName: bundle-report
+      - run: npm run modulereport

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,6 +111,17 @@ module.exports = function (grunt) {
       target: 'es6',
     };
 
+    var modulesConfig = {
+      ...baseConfig,
+      entryPoints: ['src/platform/web/modules.ts'],
+      outfile: 'build/modules/index.js',
+      format: 'esm',
+      plugins: [],
+    };
+
+    // For reasons I don't understand this build fails when run asynchronously
+    esbuild.buildSync(modulesConfig);
+
     Promise.all([
       esbuild.build(baseConfig),
       esbuild.build({

--- a/package.json
+++ b/package.json
@@ -122,10 +122,11 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "prepare": "npm run build",
-    "format": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts webpack.config.js Gruntfile.js scripts/cdn_deploy.js docs/chrome-mv3.md",
-    "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts webpack.config.js Gruntfile.js scripts/cdn_deploy.js",
+    "format": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts webpack.config.js Gruntfile.js scripts/*.js docs/chrome-mv3.md",
+    "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts webpack.config.js Gruntfile.js scripts/*.js",
     "sourcemap": "source-map-explorer build/ably.min.js",
     "sourcemap:noencryption": "source-map-explorer build/ably.noencryption.min.js",
+    "modulereport": "node scripts/moduleReport.js",
     "docs": "typedoc --entryPoints ably.d.ts --out docs/generated --readme docs/landing-page.md"
   }
 }

--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -1,7 +1,7 @@
 const esbuild = require('esbuild');
 
 // List of all modules accepted in ModulesMap
-const moduleNames = [];
+const moduleNames = ['Rest'];
 
 function formatBytes(bytes) {
   const kibibytes = bytes / 1024;
@@ -40,7 +40,7 @@ const errors = [];
     const size = getImportSize([baseClient, moduleName]);
     console.log(`${baseClient} + ${moduleName}: ${formatBytes(size)}`);
 
-    if (!(baseClientSize < size)) {
+    if (!(baseClientSize < size) && !(baseClient === 'BaseRest' && moduleName === 'Rest')) {
       // Emit an error if adding the module does not increase the bundle size
       // (this means that the module is not being tree-shaken correctly).
       errors.push(new Error(`Adding ${moduleName} to ${baseClient} does not increase the bundle size.`));

--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -27,12 +27,30 @@ function getImportSize(modules) {
   return result.metafile.outputs[outfile].bytes;
 }
 
+const errors = [];
+
 ['BaseRest', 'BaseRealtime'].forEach((baseClient) => {
+  const baseClientSize = getImportSize([baseClient]);
+
   // First display the size of the base client
-  console.log(`${baseClient}: ${formatBytes(getImportSize([baseClient]))}`);
+  console.log(`${baseClient}: ${formatBytes(baseClientSize)}`);
 
   // Then display the size of each module together with the base client
   moduleNames.forEach((moduleName) => {
-    console.log(`${baseClient} + ${moduleName}: ${formatBytes(getImportSize([baseClient, moduleName]))}`);
+    const size = getImportSize([baseClient, moduleName]);
+    console.log(`${baseClient} + ${moduleName}: ${formatBytes(size)}`);
+
+    if (!(baseClientSize < size)) {
+      // Emit an error if adding the module does not increase the bundle size
+      // (this means that the module is not being tree-shaken correctly).
+      errors.push(new Error(`Adding ${moduleName} to ${baseClient} does not increase the bundle size.`));
+    }
   });
 });
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.log(error.message);
+  }
+  process.exit(1);
+}

--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -1,0 +1,38 @@
+const esbuild = require('esbuild');
+
+// List of all modules accepted in ModulesMap
+const moduleNames = [];
+
+function formatBytes(bytes) {
+  const kibibytes = bytes / 1024;
+  const formatted = kibibytes.toFixed(2);
+  return `${formatted} KiB`;
+}
+
+// Gets the bundled size in bytes of an array of named exports from 'ably/modules'
+function getImportSize(modules) {
+  const outfile = modules.join('');
+  const result = esbuild.buildSync({
+    stdin: {
+      contents: `export { ${modules.join(', ')} } from './build/modules'`,
+      resolveDir: '.',
+    },
+    metafile: true,
+    minify: true,
+    bundle: true,
+    outfile,
+    write: false,
+  });
+
+  return result.metafile.outputs[outfile].bytes;
+}
+
+['BaseRest', 'BaseRealtime'].forEach((baseClient) => {
+  // First display the size of the base client
+  console.log(`${baseClient}: ${formatBytes(getImportSize([baseClient]))}`);
+
+  // Then display the size of each module together with the base client
+  moduleNames.forEach((moduleName) => {
+    console.log(`${baseClient} + ${moduleName}: ${formatBytes(getImportSize([baseClient, moduleName]))}`);
+  });
+});

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -12,6 +12,7 @@ import HttpMethods from '../../constants/HttpMethods';
 import HttpStatusCodes from 'common/constants/HttpStatusCodes';
 import Platform from '../../platform';
 import Resource from './resource';
+import Defaults from '../util/defaults';
 
 type BatchResult<T> = API.Types.BatchResult<T>;
 type TokenRevocationTargetSpecifier = API.Types.TokenRevocationTargetSpecifier;
@@ -584,7 +585,7 @@ class Auth {
           return client.baseUri(host) + path;
         };
 
-      const requestHeaders = Utils.defaultPostHeaders(this.client.options);
+      const requestHeaders = Defaults.defaultPostHeaders(this.client.options);
       if (authOptions.requestHeaders) Utils.mixin(requestHeaders, authOptions.requestHeaders);
       Logger.logAction(
         Logger.LOG_MICRO,
@@ -1073,7 +1074,7 @@ class Auth {
     };
 
     const format = this.client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(this.client.options, { format });
+      headers = Defaults.defaultPostHeaders(this.client.options, { format });
 
     if (this.client.options.headers) Utils.mixin(headers, this.client.options.headers);
 

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -26,7 +26,7 @@ function random() {
   return ('000000' + Math.floor(Math.random() * 1e16)).slice(-16);
 }
 
-function isRealtime(client: BaseClient | BaseRealtime): client is BaseRealtime {
+function isRealtime(client: BaseClient): client is BaseRealtime {
   return !!(client as BaseRealtime).connection;
 }
 
@@ -113,7 +113,7 @@ function getTokenRequestId() {
 }
 
 class Auth {
-  client: BaseClient | BaseRealtime;
+  client: BaseClient;
   tokenParams: API.Types.TokenParams;
   currentTokenRequestId: number | null;
   waitingForTokenRequest: ReturnType<typeof Multicaster.create> | null;
@@ -125,7 +125,7 @@ class Auth {
   basicKey?: string;
   clientId?: string | null;
 
-  constructor(client: BaseClient | BaseRealtime, options: ClientOptions) {
+  constructor(client: BaseClient, options: ClientOptions) {
     this.client = client;
     this.tokenParams = options.defaultTokenParams || {};
     /* The id of the current token request if one is in progress, else null */

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -118,7 +118,7 @@ class BaseClient {
         return Utils.promisify(this, 'stats', [params]) as Promise<PaginatedResult<Stats>>;
       }
     }
-    const headers = Utils.defaultGetHeaders(this.options),
+    const headers = Defaults.defaultGetHeaders(this.options),
       format = this.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.http.supportsLinkHeaders ? undefined : format;
 
@@ -148,7 +148,7 @@ class BaseClient {
 
     const _callback = callback || noop;
 
-    const headers = Utils.defaultGetHeaders(this.options);
+    const headers = Defaults.defaultGetHeaders(this.options);
     if (this.options.headers) Utils.mixin(headers, this.options.headers);
     const timeUri = (host: string) => {
       return this.baseUri(host) + '/time';
@@ -201,8 +201,8 @@ class BaseClient {
     const _method = method.toLowerCase() as HttpMethods;
     const headers =
       _method == 'get'
-        ? Utils.defaultGetHeaders(this.options, { format, protocolVersion: version })
-        : Utils.defaultPostHeaders(this.options, { format, protocolVersion: version });
+        ? Defaults.defaultGetHeaders(this.options, { format, protocolVersion: version })
+        : Defaults.defaultPostHeaders(this.options, { format, protocolVersion: version });
 
     if (callback === undefined) {
       return Utils.promisify(this, 'request', [method, path, version, params, body, customHeaders]) as Promise<
@@ -264,7 +264,7 @@ class BaseClient {
     }
 
     const format = this.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(this.options, { format });
+      headers = Defaults.defaultPostHeaders(this.options, { format });
 
     if (this.options.headers) Utils.mixin(headers, this.options.headers);
 
@@ -304,7 +304,7 @@ class BaseClient {
     }
 
     const format = this.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(this.options, { format });
+      headers = Defaults.defaultPostHeaders(this.options, { format });
 
     if (this.options.headers) Utils.mixin(headers, this.options.headers);
 

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -340,11 +340,11 @@ class BaseClient {
 }
 
 class Channels {
-  rest: BaseClient;
+  client: BaseClient;
   all: Record<string, Channel>;
 
-  constructor(rest: BaseClient) {
-    this.rest = rest;
+  constructor(client: BaseClient) {
+    this.client = client;
     this.all = Object.create(null);
   }
 
@@ -352,7 +352,7 @@ class Channels {
     name = String(name);
     let channel = this.all[name];
     if (!channel) {
-      this.all[name] = channel = new Channel(this.rest, name, channelOptions);
+      this.all[name] = channel = new Channel(this.client, name, channelOptions);
     } else if (channelOptions) {
       channel.setOptions(channelOptions);
     }

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -18,6 +18,7 @@ import Platform from '../../platform';
 import Message from '../types/message';
 import PresenceMessage from '../types/presencemessage';
 import Resource from './resource';
+import { ModulesMap } from './modulesmap';
 
 type BatchResult<T> = API.Types.BatchResult<T>;
 type BatchPublishSpec = API.Types.BatchPublishSpec;
@@ -47,7 +48,11 @@ class BaseClient {
   channels: Channels;
   push: Push;
 
-  constructor(options: ClientOptions | string) {
+  constructor(
+    options: ClientOptions | string,
+    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+    modules: ModulesMap
+  ) {
     if (!options) {
       const msg = 'no options provided';
       Logger.logAction(Logger.LOG_ERROR, 'BaseClient()', msg);

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -29,7 +29,11 @@ type BatchPresenceFailureResult = API.Types.BatchPresenceFailureResult;
 type BatchPresenceResult = BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult>;
 
 const noop = function () {};
-class Rest {
+
+/**
+ `BaseClient` acts as the base class for all of the client classes exported by the SDK. It is an implementation detail and this class is not advertised publicly.
+ */
+class BaseClient {
   options: NormalisedClientOptions;
   baseUri: (host: string) => string;
   authority: (host: string) => string;
@@ -46,13 +50,17 @@ class Rest {
   constructor(options: ClientOptions | string) {
     if (!options) {
       const msg = 'no options provided';
-      Logger.logAction(Logger.LOG_ERROR, 'Rest()', msg);
+      Logger.logAction(Logger.LOG_ERROR, 'BaseClient()', msg);
       throw new Error(msg);
     }
     const optionsObj = Defaults.objectifyOptions(options);
 
     Logger.setLog(optionsObj.logLevel, optionsObj.logHandler);
-    Logger.logAction(Logger.LOG_MICRO, 'Rest()', 'initialized with clientOptions ' + Platform.Config.inspect(options));
+    Logger.logAction(
+      Logger.LOG_MICRO,
+      'BaseClient()',
+      'initialized with clientOptions ' + Platform.Config.inspect(options)
+    );
 
     const normalOptions = (this.options = Defaults.normaliseOptions(optionsObj));
 
@@ -61,7 +69,7 @@ class Rest {
       const keyMatch = normalOptions.key.match(/^([^:\s]+):([^:.\s]+)$/);
       if (!keyMatch) {
         const msg = 'invalid key parameter';
-        Logger.logAction(Logger.LOG_ERROR, 'Rest()', msg);
+        Logger.logAction(Logger.LOG_ERROR, 'BaseClient()', msg);
         throw new ErrorInfo(msg, 40400, 404);
       }
       normalOptions.keyName = keyMatch[1];
@@ -79,7 +87,7 @@ class Rest {
         );
     }
 
-    Logger.logAction(Logger.LOG_MINOR, 'Rest()', 'started; version = ' + Defaults.version);
+    Logger.logAction(Logger.LOG_MINOR, 'BaseClient()', 'started; version = ' + Defaults.version);
 
     this.baseUri = this.authority = function (host) {
       return Defaults.getHttpScheme(normalOptions) + host + ':' + Defaults.getPort(normalOptions, false);
@@ -328,10 +336,10 @@ class Rest {
 }
 
 class Channels {
-  rest: Rest;
+  rest: BaseClient;
   all: Record<string, Channel>;
 
-  constructor(rest: Rest) {
+  constructor(rest: BaseClient) {
     this.rest = rest;
     this.all = Object.create(null);
   }
@@ -355,4 +363,4 @@ class Channels {
   }
 }
 
-export default Rest;
+export default BaseClient;

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -1,24 +1,19 @@
-import * as Utils from '../util/utils';
 import Logger, { LoggerOptions } from '../util/logger';
 import Defaults from '../util/defaults';
 import Auth from './auth';
-import Push from './push';
-import PaginatedResource, { HttpPaginatedResponse, PaginatedResult } from './paginatedresource';
-import Channel from './channel';
+import { HttpPaginatedResponse, PaginatedResult } from './paginatedresource';
 import ErrorInfo from '../types/errorinfo';
 import Stats from '../types/stats';
-import HttpMethods from '../../constants/HttpMethods';
-import { ChannelOptions } from '../../types/channel';
-import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
-import { ErrnoException, IHttp, RequestParams } from '../../types/http';
+import { StandardCallback } from '../../types/utils';
+import { IHttp, RequestParams } from '../../types/http';
 import ClientOptions, { NormalisedClientOptions } from '../../types/ClientOptions';
 import * as API from '../../../../ably';
 
 import Platform from '../../platform';
 import Message from '../types/message';
 import PresenceMessage from '../types/presencemessage';
-import Resource from './resource';
 import { ModulesMap } from './modulesmap';
+import { Rest } from './rest';
 
 type BatchResult<T> = API.Types.BatchResult<T>;
 type BatchPublishSpec = API.Types.BatchPublishSpec;
@@ -28,8 +23,6 @@ type BatchPublishResult = BatchResult<BatchPublishSuccessResult | BatchPublishFa
 type BatchPresenceSuccessResult = API.Types.BatchPresenceSuccessResult;
 type BatchPresenceFailureResult = API.Types.BatchPresenceFailureResult;
 type BatchPresenceResult = BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult>;
-
-const noop = function () {};
 
 /**
  `BaseClient` acts as the base class for all of the client classes exported by the SDK. It is an implementation detail and this class is not advertised publicly.
@@ -43,14 +36,10 @@ class BaseClient {
   serverTimeOffset: number | null;
   http: IHttp;
   auth: Auth;
-  channels: Channels;
-  push: Push;
 
-  constructor(
-    options: ClientOptions | string,
-    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-    modules: ModulesMap
-  ) {
+  private readonly _rest: Rest | null;
+
+  constructor(options: ClientOptions | string, modules: ModulesMap) {
     if (!options) {
       const msg = 'no options provided';
       Logger.logAction(Logger.LOG_ERROR, 'BaseClient()', msg);
@@ -97,8 +86,23 @@ class BaseClient {
     this.serverTimeOffset = null;
     this.http = new Platform.Http(normalOptions);
     this.auth = new Auth(this, normalOptions);
-    this.channels = new Channels(this);
-    this.push = new Push(this);
+
+    this._rest = modules.Rest ? new modules.Rest(this) : null;
+  }
+
+  private get rest(): Rest {
+    if (!this._rest) {
+      throw new ErrorInfo('Rest module not provided', 400, 40000);
+    }
+    return this._rest;
+  }
+
+  get channels() {
+    return this.rest.channels;
+  }
+
+  get push() {
+    return this.rest.push;
   }
 
   baseUri(host: string) {
@@ -109,78 +113,11 @@ class BaseClient {
     params: RequestParams,
     callback: StandardCallback<PaginatedResult<Stats>>
   ): Promise<PaginatedResult<Stats>> | void {
-    /* params and callback are optional; see if params contains the callback */
-    if (callback === undefined) {
-      if (typeof params == 'function') {
-        callback = params;
-        params = null;
-      } else {
-        return Utils.promisify(this, 'stats', [params]) as Promise<PaginatedResult<Stats>>;
-      }
-    }
-    const headers = Defaults.defaultGetHeaders(this.options),
-      format = this.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.http.supportsLinkHeaders ? undefined : format;
-
-    Utils.mixin(headers, this.options.headers);
-
-    new PaginatedResource(this, '/stats', headers, envelope, function (
-      body: unknown,
-      headers: Record<string, string>,
-      unpacked?: boolean
-    ) {
-      const statsValues = unpacked ? body : JSON.parse(body as string);
-      for (let i = 0; i < statsValues.length; i++) statsValues[i] = Stats.fromValues(statsValues[i]);
-      return statsValues;
-    }).get(params as Record<string, string>, callback);
+    return this.rest.stats(params, callback);
   }
 
   time(params?: RequestParams | StandardCallback<number>, callback?: StandardCallback<number>): Promise<number> | void {
-    /* params and callback are optional; see if params contains the callback */
-    if (callback === undefined) {
-      if (typeof params == 'function') {
-        callback = params;
-        params = null;
-      } else {
-        return Utils.promisify(this, 'time', [params]) as Promise<number>;
-      }
-    }
-
-    const _callback = callback || noop;
-
-    const headers = Defaults.defaultGetHeaders(this.options);
-    if (this.options.headers) Utils.mixin(headers, this.options.headers);
-    const timeUri = (host: string) => {
-      return this.baseUri(host) + '/time';
-    };
-    this.http.do(
-      HttpMethods.Get,
-      this,
-      timeUri,
-      headers,
-      null,
-      params as RequestParams,
-      (
-        err?: ErrorInfo | ErrnoException | null,
-        res?: unknown,
-        headers?: Record<string, string>,
-        unpacked?: boolean
-      ) => {
-        if (err) {
-          _callback(err);
-          return;
-        }
-        if (!unpacked) res = JSON.parse(res as string);
-        const time = (res as number[])[0];
-        if (!time) {
-          _callback(new ErrorInfo('Internal error (unexpected result type from GET /time)', 50000, 500));
-          return;
-        }
-        /* calculate time offset only once for this device by adding to the prototype */
-        this.serverTimeOffset = time - Utils.now();
-        _callback(null, time);
-      }
-    );
+    return this.rest.time(params, callback);
   }
 
   request(
@@ -192,141 +129,17 @@ class BaseClient {
     customHeaders: Record<string, string>,
     callback: StandardCallback<HttpPaginatedResponse<unknown>>
   ): Promise<HttpPaginatedResponse<unknown>> | void {
-    const useBinary = this.options.useBinaryProtocol,
-      encoder = useBinary ? Platform.Config.msgpack.encode : JSON.stringify,
-      decoder = useBinary ? Platform.Config.msgpack.decode : JSON.parse,
-      format = useBinary ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.http.supportsLinkHeaders ? undefined : format;
-    params = params || {};
-    const _method = method.toLowerCase() as HttpMethods;
-    const headers =
-      _method == 'get'
-        ? Defaults.defaultGetHeaders(this.options, { format, protocolVersion: version })
-        : Defaults.defaultPostHeaders(this.options, { format, protocolVersion: version });
-
-    if (callback === undefined) {
-      return Utils.promisify(this, 'request', [method, path, version, params, body, customHeaders]) as Promise<
-        HttpPaginatedResponse<unknown>
-      >;
-    }
-
-    if (typeof body !== 'string') {
-      body = encoder(body);
-    }
-    Utils.mixin(headers, this.options.headers);
-    if (customHeaders) {
-      Utils.mixin(headers, customHeaders);
-    }
-    const paginatedResource = new PaginatedResource(
-      this,
-      path,
-      headers,
-      envelope,
-      async function (resbody: unknown, headers: Record<string, string>, unpacked?: boolean) {
-        return Utils.ensureArray(unpacked ? resbody : decoder(resbody as string & Buffer));
-      },
-      /* useHttpPaginatedResponse: */ true
-    );
-
-    if (!Utils.arrIn(Platform.Http.methods, _method)) {
-      throw new ErrorInfo('Unsupported method ' + _method, 40500, 405);
-    }
-
-    if (Utils.arrIn(Platform.Http.methodsWithBody, _method)) {
-      paginatedResource[_method as HttpMethods.Post](params, body, callback as PaginatedResultCallback<unknown>);
-    } else {
-      paginatedResource[_method as HttpMethods.Get | HttpMethods.Delete](
-        params,
-        callback as PaginatedResultCallback<unknown>
-      );
-    }
+    return this.rest.request(method, path, version, params, body, customHeaders, callback);
   }
 
   batchPublish<T extends BatchPublishSpec | BatchPublishSpec[]>(
     specOrSpecs: T
-  ): Promise<T extends BatchPublishSpec ? BatchPublishResult : BatchPublishResult[]>;
-  batchPublish<T extends BatchPublishSpec | BatchPublishSpec[]>(
-    specOrSpecs: T,
-    callback?: StandardCallback<T extends BatchPublishSpec ? BatchPublishResult : BatchPublishResult[]>
-  ): void | Promise<T extends BatchPublishSpec ? BatchPublishResult : BatchPublishResult[]> {
-    if (callback === undefined) {
-      return Utils.promisify(this, 'batchPublish', [specOrSpecs]);
-    }
-
-    let requestBodyDTO: BatchPublishSpec[];
-    let singleSpecMode: boolean;
-    if (Utils.isArray(specOrSpecs)) {
-      requestBodyDTO = specOrSpecs;
-      singleSpecMode = false;
-    } else {
-      requestBodyDTO = [specOrSpecs];
-      singleSpecMode = true;
-    }
-
-    const format = this.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Defaults.defaultPostHeaders(this.options, { format });
-
-    if (this.options.headers) Utils.mixin(headers, this.options.headers);
-
-    const requestBody = Utils.encodeBody(requestBodyDTO, format);
-    Resource.post(
-      this,
-      '/messages',
-      requestBody,
-      headers,
-      { newBatchResponse: 'true' },
-      null,
-      (err, body, headers, unpacked) => {
-        if (err) {
-          callback(err);
-          return;
-        }
-
-        const batchResults = (unpacked ? body : Utils.decodeBody(body, format)) as BatchPublishResult[];
-
-        // I don't love the below type assertions for `callback` but not sure how to avoid them
-        if (singleSpecMode) {
-          (callback as StandardCallback<BatchPublishResult>)(null, batchResults[0]);
-        } else {
-          (callback as StandardCallback<BatchPublishResult[]>)(null, batchResults);
-        }
-      }
-    );
+  ): Promise<T extends BatchPublishSpec ? BatchPublishResult : BatchPublishResult[]> {
+    return this.rest.batchPublish(specOrSpecs);
   }
 
-  batchPresence(channels: string[]): Promise<BatchPresenceResult>;
-  batchPresence(
-    channels: string[],
-    callback?: StandardCallback<BatchPresenceResult>
-  ): void | Promise<BatchPresenceResult> {
-    if (callback === undefined) {
-      return Utils.promisify(this, 'batchPresence', [channels]);
-    }
-
-    const format = this.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Defaults.defaultPostHeaders(this.options, { format });
-
-    if (this.options.headers) Utils.mixin(headers, this.options.headers);
-
-    const channelsParam = channels.join(',');
-
-    Resource.get(
-      this,
-      '/presence',
-      headers,
-      { newBatchResponse: 'true', channels: channelsParam },
-      null,
-      (err, body, headers, unpacked) => {
-        if (err) {
-          callback(err);
-          return;
-        }
-
-        const batchResult = (unpacked ? body : Utils.decodeBody(body, format)) as BatchPresenceResult;
-
-        callback(null, batchResult);
-      }
-    );
+  batchPresence(channels: string[]): Promise<BatchPresenceResult> {
+    return this.rest.batchPresence(channels);
   }
 
   setLog(logOptions: LoggerOptions): void {
@@ -337,34 +150,6 @@ class BaseClient {
   static Crypto?: typeof Platform.Crypto;
   static Message = Message;
   static PresenceMessage = PresenceMessage;
-}
-
-class Channels {
-  client: BaseClient;
-  all: Record<string, Channel>;
-
-  constructor(client: BaseClient) {
-    this.client = client;
-    this.all = Object.create(null);
-  }
-
-  get(name: string, channelOptions?: ChannelOptions) {
-    name = String(name);
-    let channel = this.all[name];
-    if (!channel) {
-      this.all[name] = channel = new Channel(this.client, name, channelOptions);
-    } else if (channelOptions) {
-      channel.setOptions(channelOptions);
-    }
-
-    return channel;
-  }
-
-  /* Included to support certain niche use-cases; most users should ignore this.
-   * Please do not use this unless you know what you're doing */
-  release(name: string) {
-    delete this.all[String(name)];
-  }
 }
 
 export default BaseClient;

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -36,8 +36,6 @@ const noop = function () {};
  */
 class BaseClient {
   options: NormalisedClientOptions;
-  baseUri: (host: string) => string;
-  authority: (host: string) => string;
   _currentFallback: null | {
     host: string;
     validUntil: number;
@@ -94,9 +92,6 @@ class BaseClient {
 
     Logger.logAction(Logger.LOG_MINOR, 'BaseClient()', 'started; version = ' + Defaults.version);
 
-    this.baseUri = this.authority = function (host) {
-      return Defaults.getHttpScheme(normalOptions) + host + ':' + Defaults.getPort(normalOptions, false);
-    };
     this._currentFallback = null;
 
     this.serverTimeOffset = null;
@@ -104,6 +99,10 @@ class BaseClient {
     this.auth = new Auth(this, normalOptions);
     this.channels = new Channels(this);
     this.push = new Push(this);
+  }
+
+  baseUri(host: string) {
+    return Defaults.getHttpScheme(this.options) + host + ':' + Defaults.getPort(this.options, false);
   }
 
   stats(
@@ -152,7 +151,7 @@ class BaseClient {
     const headers = Utils.defaultGetHeaders(this.options);
     if (this.options.headers) Utils.mixin(headers, this.options.headers);
     const timeUri = (host: string) => {
-      return this.authority(host) + '/time';
+      return this.baseUri(host) + '/time';
     };
     this.http.do(
       HttpMethods.Get,

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -9,7 +9,6 @@ import ProtocolMessage from '../types/protocolmessage';
 import { ChannelOptions } from '../../types/channel';
 import ClientOptions from '../../types/ClientOptions';
 import * as API from '../../../../ably';
-import ConnectionManager from '../transport/connectionmanager';
 import { ModulesMap } from './modulesmap';
 
 /**
@@ -40,10 +39,6 @@ class BaseRealtime extends BaseClient {
     Logger.logAction(Logger.LOG_MINOR, 'Realtime.close()', '');
     this.connection.close();
   }
-
-  static Utils = Utils;
-  static ConnectionManager = ConnectionManager;
-  static ProtocolMessage = ProtocolMessage;
 }
 
 class Channels extends EventEmitter {

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -10,8 +10,6 @@ import { ChannelOptions } from '../../types/channel';
 import ClientOptions from '../../types/ClientOptions';
 import * as API from '../../../../ably';
 import ConnectionManager from '../transport/connectionmanager';
-import Platform from 'common/platform';
-import Message from '../types/message';
 import { ModulesMap } from './modulesmap';
 
 /**
@@ -45,10 +43,7 @@ class BaseRealtime extends BaseClient {
 
   static Utils = Utils;
   static ConnectionManager = ConnectionManager;
-  static Platform = Platform;
   static ProtocolMessage = ProtocolMessage;
-  static Message = Message;
-  static Crypto?: typeof Platform.Crypto;
 }
 
 class Channels extends EventEmitter {

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -18,15 +18,19 @@ import { ModulesMap } from './modulesmap';
  `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
  */
 class BaseRealtime extends BaseClient {
-  channels: any;
+  _channels: any;
   connection: Connection;
 
   constructor(options: ClientOptions, modules: ModulesMap) {
     super(options, modules);
     Logger.logAction(Logger.LOG_MINOR, 'Realtime()', '');
     this.connection = new Connection(this, this.options);
-    this.channels = new Channels(this);
+    this._channels = new Channels(this);
     if (options.autoConnect !== false) this.connect();
+  }
+
+  get channels() {
+    return this._channels;
   }
 
   connect(): void {

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -1,5 +1,5 @@
 import * as Utils from '../util/utils';
-import Rest from './rest';
+import BaseClient from './baseclient';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
 import Connection from './connection';
@@ -13,7 +13,10 @@ import ConnectionManager from '../transport/connectionmanager';
 import Platform from 'common/platform';
 import Message from '../types/message';
 
-class Realtime extends Rest {
+/**
+ `BaseRealtime` acts as the base class for the `DefaultRealtime` class exported by the SDK. It is currently an implementation detail, but will become an export of the forthcoming tree-shakable version of the SDK.
+ */
+class BaseRealtime extends BaseClient {
   channels: any;
   connection: Connection;
 
@@ -44,10 +47,10 @@ class Realtime extends Rest {
 }
 
 class Channels extends EventEmitter {
-  realtime: Realtime;
+  realtime: BaseRealtime;
   all: Record<string, RealtimeChannel>;
 
-  constructor(realtime: Realtime) {
+  constructor(realtime: BaseRealtime) {
     super();
     this.realtime = realtime;
     this.all = Object.create(null);
@@ -179,4 +182,4 @@ class Channels extends EventEmitter {
   }
 }
 
-export default Realtime;
+export default BaseRealtime;

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -14,7 +14,7 @@ import Platform from 'common/platform';
 import Message from '../types/message';
 
 /**
- `BaseRealtime` acts as the base class for the `DefaultRealtime` class exported by the SDK. It is currently an implementation detail, but will become an export of the forthcoming tree-shakable version of the SDK.
+ `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
  */
 class BaseRealtime extends BaseClient {
   channels: any;

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -12,6 +12,7 @@ import * as API from '../../../../ably';
 import ConnectionManager from '../transport/connectionmanager';
 import Platform from 'common/platform';
 import Message from '../types/message';
+import { ModulesMap } from './modulesmap';
 
 /**
  `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
@@ -20,8 +21,8 @@ class BaseRealtime extends BaseClient {
   channels: any;
   connection: Connection;
 
-  constructor(options: ClientOptions) {
-    super(options);
+  constructor(options: ClientOptions, modules: ModulesMap) {
+    super(options, modules);
     Logger.logAction(Logger.LOG_MINOR, 'Realtime()', '');
     this.connection = new Connection(this, this.options);
     this.channels = new Channels(this);

--- a/src/common/lib/client/baserest.ts
+++ b/src/common/lib/client/baserest.ts
@@ -1,6 +1,6 @@
 import BaseClient from './baseclient';
 
 /**
- `BaseRest` acts as the base class for the `DefaultRest` class exported by the SDK. It is currently an implementation detail, but will become an export of the forthcoming tree-shakable version of the SDK.
+ `BaseRest` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRest` class exported by the non tree-shakable version.
  */
 export class BaseRest extends BaseClient {}

--- a/src/common/lib/client/baserest.ts
+++ b/src/common/lib/client/baserest.ts
@@ -1,0 +1,6 @@
+import BaseClient from './baseclient';
+
+/**
+ `BaseRest` acts as the base class for the `DefaultRest` class exported by the SDK. It is currently an implementation detail, but will become an export of the forthcoming tree-shakable version of the SDK.
+ */
+export class BaseRest extends BaseClient {}

--- a/src/common/lib/client/baserest.ts
+++ b/src/common/lib/client/baserest.ts
@@ -1,6 +1,15 @@
 import BaseClient from './baseclient';
+import ClientOptions from '../../types/ClientOptions';
+import { ModulesMap } from './modulesmap';
+import { Rest } from './rest';
 
 /**
  `BaseRest` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRest` class exported by the non tree-shakable version.
+
+ It always includes the `Rest` module.
  */
-export class BaseRest extends BaseClient {}
+export class BaseRest extends BaseClient {
+  constructor(options: ClientOptions | string, modules: ModulesMap) {
+    super(options, { Rest, ...modules });
+  }
+}

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -47,16 +47,16 @@ function normaliseChannelOptions(options?: ChannelOptions) {
 }
 
 class Channel extends EventEmitter {
-  rest: BaseClient | BaseRealtime;
+  client: BaseClient | BaseRealtime;
   name: string;
   basePath: string;
   presence: Presence;
   channelOptions: ChannelOptions;
 
-  constructor(rest: BaseClient | BaseRealtime, name: string, channelOptions?: ChannelOptions) {
+  constructor(client: BaseClient | BaseRealtime, name: string, channelOptions?: ChannelOptions) {
     super();
     Logger.logAction(Logger.LOG_MINOR, 'Channel()', 'started; name = ' + name);
-    this.rest = rest;
+    this.client = client;
     this.name = name;
     this.basePath = '/channels/' + encodeURIComponent(name);
     this.presence = new Presence(this);
@@ -86,15 +86,15 @@ class Channel extends EventEmitter {
   }
 
   _history(params: RestHistoryParams | null, callback: PaginatedResultCallback<Message>): void {
-    const rest = this.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+    const client = this.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Utils.defaultGetHeaders(client.options, { format });
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
     const options = this.channelOptions;
-    new PaginatedResource(rest, this.basePath + '/messages', headers, envelope, async function (
+    new PaginatedResource(client, this.basePath + '/messages', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -138,11 +138,11 @@ class Channel extends EventEmitter {
       params = {};
     }
 
-    const rest = this.rest,
-      options = rest.options,
+    const client = this.client,
+      options = client.options,
       format = options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      idempotentRestPublishing = rest.options.idempotentRestPublishing,
-      headers = Utils.defaultPostHeaders(rest.options, { format });
+      idempotentRestPublishing = client.options.idempotentRestPublishing,
+      headers = Utils.defaultPostHeaders(client.options, { format });
 
     Utils.mixin(headers, options.headers);
 
@@ -182,7 +182,7 @@ class Channel extends EventEmitter {
   }
 
   _publish(requestBody: unknown, headers: Record<string, string>, params: any, callback: ResourceCallback): void {
-    Resource.post(this.rest, this.basePath + '/messages', requestBody, headers, params, null, callback);
+    Resource.post(this.client, this.basePath + '/messages', requestBody, headers, params, null, callback);
   }
 
   status(callback?: StandardCallback<API.Types.ChannelDetails>): void | Promise<API.Types.ChannelDetails> {
@@ -190,10 +190,10 @@ class Channel extends EventEmitter {
       return Utils.promisify(this, 'status', []);
     }
 
-    const format = this.rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json;
-    const headers = Utils.defaultPostHeaders(this.rest.options, { format });
+    const format = this.client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json;
+    const headers = Utils.defaultPostHeaders(this.client.options, { format });
 
-    Resource.get<API.Types.ChannelDetails>(this.rest, this.basePath, headers, {}, format, callback || noop);
+    Resource.get<API.Types.ChannelDetails>(this.client, this.basePath, headers, {}, format, callback || noop);
   }
 }
 

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -11,6 +11,7 @@ import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
 import BaseClient from './baseclient';
 import * as API from '../../../../ably';
 import Platform from 'common/platform';
+import Defaults from '../util/defaults';
 
 interface RestHistoryParams {
   start?: number;
@@ -88,7 +89,7 @@ class Channel extends EventEmitter {
     const client = this.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.client.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(client.options, { format });
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
     Utils.mixin(headers, client.options.headers);
 
@@ -141,7 +142,7 @@ class Channel extends EventEmitter {
       options = client.options,
       format = options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       idempotentRestPublishing = client.options.idempotentRestPublishing,
-      headers = Utils.defaultPostHeaders(client.options, { format });
+      headers = Defaults.defaultPostHeaders(client.options, { format });
 
     Utils.mixin(headers, options.headers);
 
@@ -190,7 +191,7 @@ class Channel extends EventEmitter {
     }
 
     const format = this.client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json;
-    const headers = Utils.defaultPostHeaders(this.client.options, { format });
+    const headers = Defaults.defaultPostHeaders(this.client.options, { format });
 
     Resource.get<API.Types.ChannelDetails>(this.client, this.basePath, headers, {}, format, callback || noop);
   }

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -8,8 +8,8 @@ import PaginatedResource, { PaginatedResult } from './paginatedresource';
 import Resource, { ResourceCallback } from './resource';
 import { ChannelOptions } from '../../types/channel';
 import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
-import Rest from './rest';
-import Realtime from './realtime';
+import BaseClient from './baseclient';
+import BaseRealtime from './baserealtime';
 import * as API from '../../../../ably';
 import Platform from 'common/platform';
 
@@ -47,13 +47,13 @@ function normaliseChannelOptions(options?: ChannelOptions) {
 }
 
 class Channel extends EventEmitter {
-  rest: Rest | Realtime;
+  rest: BaseClient | BaseRealtime;
   name: string;
   basePath: string;
   presence: Presence;
   channelOptions: ChannelOptions;
 
-  constructor(rest: Rest | Realtime, name: string, channelOptions?: ChannelOptions) {
+  constructor(rest: BaseClient | BaseRealtime, name: string, channelOptions?: ChannelOptions) {
     super();
     Logger.logAction(Logger.LOG_MINOR, 'Channel()', 'started; name = ' + name);
     this.rest = rest;

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -9,7 +9,6 @@ import Resource, { ResourceCallback } from './resource';
 import { ChannelOptions } from '../../types/channel';
 import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
 import BaseClient from './baseclient';
-import BaseRealtime from './baserealtime';
 import * as API from '../../../../ably';
 import Platform from 'common/platform';
 
@@ -47,13 +46,13 @@ function normaliseChannelOptions(options?: ChannelOptions) {
 }
 
 class Channel extends EventEmitter {
-  client: BaseClient | BaseRealtime;
+  client: BaseClient;
   name: string;
   basePath: string;
   presence: Presence;
   channelOptions: ChannelOptions;
 
-  constructor(client: BaseClient | BaseRealtime, name: string, channelOptions?: ChannelOptions) {
+  constructor(client: BaseClient, name: string, channelOptions?: ChannelOptions) {
     super();
     Logger.logAction(Logger.LOG_MINOR, 'Channel()', 'started; name = ' + name);
     this.client = client;

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -5,18 +5,18 @@ import Logger from '../util/logger';
 import ConnectionStateChange from './connectionstatechange';
 import ErrorInfo from '../types/errorinfo';
 import { NormalisedClientOptions } from '../../types/ClientOptions';
-import Realtime from './realtime';
+import BaseRealtime from './baserealtime';
 import Platform from 'common/platform';
 
 class Connection extends EventEmitter {
-  ably: Realtime;
+  ably: BaseRealtime;
   connectionManager: ConnectionManager;
   state: string;
   key?: string;
   id?: string;
   errorReason: ErrorInfo | null;
 
-  constructor(ably: Realtime, options: NormalisedClientOptions) {
+  constructor(ably: BaseRealtime, options: NormalisedClientOptions) {
     super();
     this.ably = ably;
     this.connectionManager = new ConnectionManager(ably, options);

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -1,6 +1,9 @@
 import BaseRealtime from './baserealtime';
 import ClientOptions from '../../types/ClientOptions';
 import { allCommonModules } from './modulesmap';
+import * as Utils from '../util/utils';
+import ConnectionManager from '../transport/connectionmanager';
+import ProtocolMessage from '../types/protocolmessage';
 
 /**
  `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -9,4 +12,8 @@ export class DefaultRealtime extends BaseRealtime {
   constructor(options: ClientOptions) {
     super(options, allCommonModules);
   }
+
+  static Utils = Utils;
+  static ConnectionManager = ConnectionManager;
+  static ProtocolMessage = ProtocolMessage;
 }

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -1,0 +1,6 @@
+import BaseRealtime from './baserealtime';
+
+/**
+ `DefaultRealtime` is the class that the SDK exports as `Realtime`. This is currently the only Realtime class exported by the SDK. When we introduce the forthcoming tree-shakable version of the SDK, which will export `BaseRealtime`, `DefaultRealtime` will remain an export of the non-tree-shakable version.
+ */
+export class DefaultRealtime extends BaseRealtime {}

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -1,6 +1,6 @@
 import BaseRealtime from './baserealtime';
 
 /**
- `DefaultRealtime` is the class that the SDK exports as `Realtime`. This is currently the only Realtime class exported by the SDK. When we introduce the forthcoming tree-shakable version of the SDK, which will export `BaseRealtime`, `DefaultRealtime` will remain an export of the non-tree-shakable version.
+ `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`.
  */
 export class DefaultRealtime extends BaseRealtime {}

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -1,6 +1,12 @@
 import BaseRealtime from './baserealtime';
+import ClientOptions from '../../types/ClientOptions';
+import { allCommonModules } from './modulesmap';
 
 /**
- `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`.
+ `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
  */
-export class DefaultRealtime extends BaseRealtime {}
+export class DefaultRealtime extends BaseRealtime {
+  constructor(options: ClientOptions) {
+    super(options, allCommonModules);
+  }
+}

--- a/src/common/lib/client/defaultrest.ts
+++ b/src/common/lib/client/defaultrest.ts
@@ -1,0 +1,6 @@
+import { BaseRest } from './baserest';
+
+/**
+ `DefaultRest` is the class that the SDK exports as `Rest`. This is currently the only REST class exported by the SDK. When we introduce the forthcoming tree-shakable version of the SDK, which will export `BaseRest`, `DefaultRest` will remain an export of the non-tree-shakable version.
+ */
+export class DefaultRest extends BaseRest {}

--- a/src/common/lib/client/defaultrest.ts
+++ b/src/common/lib/client/defaultrest.ts
@@ -1,6 +1,12 @@
 import { BaseRest } from './baserest';
+import ClientOptions from '../../types/ClientOptions';
+import { allCommonModules } from './modulesmap';
 
 /**
- `DefaultRest` is the class that the non tree-shakable version of the SDK exports as `Rest`.
+ `DefaultRest` is the class that the non tree-shakable version of the SDK exports as `Rest`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
  */
-export class DefaultRest extends BaseRest {}
+export class DefaultRest extends BaseRest {
+  constructor(options: ClientOptions | string) {
+    super(options, allCommonModules);
+  }
+}

--- a/src/common/lib/client/defaultrest.ts
+++ b/src/common/lib/client/defaultrest.ts
@@ -1,6 +1,6 @@
 import { BaseRest } from './baserest';
 
 /**
- `DefaultRest` is the class that the SDK exports as `Rest`. This is currently the only REST class exported by the SDK. When we introduce the forthcoming tree-shakable version of the SDK, which will export `BaseRest`, `DefaultRest` will remain an export of the non-tree-shakable version.
+ `DefaultRest` is the class that the non tree-shakable version of the SDK exports as `Rest`.
  */
 export class DefaultRest extends BaseRest {}

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -1,3 +1,7 @@
-export interface ModulesMap {}
+import { Rest } from './rest';
 
-export const allCommonModules: ModulesMap = {};
+export interface ModulesMap {
+  Rest?: typeof Rest;
+}
+
+export const allCommonModules: ModulesMap = { Rest };

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -1,0 +1,3 @@
+export interface ModulesMap {}
+
+export const allCommonModules: ModulesMap = {};

--- a/src/common/lib/client/paginatedresource.ts
+++ b/src/common/lib/client/paginatedresource.ts
@@ -35,7 +35,7 @@ function returnErrOnly(err: IPartialErrorInfo, body: unknown, useHPR?: boolean) 
 }
 
 class PaginatedResource {
-  rest: BaseClient;
+  client: BaseClient;
   path: string;
   headers: Record<string, string>;
   envelope: Utils.Format | null;
@@ -43,14 +43,14 @@ class PaginatedResource {
   useHttpPaginatedResponse: boolean;
 
   constructor(
-    rest: BaseClient,
+    client: BaseClient,
     path: string,
     headers: Record<string, string>,
     envelope: Utils.Format | undefined,
     bodyHandler: BodyHandler,
     useHttpPaginatedResponse?: boolean
   ) {
-    this.rest = rest;
+    this.client = client;
     this.path = path;
     this.headers = headers;
     this.envelope = envelope ?? null;
@@ -60,7 +60,7 @@ class PaginatedResource {
 
   get<T1, T2>(params: Record<string, T2>, callback: PaginatedResultCallback<T1>): void {
     Resource.get(
-      this.rest,
+      this.client,
       this.path,
       this.headers,
       params,
@@ -73,7 +73,7 @@ class PaginatedResource {
 
   delete<T1, T2>(params: Record<string, T2>, callback: PaginatedResultCallback<T1>): void {
     Resource.delete(
-      this.rest,
+      this.client,
       this.path,
       this.headers,
       params,
@@ -86,7 +86,7 @@ class PaginatedResource {
 
   post<T1, T2>(params: Record<string, T2>, body: unknown, callback: PaginatedResultCallback<T1>): void {
     Resource.post(
-      this.rest,
+      this.client,
       this.path,
       body,
       this.headers,
@@ -102,7 +102,7 @@ class PaginatedResource {
 
   put<T1, T2>(params: Record<string, T2>, body: unknown, callback: PaginatedResultCallback<T1>): void {
     Resource.put(
-      this.rest,
+      this.client,
       this.path,
       body,
       this.headers,
@@ -118,7 +118,7 @@ class PaginatedResource {
 
   patch<T1, T2>(params: Record<string, T2>, body: unknown, callback: PaginatedResultCallback<T1>): void {
     Resource.patch(
-      this.rest,
+      this.client,
       this.path,
       body,
       this.headers,
@@ -234,7 +234,7 @@ export class PaginatedResult<T> {
   get(params: any, callback: PaginatedResultCallback<T>): void {
     const res = this.resource;
     Resource.get(
-      res.rest,
+      res.client,
       res.path,
       res.headers,
       params,

--- a/src/common/lib/client/paginatedresource.ts
+++ b/src/common/lib/client/paginatedresource.ts
@@ -3,7 +3,7 @@ import Logger from '../util/logger';
 import Resource from './resource';
 import ErrorInfo, { IPartialErrorInfo } from '../types/errorinfo';
 import { PaginatedResultCallback } from '../../types/utils';
-import Rest from './rest';
+import BaseClient from './baseclient';
 
 export type BodyHandler = (body: unknown, headers: Record<string, string>, unpacked?: boolean) => Promise<any>;
 
@@ -35,7 +35,7 @@ function returnErrOnly(err: IPartialErrorInfo, body: unknown, useHPR?: boolean) 
 }
 
 class PaginatedResource {
-  rest: Rest;
+  rest: BaseClient;
   path: string;
   headers: Record<string, string>;
   envelope: Utils.Format | null;
@@ -43,7 +43,7 @@ class PaginatedResource {
   useHttpPaginatedResponse: boolean;
 
   constructor(
-    rest: Rest,
+    rest: BaseClient,
     path: string,
     headers: Record<string, string>,
     envelope: Utils.Format | undefined,

--- a/src/common/lib/client/presence.ts
+++ b/src/common/lib/client/presence.ts
@@ -29,15 +29,15 @@ class Presence extends EventEmitter {
         return Utils.promisify(this, 'get', arguments);
       }
     }
-    const rest = this.channel.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.channel.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+    const client = this.channel.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.channel.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Utils.defaultGetHeaders(client.options, { format });
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
     const options = this.channel.channelOptions;
-    new PaginatedResource(rest, this.basePath, headers, envelope, async function (
+    new PaginatedResource(client, this.basePath, headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -68,15 +68,15 @@ class Presence extends EventEmitter {
       }
     }
 
-    const rest = this.channel.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.channel.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+    const client = this.channel.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.channel.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Utils.defaultGetHeaders(client.options, { format });
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
     const options = this.channel.channelOptions;
-    new PaginatedResource(rest, this.basePath + '/history', headers, envelope, async function (
+    new PaginatedResource(client, this.basePath + '/history', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean

--- a/src/common/lib/client/presence.ts
+++ b/src/common/lib/client/presence.ts
@@ -7,6 +7,7 @@ import { CipherOptions } from '../types/message';
 import { PaginatedResultCallback } from '../../types/utils';
 import Channel from './channel';
 import RealtimeChannel from './realtimechannel';
+import Defaults from '../util/defaults';
 
 class Presence extends EventEmitter {
   channel: RealtimeChannel | Channel;
@@ -32,7 +33,7 @@ class Presence extends EventEmitter {
     const client = this.channel.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.channel.client.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(client.options, { format });
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
     Utils.mixin(headers, client.options.headers);
 
@@ -71,7 +72,7 @@ class Presence extends EventEmitter {
     const client = this.channel.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.channel.client.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(client.options, { format });
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
     Utils.mixin(headers, client.options.headers);
 

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -6,6 +6,7 @@ import ErrorInfo from '../types/errorinfo';
 import PushChannelSubscription from '../types/pushchannelsubscription';
 import { ErrCallback, PaginatedResultCallback, StandardCallback } from '../../types/utils';
 import BaseClient from './baseclient';
+import Defaults from '../util/defaults';
 
 class Push {
   client: BaseClient;
@@ -31,7 +32,7 @@ class Admin {
   publish(recipient: any, payload: any, callback: ErrCallback) {
     const client = this.client;
     const format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(client.options, { format }),
+      headers = Defaults.defaultPostHeaders(client.options, { format }),
       params = {};
     const body = Utils.mixin({ recipient: recipient }, payload);
 
@@ -59,7 +60,7 @@ class DeviceRegistrations {
     const client = this.client;
     const body = DeviceDetails.fromValues(device);
     const format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(client.options, { format }),
+      headers = Defaults.defaultPostHeaders(client.options, { format }),
       params = {};
 
     if (typeof callback !== 'function') {
@@ -95,7 +96,7 @@ class DeviceRegistrations {
   get(deviceIdOrDetails: any, callback: StandardCallback<DeviceDetails>) {
     const client = this.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(client.options, { format }),
+      headers = Defaults.defaultGetHeaders(client.options, { format }),
       deviceId = deviceIdOrDetails.id || deviceIdOrDetails;
 
     if (typeof callback !== 'function') {
@@ -139,7 +140,7 @@ class DeviceRegistrations {
     const client = this.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.client.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(client.options, { format });
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'list', arguments);
@@ -159,7 +160,7 @@ class DeviceRegistrations {
   remove(deviceIdOrDetails: any, callback: ErrCallback) {
     const client = this.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(client.options, { format }),
+      headers = Defaults.defaultGetHeaders(client.options, { format }),
       params = {},
       deviceId = deviceIdOrDetails.id || deviceIdOrDetails;
 
@@ -195,7 +196,7 @@ class DeviceRegistrations {
   removeWhere(params: any, callback: ErrCallback) {
     const client = this.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(client.options, { format });
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'removeWhere', arguments);
@@ -220,7 +221,7 @@ class ChannelSubscriptions {
     const client = this.client;
     const body = PushChannelSubscription.fromValues(subscription);
     const format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(client.options, { format }),
+      headers = Defaults.defaultPostHeaders(client.options, { format }),
       params = {};
 
     if (typeof callback !== 'function') {
@@ -252,7 +253,7 @@ class ChannelSubscriptions {
     const client = this.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.client.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(client.options, { format });
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'list', arguments);
@@ -272,7 +273,7 @@ class ChannelSubscriptions {
   removeWhere(params: any, callback: PaginatedResultCallback<unknown>) {
     const client = this.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(client.options, { format });
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'removeWhere', arguments);
@@ -292,7 +293,7 @@ class ChannelSubscriptions {
     const client = this.client,
       format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
       envelope = this.client.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(client.options, { format });
+      headers = Defaults.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'listChannels', arguments);

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -8,30 +8,30 @@ import { ErrCallback, PaginatedResultCallback, StandardCallback } from '../../ty
 import BaseClient from './baseclient';
 
 class Push {
-  rest: BaseClient;
+  client: BaseClient;
   admin: Admin;
 
-  constructor(rest: BaseClient) {
-    this.rest = rest;
-    this.admin = new Admin(rest);
+  constructor(client: BaseClient) {
+    this.client = client;
+    this.admin = new Admin(client);
   }
 }
 
 class Admin {
-  rest: BaseClient;
+  client: BaseClient;
   deviceRegistrations: DeviceRegistrations;
   channelSubscriptions: ChannelSubscriptions;
 
-  constructor(rest: BaseClient) {
-    this.rest = rest;
-    this.deviceRegistrations = new DeviceRegistrations(rest);
-    this.channelSubscriptions = new ChannelSubscriptions(rest);
+  constructor(client: BaseClient) {
+    this.client = client;
+    this.deviceRegistrations = new DeviceRegistrations(client);
+    this.channelSubscriptions = new ChannelSubscriptions(client);
   }
 
   publish(recipient: any, payload: any, callback: ErrCallback) {
-    const rest = this.rest;
-    const format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(rest.options, { format }),
+    const client = this.client;
+    const format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Utils.defaultPostHeaders(client.options, { format }),
       params = {};
     const body = Utils.mixin({ recipient: recipient }, payload);
 
@@ -39,40 +39,40 @@ class Admin {
       return Utils.promisify(this, 'publish', arguments);
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
+    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
     const requestBody = Utils.encodeBody(body, format);
-    Resource.post(rest, '/push/publish', requestBody, headers, params, null, (err) => callback(err));
+    Resource.post(client, '/push/publish', requestBody, headers, params, null, (err) => callback(err));
   }
 }
 
 class DeviceRegistrations {
-  rest: BaseClient;
+  client: BaseClient;
 
-  constructor(rest: BaseClient) {
-    this.rest = rest;
+  constructor(client: BaseClient) {
+    this.client = client;
   }
 
   save(device: any, callback: StandardCallback<DeviceDetails>) {
-    const rest = this.rest;
+    const client = this.client;
     const body = DeviceDetails.fromValues(device);
-    const format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(rest.options, { format }),
+    const format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Utils.defaultPostHeaders(client.options, { format }),
       params = {};
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'save', arguments);
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
+    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
     const requestBody = Utils.encodeBody(body, format);
     Resource.put(
-      rest,
+      client,
       '/push/deviceRegistrations/' + encodeURIComponent(device.id),
       requestBody,
       headers,
@@ -93,9 +93,9 @@ class DeviceRegistrations {
   }
 
   get(deviceIdOrDetails: any, callback: StandardCallback<DeviceDetails>) {
-    const rest = this.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(rest.options, { format }),
+    const client = this.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Utils.defaultGetHeaders(client.options, { format }),
       deviceId = deviceIdOrDetails.id || deviceIdOrDetails;
 
     if (typeof callback !== 'function') {
@@ -113,10 +113,10 @@ class DeviceRegistrations {
       return;
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
     Resource.get(
-      rest,
+      client,
       '/push/deviceRegistrations/' + encodeURIComponent(deviceId),
       headers,
       {},
@@ -136,18 +136,18 @@ class DeviceRegistrations {
   }
 
   list(params: any, callback: PaginatedResultCallback<unknown>) {
-    const rest = this.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+    const client = this.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Utils.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'list', arguments);
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    new PaginatedResource(rest, '/push/deviceRegistrations', headers, envelope, async function (
+    new PaginatedResource(client, '/push/deviceRegistrations', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -157,9 +157,9 @@ class DeviceRegistrations {
   }
 
   remove(deviceIdOrDetails: any, callback: ErrCallback) {
-    const rest = this.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(rest.options, { format }),
+    const client = this.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Utils.defaultGetHeaders(client.options, { format }),
       params = {},
       deviceId = deviceIdOrDetails.id || deviceIdOrDetails;
 
@@ -178,12 +178,12 @@ class DeviceRegistrations {
       return;
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
+    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
     Resource['delete'](
-      rest,
+      client,
       '/push/deviceRegistrations/' + encodeURIComponent(deviceId),
       headers,
       params,
@@ -193,47 +193,47 @@ class DeviceRegistrations {
   }
 
   removeWhere(params: any, callback: ErrCallback) {
-    const rest = this.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+    const client = this.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Utils.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'removeWhere', arguments);
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
+    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
-    Resource['delete'](rest, '/push/deviceRegistrations', headers, params, null, (err) => callback(err));
+    Resource['delete'](client, '/push/deviceRegistrations', headers, params, null, (err) => callback(err));
   }
 }
 
 class ChannelSubscriptions {
-  rest: BaseClient;
+  client: BaseClient;
 
-  constructor(rest: BaseClient) {
-    this.rest = rest;
+  constructor(client: BaseClient) {
+    this.client = client;
   }
 
   save(subscription: Record<string, unknown>, callback: PaginatedResultCallback<unknown>) {
-    const rest = this.rest;
+    const client = this.client;
     const body = PushChannelSubscription.fromValues(subscription);
-    const format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultPostHeaders(rest.options, { format }),
+    const format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Utils.defaultPostHeaders(client.options, { format }),
       params = {};
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'save', arguments);
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
+    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
     const requestBody = Utils.encodeBody(body, format);
     Resource.post(
-      rest,
+      client,
       '/push/channelSubscriptions',
       requestBody,
       headers,
@@ -249,18 +249,18 @@ class ChannelSubscriptions {
   }
 
   list(params: any, callback: PaginatedResultCallback<unknown>) {
-    const rest = this.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+    const client = this.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Utils.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'list', arguments);
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    new PaginatedResource(rest, '/push/channelSubscriptions', headers, envelope, async function (
+    new PaginatedResource(client, '/push/channelSubscriptions', headers, envelope, async function (
       body: any,
       headers: Record<string, string>,
       unpacked?: boolean
@@ -270,39 +270,39 @@ class ChannelSubscriptions {
   }
 
   removeWhere(params: any, callback: PaginatedResultCallback<unknown>) {
-    const rest = this.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+    const client = this.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Utils.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'removeWhere', arguments);
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
+    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
-    Resource['delete'](rest, '/push/channelSubscriptions', headers, params, null, (err) => callback(err));
+    Resource['delete'](client, '/push/channelSubscriptions', headers, params, null, (err) => callback(err));
   }
 
   /* ChannelSubscriptions have no unique id; removing one is equivalent to removeWhere by its properties */
   remove = ChannelSubscriptions.prototype.removeWhere;
 
   listChannels(params: any, callback: PaginatedResultCallback<unknown>) {
-    const rest = this.rest,
-      format = rest.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
-      envelope = this.rest.http.supportsLinkHeaders ? undefined : format,
-      headers = Utils.defaultGetHeaders(rest.options, { format });
+    const client = this.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Utils.defaultGetHeaders(client.options, { format });
 
     if (typeof callback !== 'function') {
       return Utils.promisify(this, 'listChannels', arguments);
     }
 
-    Utils.mixin(headers, rest.options.headers);
+    Utils.mixin(headers, client.options.headers);
 
-    if (rest.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
+    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
 
-    new PaginatedResource(rest, '/push/channels', headers, envelope, async function (
+    new PaginatedResource(client, '/push/channels', headers, envelope, async function (
       body: unknown,
       headers: Record<string, string>,
       unpacked?: boolean

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -5,24 +5,24 @@ import PaginatedResource from './paginatedresource';
 import ErrorInfo from '../types/errorinfo';
 import PushChannelSubscription from '../types/pushchannelsubscription';
 import { ErrCallback, PaginatedResultCallback, StandardCallback } from '../../types/utils';
-import Rest from './rest';
+import BaseClient from './baseclient';
 
 class Push {
-  rest: Rest;
+  rest: BaseClient;
   admin: Admin;
 
-  constructor(rest: Rest) {
+  constructor(rest: BaseClient) {
     this.rest = rest;
     this.admin = new Admin(rest);
   }
 }
 
 class Admin {
-  rest: Rest;
+  rest: BaseClient;
   deviceRegistrations: DeviceRegistrations;
   channelSubscriptions: ChannelSubscriptions;
 
-  constructor(rest: Rest) {
+  constructor(rest: BaseClient) {
     this.rest = rest;
     this.deviceRegistrations = new DeviceRegistrations(rest);
     this.channelSubscriptions = new ChannelSubscriptions(rest);
@@ -49,9 +49,9 @@ class Admin {
 }
 
 class DeviceRegistrations {
-  rest: Rest;
+  rest: BaseClient;
 
-  constructor(rest: Rest) {
+  constructor(rest: BaseClient) {
     this.rest = rest;
   }
 
@@ -210,9 +210,9 @@ class DeviceRegistrations {
 }
 
 class ChannelSubscriptions {
-  rest: Rest;
+  rest: BaseClient;
 
-  constructor(rest: Rest) {
+  constructor(rest: BaseClient) {
     this.rest = rest;
   }
 

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -13,7 +13,7 @@ import * as API from '../../../../ably';
 import ConnectionManager from '../transport/connectionmanager';
 import ConnectionStateChange from './connectionstatechange';
 import { ErrCallback, PaginatedResultCallback, StandardCallback } from '../../types/utils';
-import Realtime from './realtime';
+import BaseRealtime from './baserealtime';
 
 interface RealtimeHistoryParams {
   start?: number;
@@ -49,7 +49,7 @@ function validateChannelOptions(options?: API.Types.ChannelOptions) {
 }
 
 class RealtimeChannel extends Channel {
-  realtime: Realtime;
+  realtime: BaseRealtime;
   presence: RealtimePresence;
   connectionManager: ConnectionManager;
   state: API.Types.ChannelState;
@@ -80,7 +80,7 @@ class RealtimeChannel extends Channel {
   retryTimer?: number | NodeJS.Timeout | null;
   retryCount: number = 0;
 
-  constructor(realtime: Realtime, name: string, options?: API.Types.ChannelOptions) {
+  constructor(realtime: BaseRealtime, name: string, options?: API.Types.ChannelOptions) {
     super(realtime, name, options);
     Logger.logAction(Logger.LOG_MINOR, 'RealtimeChannel()', 'started; name = ' + name);
     this.realtime = realtime;

--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -8,19 +8,19 @@ import BaseClient from './baseclient';
 import { ErrnoException } from '../../types/http';
 
 function withAuthDetails(
-  rest: BaseClient,
+  client: BaseClient,
   headers: Record<string, string>,
   params: Record<string, any>,
   errCallback: Function,
   opCallback: Function
 ) {
-  if (rest.http.supportsAuthHeaders) {
-    rest.auth.getAuthHeaders(function (err: Error, authHeaders: Record<string, string>) {
+  if (client.http.supportsAuthHeaders) {
+    client.auth.getAuthHeaders(function (err: Error, authHeaders: Record<string, string>) {
       if (err) errCallback(err);
       else opCallback(Utils.mixin(authHeaders, headers), params);
     });
   } else {
-    rest.auth.getAuthParams(function (err: Error, authParams: Record<string, string>) {
+    client.auth.getAuthParams(function (err: Error, authParams: Record<string, string>) {
       if (err) errCallback(err);
       else opCallback(headers, Utils.mixin(authParams, params));
     });
@@ -132,29 +132,29 @@ export type ResourceCallback<T = unknown> = (
 
 class Resource {
   static get<T = unknown>(
-    rest: BaseClient,
+    client: BaseClient,
     path: string,
     headers: Record<string, string>,
     params: Record<string, any>,
     envelope: Utils.Format | null,
     callback: ResourceCallback<T>
   ): void {
-    Resource.do(HttpMethods.Get, rest, path, null, headers, params, envelope, callback);
+    Resource.do(HttpMethods.Get, client, path, null, headers, params, envelope, callback);
   }
 
   static delete(
-    rest: BaseClient,
+    client: BaseClient,
     path: string,
     headers: Record<string, string>,
     params: Record<string, any>,
     envelope: Utils.Format | null,
     callback: ResourceCallback
   ): void {
-    Resource.do(HttpMethods.Delete, rest, path, null, headers, params, envelope, callback);
+    Resource.do(HttpMethods.Delete, client, path, null, headers, params, envelope, callback);
   }
 
   static post(
-    rest: BaseClient,
+    client: BaseClient,
     path: string,
     body: unknown,
     headers: Record<string, string>,
@@ -162,11 +162,11 @@ class Resource {
     envelope: Utils.Format | null,
     callback: ResourceCallback
   ): void {
-    Resource.do(HttpMethods.Post, rest, path, body, headers, params, envelope, callback);
+    Resource.do(HttpMethods.Post, client, path, body, headers, params, envelope, callback);
   }
 
   static patch(
-    rest: BaseClient,
+    client: BaseClient,
     path: string,
     body: unknown,
     headers: Record<string, string>,
@@ -174,11 +174,11 @@ class Resource {
     envelope: Utils.Format | null,
     callback: ResourceCallback
   ): void {
-    Resource.do(HttpMethods.Patch, rest, path, body, headers, params, envelope, callback);
+    Resource.do(HttpMethods.Patch, client, path, body, headers, params, envelope, callback);
   }
 
   static put(
-    rest: BaseClient,
+    client: BaseClient,
     path: string,
     body: unknown,
     headers: Record<string, string>,
@@ -186,12 +186,12 @@ class Resource {
     envelope: Utils.Format | null,
     callback: ResourceCallback
   ): void {
-    Resource.do(HttpMethods.Put, rest, path, body, headers, params, envelope, callback);
+    Resource.do(HttpMethods.Put, client, path, body, headers, params, envelope, callback);
   }
 
   static do<T>(
     method: HttpMethods,
-    rest: BaseClient,
+    client: BaseClient,
     path: string,
     body: unknown,
     headers: Record<string, string>,
@@ -237,9 +237,9 @@ class Resource {
         );
       }
 
-      rest.http.do(
+      client.http.do(
         method,
-        rest,
+        client,
         path,
         headers,
         body,
@@ -253,13 +253,13 @@ class Resource {
         ) {
           if (err && Auth.isTokenErr(err as ErrorInfo)) {
             /* token has expired, so get a new one */
-            rest.auth.authorize(null, null, function (err: ErrorInfo) {
+            client.auth.authorize(null, null, function (err: ErrorInfo) {
               if (err) {
                 callback(err);
                 return;
               }
               /* retry ... */
-              withAuthDetails(rest, headers, params, callback, doRequest);
+              withAuthDetails(client, headers, params, callback, doRequest);
             });
             return;
           }
@@ -268,7 +268,7 @@ class Resource {
       );
     }
 
-    withAuthDetails(rest, headers, params, callback, doRequest);
+    withAuthDetails(client, headers, params, callback, doRequest);
   }
 }
 

--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -4,11 +4,11 @@ import Logger from '../util/logger';
 import Auth from './auth';
 import HttpMethods from '../../constants/HttpMethods';
 import ErrorInfo, { IPartialErrorInfo, PartialErrorInfo } from '../types/errorinfo';
-import Rest from './rest';
+import BaseClient from './baseclient';
 import { ErrnoException } from '../../types/http';
 
 function withAuthDetails(
-  rest: Rest,
+  rest: BaseClient,
   headers: Record<string, string>,
   params: Record<string, any>,
   errCallback: Function,
@@ -132,7 +132,7 @@ export type ResourceCallback<T = unknown> = (
 
 class Resource {
   static get<T = unknown>(
-    rest: Rest,
+    rest: BaseClient,
     path: string,
     headers: Record<string, string>,
     params: Record<string, any>,
@@ -143,7 +143,7 @@ class Resource {
   }
 
   static delete(
-    rest: Rest,
+    rest: BaseClient,
     path: string,
     headers: Record<string, string>,
     params: Record<string, any>,
@@ -154,7 +154,7 @@ class Resource {
   }
 
   static post(
-    rest: Rest,
+    rest: BaseClient,
     path: string,
     body: unknown,
     headers: Record<string, string>,
@@ -166,7 +166,7 @@ class Resource {
   }
 
   static patch(
-    rest: Rest,
+    rest: BaseClient,
     path: string,
     body: unknown,
     headers: Record<string, string>,
@@ -178,7 +178,7 @@ class Resource {
   }
 
   static put(
-    rest: Rest,
+    rest: BaseClient,
     path: string,
     body: unknown,
     headers: Record<string, string>,
@@ -191,7 +191,7 @@ class Resource {
 
   static do<T>(
     method: HttpMethods,
-    rest: Rest,
+    rest: BaseClient,
     path: string,
     body: unknown,
     headers: Record<string, string>,

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -1,0 +1,295 @@
+import * as Utils from '../util/utils';
+import Logger, { LoggerOptions } from '../util/logger';
+import Defaults from '../util/defaults';
+import Push from './push';
+import PaginatedResource, { HttpPaginatedResponse, PaginatedResult } from './paginatedresource';
+import Channel from './channel';
+import ErrorInfo from '../types/errorinfo';
+import Stats from '../types/stats';
+import HttpMethods from '../../constants/HttpMethods';
+import { ChannelOptions } from '../../types/channel';
+import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
+import { ErrnoException, RequestParams } from '../../types/http';
+import * as API from '../../../../ably';
+import Resource from './resource';
+
+import Platform from '../../platform';
+import BaseClient from './baseclient';
+
+type BatchResult<T> = API.Types.BatchResult<T>;
+type BatchPublishSpec = API.Types.BatchPublishSpec;
+type BatchPublishSuccessResult = API.Types.BatchPublishSuccessResult;
+type BatchPublishFailureResult = API.Types.BatchPublishFailureResult;
+type BatchPublishResult = BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>;
+type BatchPresenceSuccessResult = API.Types.BatchPresenceSuccessResult;
+type BatchPresenceFailureResult = API.Types.BatchPresenceFailureResult;
+type BatchPresenceResult = BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult>;
+
+const noop = function () {};
+export class Rest {
+  private readonly client: BaseClient;
+  readonly channels: Channels;
+  readonly push: Push;
+
+  constructor(client: BaseClient) {
+    this.client = client;
+    this.channels = new Channels(this.client);
+    this.push = new Push(this.client);
+  }
+
+  stats(
+    params: RequestParams,
+    callback: StandardCallback<PaginatedResult<Stats>>
+  ): Promise<PaginatedResult<Stats>> | void {
+    /* params and callback are optional; see if params contains the callback */
+    if (callback === undefined) {
+      if (typeof params == 'function') {
+        callback = params;
+        params = null;
+      } else {
+        return Utils.promisify(this, 'stats', [params]) as Promise<PaginatedResult<Stats>>;
+      }
+    }
+    const headers = Defaults.defaultGetHeaders(this.client.options),
+      format = this.client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.client.http.supportsLinkHeaders ? undefined : format;
+
+    Utils.mixin(headers, this.client.options.headers);
+
+    new PaginatedResource(this.client, '/stats', headers, envelope, function (
+      body: unknown,
+      headers: Record<string, string>,
+      unpacked?: boolean
+    ) {
+      const statsValues = unpacked ? body : JSON.parse(body as string);
+      for (let i = 0; i < statsValues.length; i++) statsValues[i] = Stats.fromValues(statsValues[i]);
+      return statsValues;
+    }).get(params as Record<string, string>, callback);
+  }
+
+  time(params?: RequestParams | StandardCallback<number>, callback?: StandardCallback<number>): Promise<number> | void {
+    /* params and callback are optional; see if params contains the callback */
+    if (callback === undefined) {
+      if (typeof params == 'function') {
+        callback = params;
+        params = null;
+      } else {
+        return Utils.promisify(this, 'time', [params]) as Promise<number>;
+      }
+    }
+
+    const _callback = callback || noop;
+
+    const headers = Defaults.defaultGetHeaders(this.client.options);
+    if (this.client.options.headers) Utils.mixin(headers, this.client.options.headers);
+    const timeUri = (host: string) => {
+      return this.client.baseUri(host) + '/time';
+    };
+    this.client.http.do(
+      HttpMethods.Get,
+      this.client,
+      timeUri,
+      headers,
+      null,
+      params as RequestParams,
+      (
+        err?: ErrorInfo | ErrnoException | null,
+        res?: unknown,
+        headers?: Record<string, string>,
+        unpacked?: boolean
+      ) => {
+        if (err) {
+          _callback(err);
+          return;
+        }
+        if (!unpacked) res = JSON.parse(res as string);
+        const time = (res as number[])[0];
+        if (!time) {
+          _callback(new ErrorInfo('Internal error (unexpected result type from GET /time)', 50000, 500));
+          return;
+        }
+        /* calculate time offset only once for this device by adding to the prototype */
+        this.client.serverTimeOffset = time - Utils.now();
+        _callback(null, time);
+      }
+    );
+  }
+
+  request(
+    method: string,
+    path: string,
+    version: number,
+    params: RequestParams,
+    body: unknown,
+    customHeaders: Record<string, string>,
+    callback: StandardCallback<HttpPaginatedResponse<unknown>>
+  ): Promise<HttpPaginatedResponse<unknown>> | void {
+    const useBinary = this.client.options.useBinaryProtocol,
+      encoder = useBinary ? Platform.Config.msgpack.encode : JSON.stringify,
+      decoder = useBinary ? Platform.Config.msgpack.decode : JSON.parse,
+      format = useBinary ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = this.client.http.supportsLinkHeaders ? undefined : format;
+    params = params || {};
+    const _method = method.toLowerCase() as HttpMethods;
+    const headers =
+      _method == 'get'
+        ? Defaults.defaultGetHeaders(this.client.options, { format, protocolVersion: version })
+        : Defaults.defaultPostHeaders(this.client.options, { format, protocolVersion: version });
+
+    if (callback === undefined) {
+      return Utils.promisify(this, 'request', [method, path, version, params, body, customHeaders]) as Promise<
+        HttpPaginatedResponse<unknown>
+      >;
+    }
+
+    if (typeof body !== 'string') {
+      body = encoder(body);
+    }
+    Utils.mixin(headers, this.client.options.headers);
+    if (customHeaders) {
+      Utils.mixin(headers, customHeaders);
+    }
+    const paginatedResource = new PaginatedResource(
+      this.client,
+      path,
+      headers,
+      envelope,
+      async function (resbody: unknown, headers: Record<string, string>, unpacked?: boolean) {
+        return Utils.ensureArray(unpacked ? resbody : decoder(resbody as string & Buffer));
+      },
+      /* useHttpPaginatedResponse: */ true
+    );
+
+    if (!Utils.arrIn(Platform.Http.methods, _method)) {
+      throw new ErrorInfo('Unsupported method ' + _method, 40500, 405);
+    }
+
+    if (Utils.arrIn(Platform.Http.methodsWithBody, _method)) {
+      paginatedResource[_method as HttpMethods.Post](params, body, callback as PaginatedResultCallback<unknown>);
+    } else {
+      paginatedResource[_method as HttpMethods.Get | HttpMethods.Delete](
+        params,
+        callback as PaginatedResultCallback<unknown>
+      );
+    }
+  }
+
+  batchPublish<T extends BatchPublishSpec | BatchPublishSpec[]>(
+    specOrSpecs: T
+  ): Promise<T extends BatchPublishSpec ? BatchPublishResult : BatchPublishResult[]>;
+  batchPublish<T extends BatchPublishSpec | BatchPublishSpec[]>(
+    specOrSpecs: T,
+    callback?: StandardCallback<T extends BatchPublishSpec ? BatchPublishResult : BatchPublishResult[]>
+  ): void | Promise<T extends BatchPublishSpec ? BatchPublishResult : BatchPublishResult[]> {
+    if (callback === undefined) {
+      return Utils.promisify(this, 'batchPublish', [specOrSpecs]);
+    }
+
+    let requestBodyDTO: BatchPublishSpec[];
+    let singleSpecMode: boolean;
+    if (Utils.isArray(specOrSpecs)) {
+      requestBodyDTO = specOrSpecs;
+      singleSpecMode = false;
+    } else {
+      requestBodyDTO = [specOrSpecs];
+      singleSpecMode = true;
+    }
+
+    const format = this.client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Defaults.defaultPostHeaders(this.client.options, { format });
+
+    if (this.client.options.headers) Utils.mixin(headers, this.client.options.headers);
+
+    const requestBody = Utils.encodeBody(requestBodyDTO, format);
+    Resource.post(
+      this.client,
+      '/messages',
+      requestBody,
+      headers,
+      { newBatchResponse: 'true' },
+      null,
+      (err, body, headers, unpacked) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        const batchResults = (unpacked ? body : Utils.decodeBody(body, format)) as BatchPublishResult[];
+
+        // I don't love the below type assertions for `callback` but not sure how to avoid them
+        if (singleSpecMode) {
+          (callback as StandardCallback<BatchPublishResult>)(null, batchResults[0]);
+        } else {
+          (callback as StandardCallback<BatchPublishResult[]>)(null, batchResults);
+        }
+      }
+    );
+  }
+
+  batchPresence(channels: string[]): Promise<BatchPresenceResult>;
+  batchPresence(
+    channels: string[],
+    callback?: StandardCallback<BatchPresenceResult>
+  ): void | Promise<BatchPresenceResult> {
+    if (callback === undefined) {
+      return Utils.promisify(this, 'batchPresence', [channels]);
+    }
+
+    const format = this.client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Defaults.defaultPostHeaders(this.client.options, { format });
+
+    if (this.client.options.headers) Utils.mixin(headers, this.client.options.headers);
+
+    const channelsParam = channels.join(',');
+
+    Resource.get(
+      this.client,
+      '/presence',
+      headers,
+      { newBatchResponse: 'true', channels: channelsParam },
+      null,
+      (err, body, headers, unpacked) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        const batchResult = (unpacked ? body : Utils.decodeBody(body, format)) as BatchPresenceResult;
+
+        callback(null, batchResult);
+      }
+    );
+  }
+
+  setLog(logOptions: LoggerOptions): void {
+    Logger.setLog(logOptions.level, logOptions.handler);
+  }
+}
+
+class Channels {
+  client: BaseClient;
+  all: Record<string, Channel>;
+
+  constructor(client: BaseClient) {
+    this.client = client;
+    this.all = Object.create(null);
+  }
+
+  get(name: string, channelOptions?: ChannelOptions) {
+    name = String(name);
+    let channel = this.all[name];
+    if (!channel) {
+      this.all[name] = channel = new Channel(this.client, name, channelOptions);
+    } else if (channelOptions) {
+      channel.setOptions(channelOptions);
+    }
+
+    return channel;
+  }
+
+  /* Included to support certain niche use-cases; most users should ignore this.
+   * Please do not use this unless you know what you're doing */
+  release(name: string) {
+    delete this.all[String(name)];
+  }
+}

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -99,6 +99,8 @@ function decodeRecoveryKey(recoveryKey: string): RecoveryContext | null {
   }
 }
 
+const supportedTransports: Record<string, TransportCtor> = {};
+
 export class TransportParams {
   options: ClientOptions;
   host: string | null;
@@ -402,7 +404,9 @@ class ConnectionManager extends EventEmitter {
    * transport management
    *********************/
 
-  static supportedTransports: Record<string, TransportCtor> = {};
+  static get supportedTransports() {
+    return supportedTransports;
+  }
 
   static initTransports() {
     WebSocketTransport(ConnectionManager);

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -42,6 +42,8 @@ type CompleteDefaults = IDefaults & {
   getRealtimeHost(options: ClientOptions, production: boolean, environment: string): string;
   objectifyOptions(options: ClientOptions | string): ClientOptions;
   normaliseOptions(options: InternalClientOptions): NormalisedClientOptions;
+  defaultGetHeaders(options: NormalisedClientOptions, headersOptions?: HeadersOptions): Record<string, string>;
+  defaultPostHeaders(options: NormalisedClientOptions, headersOptions?: HeadersOptions): Record<string, string>;
 };
 
 const Defaults = {
@@ -87,6 +89,8 @@ const Defaults = {
   checkHost,
   objectifyOptions,
   normaliseOptions,
+  defaultGetHeaders,
+  defaultPostHeaders,
 };
 
 export function getHost(options: ClientOptions, host?: string | null, ws?: boolean): string {
@@ -257,6 +261,56 @@ export function normaliseOptions(options: InternalClientOptions): NormalisedClie
     connectivityCheckParams,
     connectivityCheckUrl,
     headers,
+  };
+}
+
+const contentTypes = {
+  json: 'application/json',
+  xml: 'application/xml',
+  html: 'text/html',
+  msgpack: 'application/x-msgpack',
+};
+
+export interface HeadersOptions {
+  format?: Utils.Format;
+  protocolVersion?: number;
+}
+
+const defaultHeadersOptions: Required<HeadersOptions> = {
+  format: Utils.Format.json,
+  protocolVersion: Defaults.protocolVersion,
+};
+
+export function defaultGetHeaders(
+  options: NormalisedClientOptions,
+  {
+    format = defaultHeadersOptions.format,
+    protocolVersion = defaultHeadersOptions.protocolVersion,
+  }: HeadersOptions = {}
+): Record<string, string> {
+  const accept = contentTypes[format];
+  return {
+    accept: accept,
+    'X-Ably-Version': protocolVersion.toString(),
+    'Ably-Agent': getAgentString(options),
+  };
+}
+
+export function defaultPostHeaders(
+  options: NormalisedClientOptions,
+  {
+    format = defaultHeadersOptions.format,
+    protocolVersion = defaultHeadersOptions.protocolVersion,
+  }: HeadersOptions = {}
+): Record<string, string> {
+  let contentType;
+  const accept = (contentType = contentTypes[format]);
+
+  return {
+    accept: accept,
+    'content-type': contentType,
+    'X-Ably-Version': protocolVersion.toString(),
+    'Ably-Agent': getAgentString(options),
   };
 }
 

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -1,7 +1,5 @@
 import Platform from 'common/platform';
-import Defaults, { getAgentString } from './defaults';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
-import { NormalisedClientOptions } from 'common/types/ClientOptions';
 
 function randomPosn(arrOrStr: Array<unknown> | string) {
   return Math.floor(Math.random() * arrOrStr.length);
@@ -330,59 +328,9 @@ export function allSame(arr: Array<Record<string, unknown>>, prop: string): bool
   });
 }
 
-const contentTypes = {
-  json: 'application/json',
-  xml: 'application/xml',
-  html: 'text/html',
-  msgpack: 'application/x-msgpack',
-};
-
 export enum Format {
   msgpack = 'msgpack',
   json = 'json',
-}
-
-export interface HeadersOptions {
-  format?: Format;
-  protocolVersion?: number;
-}
-
-const defaultHeadersOptions: Required<HeadersOptions> = {
-  format: Format.json,
-  protocolVersion: Defaults.protocolVersion,
-};
-
-export function defaultGetHeaders(
-  options: NormalisedClientOptions,
-  {
-    format = defaultHeadersOptions.format,
-    protocolVersion = defaultHeadersOptions.protocolVersion,
-  }: HeadersOptions = {}
-): Record<string, string> {
-  const accept = contentTypes[format];
-  return {
-    accept: accept,
-    'X-Ably-Version': protocolVersion.toString(),
-    'Ably-Agent': getAgentString(options),
-  };
-}
-
-export function defaultPostHeaders(
-  options: NormalisedClientOptions,
-  {
-    format = defaultHeadersOptions.format,
-    protocolVersion = defaultHeadersOptions.protocolVersion,
-  }: HeadersOptions = {}
-): Record<string, string> {
-  let contentType;
-  const accept = (contentType = contentTypes[format]);
-
-  return {
-    accept: accept,
-    'content-type': contentType,
-    'X-Ably-Version': protocolVersion.toString(),
-    'Ably-Agent': getAgentString(options),
-  };
 }
 
 export function arrPopRandomElement<T>(arr: Array<T>): T {

--- a/src/common/types/http.d.ts
+++ b/src/common/types/http.d.ts
@@ -1,5 +1,5 @@
 import HttpMethods from '../constants/HttpMethods';
-import BaseClient from '../lib/client/baseclient';
+import { BaseClient } from '../lib/client/baseclient';
 import ErrorInfo from '../lib/types/errorinfo';
 import { Agents } from 'got';
 

--- a/src/common/types/http.d.ts
+++ b/src/common/types/http.d.ts
@@ -1,5 +1,5 @@
 import HttpMethods from '../constants/HttpMethods';
-import Rest from '../lib/client/rest';
+import BaseClient from '../lib/client/baseclient';
 import ErrorInfo from '../lib/types/errorinfo';
 import { Agents } from 'got';
 
@@ -25,17 +25,17 @@ export declare class IHttp {
 
   Request?: (
     method: HttpMethods,
-    rest: Rest | null,
+    rest: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     params: RequestParams,
     body: unknown,
     callback: RequestCallback
   ) => void;
-  _getHosts: (client: Rest | Realtime) => string[];
+  _getHosts: (client: BaseClient | Realtime) => string[];
   do(
     method: HttpMethods,
-    rest: Rest | null,
+    rest: BaseClient | null,
     path: PathParameter,
     headers: Record<string, string> | null,
     body: unknown,
@@ -44,7 +44,7 @@ export declare class IHttp {
   ): void;
   doUri(
     method: HttpMethods,
-    rest: Rest | null,
+    rest: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     body: unknown,

--- a/src/common/types/http.d.ts
+++ b/src/common/types/http.d.ts
@@ -25,7 +25,7 @@ export declare class IHttp {
 
   Request?: (
     method: HttpMethods,
-    rest: BaseClient | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     params: RequestParams,
@@ -35,7 +35,7 @@ export declare class IHttp {
   _getHosts: (client: BaseClient | Realtime) => string[];
   do(
     method: HttpMethods,
-    rest: BaseClient | null,
+    client: BaseClient | null,
     path: PathParameter,
     headers: Record<string, string> | null,
     body: unknown,
@@ -44,7 +44,7 @@ export declare class IHttp {
   ): void;
   doUri(
     method: HttpMethods,
-    rest: BaseClient | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     body: unknown,

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -1,4 +1,5 @@
 // Common
+import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -29,8 +30,7 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-DefaultRest.Crypto = Crypto;
-DefaultRealtime.Crypto = Crypto;
+BaseClient.Crypto = Crypto;
 
 Logger.initLogHandlers();
 

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -1,6 +1,6 @@
 // Common
-import Rest from '../../common/lib/client/rest';
-import Realtime from '../../common/lib/client/realtime';
+import { DefaultRest } from '../../common/lib/client/defaultrest';
+import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
 
@@ -29,8 +29,8 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-Rest.Crypto = Crypto;
-Realtime.Crypto = Crypto;
+DefaultRest.Crypto = Crypto;
+DefaultRealtime.Crypto = Crypto;
 
 Logger.initLogHandlers();
 
@@ -43,7 +43,7 @@ if (Platform.Config.agent) {
 
 export default {
   ErrorInfo,
-  Rest,
-  Realtime,
+  Rest: DefaultRest,
+  Realtime: DefaultRealtime,
   msgpack,
 };

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -1,6 +1,6 @@
 // Common
-import Rest from '../../common/lib/client/rest';
-import Realtime from '../../common/lib/client/realtime';
+import { DefaultRest } from '../../common/lib/client/defaultrest';
+import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
 
@@ -25,8 +25,8 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = null;
 
-Rest.Crypto = Crypto;
-Realtime.Crypto = Crypto;
+DefaultRest.Crypto = Crypto;
+DefaultRealtime.Crypto = Crypto;
 
 Logger.initLogHandlers();
 
@@ -39,7 +39,7 @@ if (Platform.Config.agent) {
 
 export default {
   ErrorInfo,
-  Rest,
-  Realtime,
+  Rest: DefaultRest,
+  Realtime: DefaultRealtime,
   msgpack: null,
 };

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -1,4 +1,5 @@
 // Common
+import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -25,8 +26,7 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = null;
 
-DefaultRest.Crypto = Crypto;
-DefaultRealtime.Crypto = Crypto;
+BaseClient.Crypto = Crypto;
 
 Logger.initLogHandlers();
 

--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -74,7 +74,7 @@ function shouldFallback(err: ErrnoException) {
   );
 }
 
-function getHosts(client: BaseClient | BaseRealtime): string[] {
+function getHosts(client: BaseClient): string[] {
   /* If we're a connected realtime client, try the endpoint we're connected
    * to first -- but still have fallbacks, being connected is not an absolute
    * guarantee that a datacenter has free capacity to service REST requests. */

--- a/src/platform/nodejs/lib/util/http.ts
+++ b/src/platform/nodejs/lib/util/http.ts
@@ -6,8 +6,8 @@ import HttpMethods from '../../../../common/constants/HttpMethods';
 import got, { Response, Options, CancelableRequest, Agents } from 'got';
 import http from 'http';
 import https from 'https';
-import Rest from 'common/lib/client/rest';
-import Realtime from 'common/lib/client/realtime';
+import BaseClient from 'common/lib/client/baseclient';
+import BaseRealtime from 'common/lib/client/baserealtime';
 import { NormalisedClientOptions, RestAgentOptions } from 'common/types/ClientOptions';
 import { isSuccessCode } from 'common/constants/HttpStatusCodes';
 import { shallowEquals } from 'common/lib/util/utils';
@@ -74,11 +74,11 @@ function shouldFallback(err: ErrnoException) {
   );
 }
 
-function getHosts(client: Rest | Realtime): string[] {
+function getHosts(client: BaseClient | BaseRealtime): string[] {
   /* If we're a connected realtime client, try the endpoint we're connected
    * to first -- but still have fallbacks, being connected is not an absolute
    * guarantee that a datacenter has free capacity to service REST requests. */
-  const connection = (client as Realtime).connection;
+  const connection = (client as BaseRealtime).connection;
   const connectionHost = connection && connection.connectionManager.host;
 
   if (connectionHost) {
@@ -105,7 +105,7 @@ const Http: typeof IHttp = class {
   /* Unlike for doUri, the 'rest' param here is mandatory, as it's used to generate the hosts */
   do(
     method: HttpMethods,
-    rest: Rest,
+    rest: BaseClient,
     path: PathParameter,
     headers: Record<string, string> | null,
     body: unknown,
@@ -185,7 +185,7 @@ const Http: typeof IHttp = class {
 
   doUri(
     method: HttpMethods,
-    rest: Rest,
+    rest: BaseClient,
     uri: string,
     headers: Record<string, string> | null,
     body: unknown,
@@ -275,7 +275,7 @@ const Http: typeof IHttp = class {
 
   Request?: (
     method: HttpMethods,
-    rest: Rest | null,
+    rest: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     params: RequestParams,

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -1,4 +1,5 @@
 // Common
+import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -29,8 +30,7 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-DefaultRest.Crypto = Crypto;
-DefaultRealtime.Crypto = Crypto;
+BaseClient.Crypto = Crypto;
 
 Logger.initLogHandlers();
 

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -1,6 +1,6 @@
 // Common
-import Rest from '../../common/lib/client/rest';
-import Realtime from '../../common/lib/client/realtime';
+import { DefaultRest } from '../../common/lib/client/defaultrest';
+import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
 
@@ -29,8 +29,8 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-Rest.Crypto = Crypto;
-Realtime.Crypto = Crypto;
+DefaultRest.Crypto = Crypto;
+DefaultRealtime.Crypto = Crypto;
 
 Logger.initLogHandlers();
 
@@ -43,7 +43,7 @@ if (Platform.Config.agent) {
 
 export default {
   ErrorInfo,
-  Rest,
-  Realtime,
+  Rest: DefaultRest,
+  Realtime: DefaultRealtime,
   msgpack,
 };

--- a/src/platform/web-noencryption/index.ts
+++ b/src/platform/web-noencryption/index.ts
@@ -1,4 +1,5 @@
 // Common
+import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -24,8 +25,7 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-DefaultRest.Crypto = null;
-DefaultRealtime.Crypto = null;
+BaseClient.Crypto = null;
 
 Logger.initLogHandlers();
 

--- a/src/platform/web-noencryption/index.ts
+++ b/src/platform/web-noencryption/index.ts
@@ -1,6 +1,6 @@
 // Common
-import Rest from '../../common/lib/client/rest';
-import Realtime from '../../common/lib/client/realtime';
+import { DefaultRest } from '../../common/lib/client/defaultrest';
+import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
 
@@ -24,8 +24,8 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-Rest.Crypto = null;
-Realtime.Crypto = null;
+DefaultRest.Crypto = null;
+DefaultRealtime.Crypto = null;
 
 Logger.initLogHandlers();
 
@@ -38,7 +38,7 @@ if (Platform.Config.agent) {
 
 export default {
   ErrorInfo,
-  Rest,
-  Realtime,
+  Rest: DefaultRest,
+  Realtime: DefaultRealtime,
   msgpack,
 };

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -1,4 +1,5 @@
 // Common
+import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -27,8 +28,7 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-DefaultRest.Crypto = Crypto;
-DefaultRealtime.Crypto = Crypto;
+BaseClient.Crypto = Crypto;
 
 Logger.initLogHandlers();
 

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -1,6 +1,6 @@
 // Common
-import Rest from '../../common/lib/client/rest';
-import Realtime from '../../common/lib/client/realtime';
+import { DefaultRest } from '../../common/lib/client/defaultrest';
+import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
 
@@ -27,8 +27,8 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-Rest.Crypto = Crypto;
-Realtime.Crypto = Crypto;
+DefaultRest.Crypto = Crypto;
+DefaultRealtime.Crypto = Crypto;
 
 Logger.initLogHandlers();
 
@@ -47,11 +47,11 @@ if (Platform.Config.noUpgrade) {
   Platform.Defaults.upgradeTransports = [];
 }
 
-export { Rest, Realtime, msgpack };
+export { DefaultRest as Rest, DefaultRealtime as Realtime, msgpack };
 
 export default {
   ErrorInfo,
-  Rest,
-  Realtime,
+  Rest: DefaultRest,
+  Realtime: DefaultRealtime,
   msgpack,
 };

--- a/src/platform/web/lib/transport/fetchrequest.ts
+++ b/src/platform/web/lib/transport/fetchrequest.ts
@@ -1,5 +1,5 @@
 import HttpMethods from 'common/constants/HttpMethods';
-import Rest from 'common/lib/client/rest';
+import BaseClient from 'common/lib/client/baseclient';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
 import { RequestCallback, RequestParams } from 'common/types/http';
 import Platform from 'common/platform';
@@ -19,7 +19,7 @@ function getAblyError(responseBody: unknown, headers: Headers) {
 
 export default function fetchRequest(
   method: HttpMethods,
-  rest: Rest | null,
+  rest: BaseClient | null,
   uri: string,
   headers: Record<string, string> | null,
   params: RequestParams,

--- a/src/platform/web/lib/transport/fetchrequest.ts
+++ b/src/platform/web/lib/transport/fetchrequest.ts
@@ -19,7 +19,7 @@ function getAblyError(responseBody: unknown, headers: Headers) {
 
 export default function fetchRequest(
   method: HttpMethods,
-  rest: BaseClient | null,
+  client: BaseClient | null,
   uri: string,
   headers: Record<string, string> | null,
   params: RequestParams,
@@ -36,7 +36,7 @@ export default function fetchRequest(
       controller.abort();
       callback(new PartialErrorInfo('Request timed out', null, 408));
     },
-    rest ? rest.options.timeouts.httpRequestTimeout : Defaults.TIMEOUTS.httpRequestTimeout
+    client ? client.options.timeouts.httpRequestTimeout : Defaults.TIMEOUTS.httpRequestTimeout
   );
 
   const requestInit: RequestInit = {

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -4,8 +4,8 @@ import Defaults from 'common/lib/util/defaults';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
 import { ErrnoException, IHttp, RequestCallback, RequestParams } from 'common/types/http';
 import HttpMethods from 'common/constants/HttpMethods';
-import Rest from 'common/lib/client/rest';
-import Realtime from 'common/lib/client/realtime';
+import BaseClient from 'common/lib/client/baseclient';
+import BaseRealtime from 'common/lib/client/baserealtime';
 import XHRRequest from '../transport/xhrrequest';
 import XHRStates from 'common/constants/XHRStates';
 import Logger from 'common/lib/util/logger';
@@ -26,11 +26,11 @@ function shouldFallback(errorInfo: ErrorInfo) {
   );
 }
 
-function getHosts(client: Rest | Realtime): string[] {
+function getHosts(client: BaseClient | BaseRealtime): string[] {
   /* If we're a connected realtime client, try the endpoint we're connected
    * to first -- but still have fallbacks, being connected is not an absolute
    * guarantee that a datacenter has free capacity to service REST requests. */
-  const connection = (client as Realtime).connection,
+  const connection = (client as BaseRealtime).connection,
     connectionHost = connection && connection.connectionManager.host;
 
   if (connectionHost) {
@@ -57,7 +57,7 @@ const Http: typeof IHttp = class {
       this.supportsAuthHeaders = true;
       this.Request = function (
         method: HttpMethods,
-        rest: Rest | null,
+        rest: BaseClient | null,
         uri: string,
         headers: Record<string, string> | null,
         params: RequestParams,
@@ -143,7 +143,7 @@ const Http: typeof IHttp = class {
   /* Unlike for doUri, the 'rest' param here is mandatory, as it's used to generate the hosts */
   do(
     method: HttpMethods,
-    rest: Rest,
+    rest: BaseClient,
     path: string,
     headers: Record<string, string> | null,
     body: unknown,
@@ -230,7 +230,7 @@ const Http: typeof IHttp = class {
 
   doUri(
     method: HttpMethods,
-    rest: Rest | null,
+    rest: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     body: unknown,
@@ -246,7 +246,7 @@ const Http: typeof IHttp = class {
 
   Request?: (
     method: HttpMethods,
-    rest: Rest | null,
+    rest: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     params: RequestParams,

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -26,7 +26,7 @@ function shouldFallback(errorInfo: ErrorInfo) {
   );
 }
 
-function getHosts(client: BaseClient | BaseRealtime): string[] {
+function getHosts(client: BaseClient): string[] {
   /* If we're a connected realtime client, try the endpoint we're connected
    * to first -- but still have fallbacks, being connected is not an absolute
    * guarantee that a datacenter has free capacity to service REST requests. */

--- a/src/platform/web/lib/util/http.ts
+++ b/src/platform/web/lib/util/http.ts
@@ -57,7 +57,7 @@ const Http: typeof IHttp = class {
       this.supportsAuthHeaders = true;
       this.Request = function (
         method: HttpMethods,
-        rest: BaseClient | null,
+        client: BaseClient | null,
         uri: string,
         headers: Record<string, string> | null,
         params: RequestParams,
@@ -70,7 +70,7 @@ const Http: typeof IHttp = class {
           params,
           body,
           XHRStates.REQ_SEND,
-          rest && rest.options.timeouts,
+          client && client.options.timeouts,
           method
         );
         req.once('complete', callback);
@@ -134,16 +134,16 @@ const Http: typeof IHttp = class {
         );
       };
     } else {
-      this.Request = (method, rest, uri, headers, params, body, callback) => {
+      this.Request = (method, client, uri, headers, params, body, callback) => {
         callback(new PartialErrorInfo('no supported HTTP transports available', null, 400), null);
       };
     }
   }
 
-  /* Unlike for doUri, the 'rest' param here is mandatory, as it's used to generate the hosts */
+  /* Unlike for doUri, the 'client' param here is mandatory, as it's used to generate the hosts */
   do(
     method: HttpMethods,
-    rest: BaseClient,
+    client: BaseClient,
     path: string,
     headers: Record<string, string> | null,
     body: unknown,
@@ -154,10 +154,10 @@ const Http: typeof IHttp = class {
       typeof path == 'function'
         ? path
         : function (host: string) {
-            return rest.baseUri(host) + path;
+            return client.baseUri(host) + path;
           };
 
-    const currentFallback = rest._currentFallback;
+    const currentFallback = client._currentFallback;
     if (currentFallback) {
       if (currentFallback.validUntil > Utils.now()) {
         /* Use stored fallback */
@@ -167,7 +167,7 @@ const Http: typeof IHttp = class {
         }
         this.Request(
           method,
-          rest,
+          client,
           uriFromHost(currentFallback.host),
           headers,
           params,
@@ -176,8 +176,8 @@ const Http: typeof IHttp = class {
             // This typecast is safe because ErrnoExceptions are only thrown in NodeJS
             if (err && shouldFallback(err as ErrorInfo)) {
               /* unstore the fallback and start from the top with the default sequence */
-              rest._currentFallback = null;
-              this.do(method, rest, path, headers, body, params, callback);
+              client._currentFallback = null;
+              this.do(method, client, path, headers, body, params, callback);
               return;
             }
             callback?.(err, ...args);
@@ -186,15 +186,15 @@ const Http: typeof IHttp = class {
         return;
       } else {
         /* Fallback expired; remove it and fallthrough to normal sequence */
-        rest._currentFallback = null;
+        client._currentFallback = null;
       }
     }
 
-    const hosts = getHosts(rest);
+    const hosts = getHosts(client);
 
     /* if there is only one host do it */
     if (hosts.length === 1) {
-      this.doUri(method, rest, uriFromHost(hosts[0]), headers, body, params, callback as RequestCallback);
+      this.doUri(method, client, uriFromHost(hosts[0]), headers, body, params, callback as RequestCallback);
       return;
     }
 
@@ -203,7 +203,7 @@ const Http: typeof IHttp = class {
       const host = candidateHosts.shift();
       this.doUri(
         method,
-        rest,
+        client,
         uriFromHost(host as string),
         headers,
         body,
@@ -216,9 +216,9 @@ const Http: typeof IHttp = class {
           }
           if (persistOnSuccess) {
             /* RSC15f */
-            rest._currentFallback = {
+            client._currentFallback = {
               host: host as string,
-              validUntil: Utils.now() + rest.options.timeouts.fallbackRetryTimeout,
+              validUntil: Utils.now() + client.options.timeouts.fallbackRetryTimeout,
             };
           }
           callback?.(err, ...args);
@@ -230,7 +230,7 @@ const Http: typeof IHttp = class {
 
   doUri(
     method: HttpMethods,
-    rest: BaseClient | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     body: unknown,
@@ -241,12 +241,12 @@ const Http: typeof IHttp = class {
       callback(new PartialErrorInfo('Request invoked before assigned to', null, 500));
       return;
     }
-    this.Request(method, rest, uri, headers, params, body, callback);
+    this.Request(method, client, uri, headers, params, body, callback);
   }
 
   Request?: (
     method: HttpMethods,
-    rest: BaseClient | null,
+    client: BaseClient | null,
     uri: string,
     headers: Record<string, string> | null,
     params: RequestParams,

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -47,4 +47,5 @@ if (Platform.Config.noUpgrade) {
   Platform.Defaults.upgradeTransports = [];
 }
 
+export { Rest } from '../../common/lib/client/rest';
 export { BaseRest, BaseRealtime, ErrorInfo };

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -28,7 +28,6 @@ Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
 BaseClient.Crypto = Crypto;
-BaseRealtime.Crypto = Crypto;
 
 Logger.initLogHandlers();
 

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -1,0 +1,50 @@
+// Common
+import BaseClient from 'common/lib/client/baseclient';
+import { BaseRest } from '../../common/lib/client/baserest';
+import BaseRealtime from '../../common/lib/client/baserealtime';
+import Platform from '../../common/platform';
+import ErrorInfo from '../../common/lib/types/errorinfo';
+
+// Platform Specific
+import BufferUtils from './lib/util/bufferutils';
+// @ts-ignore
+import CryptoFactory from './lib/util/crypto';
+import Http from './lib/util/http';
+import Config from './config';
+// @ts-ignore
+import Transports from './lib/transport';
+import Logger from '../../common/lib/util/logger';
+import { getDefaults } from '../../common/lib/util/defaults';
+import WebStorage from './lib/util/webstorage';
+import PlatformDefaults from './lib/util/defaults';
+
+const Crypto = CryptoFactory(Config, BufferUtils);
+
+Platform.Crypto = Crypto;
+Platform.BufferUtils = BufferUtils;
+Platform.Http = Http;
+Platform.Config = Config;
+Platform.Transports = Transports;
+Platform.WebStorage = WebStorage;
+
+BaseClient.Crypto = Crypto;
+BaseRealtime.Crypto = Crypto;
+
+Logger.initLogHandlers();
+
+Platform.Defaults = getDefaults(PlatformDefaults);
+
+if (Platform.Config.agent) {
+  // @ts-ignore
+  Platform.Defaults.agent += ' ' + Platform.Config.agent;
+}
+
+/* If using IE8, don't attempt to upgrade from xhr_polling to xhr_streaming -
+ * while it can do streaming, the low max http-connections-per-host limit means
+ * that the polling transport is crippled during the upgrade process. So just
+ * leave it at the base transport */
+if (Platform.Config.noUpgrade) {
+  Platform.Defaults.upgradeTransports = [];
+}
+
+export { BaseRest, BaseRealtime, ErrorInfo };

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -1,0 +1,20 @@
+import { BaseRest, BaseRealtime } from '../../build/modules/index.js';
+
+describe('browser/modules', function () {
+  this.timeout(10 * 1000);
+  const expect = chai.expect;
+  let ablyClientOptions;
+
+  before((done) => {
+    ablyClientOptions = window.ablyHelpers.ablyClientOptions;
+    window.ablyHelpers.setupApp(done);
+  });
+
+  for (const clientClass of [BaseRest, BaseRealtime]) {
+    it(clientClass.name, async () => {
+      const client = new clientClass(ablyClientOptions());
+      const time = await client.time();
+      expect(time).to.be.a('number');
+    });
+  }
+});

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -1,4 +1,4 @@
-import { BaseRest, BaseRealtime } from '../../build/modules/index.js';
+import { BaseRest, BaseRealtime, Rest } from '../../build/modules/index.js';
 
 describe('browser/modules', function () {
   this.timeout(10 * 1000);
@@ -12,11 +12,36 @@ describe('browser/modules', function () {
 
   describe('without any modules', () => {
     for (const clientClass of [BaseRest, BaseRealtime]) {
-      it(clientClass.name, async () => {
-        const client = new clientClass(ablyClientOptions());
+      describe(clientClass.name, () => {
+        it('can be constructed', async () => {
+          expect(() => new clientClass(ablyClientOptions(), {})).not.to.throw();
+        });
+      });
+    }
+  });
+
+  describe('Rest', () => {
+    describe('BaseRest without explicit Rest', () => {
+      it('offers REST functionality', async () => {
+        const client = new BaseRest(ablyClientOptions(), {});
         const time = await client.time();
         expect(time).to.be.a('number');
       });
-    }
+    });
+
+    describe('BaseRealtime with Rest', () => {
+      it('offers REST functionality', async () => {
+        const client = new BaseRealtime(ablyClientOptions(), { Rest });
+        const time = await client.time();
+        expect(time).to.be.a('number');
+      });
+    });
+
+    describe('BaseRealtime without Rest', () => {
+      it('throws an error when attempting to use REST functionality', async () => {
+        const client = new BaseRealtime(ablyClientOptions(), {});
+        expect(() => client.time()).to.throw('Rest module not provided');
+      });
+    });
   });
 });

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -10,11 +10,13 @@ describe('browser/modules', function () {
     window.ablyHelpers.setupApp(done);
   });
 
-  for (const clientClass of [BaseRest, BaseRealtime]) {
-    it(clientClass.name, async () => {
-      const client = new clientClass(ablyClientOptions());
-      const time = await client.time();
-      expect(time).to.be.a('number');
-    });
-  }
+  describe('without any modules', () => {
+    for (const clientClass of [BaseRest, BaseRealtime]) {
+      it(clientClass.name, async () => {
+        const client = new clientClass(ablyClientOptions());
+        const time = await client.time();
+        expect(time).to.be.a('number');
+      });
+    }
+  });
 });

--- a/test/common/modules/client_module.js
+++ b/test/common/modules/client_module.js
@@ -34,5 +34,6 @@ define(['ably', 'globals', 'test/common/modules/testapp_module'], function (Ably
     Ably: Ably,
     AblyRest: ablyRest,
     AblyRealtime: ablyRealtime,
+    ablyClientOptions,
   });
 });

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -222,7 +222,7 @@ define([
     return Math.random().toString().slice(2);
   }
 
-  return (module.exports = {
+  var exports = {
     setupApp: testAppModule.setup,
     tearDownApp: testAppModule.tearDown,
     createStats: testAppModule.createStatsFixtureData,
@@ -231,6 +231,7 @@ define([
     Ably: clientModule.Ably,
     AblyRest: clientModule.AblyRest,
     AblyRealtime: clientModule.AblyRealtime,
+    ablyClientOptions: clientModule.ablyClientOptions,
     Utils: utils,
 
     loadTestData: testAppManager.loadJsonData,
@@ -254,5 +255,11 @@ define([
     arrFilter: arrFilter,
     whenPromiseSettles: whenPromiseSettles,
     randomString: randomString,
-  });
+  };
+
+  if (typeof window !== 'undefined') {
+    window.ablyHelpers = exports;
+  }
+
+  return (module.exports = exports);
 });

--- a/test/mocha.html
+++ b/test/mocha.html
@@ -22,6 +22,7 @@
     <script type="text/javascript" src="support/modules_helper.js"></script>
     <script type="text/javascript" src="support/test_helper.js"></script>
     <script type="text/javascript" src="support/browser_file_list.js"></script>
+    <script type="module" src="test/browser/modules.test.js"></script>
     <script type="text/javascript" src="support/browser_setup.js"></script>
   </body>
 </html>

--- a/test/playwright.html
+++ b/test/playwright.html
@@ -20,6 +20,7 @@
     <script type="text/javascript" src="support/modules_helper.js"></script>
     <script type="text/javascript" src="support/test_helper.js"></script>
     <script type="text/javascript" src="support/browser_file_list.js"></script>
+    <script type="module" src="test/browser/modules.test.js"></script>
     <script type="text/javascript" src="support/browser_setup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR replaces #1400. It copies a lot from that PR but uses the class hierarchy described by #1415.

See commit messages for more details.

The output of `npm run modulereport` is as follows:

```
BaseRest: 74.28 KiB
BaseRest + Rest: 91.14 KiB
BaseRealtime: 148.03 KiB
BaseRealtime + Rest: 156.68 KiB
```

(Note that `BaseRest` is currently somewhat larger than `BaseClient` in #1415. This is because it includes the transports and `EventEmitter`, which are included due to [this line](https://github.com/ably/ably-js/blob/77e48be4dce3c501359d703137065dbd14435753/src/platform/web/modules.ts#L25). This line is absent in #1415 because that PR takes the approach of stripping everything out to add it back in again later, whereas I've taken the approach of keeping everything as it is until we explicitly decide to split it out. We'll be splitting out the transports in https://github.com/ably/ably-js/issues/1394.)

Resolves #1415.