### PR TITLE
[SDK-3735] Create tree-shakable `Crypto` module

### DIFF
--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -4,7 +4,7 @@ const esbuild = require('esbuild');
 const moduleNames = ['Rest'];
 
 // List of all free-standing functions exported by the library
-const functionNames = ['generateRandomKey', 'getDefaultCryptoParams'];
+const functionNames = ['generateRandomKey', 'getDefaultCryptoParams', 'decodeMessage', 'decodeMessages'];
 
 function formatBytes(bytes) {
   const kibibytes = bytes / 1024;

--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -3,6 +3,9 @@ const esbuild = require('esbuild');
 // List of all modules accepted in ModulesMap
 const moduleNames = ['Rest'];
 
+// List of all free-standing functions exported by the library
+const functionNames = ['generateRandomKey', 'getDefaultCryptoParams'];
+
 function formatBytes(bytes) {
   const kibibytes = bytes / 1024;
   const formatted = kibibytes.toFixed(2);
@@ -35,15 +38,15 @@ const errors = [];
   // First display the size of the base client
   console.log(`${baseClient}: ${formatBytes(baseClientSize)}`);
 
-  // Then display the size of each module together with the base client
-  moduleNames.forEach((moduleName) => {
-    const size = getImportSize([baseClient, moduleName]);
-    console.log(`${baseClient} + ${moduleName}: ${formatBytes(size)}`);
+  // Then display the size of each export together with the base client
+  [...moduleNames, ...functionNames].forEach((exportName) => {
+    const size = getImportSize([baseClient, exportName]);
+    console.log(`${baseClient} + ${exportName}: ${formatBytes(size)}`);
 
-    if (!(baseClientSize < size) && !(baseClient === 'BaseRest' && moduleName === 'Rest')) {
+    if (!(baseClientSize < size) && !(baseClient === 'BaseRest' && exportName === 'Rest')) {
       // Emit an error if adding the module does not increase the bundle size
       // (this means that the module is not being tree-shaken correctly).
-      errors.push(new Error(`Adding ${moduleName} to ${baseClient} does not increase the bundle size.`));
+      errors.push(new Error(`Adding ${exportName} to ${baseClient} does not increase the bundle size.`));
     }
   });
 });

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -147,7 +147,19 @@ class BaseClient {
   }
 
   static Platform = Platform;
-  static Crypto?: typeof Platform.Crypto;
+
+  private static _Crypto: typeof Platform.Crypto = null;
+  static get Crypto() {
+    if (this._Crypto === null) {
+      throw new Error('Encryption not enabled; use ably.encryption.js instead');
+    }
+
+    return this._Crypto;
+  }
+  static set Crypto(newValue: typeof Platform.Crypto) {
+    this._Crypto = newValue;
+  }
+
   static Message = Message;
   static PresenceMessage = PresenceMessage;
 }

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -10,7 +10,6 @@ import ClientOptions, { NormalisedClientOptions } from '../../types/ClientOption
 import * as API from '../../../../ably';
 
 import Platform from '../../platform';
-import Message from '../types/message';
 import PresenceMessage from '../types/presencemessage';
 import { ModulesMap } from './modulesmap';
 import { Rest } from './rest';
@@ -147,7 +146,6 @@ class BaseClient {
   }
 
   static Platform = Platform;
-  static Message = Message;
   static PresenceMessage = PresenceMessage;
 }
 

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -13,6 +13,8 @@ import Platform from '../../platform';
 import PresenceMessage from '../types/presencemessage';
 import { ModulesMap } from './modulesmap';
 import { Rest } from './rest';
+import { IUntypedCryptoStatic } from 'common/types/ICryptoStatic';
+import { throwMissingModuleError } from '../util/utils';
 
 type BatchResult<T> = API.Types.BatchResult<T>;
 type BatchPublishSpec = API.Types.BatchPublishSpec;
@@ -37,6 +39,7 @@ class BaseClient {
   auth: Auth;
 
   private readonly _rest: Rest | null;
+  readonly _Crypto: IUntypedCryptoStatic | null;
 
   constructor(options: ClientOptions | string, modules: ModulesMap) {
     if (!options) {
@@ -87,11 +90,12 @@ class BaseClient {
     this.auth = new Auth(this, normalOptions);
 
     this._rest = modules.Rest ? new modules.Rest(this) : null;
+    this._Crypto = modules.Crypto ?? null;
   }
 
   private get rest(): Rest {
     if (!this._rest) {
-      throw new ErrorInfo('Rest module not provided', 400, 40000);
+      throwMissingModuleError('Rest');
     }
     return this._rest;
   }

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -147,19 +147,6 @@ class BaseClient {
   }
 
   static Platform = Platform;
-
-  private static _Crypto: typeof Platform.Crypto = null;
-  static get Crypto() {
-    if (this._Crypto === null) {
-      throw new Error('Encryption not enabled; use ably.encryption.js instead');
-    }
-
-    return this._Crypto;
-  }
-  static set Crypto(newValue: typeof Platform.Crypto) {
-    this._Crypto = newValue;
-  }
-
   static Message = Message;
   static PresenceMessage = PresenceMessage;
 }

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -12,6 +12,7 @@ import BaseClient from './baseclient';
 import * as API from '../../../../ably';
 import Platform from 'common/platform';
 import Defaults from '../util/defaults';
+import { IUntypedCryptoStatic } from 'common/types/ICryptoStatic';
 
 interface RestHistoryParams {
   start?: number;
@@ -30,11 +31,11 @@ function allEmptyIds(messages: Array<Message>) {
   });
 }
 
-function normaliseChannelOptions(options?: ChannelOptions) {
+function normaliseChannelOptions(Crypto: IUntypedCryptoStatic | null, options?: ChannelOptions) {
   const channelOptions = options || {};
   if (channelOptions.cipher) {
-    if (!Platform.Crypto) throw new Error('Encryption not enabled; use ably.encryption.js instead');
-    const cipher = Platform.Crypto.getCipher(channelOptions.cipher);
+    if (!Crypto) throw new Error('Encryption not enabled; use ably.encryption.js instead');
+    const cipher = Crypto.getCipher(channelOptions.cipher);
     channelOptions.cipher = cipher.cipherParams;
     channelOptions.channelCipher = cipher.cipher;
   } else if ('cipher' in channelOptions) {
@@ -60,11 +61,11 @@ class Channel extends EventEmitter {
     this.name = name;
     this.basePath = '/channels/' + encodeURIComponent(name);
     this.presence = new Presence(this);
-    this.channelOptions = normaliseChannelOptions(channelOptions);
+    this.channelOptions = normaliseChannelOptions(Platform.Crypto, channelOptions);
   }
 
   setOptions(options?: ChannelOptions): void {
-    this.channelOptions = normaliseChannelOptions(options);
+    this.channelOptions = normaliseChannelOptions(Platform.Crypto, options);
   }
 
   history(

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -10,7 +10,6 @@ import { ChannelOptions } from '../../types/channel';
 import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
 import BaseClient from './baseclient';
 import * as API from '../../../../ably';
-import Platform from 'common/platform';
 import Defaults from '../util/defaults';
 import { IUntypedCryptoStatic } from 'common/types/ICryptoStatic';
 
@@ -34,7 +33,7 @@ function allEmptyIds(messages: Array<Message>) {
 function normaliseChannelOptions(Crypto: IUntypedCryptoStatic | null, options?: ChannelOptions) {
   const channelOptions = options || {};
   if (channelOptions.cipher) {
-    if (!Crypto) throw new Error('Encryption not enabled; use ably.encryption.js instead');
+    if (!Crypto) Utils.throwMissingModuleError('Crypto');
     const cipher = Crypto.getCipher(channelOptions.cipher);
     channelOptions.cipher = cipher.cipherParams;
     channelOptions.channelCipher = cipher.cipher;
@@ -61,11 +60,11 @@ class Channel extends EventEmitter {
     this.name = name;
     this.basePath = '/channels/' + encodeURIComponent(name);
     this.presence = new Presence(this);
-    this.channelOptions = normaliseChannelOptions(Platform.Crypto, channelOptions);
+    this.channelOptions = normaliseChannelOptions(client._Crypto ?? null, channelOptions);
   }
 
   setOptions(options?: ChannelOptions): void {
-    this.channelOptions = normaliseChannelOptions(Platform.Crypto, options);
+    this.channelOptions = normaliseChannelOptions(this.client._Crypto ?? null, options);
   }
 
   history(

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -4,6 +4,7 @@ import { allCommonModules } from './modulesmap';
 import * as Utils from '../util/utils';
 import ConnectionManager from '../transport/connectionmanager';
 import ProtocolMessage from '../types/protocolmessage';
+import Platform from 'common/platform';
 
 /**
  `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -16,4 +17,16 @@ export class DefaultRealtime extends BaseRealtime {
   static Utils = Utils;
   static ConnectionManager = ConnectionManager;
   static ProtocolMessage = ProtocolMessage;
+
+  private static _Crypto: typeof Platform.Crypto = null;
+  static get Crypto() {
+    if (this._Crypto === null) {
+      throw new Error('Encryption not enabled; use ably.encryption.js instead');
+    }
+
+    return this._Crypto;
+  }
+  static set Crypto(newValue: typeof Platform.Crypto) {
+    this._Crypto = newValue;
+  }
 }

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -12,7 +12,7 @@ import { DefaultMessage } from '../types/defaultmessage';
  */
 export class DefaultRealtime extends BaseRealtime {
   constructor(options: ClientOptions) {
-    super(options, allCommonModules);
+    super(options, { ...allCommonModules, Crypto: DefaultRealtime.Crypto ?? undefined });
   }
 
   static Utils = Utils;

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -5,6 +5,7 @@ import * as Utils from '../util/utils';
 import ConnectionManager from '../transport/connectionmanager';
 import ProtocolMessage from '../types/protocolmessage';
 import Platform from 'common/platform';
+import { DefaultMessage } from '../types/defaultmessage';
 
 /**
  `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -29,4 +30,6 @@ export class DefaultRealtime extends BaseRealtime {
   static set Crypto(newValue: typeof Platform.Crypto) {
     this._Crypto = newValue;
   }
+
+  static Message = DefaultMessage;
 }

--- a/src/common/lib/client/defaultrest.ts
+++ b/src/common/lib/client/defaultrest.ts
@@ -2,6 +2,7 @@ import { BaseRest } from './baserest';
 import ClientOptions from '../../types/ClientOptions';
 import { allCommonModules } from './modulesmap';
 import Platform from 'common/platform';
+import { DefaultMessage } from '../types/defaultmessage';
 
 /**
  `DefaultRest` is the class that the non tree-shakable version of the SDK exports as `Rest`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -22,4 +23,6 @@ export class DefaultRest extends BaseRest {
   static set Crypto(newValue: typeof Platform.Crypto) {
     this._Crypto = newValue;
   }
+
+  static Message = DefaultMessage;
 }

--- a/src/common/lib/client/defaultrest.ts
+++ b/src/common/lib/client/defaultrest.ts
@@ -1,6 +1,7 @@
 import { BaseRest } from './baserest';
 import ClientOptions from '../../types/ClientOptions';
 import { allCommonModules } from './modulesmap';
+import Platform from 'common/platform';
 
 /**
  `DefaultRest` is the class that the non tree-shakable version of the SDK exports as `Rest`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -8,5 +9,17 @@ import { allCommonModules } from './modulesmap';
 export class DefaultRest extends BaseRest {
   constructor(options: ClientOptions | string) {
     super(options, allCommonModules);
+  }
+
+  private static _Crypto: typeof Platform.Crypto = null;
+  static get Crypto() {
+    if (this._Crypto === null) {
+      throw new Error('Encryption not enabled; use ably.encryption.js instead');
+    }
+
+    return this._Crypto;
+  }
+  static set Crypto(newValue: typeof Platform.Crypto) {
+    this._Crypto = newValue;
   }
 }

--- a/src/common/lib/client/defaultrest.ts
+++ b/src/common/lib/client/defaultrest.ts
@@ -9,7 +9,7 @@ import { DefaultMessage } from '../types/defaultmessage';
  */
 export class DefaultRest extends BaseRest {
   constructor(options: ClientOptions | string) {
-    super(options, allCommonModules);
+    super(options, { ...allCommonModules, Crypto: DefaultRest.Crypto ?? undefined });
   }
 
   private static _Crypto: typeof Platform.Crypto = null;

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -1,7 +1,9 @@
 import { Rest } from './rest';
+import { IUntypedCryptoStatic } from '../../types/ICryptoStatic';
 
 export interface ModulesMap {
   Rest?: typeof Rest;
+  Crypto?: IUntypedCryptoStatic;
 }
 
 export const allCommonModules: ModulesMap = { Rest };

--- a/src/common/lib/types/defaultmessage.ts
+++ b/src/common/lib/types/defaultmessage.ts
@@ -1,0 +1,16 @@
+import Message, { fromEncoded, fromEncodedArray } from './message';
+import * as API from '../../../../ably';
+import Platform from 'common/platform';
+
+/**
+ `DefaultMessage` is the class returned by `DefaultRest` and `DefaultRealtime`’s `Message` static property. It introduces the static methods described in the `MessageStatic` interface of the public API of the non tree-shakable version of the library.
+ */
+export class DefaultMessage extends Message {
+  static async fromEncoded(encoded: unknown, inputOptions?: API.Types.ChannelOptions): Promise<Message> {
+    return fromEncoded(Platform.Crypto, encoded, inputOptions);
+  }
+
+  static async fromEncodedArray(encodedArray: Array<unknown>, options?: API.Types.ChannelOptions): Promise<Message[]> {
+    return fromEncodedArray(Platform.Crypto, encodedArray, options);
+  }
+}

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -48,7 +48,7 @@ function normalizeCipherOptions(
   options: API.Types.ChannelOptions | null
 ): ChannelOptions {
   if (options && options.cipher) {
-    if (!Crypto) throw new Error('Encryption not enabled; use ably.encryption.js instead');
+    if (!Crypto) Utils.throwMissingModuleError('Crypto');
     const cipher = Crypto.getCipher(options.cipher);
     return {
       cipher: cipher.cipherParams,

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -363,14 +363,6 @@ class Message {
     return result;
   }
 
-  static async fromEncoded(encoded: unknown, inputOptions?: API.Types.ChannelOptions): Promise<Message> {
-    return fromEncoded(Platform.Crypto, encoded, inputOptions);
-  }
-
-  static async fromEncodedArray(encodedArray: Array<unknown>, options?: API.Types.ChannelOptions): Promise<Message[]> {
-    return fromEncodedArray(Platform.Crypto, encodedArray, options);
-  }
-
   /* This should be called on encode()d (and encrypt()d) Messages (as it
    * assumes the data is a string or buffer) */
   static getMessagesSize(messages: Message[]): number {

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -1,5 +1,6 @@
 import Platform from 'common/platform';
 import ErrorInfo, { PartialErrorInfo } from 'common/lib/types/errorinfo';
+import { ModulesMap } from '../client/modulesmap';
 
 function randomPosn(arrOrStr: Array<unknown> | string) {
   return Math.floor(Math.random() * arrOrStr.length);
@@ -550,4 +551,8 @@ export function arrEquals(a: any[], b: any[]) {
       return val === b[i];
     })
   );
+}
+
+export function throwMissingModuleError(moduleName: keyof ModulesMap): never {
+  throw new ErrorInfo(`${moduleName} module not provided`, 400, 40000);
 }

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -7,6 +7,7 @@ import IBufferUtils from './types/IBufferUtils';
 import Transport from './lib/transport/transport';
 import * as WebBufferUtils from '../platform/web/lib/util/bufferutils';
 import * as NodeBufferUtils from '../platform/nodejs/lib/util/bufferutils';
+import { IUntypedCryptoStatic } from '../common/types/ICryptoStatic';
 
 type Bufferlike = WebBufferUtils.Bufferlike | NodeBufferUtils.Bufferlike;
 type BufferUtilsOutput = WebBufferUtils.Output | NodeBufferUtils.Output;
@@ -23,12 +24,11 @@ export default class Platform {
    */
   static BufferUtils: IBufferUtils<Bufferlike, BufferUtilsOutput, ToBufferOutput>;
   /*
-     This should be a class whose static methods implement the ICryptoStatic
-     interface, but (for the same reasons as described in the BufferUtils
-     comment above) Platform doesn’t currently allow us to express the
-     generic parameters, hence keeping the type as `any`.
+     We’d like this to be ICryptoStatic with the correct generic arguments,
+     but Platform doesn’t currently allow that, as described in the BufferUtils
+     comment above.
    */
-  static Crypto: any;
+  static Crypto: IUntypedCryptoStatic | null;
   static Http: typeof IHttp;
   static Transports: Array<(connectionManager: typeof ConnectionManager) => Transport>;
   static Defaults: IDefaults;

--- a/src/common/types/ICryptoStatic.ts
+++ b/src/common/types/ICryptoStatic.ts
@@ -13,3 +13,11 @@ export default interface ICryptoStatic<IV, InputPlaintext, OutputCiphertext, Inp
     params: IGetCipherParams<IV>
   ): IGetCipherReturnValue<ICipher<InputPlaintext, OutputCiphertext, InputCiphertext, OutputPlaintext>>;
 }
+
+/*
+ A less strongly typed version of ICryptoStatic to use until we
+ can make Platform a generic type (see comment there).
+ */
+export interface IUntypedCryptoStatic extends API.Types.Crypto {
+  getCipher(params: any): any;
+}

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -8,7 +8,7 @@ import ErrorInfo from '../../common/lib/types/errorinfo';
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
 // @ts-ignore
-import CryptoFactory from '../web/lib/util/crypto';
+import { createCryptoClass } from '../web/lib/util/crypto';
 import Http from '../web/lib/util/http';
 // @ts-ignore
 import Config from './config';
@@ -21,7 +21,7 @@ import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
 
-const Crypto = CryptoFactory(Config, BufferUtils);
+const Crypto = createCryptoClass(Config, BufferUtils);
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -1,5 +1,4 @@
 // Common
-import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -30,7 +29,9 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-BaseClient.Crypto = Crypto;
+for (const clientClass of [DefaultRest, DefaultRealtime]) {
+  clientClass.Crypto = Crypto;
+}
 
 Logger.initLogHandlers();
 

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -8,7 +8,7 @@ import ErrorInfo from '../../common/lib/types/errorinfo';
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
 // @ts-ignore
-import CryptoFactory from './lib/util/crypto';
+import { createCryptoClass } from './lib/util/crypto';
 import Http from './lib/util/http';
 import Config from './config';
 // @ts-ignore
@@ -17,7 +17,7 @@ import Logger from '../../common/lib/util/logger';
 import { getDefaults } from '../../common/lib/util/defaults';
 import PlatformDefaults from './lib/util/defaults';
 
-const Crypto = CryptoFactory(BufferUtils);
+const Crypto = createCryptoClass(BufferUtils);
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils as typeof Platform.BufferUtils;

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -1,5 +1,4 @@
 // Common
-import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -26,7 +25,9 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = null;
 
-BaseClient.Crypto = Crypto;
+for (const clientClass of [DefaultRest, DefaultRealtime]) {
+  clientClass.Crypto = Crypto;
+}
 
 Logger.initLogHandlers();
 

--- a/src/platform/nodejs/lib/util/crypto.ts
+++ b/src/platform/nodejs/lib/util/crypto.ts
@@ -18,7 +18,7 @@ type OutputCiphertext = Buffer;
 type InputCiphertext = CryptoDataTypes.InputCiphertext<MessagePackBinaryType, BufferUtilsOutput>;
 type OutputPlaintext = Buffer;
 
-var CryptoFactory = function (bufferUtils: typeof BufferUtils) {
+var createCryptoClass = function (bufferUtils: typeof BufferUtils) {
   var DEFAULT_ALGORITHM = 'aes';
   var DEFAULT_KEYLENGTH = 256; // bits
   var DEFAULT_MODE = 'cbc';
@@ -276,4 +276,4 @@ var CryptoFactory = function (bufferUtils: typeof BufferUtils) {
   return Crypto;
 };
 
-export default CryptoFactory;
+export { createCryptoClass };

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -1,5 +1,4 @@
 // Common
-import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -30,7 +29,9 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-BaseClient.Crypto = Crypto;
+for (const clientClass of [DefaultRest, DefaultRealtime]) {
+  clientClass.Crypto = Crypto;
+}
 
 Logger.initLogHandlers();
 

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -8,7 +8,7 @@ import ErrorInfo from '../../common/lib/types/errorinfo';
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
 // @ts-ignore
-import CryptoFactory from '../web/lib/util/crypto';
+import { createCryptoClass } from '../web/lib/util/crypto';
 import Http from '../web/lib/util/http';
 import configFactory from './config';
 // @ts-ignore
@@ -21,7 +21,7 @@ import msgpack from '../web/lib/util/msgpack';
 
 const Config = configFactory(BufferUtils);
 
-const Crypto = CryptoFactory(Config, BufferUtils);
+const Crypto = createCryptoClass(Config, BufferUtils);
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;

--- a/src/platform/web-noencryption/index.ts
+++ b/src/platform/web-noencryption/index.ts
@@ -1,5 +1,4 @@
 // Common
-import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -24,8 +23,6 @@ Platform.Http = Http;
 Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
-
-BaseClient.Crypto = null;
 
 Logger.initLogHandlers();
 

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -1,5 +1,4 @@
 // Common
-import BaseClient from '../../common/lib/client/baseclient';
 import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
@@ -28,7 +27,9 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-BaseClient.Crypto = Crypto;
+for (const clientClass of [DefaultRest, DefaultRealtime]) {
+  clientClass.Crypto = Crypto;
+}
 
 Logger.initLogHandlers();
 

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -8,7 +8,7 @@ import ErrorInfo from '../../common/lib/types/errorinfo';
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
 // @ts-ignore
-import CryptoFactory from './lib/util/crypto';
+import { createCryptoClass } from './lib/util/crypto';
 import Http from './lib/util/http';
 import Config from './config';
 // @ts-ignore
@@ -19,7 +19,7 @@ import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from './lib/util/defaults';
 import msgpack from './lib/util/msgpack';
 
-const Crypto = CryptoFactory(Config, BufferUtils);
+const Crypto = createCryptoClass(Config, BufferUtils);
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -16,7 +16,7 @@ type OutputCiphertext = ArrayBuffer;
 type InputCiphertext = CryptoDataTypes.InputCiphertext<MessagePackBinaryType, BufferUtilsOutput>;
 type OutputPlaintext = ArrayBuffer;
 
-var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof BufferUtils) {
+var createCryptoClass = function (config: IPlatformConfig, bufferUtils: typeof BufferUtils) {
   var DEFAULT_ALGORITHM = 'aes';
   var DEFAULT_KEYLENGTH = 256; // bits
   var DEFAULT_MODE = 'cbc';
@@ -318,4 +318,4 @@ var CryptoFactory = function (config: IPlatformConfig, bufferUtils: typeof Buffe
   return Crypto;
 };
 
-export default CryptoFactory;
+export { createCryptoClass };

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -8,7 +8,7 @@ import ErrorInfo from '../../common/lib/types/errorinfo';
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
 // @ts-ignore
-import CryptoFactory from './lib/util/crypto';
+import { createCryptoClass } from './lib/util/crypto';
 import Http from './lib/util/http';
 import Config from './config';
 // @ts-ignore
@@ -18,7 +18,7 @@ import { getDefaults } from '../../common/lib/util/defaults';
 import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from './lib/util/defaults';
 
-const Crypto = CryptoFactory(Config, BufferUtils);
+const Crypto = createCryptoClass(Config, BufferUtils);
 
 Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -44,5 +44,6 @@ if (Platform.Config.noUpgrade) {
 }
 
 export * from './modules/crypto';
+export * from './modules/message';
 export { Rest } from '../../common/lib/client/rest';
 export { BaseRest, BaseRealtime, ErrorInfo };

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -1,5 +1,4 @@
 // Common
-import BaseClient from 'common/lib/client/baseclient';
 import { BaseRest } from '../../common/lib/client/baserest';
 import BaseRealtime from '../../common/lib/client/baserealtime';
 import Platform from '../../common/platform';
@@ -27,8 +26,6 @@ Platform.Config = Config;
 Platform.Transports = Transports;
 Platform.WebStorage = WebStorage;
 
-BaseClient.Crypto = Crypto;
-
 Logger.initLogHandlers();
 
 Platform.Defaults = getDefaults(PlatformDefaults);
@@ -46,5 +43,6 @@ if (Platform.Config.noUpgrade) {
   Platform.Defaults.upgradeTransports = [];
 }
 
+export * from './modules/crypto';
 export { Rest } from '../../common/lib/client/rest';
 export { BaseRest, BaseRealtime, ErrorInfo };

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -7,7 +7,6 @@ import ErrorInfo from '../../common/lib/types/errorinfo';
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
 // @ts-ignore
-import { createCryptoClass } from './lib/util/crypto';
 import Http from './lib/util/http';
 import Config from './config';
 // @ts-ignore
@@ -17,9 +16,6 @@ import { getDefaults } from '../../common/lib/util/defaults';
 import WebStorage from './lib/util/webstorage';
 import PlatformDefaults from './lib/util/defaults';
 
-const Crypto = createCryptoClass(Config, BufferUtils);
-
-Platform.Crypto = Crypto;
 Platform.BufferUtils = BufferUtils;
 Platform.Http = Http;
 Platform.Config = Config;

--- a/src/platform/web/modules/crypto.ts
+++ b/src/platform/web/modules/crypto.ts
@@ -1,0 +1,10 @@
+import * as API from '../../../../ably';
+import Platform from 'common/platform';
+
+export const generateRandomKey: API.Types.Crypto['generateRandomKey'] = (keyLength) => {
+  return Platform.Crypto!.generateRandomKey(keyLength);
+};
+
+export const getDefaultCryptoParams: API.Types.Crypto['getDefaultParams'] = (params) => {
+  return Platform.Crypto!.getDefaultParams(params);
+};

--- a/src/platform/web/modules/crypto.ts
+++ b/src/platform/web/modules/crypto.ts
@@ -1,10 +1,14 @@
+import BufferUtils from '../lib/util/bufferutils';
+import { createCryptoClass } from '../lib/util/crypto';
+import Config from '../config';
 import * as API from '../../../../ably';
-import Platform from 'common/platform';
+
+export const Crypto = /* @__PURE__@ */ createCryptoClass(Config, BufferUtils);
 
 export const generateRandomKey: API.Types.Crypto['generateRandomKey'] = (keyLength) => {
-  return Platform.Crypto!.generateRandomKey(keyLength);
+  return Crypto.generateRandomKey(keyLength);
 };
 
 export const getDefaultCryptoParams: API.Types.Crypto['getDefaultParams'] = (params) => {
-  return Platform.Crypto!.getDefaultParams(params);
+  return Crypto.getDefaultParams(params);
 };

--- a/src/platform/web/modules/message.ts
+++ b/src/platform/web/modules/message.ts
@@ -1,0 +1,13 @@
+import * as API from '../../../../ably';
+import Platform from 'common/platform';
+import { fromEncoded, fromEncodedArray } from '../../../common/lib/types/message';
+
+// The type assertions for the decode* functions below are due to https://github.com/ably/ably-js/issues/1421
+
+export const decodeMessage = ((obj, options) => {
+  return fromEncoded(Platform.Crypto, obj, options);
+}) as API.Types.MessageStatic['fromEncoded'];
+
+export const decodeMessages = ((obj, options) => {
+  return fromEncodedArray(Platform.Crypto, obj, options);
+}) as API.Types.MessageStatic['fromEncodedArray'];

--- a/src/platform/web/modules/message.ts
+++ b/src/platform/web/modules/message.ts
@@ -1,13 +1,21 @@
 import * as API from '../../../../ably';
-import Platform from 'common/platform';
+import { Crypto } from './crypto';
 import { fromEncoded, fromEncodedArray } from '../../../common/lib/types/message';
 
 // The type assertions for the decode* functions below are due to https://github.com/ably/ably-js/issues/1421
 
 export const decodeMessage = ((obj, options) => {
-  return fromEncoded(Platform.Crypto, obj, options);
+  return fromEncoded(null, obj, options);
+}) as API.Types.MessageStatic['fromEncoded'];
+
+export const decodeEncryptedMessage = ((obj, options) => {
+  return fromEncoded(Crypto, obj, options);
 }) as API.Types.MessageStatic['fromEncoded'];
 
 export const decodeMessages = ((obj, options) => {
-  return fromEncodedArray(Platform.Crypto, obj, options);
+  return fromEncodedArray(null, obj, options);
+}) as API.Types.MessageStatic['fromEncodedArray'];
+
+export const decodeEncryptedMessages = ((obj, options) => {
+  return fromEncodedArray(Crypto, obj, options);
 }) as API.Types.MessageStatic['fromEncodedArray'];

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -5,7 +5,10 @@ import {
   generateRandomKey,
   getDefaultCryptoParams,
   decodeMessage,
+  decodeEncryptedMessage,
   decodeMessages,
+  decodeEncryptedMessages,
+  Crypto,
 } from '../../build/modules/index.js';
 
 describe('browser/modules', function () {
@@ -80,14 +83,40 @@ describe('browser/modules', function () {
   });
 
   describe('Message standalone functions', () => {
+    async function testDecodesMessageData(functionUnderTest) {
+      const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+
+      const item = testData.items[1];
+      const decoded = await functionUnderTest(item.encoded);
+
+      expect(decoded.data).to.be.an('ArrayBuffer');
+    }
+
     describe('decodeMessage', () => {
       it('decodes a message’s data', async () => {
+        testDecodesMessageData(decodeMessage);
+      });
+
+      it('throws an error when given channel options with a cipher', async () => {
         const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+        const key = BufferUtils.base64Decode(testData.key);
+        const iv = BufferUtils.base64Decode(testData.iv);
 
-        const item = testData.items[1];
-        const decoded = await decodeMessage(item.encoded);
+        let thrownError = null;
+        try {
+          await decodeMessage(testData.items[0].encrypted, { cipher: { key, iv } });
+        } catch (error) {
+          thrownError = error;
+        }
 
-        expect(decoded.data).to.be.an('ArrayBuffer');
+        expect(thrownError).not.to.be.null;
+        expect(thrownError.message).to.equal('Crypto module not provided');
+      });
+    });
+
+    describe('decodeEncryptedMessage', async () => {
+      it('decodes a message’s data', async () => {
+        testDecodesMessageData(decodeEncryptedMessage);
       });
 
       it('decrypts a message', async () => {
@@ -99,7 +128,7 @@ describe('browser/modules', function () {
         for (const item of testData.items) {
           const [decodedFromEncoded, decodedFromEncrypted] = await Promise.all([
             decodeMessage(item.encoded),
-            decodeMessage(item.encrypted, { cipher: { key, iv } }),
+            decodeEncryptedMessage(item.encrypted, { cipher: { key, iv } }),
           ]);
 
           testMessageEquality(decodedFromEncoded, decodedFromEncrypted);
@@ -107,15 +136,44 @@ describe('browser/modules', function () {
       });
     });
 
+    async function testDecodesMessagesData(functionUnderTest) {
+      const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+
+      const items = [testData.items[1], testData.items[3]];
+      const decoded = await functionUnderTest(items.map((item) => item.encoded));
+
+      expect(decoded[0].data).to.be.an('ArrayBuffer');
+      expect(decoded[1].data).to.be.an('array');
+    }
+
     describe('decodeMessages', () => {
       it('decodes messages’ data', async () => {
+        testDecodesMessagesData(decodeMessages);
+      });
+
+      it('throws an error when given channel options with a cipher', async () => {
         const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+        const key = BufferUtils.base64Decode(testData.key);
+        const iv = BufferUtils.base64Decode(testData.iv);
 
-        const items = [testData.items[1], testData.items[3]];
-        const decoded = await decodeMessages(items.map((item) => item.encoded));
+        let thrownError = null;
+        try {
+          await decodeMessages(
+            testData.items.map((item) => item.encrypted),
+            { cipher: { key, iv } }
+          );
+        } catch (error) {
+          thrownError = error;
+        }
 
-        expect(decoded[0].data).to.be.an('ArrayBuffer');
-        expect(decoded[1].data).to.be.an('array');
+        expect(thrownError).not.to.be.null;
+        expect(thrownError.message).to.equal('Crypto module not provided');
+      });
+    });
+
+    describe('decodeEncryptedMessages', () => {
+      it('decodes messages’ data', async () => {
+        testDecodesMessagesData(decodeEncryptedMessages);
       });
 
       it('decrypts messages', async () => {
@@ -126,7 +184,7 @@ describe('browser/modules', function () {
 
         const [decodedFromEncoded, decodedFromEncrypted] = await Promise.all([
           decodeMessages(testData.items.map((item) => item.encoded)),
-          decodeMessages(
+          decodeEncryptedMessages(
             testData.items.map((item) => item.encrypted),
             { cipher: { key, iv } }
           ),
@@ -136,6 +194,56 @@ describe('browser/modules', function () {
           testMessageEquality(decodedFromEncoded[i], decodedFromEncrypted[i]);
         }
       });
+    });
+  });
+
+  describe('Crypto', () => {
+    describe('without Crypto', () => {
+      for (const clientClass of [BaseRest, BaseRealtime]) {
+        describe(clientClass.name, () => {
+          it('throws an error when given channel options with a cipher', async () => {
+            const client = new clientClass(ablyClientOptions(), {});
+            const key = await generateRandomKey();
+            expect(() => client.channels.get('channel', { cipher: { key } })).to.throw('Crypto module not provided');
+          });
+        });
+      }
+    });
+
+    describe('with Crypto', () => {
+      for (const clientClass of [BaseRest, BaseRealtime]) {
+        describe(clientClass.name, () => {
+          it('is able to publish encrypted messages', async () => {
+            const clientOptions = ablyClientOptions();
+
+            const key = await generateRandomKey();
+
+            // Publish the message on a channel configured to use encryption, and receive it on one not configured to use encryption
+
+            const rxClient = new BaseRealtime(clientOptions, {});
+            const rxChannel = rxClient.channels.get('channel');
+            await rxChannel.attach();
+
+            const rxMessagePromise = new Promise((resolve, _) => rxChannel.subscribe((message) => resolve(message)));
+
+            const encryptionChannelOptions = { cipher: { key } };
+
+            const txMessage = { name: 'message', data: 'data' };
+            const txClient = new clientClass(clientOptions, { Crypto });
+            const txChannel = txClient.channels.get('channel', encryptionChannelOptions);
+            await txChannel.publish(txMessage);
+
+            const rxMessage = await rxMessagePromise;
+
+            // Verify that the message was published with encryption
+            expect(rxMessage.encoding).to.equal('utf-8/cipher+aes-256-cbc');
+
+            // Verify that the message was correctly encrypted
+            const rxMessageDecrypted = await decodeEncryptedMessage(rxMessage, encryptionChannelOptions);
+            testMessageEquality(rxMessageDecrypted, txMessage);
+          });
+        });
+      }
     });
   });
 });

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -1,4 +1,4 @@
-import { BaseRest, BaseRealtime, Rest } from '../../build/modules/index.js';
+import { BaseRest, BaseRealtime, Rest, generateRandomKey, getDefaultCryptoParams } from '../../build/modules/index.js';
 
 describe('browser/modules', function () {
   this.timeout(10 * 1000);
@@ -42,6 +42,19 @@ describe('browser/modules', function () {
         const client = new BaseRealtime(ablyClientOptions(), {});
         expect(() => client.time()).to.throw('Rest module not provided');
       });
+    });
+  });
+
+  describe('Crypto standalone functions', () => {
+    it('generateRandomKey', async () => {
+      const key = await generateRandomKey();
+      expect(key).to.be.an('ArrayBuffer');
+    });
+
+    it('getDefaultCryptoParams', async () => {
+      const key = await generateRandomKey();
+      const params = getDefaultCryptoParams({ key });
+      expect(params).to.be.an('object');
     });
   });
 });

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -25,27 +25,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
   function testMessageEquality(done, one, two) {
     try {
-      // treat `null` same as `undefined` (using ==, rather than ===)
-      expect(one.encoding == two.encoding, "Encoding mismatch ('" + one.encoding + "' != '" + two.encoding + "').").to
-        .be.ok;
-
-      if (typeof one.data === 'string' && typeof two.data === 'string') {
-        expect(one.data === two.data, 'String data contents mismatch.').to.be.ok;
-        return;
-      }
-
-      if (BufferUtils.isBuffer(one.data) && BufferUtils.isBuffer(two.data)) {
-        expect(BufferUtils.areBuffersEqual(one.data, two.data), 'Buffer data contents mismatch.').to.equal(true);
-        return;
-      }
-
-      var json1 = JSON.stringify(one.data);
-      var json2 = JSON.stringify(two.data);
-      if (null === json1 || undefined === json1 || null === json2 || undefined === json2) {
-        expect(false, 'JSON stringify failed.').to.be.ok;
-        return;
-      }
-      expect(json1 === json2, 'JSON data contents mismatch.').to.be.ok;
+      helper.testMessageEquality(one, two);
     } catch (err) {
       done(err);
     }


### PR DESCRIPTION
**Note: This PR is based on top of #1417; please review that one first.**

This encapsulates the crypto functionality in a tree-shakable module. See commit messages for more details.

```
BaseRest: 87.17 KiB
BaseRest + Rest: 87.17 KiB
BaseRest + Crypto: 90.70 KiB
BaseRest + generateRandomKey: 90.73 KiB
BaseRest + getDefaultCryptoParams: 90.73 KiB
BaseRest + decodeMessage: 87.53 KiB
BaseRest + decodeEncryptedMessage: 91.05 KiB
BaseRest + decodeMessages: 87.64 KiB
BaseRest + decodeEncryptedMessages: 91.16 KiB
BaseRealtime: 144.00 KiB
BaseRealtime + Rest: 152.65 KiB
BaseRealtime + Crypto: 147.53 KiB
BaseRealtime + generateRandomKey: 147.56 KiB
BaseRealtime + getDefaultCryptoParams: 147.56 KiB
BaseRealtime + decodeMessage: 144.36 KiB
BaseRealtime + decodeEncryptedMessage: 147.88 KiB
BaseRealtime + decodeMessages: 144.46 KiB
BaseRealtime + decodeEncryptedMessages: 147.99 KiB
generateRandomKey: 73.80 KiB
generateRandomKey + Crypto: 73.80 KiB
getDefaultCryptoParams: 73.80 KiB
getDefaultCryptoParams + Crypto: 73.80 KiB
decodeMessage: 70.61 KiB
decodeEncryptedMessage: 74.13 KiB
decodeEncryptedMessage + Crypto: 74.13 KiB
decodeMessages: 70.71 KiB
decodeEncryptedMessages: 74.23 KiB
decodeEncryptedMessages + Crypto: 74.23 KiB
```

Resolves #1396.