### PR TITLE
[SDK-3733] Make realtime transports tree-shakable

### DIFF
--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -1,7 +1,15 @@
 const esbuild = require('esbuild');
 
 // List of all modules accepted in ModulesMap
-const moduleNames = ['Rest', 'Crypto', 'MsgPack', 'RealtimePresence'];
+const moduleNames = [
+  'Rest',
+  'Crypto',
+  'MsgPack',
+  'RealtimePresence',
+  'XHRPolling',
+  'XHRStreaming',
+  'WebSocketTransport',
+];
 
 // List of all free-standing functions exported by the library along with the
 // ModulesMap entries that we expect them to transitively import

--- a/src/common/constants/TransportName.ts
+++ b/src/common/constants/TransportName.ts
@@ -1,8 +1,8 @@
-enum TransportNames {
+enum TransportName {
   WebSocket = 'web_socket',
   Comet = 'comet',
   XhrStreaming = 'xhr_streaming',
   XhrPolling = 'xhr_polling',
 }
 
-export default TransportNames;
+export default TransportName;

--- a/src/common/constants/TransportName.ts
+++ b/src/common/constants/TransportName.ts
@@ -1,8 +1,14 @@
-enum TransportName {
-  WebSocket = 'web_socket',
-  Comet = 'comet',
-  XhrStreaming = 'xhr_streaming',
-  XhrPolling = 'xhr_polling',
+export namespace TransportNames {
+  export const WebSocket = 'web_socket' as const;
+  export const Comet = 'comet' as const;
+  export const XhrStreaming = 'xhr_streaming' as const;
+  export const XhrPolling = 'xhr_polling' as const;
 }
+
+type TransportName =
+  | typeof TransportNames.WebSocket
+  | typeof TransportNames.Comet
+  | typeof TransportNames.XhrStreaming
+  | typeof TransportNames.XhrPolling;
 
 export default TransportName;

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -9,6 +9,7 @@ import { DefaultMessage } from '../types/defaultmessage';
 import { MsgPack } from 'common/types/msgpack';
 import RealtimePresence from './realtimepresence';
 import { DefaultPresenceMessage } from '../types/defaultpresencemessage';
+import initialiseWebSocketTransport from '../transport/websockettransport';
 
 /**
  `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -20,7 +21,13 @@ export class DefaultRealtime extends BaseRealtime {
       throw new Error('Expected DefaultRealtime._MsgPack to have been set');
     }
 
-    super(options, { ...allCommonModules, Crypto: DefaultRealtime.Crypto ?? undefined, MsgPack, RealtimePresence });
+    super(options, {
+      ...allCommonModules,
+      Crypto: DefaultRealtime.Crypto ?? undefined,
+      MsgPack,
+      RealtimePresence,
+      WebSocketTransport: initialiseWebSocketTransport,
+    });
   }
 
   static Utils = Utils;

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -2,12 +2,16 @@ import { Rest } from './rest';
 import { IUntypedCryptoStatic } from '../../types/ICryptoStatic';
 import { MsgPack } from 'common/types/msgpack';
 import RealtimePresence from './realtimepresence';
+import { TransportInitialiser } from '../transport/connectionmanager';
 
 export interface ModulesMap {
   Rest?: typeof Rest;
   Crypto?: IUntypedCryptoStatic;
   MsgPack?: MsgPack;
   RealtimePresence?: typeof RealtimePresence;
+  WebSocketTransport?: TransportInitialiser;
+  XHRPolling?: TransportInitialiser;
+  XHRStreaming?: TransportInitialiser;
 }
 
 export const allCommonModules: ModulesMap = { Rest };

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -17,8 +17,8 @@ import Transport, { TransportCtor } from './transport';
 import * as API from '../../../../ably';
 import { ErrCallback } from 'common/types/utils';
 import HttpStatusCodes from 'common/constants/HttpStatusCodes';
+import BaseRealtime from '../client/baserealtime';
 
-type Realtime = any;
 type ClientOptions = any;
 
 let globalObject = typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : self;
@@ -190,7 +190,7 @@ type ConnectionState = {
 };
 
 class ConnectionManager extends EventEmitter {
-  realtime: Realtime;
+  realtime: BaseRealtime;
   options: ClientOptions;
   states: Record<string, ConnectionState>;
   state: ConnectionState;
@@ -226,7 +226,7 @@ class ConnectionManager extends EventEmitter {
     queue: { message: ProtocolMessage; transport: Transport }[];
   } = { isProcessing: false, queue: [] };
 
-  constructor(realtime: Realtime, options: ClientOptions) {
+  constructor(realtime: BaseRealtime, options: ClientOptions) {
     super();
     ConnectionManager.initTransports();
     this.realtime = realtime;
@@ -1191,7 +1191,8 @@ class ConnectionManager extends EventEmitter {
     const newState = (this.state = this.states[stateChange.current as string]);
     if (stateChange.reason) {
       this.errorReason = stateChange.reason;
-      this.realtime.connection.errorReason = stateChange.reason;
+      // TODO remove this type assertion after fixing https://github.com/ably/ably-js/issues/1405
+      this.realtime.connection.errorReason = stateChange.reason as ErrorInfo;
     }
     if (newState.terminal || newState.state === 'suspended') {
       /* suspended is nonterminal, but once in the suspended state, realtime

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -99,7 +99,7 @@ function decodeRecoveryKey(recoveryKey: string): RecoveryContext | null {
   }
 }
 
-const supportedTransports: Record<string, TransportCtor> = {};
+const supportedTransports: Partial<Record<string, TransportCtor>> = {};
 
 export class TransportParams {
   options: ClientOptions;
@@ -486,7 +486,7 @@ class ConnectionManager extends EventEmitter {
     Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.tryATransport()', 'trying ' + candidate);
 
     Transport.tryConnect(
-      ConnectionManager.supportedTransports[candidate],
+      ConnectionManager.supportedTransports[candidate]!,
       this,
       this.realtime.auth,
       transportParams,

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -410,7 +410,8 @@ class ConnectionManager extends EventEmitter {
 
   static initTransports() {
     WebSocketTransport(ConnectionManager);
-    Utils.arrForEach(Platform.Transports, function (initFn) {
+    Utils.arrForEach(Platform.Transports.order, function (transportName) {
+      const initFn = Platform.Transports.implementations[transportName]!;
       initFn(ConnectionManager);
     });
   }

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -18,8 +18,7 @@ import * as API from '../../../../ably';
 import { ErrCallback } from 'common/types/utils';
 import HttpStatusCodes from 'common/constants/HttpStatusCodes';
 import BaseRealtime from '../client/baserealtime';
-
-type ClientOptions = any;
+import { NormalisedClientOptions } from 'common/types/ClientOptions';
 
 let globalObject = typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : self;
 
@@ -91,9 +90,9 @@ type RecoveryContext = {
   channelSerials: { [name: string]: string };
 };
 
-function decodeRecoveryKey(recoveryKey: string): RecoveryContext | null {
+function decodeRecoveryKey(recoveryKey: NormalisedClientOptions['recover']): RecoveryContext | null {
   try {
-    return JSON.parse(recoveryKey);
+    return JSON.parse(recoveryKey as string);
   } catch (e) {
     return null;
   }
@@ -102,7 +101,7 @@ function decodeRecoveryKey(recoveryKey: string): RecoveryContext | null {
 const supportedTransports: Partial<Record<string, TransportCtor>> = {};
 
 export class TransportParams {
-  options: ClientOptions;
+  options: NormalisedClientOptions;
   host: string | null;
   mode: string;
   format?: Utils.Format;
@@ -110,7 +109,7 @@ export class TransportParams {
   stream?: any;
   heartbeats?: boolean;
 
-  constructor(options: ClientOptions, host: string | null, mode: string, connectionKey?: string) {
+  constructor(options: NormalisedClientOptions, host: string | null, mode: string, connectionKey?: string) {
     this.options = options;
     this.host = host;
     this.mode = mode;
@@ -191,7 +190,7 @@ type ConnectionState = {
 
 class ConnectionManager extends EventEmitter {
   realtime: BaseRealtime;
-  options: ClientOptions;
+  options: NormalisedClientOptions;
   states: Record<string, ConnectionState>;
   state: ConnectionState;
   errorReason: IPartialErrorInfo | string | null;
@@ -226,7 +225,7 @@ class ConnectionManager extends EventEmitter {
     queue: { message: ProtocolMessage; transport: Transport }[];
   } = { isProcessing: false, queue: [] };
 
-  constructor(realtime: BaseRealtime, options: ClientOptions) {
+  constructor(realtime: BaseRealtime, options: NormalisedClientOptions) {
     super();
     ConnectionManager.initTransports();
     this.realtime = realtime;
@@ -601,7 +600,7 @@ class ConnectionManager extends EventEmitter {
       if (mode === 'recover' && this.options.recover) {
         /* After a successful recovery, we unpersist, as a recovery key cannot
          * be used more than once */
-        this.options.recover = null;
+        delete this.options.recover;
         this.unpersistConnection();
       }
     });

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -2167,3 +2167,5 @@ class ConnectionManager extends EventEmitter {
 }
 
 export default ConnectionManager;
