### PR TITLE
fix: don't double url encode agent transport param

### DIFF
--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -149,7 +149,7 @@ export class TransportParams {
       params.heartbeats = this.heartbeats;
     }
     params.v = Defaults.protocolVersion;
-    params.agent = encodeURIComponent(getAgentString(this.options));
+    params.agent = getAgentString(this.options);
     if (options.transportParams !== undefined) {
       Utils.mixin(params, options.transportParams);
     }


### PR DESCRIPTION
This was never needed - encoding the connect params is the responsibility of each individual transport and the transports already do this.