### PR TITLE
Upgrade Playwright to 1.39.0

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           node-version: 16.x
       - run: npm ci
-      - name: Install playwright dependencies
-        run: sudo npx playwright install-deps
+      - name: Install Playwright browsers and dependencies
+        run: npx playwright install --with-deps
       - env:
           PLAYWRIGHT_BROWSER: ${{ matrix.browser }}
         run: npm run test:playwright

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "minimist": "^1.2.5",
         "mocha": "^8.1.3",
         "null-loader": "^4.0.1",
-        "playwright": "^1.10.0",
+        "playwright": "^1.39.0",
         "prettier": "^2.5.1",
         "react": ">=18.1.0",
         "react-dom": ">=18.1.0",
@@ -10261,31 +10261,47 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.22.2.tgz",
-      "integrity": "sha512-hUTpg7LytIl3/O4t0AQJS1V6hWsaSY5uZ7w1oCC8r3a1AQN5d6otIdCkiB3cbzgQkcMaRxisinjMFMVqZkybdQ==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.22.2"
+        "playwright-core": "1.39.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true,
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/posix-character-classes": {
@@ -22057,18 +22073,28 @@
       }
     },
     "playwright": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.22.2.tgz",
-      "integrity": "sha512-hUTpg7LytIl3/O4t0AQJS1V6hWsaSY5uZ7w1oCC8r3a1AQN5d6otIdCkiB3cbzgQkcMaRxisinjMFMVqZkybdQ==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dev": true,
       "requires": {
-        "playwright-core": "1.22.2"
+        "fsevents": "2.3.2",
+        "playwright-core": "1.39.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "playwright-core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true
     },
     "posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "minimist": "^1.2.5",
     "mocha": "^8.1.3",
     "null-loader": "^4.0.1",
-    "playwright": "^1.10.0",
+    "playwright": "^1.39.0",
     "prettier": "^2.5.1",
     "react": ">=18.1.0",
     "react-dom": ">=18.1.0",


### PR DESCRIPTION
This requires us to now explicitly install the browsers (see [this section of Playwright release notes](https://playwright.dev/docs/release-notes#breaking-changes-playwright-no-longer-downloads-browsers-automatically)).

I’m doing this upgrade not because it’s necessary but because NPM tried to make it for me when resolving a `package-lock.json` merge conflict in an upcoming commit. Given that the upgrade involves this CI change, thought it best to do it as a separate commit so it doesn’t get lost inside a merge commit.