### PR TITLE
refactor!: remove `AblyProvider` options prop

### DIFF
--- a/docs/react-migration-guide.md
+++ b/docs/react-migration-guide.md
@@ -23,14 +23,6 @@ return <AblyProvider client={ably}>
 </AblyProvider>
 ```
 
-You may also provide the client options directly to the `AblyProvider` so that the client is created automatically. If you use this prop the client will be automatically closed when the `AblyProvider` is unmounted.
-
-```jsx
-return <AblyProvider options={options}>
-  {children}
-</AblyProvider>
-```
-
 If you were already using multiple Ably clients in the same react application, you may pass in an optional `id` prop to the provider, which you can then pass to the hooks to specify which Ably client instance the hook should use:
 ```jsx
 const client = new Ably.Realtime.Promise(options);

--- a/docs/react.md
+++ b/docs/react.md
@@ -36,27 +36,9 @@ The hooks are compatible with all versions of React above 16.8.0
 
 ## Usage
 
-Start by connecting your app to Ably using the `AblyProvider` component. The options provided to the `AblyProvider` are the same options used for the Ably SDK - and requires either a `string` or an `AblyClientOptions`. You can use this configuration object to setup your API keys, or tokenAuthentication as you normally would. If you want to use the `usePresence` hook, you'll need to explicitly provide a `clientId`.
+Start by connecting your app to Ably using the `AblyProvider` component. See the [`ClientOptions` documentation](https://ably.com/docs/api/realtime-sdk/types?lang=javascript) for information about what options are available when creating an Ably client. If you want to use the `usePresence` hook, you'll need to explicitly provide a `clientId`.
 
 The `AblyProvider` should be high in your component tree, wrapping every component which needs to access Ably.
-
-
-```jsx
-import { AblyProvider } from "ably/react";
-
-const options = {
-  key: "your-ably-api-key",
-  clientId: "me",
-}
-
-root.render(
-  <AblyProvider options={options}>
-    <App />
-  </AblyProvider>
-)
-```
-
-You may also create your own client and pass it into the context provider.
 
 ```jsx
 import { AblyProvider } from "ably/react";
@@ -304,8 +286,8 @@ If you need to use multiple Ably clients on the same page, the easiest way to do
 
 ```jsx
 root.render(
-  <AblyProvider options={options} id={'providerOne'}>
-    <AblyProvider options={options} id={'providerTwo'}>
+  <AblyProvider client={client1} id={'providerOne'}>
+    <AblyProvider client={client2} id={'providerTwo'}>
       <App />
     </AblyProvider>
   </AblyProvider>


### PR DESCRIPTION
Resolves #1439

Opted for removing this prop as it's there isn't really a sensible/unopinionated way to manage the connection of the ably client if it's created implicitly by the context provider.