### PR TITLE
fix: send ably agent as header in react-hooks time ping

### DIFF
--- a/src/platform/react-hooks/src/AblyProvider.tsx
+++ b/src/platform/react-hooks/src/AblyProvider.tsx
@@ -71,8 +71,8 @@ export const AblyProvider = ({ client, children, options, id = 'default' }: Ably
   React.useEffect(() => {
     if (!hasSentAgent) {
       hasSentAgent = true;
-      realtime.request('GET', '/time', {
-        agent: `react-hooks-time-ping/${version}`,
+      realtime.request('GET', '/time', null, null, {
+        'Ably-Agent': `react-hooks-time-ping/${version}`,
       });
     }
   });


### PR DESCRIPTION
We were mistakenly sending this as a query param before which doesn't work for REST requests. This commit changes it to use the `Ably-Agent` header.