### PR TITLE
Publish to new CDN bucket only

### DIFF
--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -17,26 +17,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.version }}
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_PRODUCTION }}:role/github-actions-sdk
-          aws-region: us-east-1
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-      - run: npm ci
-      - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.event.inputs.version }}
-  publish_sdk:
-    runs-on: ubuntu-latest
-    # These permissions are necessary to run the configure-aws-credentials action
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.version }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -48,4 +28,4 @@ jobs:
         with:
           node-version: 14.x
       - run: npm ci
-      - run: node scripts/cdn_deploy.js --bucket prod-cdn.ably.com --skipCheckout --tag=${{ github.event.inputs.version }}
+      - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.event.inputs.version }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ Deploys correctly versioned code and source maps to the CDN.
 
 Arguments:
 
-* **--bucket**: The S3 bucket name to deploy to, defaults to `cdn.ably.io`.
+* **--bucket**: The S3 bucket name to deploy to, defaults to `prod-cdn.ably.com`.
 * **--root**: The base directory inside the bucket to deploy to, defaults to `lib`.
 * **--path**: The local path to retrieve source files from. Defaults to `.`.
 * **--includeDirs**: A comma separated list of directories to include. Defaults to `.`.

--- a/scripts/cdn_deploy.js
+++ b/scripts/cdn_deploy.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const { exec } = require('child_process');
 const argv = require('minimist')(process.argv.slice(2));
-const S3_DEFAULT_BUCKET = 'cdn.ably.io';
+const S3_DEFAULT_BUCKET = 'prod-cdn.ably.com';
 const S3_DEFAULT_ROOT = 'lib';
 
 async function run() {


### PR DESCRIPTION
We've finally migrated to the new bucket, so we can stop publishing to the old bucket, which I intend to delete.