### PR TITLE
Enable 'derived' options to 'useChannel' hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@ably/vcdiff-decoder": "1.0.4",
         "@testing-library/react": "^13.3.0",
         "@types/crypto-js": "^4.0.1",
+        "@types/jmespath": "^0.15.2",
         "@types/node": "^15.0.0",
         "@types/request": "^2.48.7",
         "@types/ws": "^8.2.0",
@@ -1249,6 +1250,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "node_modules/@types/jmespath": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@types/jmespath/-/jmespath-0.15.2.tgz",
+      "integrity": "sha512-pegh49FtNsC389Flyo9y8AfkVIZn9MMPE9yJrO9svhq6Fks2MwymULWjZqySuxmctd3ZH4/n7Mr98D+1Qo5vGA==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -15145,6 +15152,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "@types/jmespath": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@types/jmespath/-/jmespath-0.15.2.tgz",
+      "integrity": "sha512-pegh49FtNsC389Flyo9y8AfkVIZn9MMPE9yJrO9svhq6Fks2MwymULWjZqySuxmctd3ZH4/n7Mr98D+1Qo5vGA==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.9",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@ably/vcdiff-decoder": "1.0.4",
     "@testing-library/react": "^13.3.0",
     "@types/crypto-js": "^4.0.1",
+    "@types/jmespath": "^0.15.2",
     "@types/node": "^15.0.0",
     "@types/request": "^2.48.7",
     "@types/ws": "^8.2.0",