+
+export type TransportInitialiser = (connectionManager: typeof ConnectionManager) => typeof Transport;

--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -6,7 +6,7 @@ import Logger from '../util/logger';
 import ProtocolMessage from '../types/protocolmessage';
 import ErrorInfo from '../types/errorinfo';
 import NodeWebSocket from 'ws';
-import ConnectionManager, { TransportParams } from './connectionmanager';
+import ConnectionManager, { TransportParams, TransportStorage } from './connectionmanager';
 import Auth from '../client/auth';
 import { TransportNames } from 'common/constants/TransportName';
 
@@ -196,8 +196,8 @@ class WebSocketTransport extends Transport {
   }
 }
 
-function initialiseTransport(connectionManager: typeof ConnectionManager): typeof WebSocketTransport {
-  if (WebSocketTransport.isAvailable()) connectionManager.supportedTransports[shortName] = WebSocketTransport;
+function initialiseTransport(transportStorage: TransportStorage): typeof WebSocketTransport {
+  if (WebSocketTransport.isAvailable()) transportStorage.supportedTransports[shortName] = WebSocketTransport;
 
   return WebSocketTransport;
 }

--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -8,8 +8,9 @@ import ErrorInfo from '../types/errorinfo';
 import NodeWebSocket from 'ws';
 import ConnectionManager, { TransportParams } from './connectionmanager';
 import Auth from '../client/auth';
+import TransportName from 'common/constants/TransportName';
 
-const shortName = 'web_socket';
+const shortName = TransportName.WebSocket;
 
 function isNodeWebSocket(ws: WebSocket | NodeWebSocket): ws is NodeWebSocket {
   return !!(ws as NodeWebSocket).on;

--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -196,7 +196,7 @@ class WebSocketTransport extends Transport {
   }
 }
 
-function initialiseTransport(connectionManager: any): typeof WebSocketTransport {
+function initialiseTransport(connectionManager: typeof ConnectionManager): typeof WebSocketTransport {
   if (WebSocketTransport.isAvailable()) connectionManager.supportedTransports[shortName] = WebSocketTransport;
 
   return WebSocketTransport;

--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -8,9 +8,9 @@ import ErrorInfo from '../types/errorinfo';
 import NodeWebSocket from 'ws';
 import ConnectionManager, { TransportParams } from './connectionmanager';
 import Auth from '../client/auth';
-import TransportName from 'common/constants/TransportName';
+import { TransportNames } from 'common/constants/TransportName';
 
-const shortName = TransportName.WebSocket;
+const shortName = TransportNames.WebSocket;
 
 function isNodeWebSocket(ws: WebSocket | NodeWebSocket): ws is NodeWebSocket {
   return !!(ws as NodeWebSocket).on;

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -110,7 +110,7 @@ class ProtocolMessage {
 
   static serialize = Utils.encodeBody;
 
-  static deserialize = function (serialized: unknown, MsgPack: MsgPack, format?: Utils.Format): ProtocolMessage {
+  static deserialize = function (serialized: unknown, MsgPack: MsgPack | null, format?: Utils.Format): ProtocolMessage {
     const deserialized = Utils.decodeBody<Record<string, unknown>>(serialized, MsgPack, format);
     return ProtocolMessage.fromDeserialized(deserialized);
   };

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -156,7 +156,7 @@ export function containsValue(ob: Record<string, unknown>, val: unknown): boolea
   return false;
 }
 
-export function intersect<T>(arr: Array<string>, ob: string[] | Record<string, T>): string[] {
+export function intersect<K extends string, T>(arr: Array<K>, ob: K[] | Partial<Record<K, T>>): K[] {
   return isArray(ob) ? arrIntersect(arr, ob) : arrIntersectOb(arr, ob);
 }
 
@@ -169,7 +169,7 @@ export function arrIntersect<T>(arr1: Array<T>, arr2: Array<T>): Array<T> {
   return result;
 }
 
-export function arrIntersectOb(arr: Array<string>, ob: Record<string, unknown>): string[] {
+export function arrIntersectOb<K extends string>(arr: Array<K>, ob: Partial<Record<K, unknown>>): K[] {
   const result = [];
   for (let i = 0; i < arr.length; i++) {
     const member = arr[i];

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -34,7 +34,8 @@ export default class Platform {
   static Http: typeof IHttp;
   static Transports: {
     order: TransportName[];
-    implementations: TransportImplementations;
+    // Transport implementations that always come with this platform
+    bundledImplementations: TransportImplementations;
   };
   static Defaults: IDefaults;
   static WebStorage: IWebStorage | null;

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -7,10 +7,13 @@ import IBufferUtils from './types/IBufferUtils';
 import * as WebBufferUtils from '../platform/web/lib/util/bufferutils';
 import * as NodeBufferUtils from '../platform/nodejs/lib/util/bufferutils';
 import { IUntypedCryptoStatic } from '../common/types/ICryptoStatic';
+import TransportName from './constants/TransportName';
 
 type Bufferlike = WebBufferUtils.Bufferlike | NodeBufferUtils.Bufferlike;
 type BufferUtilsOutput = WebBufferUtils.Output | NodeBufferUtils.Output;
 type ToBufferOutput = WebBufferUtils.ToBufferOutput | NodeBufferUtils.ToBufferOutput;
+
+export type TransportImplementations = Partial<Record<TransportName, TransportInitialiser>>;
 
 export default class Platform {
   static Config: IPlatformConfig;
@@ -29,7 +32,10 @@ export default class Platform {
    */
   static Crypto: IUntypedCryptoStatic | null;
   static Http: typeof IHttp;
-  static Transports: TransportInitialiser[];
+  static Transports: {
+    order: TransportName[];
+    implementations: TransportImplementations;
+  };
   static Defaults: IDefaults;
   static WebStorage: IWebStorage | null;
 }

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -1,10 +1,9 @@
 import { IPlatformConfig } from './types/IPlatformConfig';
 import { IHttp } from './types/http';
-import ConnectionManager from './lib/transport/connectionmanager';
+import { TransportInitialiser } from './lib/transport/connectionmanager';
 import IDefaults from './types/IDefaults';
 import IWebStorage from './types/IWebStorage';
 import IBufferUtils from './types/IBufferUtils';
-import Transport from './lib/transport/transport';
 import * as WebBufferUtils from '../platform/web/lib/util/bufferutils';
 import * as NodeBufferUtils from '../platform/nodejs/lib/util/bufferutils';
 import { IUntypedCryptoStatic } from '../common/types/ICryptoStatic';
@@ -30,7 +29,7 @@ export default class Platform {
    */
   static Crypto: IUntypedCryptoStatic | null;
   static Http: typeof IHttp;
-  static Transports: Array<(connectionManager: typeof ConnectionManager) => typeof Transport>;
+  static Transports: TransportInitialiser[];
   static Defaults: IDefaults;
   static WebStorage: IWebStorage | null;
 }

--- a/src/common/platform.ts
+++ b/src/common/platform.ts
@@ -30,7 +30,7 @@ export default class Platform {
    */
   static Crypto: IUntypedCryptoStatic | null;
   static Http: typeof IHttp;
-  static Transports: Array<(connectionManager: typeof ConnectionManager) => Transport>;
+  static Transports: Array<(connectionManager: typeof ConnectionManager) => typeof Transport>;
   static Defaults: IDefaults;
   static WebStorage: IWebStorage | null;
 }

--- a/src/common/types/IDefaults.d.ts
+++ b/src/common/types/IDefaults.d.ts
@@ -1,11 +1,11 @@
-import TransportNames from '../constants/TransportNames';
+import TransportName from '../constants/TransportName';
 import { RestAgentOptions } from './ClientOptions';
 
 export default interface IDefaults {
   connectivityCheckUrl: string;
-  defaultTransports: TransportNames[];
-  baseTransportOrder: TransportNames[];
-  transportPreferenceOrder: TransportNames[];
-  upgradeTransports: TransportNames[];
+  defaultTransports: TransportName[];
+  baseTransportOrder: TransportName[];
+  transportPreferenceOrder: TransportName[];
+  upgradeTransports: TransportName[];
   restAgentOptions?: RestAgentOptions;
 }

--- a/src/platform/nodejs/lib/transport/index.js
+++ b/src/platform/nodejs/lib/transport/index.js
@@ -1,3 +1,0 @@
-import NodeCometTransport from './nodecomettransport';
-
-export default [NodeCometTransport];

--- a/src/platform/nodejs/lib/transport/index.ts
+++ b/src/platform/nodejs/lib/transport/index.ts
@@ -1,7 +1,11 @@
 import { TransportNames } from 'common/constants/TransportName';
 import initialiseNodeCometTransport from './nodecomettransport';
+import { default as initialiseWebSocketTransport } from '../../../../common/lib/transport/websockettransport';
 
 export default {
   order: [TransportNames.Comet],
-  implementations: { [TransportNames.Comet]: initialiseNodeCometTransport },
+  bundledImplementations: {
+    [TransportNames.WebSocket]: initialiseWebSocketTransport,
+    [TransportNames.Comet]: initialiseNodeCometTransport,
+  },
 };

--- a/src/platform/nodejs/lib/transport/index.ts
+++ b/src/platform/nodejs/lib/transport/index.ts
@@ -1,3 +1,7 @@
+import TransportName from 'common/constants/TransportName';
 import initialiseNodeCometTransport from './nodecomettransport';
 
-export default [initialiseNodeCometTransport];
+export default {
+  order: [TransportName.Comet],
+  implementations: { [TransportName.Comet]: initialiseNodeCometTransport },
+};

--- a/src/platform/nodejs/lib/transport/index.ts
+++ b/src/platform/nodejs/lib/transport/index.ts
@@ -1,0 +1,3 @@
+import initialiseNodeCometTransport from './nodecomettransport';
+
+export default [initialiseNodeCometTransport];

--- a/src/platform/nodejs/lib/transport/index.ts
+++ b/src/platform/nodejs/lib/transport/index.ts
@@ -1,7 +1,7 @@
-import TransportName from 'common/constants/TransportName';
+import { TransportNames } from 'common/constants/TransportName';
 import initialiseNodeCometTransport from './nodecomettransport';
 
 export default {
-  order: [TransportName.Comet],
-  implementations: { [TransportName.Comet]: initialiseNodeCometTransport },
+  order: [TransportNames.Comet],
+  implementations: { [TransportNames.Comet]: initialiseNodeCometTransport },
 };

--- a/src/platform/nodejs/lib/transport/nodecomettransport.d.ts
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.d.ts
@@ -1,0 +1,5 @@
+import ConnectionManager from '../../../../common/lib/transport/connectionmanager';
+import Transport from '../../../../common/lib/transport/transport';
+
+declare function initialiseNodeCometTransport(connectionManager: typeof ConnectionManager): typeof Transport;
+export default initialiseNodeCometTransport;

--- a/src/platform/nodejs/lib/transport/nodecomettransport.d.ts
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.d.ts
@@ -1,5 +1,5 @@
-import ConnectionManager from '../../../../common/lib/transport/connectionmanager';
+import { TransportStorage } from '../../../../common/lib/transport/connectionmanager';
 import Transport from '../../../../common/lib/transport/transport';
 
-declare function initialiseNodeCometTransport(connectionManager: typeof ConnectionManager): typeof Transport;
+declare function initialiseNodeCometTransport(transportStorage: TransportStorage): typeof Transport;
 export default initialiseNodeCometTransport;

--- a/src/platform/nodejs/lib/transport/nodecomettransport.js
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.js
@@ -10,11 +10,11 @@ import http from 'http';
 import https from 'https';
 import url from 'url';
 import util from 'util';
-import TransportName from '../../../../common/constants/TransportName';
+import { TransportNames } from '../../../../common/constants/TransportName';
 
 var NodeCometTransport = function (connectionManager) {
   var noop = function () {};
-  var shortName = TransportName.Comet;
+  var shortName = TransportNames.Comet;
 
   /*
    * A transport to use with nodejs

--- a/src/platform/nodejs/lib/transport/nodecomettransport.js
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.js
@@ -10,10 +10,11 @@ import http from 'http';
 import https from 'https';
 import url from 'url';
 import util from 'util';
+import TransportName from '../../../../common/constants/TransportName';
 
 var NodeCometTransport = function (connectionManager) {
   var noop = function () {};
-  var shortName = 'comet';
+  var shortName = TransportName.Comet;
 
   /*
    * A transport to use with nodejs

--- a/src/platform/nodejs/lib/transport/nodecomettransport.js
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.js
@@ -12,7 +12,7 @@ import url from 'url';
 import util from 'util';
 import { TransportNames } from '../../../../common/constants/TransportName';
 
-var NodeCometTransport = function (connectionManager) {
+var NodeCometTransport = function (transportStorage) {
   var noop = function () {};
   var shortName = TransportNames.Comet;
 
@@ -32,7 +32,7 @@ var NodeCometTransport = function (connectionManager) {
   NodeCometTransport.isAvailable = function () {
     return true;
   };
-  connectionManager.supportedTransports[shortName] = NodeCometTransport;
+  transportStorage.supportedTransports[shortName] = NodeCometTransport;
 
   NodeCometTransport.prototype.toString = function () {
     return (

--- a/src/platform/nodejs/lib/util/defaults.ts
+++ b/src/platform/nodejs/lib/util/defaults.ts
@@ -1,14 +1,14 @@
 import IDefaults from '../../../../common/types/IDefaults';
-import TransportName from '../../../../common/constants/TransportName';
+import { TransportNames } from '../../../../common/constants/TransportName';
 
 const Defaults: IDefaults = {
   connectivityCheckUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
   /* Note: order matters here: the base transport is the leftmost one in the
    * intersection of baseTransportOrder and the transports clientOption that's supported. */
-  defaultTransports: [TransportName.WebSocket],
-  baseTransportOrder: [TransportName.Comet, TransportName.WebSocket],
-  transportPreferenceOrder: [TransportName.Comet, TransportName.WebSocket],
-  upgradeTransports: [TransportName.WebSocket],
+  defaultTransports: [TransportNames.WebSocket],
+  baseTransportOrder: [TransportNames.Comet, TransportNames.WebSocket],
+  transportPreferenceOrder: [TransportNames.Comet, TransportNames.WebSocket],
+  upgradeTransports: [TransportNames.WebSocket],
   restAgentOptions: { maxSockets: 40, keepAlive: true },
 };
 

--- a/src/platform/nodejs/lib/util/defaults.ts
+++ b/src/platform/nodejs/lib/util/defaults.ts
@@ -1,14 +1,14 @@
 import IDefaults from '../../../../common/types/IDefaults';
-import TransportNames from '../../../../common/constants/TransportNames';
+import TransportName from '../../../../common/constants/TransportName';
 
 const Defaults: IDefaults = {
   connectivityCheckUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
   /* Note: order matters here: the base transport is the leftmost one in the
    * intersection of baseTransportOrder and the transports clientOption that's supported. */
-  defaultTransports: [TransportNames.WebSocket],
-  baseTransportOrder: [TransportNames.Comet, TransportNames.WebSocket],
-  transportPreferenceOrder: [TransportNames.Comet, TransportNames.WebSocket],
-  upgradeTransports: [TransportNames.WebSocket],
+  defaultTransports: [TransportName.WebSocket],
+  baseTransportOrder: [TransportName.Comet, TransportName.WebSocket],
+  transportPreferenceOrder: [TransportName.Comet, TransportName.WebSocket],
+  upgradeTransports: [TransportName.WebSocket],
   restAgentOptions: { maxSockets: 40, keepAlive: true },
 };
 

--- a/src/platform/web/lib/transport/index.js
+++ b/src/platform/web/lib/transport/index.js
@@ -1,4 +1,0 @@
-import XHRPollingTransport from './xhrpollingtransport';
-import XHRStreamingTransport from './xhrstreamingtransport';
-
-export default [XHRPollingTransport, XHRStreamingTransport];

--- a/src/platform/web/lib/transport/index.ts
+++ b/src/platform/web/lib/transport/index.ts
@@ -1,4 +1,11 @@
+import TransportName from 'common/constants/TransportName';
 import initialiseXHRPollingTransport from './xhrpollingtransport';
 import initialiseXHRStreamingTransport from './xhrstreamingtransport';
 
-export default [initialiseXHRPollingTransport, initialiseXHRStreamingTransport];
+export default {
+  order: [TransportName.XhrPolling, TransportName.XhrStreaming],
+  implementations: {
+    [TransportName.XhrPolling]: initialiseXHRPollingTransport,
+    [TransportName.XhrStreaming]: initialiseXHRStreamingTransport,
+  },
+};

--- a/src/platform/web/lib/transport/index.ts
+++ b/src/platform/web/lib/transport/index.ts
@@ -1,0 +1,4 @@
+import initialiseXHRPollingTransport from './xhrpollingtransport';
+import initialiseXHRStreamingTransport from './xhrstreamingtransport';
+
+export default [initialiseXHRPollingTransport, initialiseXHRStreamingTransport];

--- a/src/platform/web/lib/transport/index.ts
+++ b/src/platform/web/lib/transport/index.ts
@@ -1,11 +1,11 @@
-import TransportName from 'common/constants/TransportName';
+import { TransportNames } from 'common/constants/TransportName';
 import initialiseXHRPollingTransport from './xhrpollingtransport';
 import initialiseXHRStreamingTransport from './xhrstreamingtransport';
 
 export default {
-  order: [TransportName.XhrPolling, TransportName.XhrStreaming],
+  order: [TransportNames.XhrPolling, TransportNames.XhrStreaming],
   implementations: {
-    [TransportName.XhrPolling]: initialiseXHRPollingTransport,
-    [TransportName.XhrStreaming]: initialiseXHRStreamingTransport,
+    [TransportNames.XhrPolling]: initialiseXHRPollingTransport,
+    [TransportNames.XhrStreaming]: initialiseXHRStreamingTransport,
   },
 };

--- a/src/platform/web/lib/transport/index.ts
+++ b/src/platform/web/lib/transport/index.ts
@@ -1,11 +1,25 @@
-import { TransportNames } from 'common/constants/TransportName';
+import TransportName from 'common/constants/TransportName';
+import Platform from 'common/platform';
 import initialiseXHRPollingTransport from './xhrpollingtransport';
 import initialiseXHRStreamingTransport from './xhrstreamingtransport';
+import { default as initialiseWebSocketTransport } from '../../../../common/lib/transport/websockettransport';
 
-export default {
-  order: [TransportNames.XhrPolling, TransportNames.XhrStreaming],
-  implementations: {
-    [TransportNames.XhrPolling]: initialiseXHRPollingTransport,
-    [TransportNames.XhrStreaming]: initialiseXHRStreamingTransport,
+// For reasons that I don’t understand, if we use [TransportNames.XhrStreaming] and [TransportNames.XhrPolling] for the keys in defaultTransports’s, then defaultTransports does not get tree-shaken. Hence using literals instead. They’re still correctly type-checked.
+
+const order: TransportName[] = ['xhr_polling', 'xhr_streaming'];
+
+const defaultTransports: (typeof Platform)['Transports'] = {
+  order,
+  bundledImplementations: {
+    web_socket: initialiseWebSocketTransport,
+    xhr_polling: initialiseXHRPollingTransport,
+    xhr_streaming: initialiseXHRStreamingTransport,
   },
+};
+
+export default defaultTransports;
+
+export const ModulesTransports: (typeof Platform)['Transports'] = {
+  order,
+  bundledImplementations: {},
 };

--- a/src/platform/web/lib/transport/xhrpollingtransport.ts
+++ b/src/platform/web/lib/transport/xhrpollingtransport.ts
@@ -34,7 +34,7 @@ class XHRPollingTransport extends CometTransport {
   }
 }
 
-function initialiseTransport(connectionManager: any): typeof XHRPollingTransport {
+function initialiseTransport(connectionManager: typeof ConnectionManager): typeof XHRPollingTransport {
   if (XHRPollingTransport.isAvailable()) connectionManager.supportedTransports[shortName] = XHRPollingTransport;
 
   return XHRPollingTransport;

--- a/src/platform/web/lib/transport/xhrpollingtransport.ts
+++ b/src/platform/web/lib/transport/xhrpollingtransport.ts
@@ -4,9 +4,9 @@ import XHRRequest from './xhrrequest';
 import ConnectionManager, { TransportParams } from 'common/lib/transport/connectionmanager';
 import Auth from 'common/lib/client/auth';
 import { RequestParams } from 'common/types/http';
-import TransportName from 'common/constants/TransportName';
+import { TransportNames } from 'common/constants/TransportName';
 
-var shortName = TransportName.XhrPolling;
+var shortName = TransportNames.XhrPolling;
 class XHRPollingTransport extends CometTransport {
   shortName = shortName;
   constructor(connectionManager: ConnectionManager, auth: Auth, params: TransportParams) {

--- a/src/platform/web/lib/transport/xhrpollingtransport.ts
+++ b/src/platform/web/lib/transport/xhrpollingtransport.ts
@@ -1,7 +1,7 @@
 import Platform from '../../../../common/platform';
 import CometTransport from '../../../../common/lib/transport/comettransport';
 import XHRRequest from './xhrrequest';
-import ConnectionManager, { TransportParams } from 'common/lib/transport/connectionmanager';
+import ConnectionManager, { TransportParams, TransportStorage } from 'common/lib/transport/connectionmanager';
 import Auth from 'common/lib/client/auth';
 import { RequestParams } from 'common/types/http';
 import { TransportNames } from 'common/constants/TransportName';
@@ -34,8 +34,8 @@ class XHRPollingTransport extends CometTransport {
   }
 }
 
-function initialiseTransport(connectionManager: typeof ConnectionManager): typeof XHRPollingTransport {
-  if (XHRPollingTransport.isAvailable()) connectionManager.supportedTransports[shortName] = XHRPollingTransport;
+function initialiseTransport(transportStorage: TransportStorage): typeof XHRPollingTransport {
+  if (XHRPollingTransport.isAvailable()) transportStorage.supportedTransports[shortName] = XHRPollingTransport;
 
   return XHRPollingTransport;
 }

--- a/src/platform/web/lib/transport/xhrpollingtransport.ts
+++ b/src/platform/web/lib/transport/xhrpollingtransport.ts
@@ -4,8 +4,9 @@ import XHRRequest from './xhrrequest';
 import ConnectionManager, { TransportParams } from 'common/lib/transport/connectionmanager';
 import Auth from 'common/lib/client/auth';
 import { RequestParams } from 'common/types/http';
+import TransportName from 'common/constants/TransportName';
 
-var shortName = 'xhr_polling';
+var shortName = TransportName.XhrPolling;
 class XHRPollingTransport extends CometTransport {
   shortName = shortName;
   constructor(connectionManager: ConnectionManager, auth: Auth, params: TransportParams) {

--- a/src/platform/web/lib/transport/xhrstreamingtransport.ts
+++ b/src/platform/web/lib/transport/xhrstreamingtransport.ts
@@ -1,7 +1,7 @@
 import CometTransport from '../../../../common/lib/transport/comettransport';
 import Platform from '../../../../common/platform';
 import XHRRequest from './xhrrequest';
-import ConnectionManager, { TransportParams } from 'common/lib/transport/connectionmanager';
+import ConnectionManager, { TransportParams, TransportStorage } from 'common/lib/transport/connectionmanager';
 import Auth from 'common/lib/client/auth';
 import { RequestParams } from 'common/types/http';
 import { TransportNames } from 'common/constants/TransportName';
@@ -32,8 +32,8 @@ class XHRStreamingTransport extends CometTransport {
   }
 }
 
-function initialiseTransport(connectionManager: typeof ConnectionManager): typeof XHRStreamingTransport {
-  if (XHRStreamingTransport.isAvailable()) connectionManager.supportedTransports[shortName] = XHRStreamingTransport;
+function initialiseTransport(transportStorage: TransportStorage): typeof XHRStreamingTransport {
+  if (XHRStreamingTransport.isAvailable()) transportStorage.supportedTransports[shortName] = XHRStreamingTransport;
 
   return XHRStreamingTransport;
 }

--- a/src/platform/web/lib/transport/xhrstreamingtransport.ts
+++ b/src/platform/web/lib/transport/xhrstreamingtransport.ts
@@ -32,7 +32,7 @@ class XHRStreamingTransport extends CometTransport {
   }
 }
 
-function initialiseTransport(connectionManager: any): typeof XHRStreamingTransport {
+function initialiseTransport(connectionManager: typeof ConnectionManager): typeof XHRStreamingTransport {
   if (XHRStreamingTransport.isAvailable()) connectionManager.supportedTransports[shortName] = XHRStreamingTransport;
 
   return XHRStreamingTransport;

--- a/src/platform/web/lib/transport/xhrstreamingtransport.ts
+++ b/src/platform/web/lib/transport/xhrstreamingtransport.ts
@@ -4,9 +4,9 @@ import XHRRequest from './xhrrequest';
 import ConnectionManager, { TransportParams } from 'common/lib/transport/connectionmanager';
 import Auth from 'common/lib/client/auth';
 import { RequestParams } from 'common/types/http';
-import TransportName from 'common/constants/TransportName';
+import { TransportNames } from 'common/constants/TransportName';
 
-const shortName = TransportName.XhrStreaming;
+const shortName = TransportNames.XhrStreaming;
 class XHRStreamingTransport extends CometTransport {
   shortName = shortName;
   constructor(connectionManager: ConnectionManager, auth: Auth, params: TransportParams) {

--- a/src/platform/web/lib/transport/xhrstreamingtransport.ts
+++ b/src/platform/web/lib/transport/xhrstreamingtransport.ts
@@ -4,8 +4,9 @@ import XHRRequest from './xhrrequest';
 import ConnectionManager, { TransportParams } from 'common/lib/transport/connectionmanager';
 import Auth from 'common/lib/client/auth';
 import { RequestParams } from 'common/types/http';
+import TransportName from 'common/constants/TransportName';
 
-const shortName = 'xhr_streaming';
+const shortName = TransportName.XhrStreaming;
 class XHRStreamingTransport extends CometTransport {
   shortName = shortName;
   constructor(connectionManager: ConnectionManager, auth: Auth, params: TransportParams) {

--- a/src/platform/web/lib/util/defaults.ts
+++ b/src/platform/web/lib/util/defaults.ts
@@ -1,15 +1,15 @@
 import IDefaults from 'common/types/IDefaults';
-import TransportName from 'common/constants/TransportName';
+import { TransportNames } from 'common/constants/TransportName';
 
 const Defaults: IDefaults = {
   connectivityCheckUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
   /* Order matters here: the base transport is the leftmost one in the
    * intersection of baseTransportOrder and the transports clientOption that's
    * supported. */
-  defaultTransports: [TransportName.XhrPolling, TransportName.XhrStreaming, TransportName.WebSocket],
-  baseTransportOrder: [TransportName.XhrPolling, TransportName.XhrStreaming, TransportName.WebSocket],
-  transportPreferenceOrder: [TransportName.XhrPolling, TransportName.XhrStreaming, TransportName.WebSocket],
-  upgradeTransports: [TransportName.XhrStreaming, TransportName.WebSocket],
+  defaultTransports: [TransportNames.XhrPolling, TransportNames.XhrStreaming, TransportNames.WebSocket],
+  baseTransportOrder: [TransportNames.XhrPolling, TransportNames.XhrStreaming, TransportNames.WebSocket],
+  transportPreferenceOrder: [TransportNames.XhrPolling, TransportNames.XhrStreaming, TransportNames.WebSocket],
+  upgradeTransports: [TransportNames.XhrStreaming, TransportNames.WebSocket],
 };
 
 export default Defaults;

--- a/src/platform/web/lib/util/defaults.ts
+++ b/src/platform/web/lib/util/defaults.ts
@@ -1,15 +1,15 @@
 import IDefaults from 'common/types/IDefaults';
-import TransportNames from 'common/constants/TransportNames';
+import TransportName from 'common/constants/TransportName';
 
 const Defaults: IDefaults = {
   connectivityCheckUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
   /* Order matters here: the base transport is the leftmost one in the
    * intersection of baseTransportOrder and the transports clientOption that's
    * supported. */
-  defaultTransports: [TransportNames.XhrPolling, TransportNames.XhrStreaming, TransportNames.WebSocket],
-  baseTransportOrder: [TransportNames.XhrPolling, TransportNames.XhrStreaming, TransportNames.WebSocket],
-  transportPreferenceOrder: [TransportNames.XhrPolling, TransportNames.XhrStreaming, TransportNames.WebSocket],
-  upgradeTransports: [TransportNames.XhrStreaming, TransportNames.WebSocket],
+  defaultTransports: [TransportName.XhrPolling, TransportName.XhrStreaming, TransportName.WebSocket],
+  baseTransportOrder: [TransportName.XhrPolling, TransportName.XhrStreaming, TransportName.WebSocket],
+  transportPreferenceOrder: [TransportName.XhrPolling, TransportName.XhrStreaming, TransportName.WebSocket],
+  upgradeTransports: [TransportName.XhrStreaming, TransportName.WebSocket],
 };
 
 export default Defaults;

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -10,7 +10,7 @@ import BufferUtils from './lib/util/bufferutils';
 import Http from './lib/util/http';
 import Config from './config';
 // @ts-ignore
-import Transports from './lib/transport';
+import { ModulesTransports } from './lib/transport';
 import Logger from '../../common/lib/util/logger';
 import { getDefaults } from '../../common/lib/util/defaults';
 import WebStorage from './lib/util/webstorage';
@@ -19,7 +19,7 @@ import PlatformDefaults from './lib/util/defaults';
 Platform.BufferUtils = BufferUtils;
 Platform.Http = Http;
 Platform.Config = Config;
-Platform.Transports = Transports;
+Platform.Transports = ModulesTransports;
 Platform.WebStorage = WebStorage;
 
 Logger.initLogHandlers();
@@ -44,5 +44,6 @@ export * from './modules/message';
 export * from './modules/presencemessage';
 export * from './modules/msgpack';
 export * from './modules/realtimepresence';
+export * from './modules/transports';
 export { Rest } from '../../common/lib/client/rest';
 export { BaseRest, BaseRealtime, ErrorInfo };

--- a/src/platform/web/modules/transports.ts
+++ b/src/platform/web/modules/transports.ts
@@ -1,0 +1,3 @@
+export { default as XHRPolling } from '../lib/transport/xhrpollingtransport';
+export { default as XHRStreaming } from '../lib/transport/xhrstreamingtransport';
+export { default as WebSocketTransport } from '../../../common/lib/transport/websockettransport';

--- a/test/browser/simple.test.js
+++ b/test/browser/simple.test.js
@@ -17,7 +17,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
     });
 
     function isTransportAvailable(transport) {
-      return transport in Ably.Realtime.ConnectionManager.supportedTransports;
+      return transport in Ably.Realtime.ConnectionManager.supportedTransports(Ably.Realtime._transports);
     }
 
     function realtimeConnection(transports) {

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -14,7 +14,6 @@ define([
   var platform = clientModule.Ably.Realtime.Platform;
   var BufferUtils = platform.BufferUtils;
   var expect = chai.expect;
-  clientModule.Ably.Realtime.ConnectionManager.initTransports();
   var availableTransports = utils.keysArray(clientModule.Ably.Realtime.ConnectionManager.supportedTransports),
     bestTransport = availableTransports[0],
     /* IANA reserved; requests to it will hang forever */

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -14,7 +14,9 @@ define([
   var platform = clientModule.Ably.Realtime.Platform;
   var BufferUtils = platform.BufferUtils;
   var expect = chai.expect;
-  var availableTransports = utils.keysArray(clientModule.Ably.Realtime.ConnectionManager.supportedTransports),
+  var availableTransports = utils.keysArray(
+      clientModule.Ably.Realtime.ConnectionManager.supportedTransports(clientModule.Ably.Realtime._transports)
+    ),
     bestTransport = availableTransports[0],
     /* IANA reserved; requests to it will hang forever */
     unroutableHost = '10.255.255.1',


### PR DESCRIPTION
**Note: This PR is based on top of #1429; please review that one first.**

This exposes tree-shakable `WebSocketTransport`, `XHRPolling`, and `XHRStreaming` modules.

See commit messages for more details.

Resolves #1394.