### PR TITLE
[SDK-3732] Make realtime presence functionality tree-shakable

### DIFF
--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -1,7 +1,7 @@
 const esbuild = require('esbuild');
 
 // List of all modules accepted in ModulesMap
-const moduleNames = ['Rest', 'Crypto', 'MsgPack'];
+const moduleNames = ['Rest', 'Crypto', 'MsgPack', 'RealtimePresence'];
 
 // List of all free-standing functions exported by the library along with the
 // ModulesMap entries that we expect them to transitively import

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -10,17 +10,20 @@ import { ChannelOptions } from '../../types/channel';
 import ClientOptions from '../../types/ClientOptions';
 import * as API from '../../../../ably';
 import { ModulesMap } from './modulesmap';
+import RealtimePresence from './realtimepresence';
 
 /**
  `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
  */
 class BaseRealtime extends BaseClient {
+  readonly _RealtimePresence: typeof RealtimePresence | null;
   _channels: any;
   connection: Connection;
 
   constructor(options: ClientOptions, modules: ModulesMap) {
     super(options, modules);
     Logger.logAction(Logger.LOG_MINOR, 'Realtime()', '');
+    this._RealtimePresence = modules.RealtimePresence ?? null;
     this.connection = new Connection(this, this.options);
     this._channels = new Channels(this);
     if (options.autoConnect !== false) this.connect();

--- a/src/common/lib/client/channel.ts
+++ b/src/common/lib/client/channel.ts
@@ -50,7 +50,10 @@ class Channel extends EventEmitter {
   client: BaseClient;
   name: string;
   basePath: string;
-  presence: Presence;
+  private _presence: Presence;
+  get presence(): Presence {
+    return this._presence;
+  }
   channelOptions: ChannelOptions;
 
   constructor(client: BaseClient, name: string, channelOptions?: ChannelOptions) {
@@ -59,7 +62,7 @@ class Channel extends EventEmitter {
     this.client = client;
     this.name = name;
     this.basePath = '/channels/' + encodeURIComponent(name);
-    this.presence = new Presence(this);
+    this._presence = new Presence(this);
     this.channelOptions = normaliseChannelOptions(client._Crypto ?? null, channelOptions);
   }
 

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -7,6 +7,7 @@ import ProtocolMessage from '../types/protocolmessage';
 import Platform from 'common/platform';
 import { DefaultMessage } from '../types/defaultmessage';
 import { MsgPack } from 'common/types/msgpack';
+import RealtimePresence from './realtimepresence';
 
 /**
  `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -18,7 +19,7 @@ export class DefaultRealtime extends BaseRealtime {
       throw new Error('Expected DefaultRealtime._MsgPack to have been set');
     }
 
-    super(options, { ...allCommonModules, Crypto: DefaultRealtime.Crypto ?? undefined, MsgPack });
+    super(options, { ...allCommonModules, Crypto: DefaultRealtime.Crypto ?? undefined, MsgPack, RealtimePresence });
   }
 
   static Utils = Utils;

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -1,11 +1,13 @@
 import { Rest } from './rest';
 import { IUntypedCryptoStatic } from '../../types/ICryptoStatic';
 import { MsgPack } from 'common/types/msgpack';
+import RealtimePresence from './realtimepresence';
 
 export interface ModulesMap {
   Rest?: typeof Rest;
   Crypto?: IUntypedCryptoStatic;
   MsgPack?: MsgPack;
+  RealtimePresence?: typeof RealtimePresence;
 }
 
 export const allCommonModules: ModulesMap = { Rest };

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -42,5 +42,6 @@ if (Platform.Config.noUpgrade) {
 export * from './modules/crypto';
 export * from './modules/message';
 export * from './modules/msgpack';
+export * from './modules/realtimepresence';
 export { Rest } from '../../common/lib/client/rest';
 export { BaseRest, BaseRealtime, ErrorInfo };

--- a/src/platform/web/modules/realtimepresence.ts
+++ b/src/platform/web/modules/realtimepresence.ts
@@ -1,0 +1,1 @@
+export { default as RealtimePresence } from '../../../common/lib/client/realtimepresence';


### PR DESCRIPTION
**Note: This PR is based on top of #1425; please review that one first.**

We move the realtime presence functionality into a tree-shakable `RealtimePresence` module.

Resolves #1375.