### PR TITLE
fix: avoid directly exporting Ably.ErrorInfo from promises.js

### DIFF
--- a/promises.js
+++ b/promises.js
@@ -12,6 +12,10 @@ function promisifyOptions(options) {
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 var Ably = require('./build/ably-node');
 
+var ErrorInfo = function(message, code, statusCode, cause) {
+  return new Ably.ErrorInfo(message, code, statusCode, cause);
+}
+
 var RestPromise = function (options) {
   return new Ably.Rest(promisifyOptions(options));
 };
@@ -23,7 +27,7 @@ var RealtimePromise = function (options) {
 Object.assign(RealtimePromise, Ably.Realtime);
 
 module.exports = {
-  ErrorInfo: Ably.ErrorInfo,
+  ErrorInfo: ErrorInfo,
   Rest: RestPromise,
   Realtime: RealtimePromise,
 };


### PR DESCRIPTION
For confusing reasons, [this commit](https://github.com/ably/ably-js/commit/d96c33d65e5e23ee752d1bedd30d3681cc605d31) introduced a regression which changed the behaviour of ESM imports of promises.js, and this change fixes it.