### PR TITLE
fix: don't compare `agent` channel param when determining whether channel options require reattach

### DIFF
--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -189,7 +189,14 @@ class RealtimeChannel extends Channel {
       return false;
     }
     if (options?.params) {
-      if (!this.params || !Utils.shallowEquals(this.params, options.params)) {
+      // Don't check against the `agent` param - it isn't returned in the ATTACHED message
+      const requestedParams = Object.assign({}, options.params);
+      delete requestedParams.agent;
+      if (Object.keys(requestedParams).length !== 0 && !this.params) {
+        return true;
+      }
+
+      if (this.params && !Utils.shallowEquals(this.params, requestedParams)) {
         return true;
       }
     }


### PR DESCRIPTION
Resolves #1477 

Excludes the agent param is excluded when checking whether channel options provided to `Channels.get` will require re-attachment