### PR TITLE
[SDK-3936] Remove remaining REST code from `BaseRealtime`

### DIFF
--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -103,7 +103,7 @@ class BaseClient {
     this.__FilteredSubscriptions = modules.MessageInteractions ?? null;
   }
 
-  private get rest(): Rest {
+  get rest(): Rest {
     if (!this._rest) {
       throwMissingModuleError('Rest');
     }

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -1,7 +1,7 @@
 import ProtocolMessage from '../types/protocolmessage';
 import EventEmitter from '../util/eventemitter';
 import * as Utils from '../util/utils';
-import Channel from './channel';
+import RestChannel from './restchannel';
 import Logger from '../util/logger';
 import RealtimePresence from './realtimepresence';
 import Message, { CipherOptions } from '../types/message';
@@ -48,7 +48,7 @@ function validateChannelOptions(options?: API.Types.ChannelOptions) {
   }
 }
 
-class RealtimeChannel extends Channel {
+class RealtimeChannel extends RestChannel {
   realtime: BaseRealtime;
   private _realtimePresence: RealtimePresence | null;
   get presence(): RealtimePresence {
@@ -156,7 +156,7 @@ class RealtimeChannel extends Channel {
       _callback(err);
       return;
     }
-    Channel.prototype.setOptions.call(this, options);
+    RestChannel.prototype.setOptions.call(this, options);
     if (this._decodingContext) this._decodingContext.channelOptions = this.channelOptions;
     if (this._shouldReattachToSetOptions(options)) {
       /* This does not just do _attach(true, null, callback) because that would put us
@@ -900,7 +900,7 @@ class RealtimeChannel extends Channel {
       params.from_serial = this.properties.attachSerial;
     }
 
-    Channel.prototype._history.call(this, params, callback);
+    RestChannel.prototype._history.call(this, params, callback);
   } as any;
 
   whenState = ((state: string, listener: ErrCallback) => {

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -1,5 +1,5 @@
 import * as Utils from '../util/utils';
-import Presence from './presence';
+import RestPresence from './restpresence';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
 import PresenceMessage, { fromValues as presenceMessageFromValues } from '../types/presencemessage';
@@ -78,7 +78,7 @@ function newerThan(item: PresenceMessage, existing: PresenceMessage) {
   }
 }
 
-class RealtimePresence extends Presence {
+class RealtimePresence extends RestPresence {
   channel: RealtimeChannel;
   pendingPresence: { presence: PresenceMessage; callback: ErrCallback }[];
   syncComplete: boolean;
@@ -319,7 +319,7 @@ class RealtimePresence extends Presence {
       }
     }
 
-    Presence.prototype._history.call(this, params, callback);
+    RestPresence.prototype._history.call(this, params, callback);
   }
 
   setPresence(presenceSet: PresenceMessage[], isSync: boolean, syncChannelSerial?: string): void {

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -16,6 +16,8 @@ import Resource from './resource';
 import Platform from '../../platform';
 import BaseClient from './baseclient';
 import { useTokenAuth } from './auth';
+import { RestChannelMixin } from './restchannelmixin';
+import { RestPresenceMixin } from './restpresencemixin';
 
 type BatchResult<T> = API.Types.BatchResult<T>;
 
@@ -38,6 +40,9 @@ export class Rest {
   private readonly client: BaseClient;
   readonly channels: Channels;
   readonly push: Push;
+
+  readonly channelMixin = RestChannelMixin;
+  readonly presenceMixin = RestPresenceMixin;
 
   constructor(client: BaseClient) {
     this.client = client;

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -3,7 +3,7 @@ import Logger, { LoggerOptions } from '../util/logger';
 import Defaults from '../util/defaults';
 import Push from './push';
 import PaginatedResource, { HttpPaginatedResponse, PaginatedResult } from './paginatedresource';
-import Channel from './channel';
+import RestChannel from './restchannel';
 import ErrorInfo from '../types/errorinfo';
 import Stats from '../types/stats';
 import HttpMethods from '../../constants/HttpMethods';
@@ -324,7 +324,7 @@ export class Rest {
 
 class Channels {
   client: BaseClient;
-  all: Record<string, Channel>;
+  all: Record<string, RestChannel>;
 
   constructor(client: BaseClient) {
     this.client = client;
@@ -335,7 +335,7 @@ class Channels {
     name = String(name);
     let channel = this.all[name];
     if (!channel) {
-      this.all[name] = channel = new Channel(this.client, name, channelOptions);
+      this.all[name] = channel = new RestChannel(this.client, name, channelOptions);
     } else if (channelOptions) {
       channel.setOptions(channelOptions);
     }

--- a/src/common/lib/client/restchannel.ts
+++ b/src/common/lib/client/restchannel.ts
@@ -1,7 +1,7 @@
 import * as Utils from '../util/utils';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
-import Presence from './presence';
+import RestPresence from './restpresence';
 import Message, { CipherOptions } from '../types/message';
 import ErrorInfo from '../types/errorinfo';
 import PaginatedResource, { PaginatedResult } from './paginatedresource';
@@ -46,23 +46,23 @@ function normaliseChannelOptions(Crypto: IUntypedCryptoStatic | null, options?: 
   return channelOptions;
 }
 
-class Channel extends EventEmitter {
+class RestChannel extends EventEmitter {
   client: BaseClient;
   name: string;
   basePath: string;
-  private _presence: Presence;
-  get presence(): Presence {
+  private _presence: RestPresence;
+  get presence(): RestPresence {
     return this._presence;
   }
   channelOptions: ChannelOptions;
 
   constructor(client: BaseClient, name: string, channelOptions?: ChannelOptions) {
     super();
-    Logger.logAction(Logger.LOG_MINOR, 'Channel()', 'started; name = ' + name);
+    Logger.logAction(Logger.LOG_MINOR, 'RestChannel()', 'started; name = ' + name);
     this.client = client;
     this.name = name;
     this.basePath = '/channels/' + encodeURIComponent(name);
-    this._presence = new Presence(this);
+    this._presence = new RestPresence(this);
     this.channelOptions = normaliseChannelOptions(client._Crypto ?? null, channelOptions);
   }
 
@@ -74,7 +74,7 @@ class Channel extends EventEmitter {
     params: RestHistoryParams | null,
     callback: PaginatedResultCallback<Message>
   ): Promise<PaginatedResult<Message>> | void {
-    Logger.logAction(Logger.LOG_MICRO, 'Channel.history()', 'channel = ' + this.name);
+    Logger.logAction(Logger.LOG_MICRO, 'RestChannel.history()', 'channel = ' + this.name);
     /* params and callback are optional; see if params contains the callback */
     if (callback === undefined) {
       if (typeof params == 'function') {
@@ -200,4 +200,4 @@ class Channel extends EventEmitter {
   }
 }
 
-export default Channel;
+export default RestChannel;

--- a/src/common/lib/client/restchannelmixin.ts
+++ b/src/common/lib/client/restchannelmixin.ts
@@ -1,0 +1,67 @@
+import * as API from '../../../../ably';
+import RestChannel from './restchannel';
+import RealtimeChannel from './realtimechannel';
+import * as Utils from '../util/utils';
+import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
+import Message from '../types/message';
+import Defaults from '../util/defaults';
+import PaginatedResource from './paginatedresource';
+import Resource from './resource';
+
+export interface RestHistoryParams {
+  start?: number;
+  end?: number;
+  direction?: string;
+  limit?: number;
+}
+
+const noop = function () {};
+
+export class RestChannelMixin {
+  static basePath(channel: RestChannel | RealtimeChannel) {
+    return '/channels/' + encodeURIComponent(channel.name);
+  }
+
+  static history(
+    channel: RestChannel | RealtimeChannel,
+    params: RestHistoryParams | null,
+    callback: PaginatedResultCallback<Message>
+  ): void {
+    const client = channel.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = channel.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Defaults.defaultGetHeaders(client.options, { format });
+
+    Utils.mixin(headers, client.options.headers);
+
+    const options = channel.channelOptions;
+    new PaginatedResource(client, this.basePath(channel) + '/messages', headers, envelope, async function (
+      body,
+      headers,
+      unpacked
+    ) {
+      return await Message.fromResponseBody(body as Message[], options, client._MsgPack, unpacked ? undefined : format);
+    }).get(params as Record<string, unknown>, callback);
+  }
+
+  static status(
+    channel: RestChannel | RealtimeChannel,
+    callback?: StandardCallback<API.Types.ChannelDetails>
+  ): void | Promise<API.Types.ChannelDetails> {
+    if (typeof callback !== 'function') {
+      return Utils.promisify(this, 'status', [channel]);
+    }
+
+    const format = channel.client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json;
+    const headers = Defaults.defaultPostHeaders(channel.client.options, { format });
+
+    Resource.get<API.Types.ChannelDetails>(
+      channel.client,
+      this.basePath(channel),
+      headers,
+      {},
+      format,
+      callback || noop
+    );
+  }
+}

--- a/src/common/lib/client/restpresence.ts
+++ b/src/common/lib/client/restpresence.ts
@@ -5,22 +5,22 @@ import PaginatedResource, { PaginatedResult } from './paginatedresource';
 import PresenceMessage from '../types/presencemessage';
 import { CipherOptions } from '../types/message';
 import { PaginatedResultCallback } from '../../types/utils';
-import Channel from './channel';
+import RestChannel from './restchannel';
 import RealtimeChannel from './realtimechannel';
 import Defaults from '../util/defaults';
 
-class Presence extends EventEmitter {
-  channel: RealtimeChannel | Channel;
+class RestPresence extends EventEmitter {
+  channel: RealtimeChannel | RestChannel;
   basePath: string;
 
-  constructor(channel: RealtimeChannel | Channel) {
+  constructor(channel: RealtimeChannel | RestChannel) {
     super();
     this.channel = channel;
     this.basePath = channel.basePath + '/presence';
   }
 
   get(params: any, callback: PaginatedResultCallback<PresenceMessage>): void | Promise<PresenceMessage> {
-    Logger.logAction(Logger.LOG_MICRO, 'Presence.get()', 'channel = ' + this.channel.name);
+    Logger.logAction(Logger.LOG_MICRO, 'RestPresence.get()', 'channel = ' + this.channel.name);
     /* params and callback are optional; see if params contains the callback */
     if (callback === undefined) {
       if (typeof params == 'function') {
@@ -52,7 +52,7 @@ class Presence extends EventEmitter {
     params: any,
     callback: PaginatedResultCallback<PresenceMessage>
   ): void | Promise<PaginatedResult<PresenceMessage>> {
-    Logger.logAction(Logger.LOG_MICRO, 'Presence.history()', 'channel = ' + this.channel.name);
+    Logger.logAction(Logger.LOG_MICRO, 'RestPresence.history()', 'channel = ' + this.channel.name);
     return this._history(params, callback);
   }
 
@@ -93,4 +93,4 @@ class Presence extends EventEmitter {
   }
 }
 
-export default Presence;
+export default RestPresence;

--- a/src/common/lib/client/restpresencemixin.ts
+++ b/src/common/lib/client/restpresencemixin.ts
@@ -1,0 +1,52 @@
+import RestPresence from './restpresence';
+import RealtimePresence from './realtimepresence';
+import * as Utils from '../util/utils';
+import { PaginatedResultCallback } from '../../types/utils';
+import Defaults from '../util/defaults';
+import PaginatedResource, { PaginatedResult } from './paginatedresource';
+import PresenceMessage from '../types/presencemessage';
+import { CipherOptions } from '../types/message';
+import { RestChannelMixin } from './restchannelmixin';
+
+export class RestPresenceMixin {
+  static basePath(presence: RestPresence | RealtimePresence) {
+    return RestChannelMixin.basePath(presence.channel) + '/presence';
+  }
+
+  static history(
+    presence: RestPresence | RealtimePresence,
+    params: any,
+    callback: PaginatedResultCallback<PresenceMessage>
+  ): void | Promise<PaginatedResult<PresenceMessage>> {
+    /* params and callback are optional; see if params contains the callback */
+    if (callback === undefined) {
+      if (typeof params == 'function') {
+        callback = params;
+        params = null;
+      } else {
+        return Utils.promisify(this, 'history', [presence, params]);
+      }
+    }
+
+    const client = presence.channel.client,
+      format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      envelope = presence.channel.client.http.supportsLinkHeaders ? undefined : format,
+      headers = Defaults.defaultGetHeaders(client.options, { format });
+
+    Utils.mixin(headers, client.options.headers);
+
+    const options = presence.channel.channelOptions;
+    new PaginatedResource(client, this.basePath(presence) + '/history', headers, envelope, async function (
+      body,
+      headers,
+      unpacked
+    ) {
+      return await PresenceMessage.fromResponseBody(
+        body as Record<string, unknown>[],
+        options as CipherOptions,
+        client._MsgPack,
+        unpacked ? undefined : format
+      );
+    }).get(params, callback);
+  }
+}

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -6,6 +6,8 @@ import { version } from '../../../../package.json';
 import ClientOptions, { InternalClientOptions, NormalisedClientOptions } from 'common/types/ClientOptions';
 import IDefaults from '../../types/IDefaults';
 import { MsgPack } from 'common/types/msgpack';
+import { IUntypedCryptoStatic } from 'common/types/ICryptoStatic';
+import { ChannelOptions } from 'common/types/channel';
 
 let agent = 'ably-js/' + version;
 
@@ -263,6 +265,22 @@ export function normaliseOptions(options: InternalClientOptions, MsgPack: MsgPac
     connectivityCheckUrl,
     headers,
   };
+}
+
+export function normaliseChannelOptions(Crypto: IUntypedCryptoStatic | null, options?: ChannelOptions) {
+  const channelOptions = options || {};
+  if (channelOptions.cipher) {
+    if (!Crypto) Utils.throwMissingModuleError('Crypto');
+    const cipher = Crypto.getCipher(channelOptions.cipher);
+    channelOptions.cipher = cipher.cipherParams;
+    channelOptions.channelCipher = cipher.cipher;
+  } else if ('cipher' in channelOptions) {
+    /* Don't deactivate an existing cipher unless options
+     * has a 'cipher' key that's falsey */
+    channelOptions.cipher = undefined;
+    channelOptions.channelCipher = null;
+  }
+  return channelOptions;
 }
 
 const contentTypes = {


### PR DESCRIPTION
**Note: This PR is based on top of #1476; please review that one first.**

This adds further testing around how `BaseRealtime` behaves when you do and don't provide the `Rest` module, and then addresses the REST-related code that `BaseRealtime` was pulling in even when the `Rest` module was not provided. See commit messages for more details.

Resolves #1489.