--- a/src/platform/react-hooks/sample-app/src/App.tsx
+++ b/src/platform/react-hooks/sample-app/src/App.tsx
@@ -11,10 +11,35 @@ import './App.css';
 
 function App() {
   const [messages, updateMessages] = useState<Types.Message[]>([]);
+  const [derivedChannelMessages, updateDerivedChannelMessages] = useState<Types.Message[]>([]);
+  const [frontOficeOnlyMessages, updateFrontOfficeOnlyMessages] = useState<Types.Message[]>([]);
+
   const [skip, setSkip] = useState(false);
   const { channel, ably } = useChannel({ channelName: 'your-channel-name', skip }, (message) => {
     updateMessages((prev) => [...prev, message]);
   });
+
+  useChannel(
+    {
+      channelName: 'your-derived-channel-name',
+      deriveOptions: { filter: 'headers.email == `"rob.pike@domain.com"` || headers.company == `"domain"`' },
+    },
+    (message) => {
+      updateDerivedChannelMessages((prev) => [...prev, message]);
+    }
+  );
+
+  useChannel(
+    {
+      channelName: 'your-derived-channel-name',
+      deriveOptions: { filter: 'headers.role == `"front-office"` || headers.company == `"domain"`' },
+    },
+    (message) => {
+      updateFrontOfficeOnlyMessages((prev) => [...prev, message]);
+    }
+  );
+
+  const { channel: anotherChannelPublisher } = useChannel({ channelName: 'your-derived-channel-name' });
 
   const { presenceData, updateStatus } = usePresence(
     { channelName: 'your-channel-name', skip },
@@ -42,7 +67,14 @@ function App() {
     setChannelStateReason(stateChange.reason ?? undefined);
   });
 
-  const messagePreviews = messages.map((msg, index) => <li key={index}>{msg.data.text}</li>);
+  const messagePreviews = messages.map((message, idx) => <MessagePreview key={idx} message={message} />);
+  const derivedChannelMessagePreviews = derivedChannelMessages.map((message, idx) => (
+    <MessagePreview key={idx} message={message} />
+  ));
+  const frontOfficeMessagePreviews = frontOficeOnlyMessages.map((message, idx) => (
+    <MessagePreview key={idx} message={message} />
+  ));
+
   const presentClients = presenceData.map((msg, index) => (
     <li key={index}>
       {msg.clientId}: {JSON.stringify(msg.data)}
@@ -69,6 +101,57 @@ function App() {
         >
           Update status to hello
         </button>
+        <button
+          onClick={() => {
+            anotherChannelPublisher.publish({
+              name: 'test-message',
+              data: {
+                text: 'This is a message for Rob',
+              },
+              extras: {
+                headers: {
+                  email: 'rob.pike@domain.com',
+                },
+              },
+            });
+          }}
+        >
+          Send Message to Rob Only
+        </button>
+        <button
+          onClick={() => {
+            anotherChannelPublisher.publish({
+              name: 'test-message',
+              data: {
+                text: 'This is a company-wide message',
+              },
+              extras: {
+                headers: {
+                  company: 'domain',
+                },
+              },
+            });
+          }}
+        >
+          Send Company-wide message
+        </button>
+        <button
+          onClick={() => {
+            anotherChannelPublisher.publish({
+              name: 'test-message',
+              data: {
+                text: 'This is a message for front office employees only',
+              },
+              extras: {
+                headers: {
+                  role: 'front-office',
+                },
+              },
+            });
+          }}
+        >
+          Send message to Front Office
+        </button>
       </div>
 
       <div style={{ position: 'fixed', width: '250px' }}>
@@ -94,13 +177,23 @@ function App() {
         <div>{ablyErr}</div>
 
         <h2>Messages</h2>
-        <ul>{messagePreviews}</ul>
+        {<ul>{messagePreviews}</ul>}
+
+        <h2>Derived Channel Messages</h2>
+        <ul>{derivedChannelMessagePreviews}</ul>
+
+        <h2>Front Office Messages</h2>
+        <ul>{frontOfficeMessagePreviews}</ul>
 
         <h2>Present Clients</h2>
         <ul>{presentClients}</ul>
       </div>
     </div>
   );
+}
+
+function MessagePreview({ message }: { message: Types.Message }) {
+  return <li>{message.data.text}</li>;
 }
 
 function ConnectionState() {

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -3,6 +3,7 @@ import { Types } from '../../../../ably.js';
 export type ChannelNameAndOptions = {
   channelName: string;
   options?: Types.ChannelOptions;
+  deriveOptions?: Types.DeriveOptions;
   id?: string;
   subscribeOnly?: boolean;
   skip?: boolean;

--- a/src/platform/react-hooks/src/fakes/ably.ts
+++ b/src/platform/react-hooks/src/fakes/ably.ts
@@ -1,4 +1,5 @@
 import { Types } from 'ably';
+import { search } from 'jmespath';
 
 export class FakeAblySdk {
   public clientId: string;
@@ -89,7 +90,7 @@ class Connection extends EventEmitter {
 export class ClientChannelsCollection {
   private client: FakeAblySdk;
   private channels: FakeAblyChannels;
-  private _channelConnections: Map<string, ClientSingleChannelConnection>;
+  private _channelConnections: Map<string, ClientSingleChannelConnection | ClientSingleDerivedChannelConnection>;
 
   constructor(client: FakeAblySdk, channels: FakeAblyChannels) {
     this.client = client;
@@ -108,9 +109,14 @@ export class ClientChannelsCollection {
     }
   }
 
-  public getDerived(name: string, options: Types.DeriveOptions): ClientSingleChannelConnection {
-    options;
-    return this.get(name);
+  public getDerived(name: string, options: Types.DeriveOptions): ClientSingleDerivedChannelConnection {
+    let channelConnection = this._channelConnections.get(name);
+    if (channelConnection) return channelConnection as ClientSingleDerivedChannelConnection;
+
+    const channel = this.channels.get(name);
+    channelConnection = new ClientSingleDerivedChannelConnection(this.client, channel, options);
+    this._channelConnections.set(name, channelConnection);
+    return channelConnection;
   }
 }
 
@@ -148,6 +154,32 @@ export class ClientSingleChannelConnection extends EventEmitter {
   }
 
   public detach() {
+    this.channel.subscriptionsPerClient.delete(this.client.clientId);
+  }
+}
+
+export class ClientSingleDerivedChannelConnection extends EventEmitter {
+  private client: FakeAblySdk;
+  private channel: Channel;
+  private deriveOpts: Types.DeriveOptions;
+
+  constructor(client: FakeAblySdk, channel: Channel, deriveOptions?: Types.DeriveOptions) {
+    super();
+    this.client = client;
+    this.channel = channel;
+    this.deriveOpts = deriveOptions;
+  }
+
+  public async subscribe(
+    eventOrCallback: Types.messageCallback<Types.Message> | string | Array<string>,
+    listener?: Types.messageCallback<Types.Message>
+  ) {
+    if (typeof eventOrCallback === 'function') eventOrCallback.deriveOptions = this.deriveOpts;
+    if (typeof listener === 'function') listener.deriveOpts = this.deriveOpts;
+    this.channel.subscribe(this.client.clientId, eventOrCallback, listener);
+  }
+
+  public unsubscribe() {
     this.channel.subscriptionsPerClient.delete(this.client.clientId);
   }
 }
@@ -251,7 +283,11 @@ export class Channel {
         }
 
         for (const subscription of subs) {
-          subscription(messageEnvelope);
+          const filter = subscription.deriveOptions?.filter;
+          if (!filter) return subscription(messageEnvelope);
+          const headers = messageEnvelope.data?.extras?.headers;
+          const found = search({ headers }, filter);
+          if (found) subscription(messageEnvelope);
         }
       }
 

--- a/src/platform/react-hooks/src/fakes/ably.ts
+++ b/src/platform/react-hooks/src/fakes/ably.ts
@@ -107,6 +107,11 @@ export class ClientChannelsCollection {
       return channelConnection;
     }
   }
+
+  public getDerived(name: string, options: Types.DeriveOptions): ClientSingleChannelConnection {
+    options;
+    return this.get(name);
+  }
 }
 
 export class ClientSingleChannelConnection extends EventEmitter {

--- a/src/platform/react-hooks/src/hooks/useChannel.test.tsx
+++ b/src/platform/react-hooks/src/hooks/useChannel.test.tsx
@@ -204,8 +204,9 @@ describe('useChannel with deriveOptions', () => {
         deriveOptions={{ filter: 'headers.user == `"robert.pike@domain.io"`' }}
       />
     );
-    await act(async () => {
-      await anotherClient.channels
+
+    act(() => {
+      anotherClient.channels
         .get(Channels.tasks)
         .publish({ text: 'A new task for you', extras: { headers: { user: 'robert.pike@domain.io' } } });
     });
@@ -223,8 +224,9 @@ describe('useChannel with deriveOptions', () => {
         deriveOptions={{ filter: 'headers.user == `"robert.pike@domain.io"`' }}
       />
     );
-    await act(async () => {
-      await anotherClient.channels
+
+    act(() => {
+      anotherClient.channels
         .get(Channels.tasks)
         .publish({ text: 'This one is for another Rob', extras: { headers: { user: 'robert.griesemer@domain.io' } } });
     });
@@ -242,21 +244,21 @@ describe('useChannel with deriveOptions', () => {
       />
     );
 
-    await act(async () => {
+    act(() => {
       const channel = anotherClient.channels.get(Channels.tasks);
-      await channel.publish({
+      channel.publish({
         text: 'This one is for another Rob',
         extras: { headers: { user: 'robert.griesemer@domain.io' } },
       });
-      await channel.publish({
+      channel.publish({
         text: 'This one is for the whole domain',
         extras: { headers: { company: 'domain' } },
       });
-      await channel.publish({
+      channel.publish({
         text: 'This one is for Ken',
         extras: { headers: { user: 'ken.thompson@domain.io' } },
       });
-      await channel.publish({
+      channel.publish({
         text: 'This one is also a domain-wide fan-out',
         extras: { headers: { company: 'domain' } },
       });
@@ -288,12 +290,12 @@ describe('useChannel with deriveOptions', () => {
       </AblyProvider>
     );
 
-    await act(async () => {
-      await yetAnotherClient.channels.get(Channels.tasks).publish({
+    act(() => {
+      yetAnotherClient.channels.get(Channels.tasks).publish({
         text: 'A task for Griesemer',
         extras: { headers: { user: 'robert.griesemer@domain.io' } },
       });
-      await yetAnotherClient.channels.get(Channels.alerts).publish({
+      yetAnotherClient.channels.get(Channels.alerts).publish({
         text: 'A company-wide alert',
         extras: { headers: { company: 'domain' } },
       });
@@ -361,9 +363,9 @@ describe('useChannel with deriveOptions', () => {
       ></UseDerivedChannelComponent>
     );
 
-    await act(async () => {
+    act(() => {
       const text = 'Will receive this text due to wildcard filter';
-      await anotherClient.channels.get(Channels.alerts).publish({ text });
+      anotherClient.channels.get(Channels.alerts).publish({ text });
     });
 
     const messageUl = screen.getAllByRole('derived-channel-messages')[0];
@@ -380,9 +382,9 @@ describe('useChannel with deriveOptions', () => {
       ></UseDerivedChannelComponent>
     );
 
-    await act(async () => {
+    act(() => {
       const text = 'Will skip due to "skip=true"';
-      await anotherClient.channels.get(Channels.alerts).publish({ text });
+      anotherClient.channels.get(Channels.alerts).publish({ text });
     });
 
     const messageUl = screen.getAllByRole('derived-channel-messages')[0];
@@ -401,29 +403,29 @@ describe('useChannel with deriveOptions', () => {
       />
     );
 
-    await act(async () => {
+    act(() => {
       const channel = anotherClient.channels.get(Channels.tasks);
-      await channel.publish({
+      channel.publish({
         text: 'This one is for another Rob',
         extras: { headers: { user: 'robert.griesemer@domain.io' } },
       });
-      await channel.publish({
+      channel.publish({
         text: 'This one is for the whole domain',
         extras: { headers: { company: 'domain' } },
       });
-      await channel.publish({
+      channel.publish({
         text: 'This one is for Ken',
         extras: { headers: { user: 'ken.thompson@domain.io' } },
       });
-      await channel.publish({
+      channel.publish({
         text: 'This one is also a domain-wide fan-out',
         extras: { headers: { company: 'domain' } },
       });
-      await channel.publish({
+      channel.publish({
         text: 'This one for Mr.Pike will also get through...',
         extras: { headers: { user: 'robert.pike@domain.io' } },
       });
-      await channel.publish({
+      channel.publish({
         text: '.... as well as this message',
         extras: { headers: { user: 'robert.pike@domain.io' } },
       });

--- a/src/platform/react-hooks/src/hooks/useChannel.ts
+++ b/src/platform/react-hooks/src/hooks/useChannel.ts
@@ -37,18 +37,23 @@ export function useChannel(
 
   const ably = useAbly(channelHookOptions.id);
 
-  const { channelName, options: channelOptions, skip } = channelHookOptions;
+  const { channelName, options: channelOptions, deriveOptions, skip } = channelHookOptions;
 
   const channelEvent = typeof eventOrCallback === 'string' ? eventOrCallback : null;
   const ablyMessageCallback = typeof eventOrCallback === 'string' ? callback : eventOrCallback;
 
+  const deriveOptionsRef = useRef(deriveOptions);
   const channelOptionsRef = useRef(channelOptions);
   const ablyMessageCallbackRef = useRef(ablyMessageCallback);
 
-  const channel = useMemo(
-    () => ably.channels.get(channelName, channelOptionsWithAgent(channelOptionsRef.current)),
-    [ably, channelName]
-  );
+  const channel = useMemo(() => {
+    const derived = deriveOptionsRef.current;
+    const withAgent = channelOptionsWithAgent(channelOptionsRef.current);
+    const channel = derived
+      ? ably.channels.getDerived(channelName, derived, withAgent)
+      : ably.channels.get(channelName, withAgent);
+    return channel;
+  }, [ably, channelName]);
 
   const { connectionError, channelError } = useStateErrors(channelHookOptions);
 
@@ -58,6 +63,10 @@ export function useChannel(
     }
     channelOptionsRef.current = channelOptions;
   }, [channel, channelOptions]);
+
+  useEffect(() => {
+    deriveOptionsRef.current = deriveOptions;
+  }, [deriveOptions]);
 
   useEffect(() => {
     ablyMessageCallbackRef.current = ablyMessageCallback;


### PR DESCRIPTION
- enabling 'derived' options to 'useChannel' hook;
- updating 'fake' ably to mimic this behavior;
- adding tests and example usage to 'sample-app'