### PR TITLE
Turn off `continue-on-error` for browser jobs

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   test-browser:
     runs-on: ubuntu-20.04
-    continue-on-error: true
     strategy:
+        fail-fast: false
         matrix:
             browser: [chromium, firefox, webkit]
     steps:


### PR DESCRIPTION
I _think_ this is preventing us from receiving email notifications when one of the browser jobs fails.

The motivation for the current configuration is not clear to me, but I’m guessing the idea was that the failure of a single browser test run shouldn’t cancel the others. Turning off `fail-fast` should do the same thing.