### PR TITLE
fix: throw descriptive error when callbacks used with react

### DIFF
--- a/src/platform/react-hooks/src/AblyProvider.tsx
+++ b/src/platform/react-hooks/src/AblyProvider.tsx
@@ -35,6 +35,10 @@ export const AblyProvider = ({ client, children, id = 'default' }: AblyProviderP
     throw new Error('AblyProvider: the `client` prop is required');
   }
 
+  if (!(client instanceof Ably.Realtime) && !client?.options?.promises) {
+    throw new Error('AblyProvider: the `client` prop must take an instance of Ably.Realtime.Promise');
+  }
+
   const realtime = useMemo(() => client, [client]);
 
   let context = getContext(id);

--- a/src/platform/react-hooks/src/fakes/ably.ts
+++ b/src/platform/react-hooks/src/fakes/ably.ts
@@ -4,6 +4,7 @@ export class FakeAblySdk {
   public clientId: string;
   public channels: ClientChannelsCollection;
   public connection: Connection;
+  public options = { promises: true };
 
   constructor() {
     this.clientId = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);


### PR DESCRIPTION
Previously the react lib would work with a non-Promise client but it would subtly break some of the hooks. This change makes it so that if someone accidentally forgets to use a Promise client they will immediately be shown a helpful error msg.