### PR TITLE
fix: add missing id param for `useStateErrors` call to `useChannelStateListener`

### DIFF
--- a/src/platform/react-hooks/src/hooks/useStateErrors.ts
+++ b/src/platform/react-hooks/src/hooks/useStateErrors.ts
@@ -19,9 +19,13 @@ export function useStateErrors(params: ChannelNameAndOptions) {
     params.id
   );
 
-  useConnectionStateListener(['connected', 'closed'], () => {
-    setConnectionError(null);
-  });
+  useConnectionStateListener(
+    ['connected', 'closed'],
+    () => {
+      setConnectionError(null);
+    },
+    params.id
+  );
 
   useChannelStateListener(params, ['suspended', 'failed', 'detached'], (stateChange) => {
     if (stateChange.reason) {


### PR DESCRIPTION
Resolves a bug where using `useChannel` or `usePresence` wouldn't work with an id'd `AblyProvider`