### PR TITLE
Export the ErrorInfo class

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -730,7 +730,7 @@ declare namespace Types {
   /**
    * A generic Ably error object that contains an Ably-specific status code, and a generic status code. Errors returned from the Ably server are compatible with the `ErrorInfo` structure and should result in errors that inherit from `ErrorInfo`.
    */
-  interface ErrorInfo extends Error {
+  class ErrorInfo extends Error {
     /**
      * Ably [error code](https://github.com/ably/ably-common/blob/main/protocol/errors.json).
      */
@@ -743,6 +743,20 @@ declare namespace Types {
      * HTTP Status Code corresponding to this error, where applicable.
      */
     statusCode: number;
+    /**
+     * The underlying cause of the error, where applicable.
+     */
+    cause?: string | Error | ErrorInfo;
+
+    /**
+     * Construct an ErrorInfo object.
+     *
+     * @param message - A string describing the error.
+     * @param code - Ably [error code](https://github.com/ably/ably-common/blob/main/protocol/errors.json).
+     * @param statusCode - HTTP Status Code corresponding to this error.
+     * @param cause - The underlying cause of the error.
+     */
+    constructor(message: string, code: number, statusCode: number, cause?: string | Error | ErrorInfo);
   }
 
   /**
@@ -3769,3 +3783,8 @@ export declare class Rest extends Types.RestCallbacks {}
  * A client that extends the functionality of {@link Rest} and provides additional realtime-specific features.
  */
 export declare class Realtime extends Types.RealtimeCallbacks {}
+
+/**
+ * A generic Ably error object that contains an Ably-specific status code, and a generic status code. Errors returned from the Ably server are compatible with the `ErrorInfo` structure and should result in errors that inherit from `ErrorInfo`.
+ */
+export declare class ErrorInfo extends Types.ErrorInfo {}

--- a/promises.d.ts
+++ b/promises.d.ts
@@ -8,6 +8,10 @@ export declare class Rest extends Ably.Rest.Promise {}
  * A client that extends the functionality of {@link Rest} and provides additional realtime-specific features.
  */
 export declare class Realtime extends Ably.Realtime.Promise {}
+/**
+ * A generic Ably error object that contains an Ably-specific status code, and a generic status code. Errors returned from the Ably server are compatible with the `ErrorInfo` structure and should result in errors that inherit from `ErrorInfo`.
+ */
+export declare class ErrorInfo extends Types.ErrorInfo {}
 
 // Re-export the Types namespace.
 import Types = Ably.Types;

--- a/promises.js
+++ b/promises.js
@@ -23,6 +23,7 @@ var RealtimePromise = function (options) {
 Object.assign(RealtimePromise, Ably.Realtime);
 
 module.exports = {
+  ErrorInfo: Ably.ErrorInfo,
   Rest: RestPromise,
   Realtime: RealtimePromise,
 };

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -2,6 +2,7 @@
 import Rest from '../../common/lib/client/rest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
+import ErrorInfo from '../../common/lib/types/errorinfo';
 
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
@@ -41,6 +42,7 @@ if (Platform.Config.agent) {
 }
 
 export default {
+  ErrorInfo,
   Rest,
   Realtime,
   msgpack,

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -2,6 +2,7 @@
 import Rest from '../../common/lib/client/rest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
+import ErrorInfo from '../../common/lib/types/errorinfo';
 
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
@@ -35,6 +36,7 @@ if (Platform.Config.agent) {
 }
 
 export default {
+  ErrorInfo,
   Rest,
   Realtime,
   msgpack: null,

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -2,6 +2,7 @@
 import Rest from '../../common/lib/client/rest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
+import ErrorInfo from '../../common/lib/types/errorinfo';
 
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
@@ -39,6 +40,7 @@ if (Platform.Config.agent) {
 }
 
 export default {
+  ErrorInfo,
   Rest,
   Realtime,
   msgpack,

--- a/src/platform/web-noencryption/index.ts
+++ b/src/platform/web-noencryption/index.ts
@@ -2,6 +2,7 @@
 import Rest from '../../common/lib/client/rest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
+import ErrorInfo from '../../common/lib/types/errorinfo';
 
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
@@ -36,6 +37,7 @@ if (Platform.Config.agent) {
 }
 
 export default {
+  ErrorInfo,
   Rest,
   Realtime,
   msgpack,

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -2,6 +2,7 @@
 import Rest from '../../common/lib/client/rest';
 import Realtime from '../../common/lib/client/realtime';
 import Platform from '../../common/platform';
+import ErrorInfo from '../../common/lib/types/errorinfo';
 
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
@@ -47,6 +48,7 @@ if (Platform.Config.noUpgrade) {
 }
 
 export default {
+  ErrorInfo,
   Rest,
   Realtime,
   msgpack,


### PR DESCRIPTION
So that wrapper SDKs like Spaces can use the ErrorInfo class, for example:

```typescript
import * as Ably from 'ably';

throw new Ably.ErrorInfo('some error', 12345, 400);
```