### PR TITLE
Remove `static` stuff from `*Message` classes

### DIFF
--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -1,7 +1,11 @@
 import * as Utils from '../util/utils';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
-import PresenceMessage, { fromValues as presenceMessageFromValues } from '../types/presencemessage';
+import PresenceMessage, {
+  fromValues as presenceMessageFromValues,
+  fromData as presenceMessageFromData,
+  encode as encodePresenceMessage,
+} from '../types/presencemessage';
 import ErrorInfo, { IPartialErrorInfo, PartialErrorInfo } from '../types/errorinfo';
 import RealtimeChannel from './realtimechannel';
 import Multicaster from '../util/multicaster';
@@ -147,7 +151,7 @@ class RealtimePresence extends EventEmitter {
       'channel = ' + channel.name + ', id = ' + id + ', client = ' + (clientId || '(implicit) ' + getClientId(this))
     );
 
-    const presence = PresenceMessage.fromData(data);
+    const presence = presenceMessageFromData(data);
     presence.action = action;
     if (id) {
       presence.id = id;
@@ -156,7 +160,7 @@ class RealtimePresence extends EventEmitter {
       presence.clientId = clientId;
     }
 
-    PresenceMessage.encode(presence, channel.channelOptions as CipherOptions, (err: IPartialErrorInfo) => {
+    encodePresenceMessage(presence, channel.channelOptions as CipherOptions, (err: IPartialErrorInfo) => {
       if (err) {
         callback(err);
         return;
@@ -214,7 +218,7 @@ class RealtimePresence extends EventEmitter {
       'RealtimePresence.leaveClient()',
       'leaving; channel = ' + this.channel.name + ', client = ' + clientId
     );
-    const presence = PresenceMessage.fromData(data);
+    const presence = presenceMessageFromData(data);
     presence.action = 'leave';
     if (clientId) {
       presence.clientId = clientId;

--- a/src/common/lib/client/restchannel.ts
+++ b/src/common/lib/client/restchannel.ts
@@ -1,7 +1,14 @@
 import * as Utils from '../util/utils';
 import Logger from '../util/logger';
 import RestPresence from './restpresence';
-import Message, { CipherOptions } from '../types/message';
+import Message, {
+  fromValues as messageFromValues,
+  fromValuesArray as messagesFromValuesArray,
+  encodeArray as encodeMessagesArray,
+  serialize as serializeMessage,
+  getMessagesSize,
+  CipherOptions,
+} from '../types/message';
 import ErrorInfo from '../types/errorinfo';
 import { PaginatedResult } from './paginatedresource';
 import Resource, { ResourceCallback } from './resource';
@@ -70,13 +77,13 @@ class RestChannel {
 
     if (typeof first === 'string' || first === null) {
       /* (name, data, ...) */
-      messages = [Message.fromValues({ name: first, data: second })];
+      messages = [messageFromValues({ name: first, data: second })];
       params = arguments[2];
     } else if (Utils.isObject(first)) {
-      messages = [Message.fromValues(first)];
+      messages = [messageFromValues(first)];
       params = arguments[1];
     } else if (Utils.isArray(first)) {
-      messages = Message.fromValuesArray(first);
+      messages = messagesFromValuesArray(first);
       params = arguments[1];
     } else {
       throw new ErrorInfo(
@@ -106,14 +113,14 @@ class RestChannel {
       });
     }
 
-    Message.encodeArray(messages, this.channelOptions as CipherOptions, (err: Error) => {
+    encodeMessagesArray(messages, this.channelOptions as CipherOptions, (err: Error) => {
       if (err) {
         callback(err);
         return;
       }
 
       /* RSL1i */
-      const size = Message.getMessagesSize(messages),
+      const size = getMessagesSize(messages),
         maxMessageSize = options.maxMessageSize;
       if (size > maxMessageSize) {
         callback(
@@ -130,7 +137,7 @@ class RestChannel {
         return;
       }
 
-      this._publish(Message.serialize(messages, client._MsgPack, format), headers, params, callback);
+      this._publish(serializeMessage(messages, client._MsgPack, format), headers, params, callback);
     });
   }
 

--- a/src/common/lib/client/restchannelmixin.ts
+++ b/src/common/lib/client/restchannelmixin.ts
@@ -3,7 +3,7 @@ import RestChannel from './restchannel';
 import RealtimeChannel from './realtimechannel';
 import * as Utils from '../util/utils';
 import { PaginatedResultCallback, StandardCallback } from '../../types/utils';
-import Message from '../types/message';
+import Message, { fromResponseBody as messageFromResponseBody } from '../types/message';
 import Defaults from '../util/defaults';
 import PaginatedResource from './paginatedresource';
 import Resource from './resource';
@@ -40,7 +40,7 @@ export class RestChannelMixin {
       headers,
       unpacked
     ) {
-      return await Message.fromResponseBody(body as Message[], options, client._MsgPack, unpacked ? undefined : format);
+      return await messageFromResponseBody(body as Message[], options, client._MsgPack, unpacked ? undefined : format);
     }).get(params as Record<string, unknown>, callback);
   }
 

--- a/src/common/lib/client/restpresence.ts
+++ b/src/common/lib/client/restpresence.ts
@@ -1,7 +1,7 @@
 import * as Utils from '../util/utils';
 import Logger from '../util/logger';
 import PaginatedResource, { PaginatedResult } from './paginatedresource';
-import PresenceMessage from '../types/presencemessage';
+import PresenceMessage, { fromResponseBody as presenceMessageFromResponseBody } from '../types/presencemessage';
 import { CipherOptions } from '../types/message';
 import { PaginatedResultCallback } from '../../types/utils';
 import RestChannel from './restchannel';
@@ -39,7 +39,7 @@ class RestPresence {
       headers,
       envelope,
       async function (body, headers, unpacked) {
-        return await PresenceMessage.fromResponseBody(
+        return await presenceMessageFromResponseBody(
           body as Record<string, unknown>[],
           options as CipherOptions,
           client._MsgPack,

--- a/src/common/lib/client/restpresencemixin.ts
+++ b/src/common/lib/client/restpresencemixin.ts
@@ -4,7 +4,7 @@ import * as Utils from '../util/utils';
 import { PaginatedResultCallback } from '../../types/utils';
 import Defaults from '../util/defaults';
 import PaginatedResource, { PaginatedResult } from './paginatedresource';
-import PresenceMessage from '../types/presencemessage';
+import PresenceMessage, { fromResponseBody as presenceMessageFromResponseBody } from '../types/presencemessage';
 import { CipherOptions } from '../types/message';
 import { RestChannelMixin } from './restchannelmixin';
 
@@ -41,7 +41,7 @@ export class RestPresenceMixin {
       headers,
       unpacked
     ) {
-      return await PresenceMessage.fromResponseBody(
+      return await presenceMessageFromResponseBody(
         body as Record<string, unknown>[],
         options as CipherOptions,
         client._MsgPack,

--- a/src/common/lib/transport/comettransport.ts
+++ b/src/common/lib/transport/comettransport.ts
@@ -1,5 +1,9 @@
 import * as Utils from '../util/utils';
-import ProtocolMessage from '../types/protocolmessage';
+import ProtocolMessage, {
+  actions,
+  fromValues as protocolMessageFromValues,
+  fromDeserialized as protocolMessageFromDeserialized,
+} from '../types/protocolmessage';
 import Transport from './transport';
 import Logger from '../util/logger';
 import Defaults from '../util/defaults';
@@ -29,9 +33,9 @@ function protocolMessageFromRawError(err: ErrorInfo) {
   /* err will be either a legacy (non-protocolmessage) comet error response
    * (which will have an err.code), or a xhr/network error (which won't). */
   if (shouldBeErrorAction(err)) {
-    return [ProtocolMessage.fromValues({ action: ProtocolMessage.Action.ERROR, error: err })];
+    return [protocolMessageFromValues({ action: actions.ERROR, error: err })];
   } else {
-    return [ProtocolMessage.fromValues({ action: ProtocolMessage.Action.DISCONNECTED, error: err })];
+    return [protocolMessageFromValues({ action: actions.DISCONNECTED, error: err })];
   }
 }
 
@@ -344,7 +348,7 @@ abstract class CometTransport extends Transport {
     try {
       const items = this.decodeResponse(responseData);
       if (items && items.length)
-        for (let i = 0; i < items.length; i++) this.onProtocolMessage(ProtocolMessage.fromDeserialized(items[i]));
+        for (let i = 0; i < items.length; i++) this.onProtocolMessage(protocolMessageFromDeserialized(items[i]));
     } catch (e) {
       Logger.logAction(
         Logger.LOG_ERROR,

--- a/src/common/lib/transport/protocol.ts
+++ b/src/common/lib/transport/protocol.ts
@@ -1,4 +1,4 @@
-import ProtocolMessage from '../types/protocolmessage';
+import ProtocolMessage, { actions, stringify as stringifyProtocolMessage } from '../types/protocolmessage';
 import * as Utils from '../util/utils';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
@@ -6,8 +6,6 @@ import MessageQueue from './messagequeue';
 import ErrorInfo from '../types/errorinfo';
 import Transport from './transport';
 import { ErrCallback } from '../../types/utils';
-
-const actions = ProtocolMessage.Action;
 
 export class PendingMessage {
   message: ProtocolMessage;
@@ -76,7 +74,7 @@ class Protocol extends EventEmitter {
       Logger.logAction(
         Logger.LOG_MICRO,
         'Protocol.send()',
-        'sending msg; ' + ProtocolMessage.stringify(pendingMessage.message)
+        'sending msg; ' + stringifyProtocolMessage(pendingMessage.message)
       );
     }
     pendingMessage.sendAttempted = true;

--- a/src/common/lib/transport/transport.ts
+++ b/src/common/lib/transport/transport.ts
@@ -1,4 +1,8 @@
-import ProtocolMessage from '../types/protocolmessage';
+import ProtocolMessage, {
+  actions,
+  fromValues as protocolMessageFromValues,
+  stringify as stringifyProtocolMessage,
+} from '../types/protocolmessage';
 import * as Utils from '../util/utils';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
@@ -21,9 +25,8 @@ export type TransportCtor = new (
   forceJsonProtocol?: boolean
 ) => Transport;
 
-const actions = ProtocolMessage.Action;
-const closeMessage = ProtocolMessage.fromValues({ action: actions.CLOSE });
-const disconnectMessage = ProtocolMessage.fromValues({ action: actions.DISCONNECT });
+const closeMessage = protocolMessageFromValues({ action: actions.CLOSE });
+const disconnectMessage = protocolMessageFromValues({ action: actions.DISCONNECT });
 
 /*
  * Transport instances inherit from EventEmitter and emit the following events:
@@ -120,7 +123,7 @@ abstract class Transport extends EventEmitter {
         'received on ' +
           this.shortName +
           ': ' +
-          ProtocolMessage.stringify(message) +
+          stringifyProtocolMessage(message) +
           '; connectionId = ' +
           this.connectionManager.connectionId
       );
@@ -239,9 +242,9 @@ abstract class Transport extends EventEmitter {
   }
 
   ping(id: string): void {
-    const msg: Record<string, number | string> = { action: ProtocolMessage.Action.HEARTBEAT };
+    const msg: Record<string, number | string> = { action: actions.HEARTBEAT };
     if (id) msg.id = id;
-    this.send(ProtocolMessage.fromValues(msg));
+    this.send(protocolMessageFromValues(msg));
   }
 
   dispose(): void {

--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -3,7 +3,10 @@ import * as Utils from '../util/utils';
 import Transport from './transport';
 import Defaults from '../util/defaults';
 import Logger from '../util/logger';
-import ProtocolMessage from '../types/protocolmessage';
+import ProtocolMessage, {
+  serialize as serializeProtocolMessage,
+  deserialize as deserializeProtocolMessage,
+} from '../types/protocolmessage';
 import ErrorInfo from '../types/errorinfo';
 import NodeWebSocket from 'ws';
 import ConnectionManager, { TransportParams, TransportStorage } from './connectionmanager';
@@ -104,7 +107,7 @@ class WebSocketTransport extends Transport {
     }
     try {
       (wsConnection as NodeWebSocket).send(
-        ProtocolMessage.serialize(message, this.connectionManager.realtime._MsgPack, this.params.format)
+        serializeProtocolMessage(message, this.connectionManager.realtime._MsgPack, this.params.format)
       );
     } catch (e) {
       const msg = 'Exception from ws connection when trying to send: ' + Utils.inspectError(e);
@@ -122,7 +125,7 @@ class WebSocketTransport extends Transport {
       'data received; length = ' + data.length + '; type = ' + typeof data
     );
     try {
-      this.onProtocolMessage(ProtocolMessage.deserialize(data, this.connectionManager.realtime._MsgPack, this.format));
+      this.onProtocolMessage(deserializeProtocolMessage(data, this.connectionManager.realtime._MsgPack, this.format));
     } catch (e) {
       Logger.logAction(
         Logger.LOG_ERROR,

--- a/src/common/lib/types/defaultmessage.ts
+++ b/src/common/lib/types/defaultmessage.ts
@@ -1,6 +1,15 @@
-import Message, { fromEncoded, fromEncodedArray } from './message';
+import Message, {
+  CipherOptions,
+  fromEncoded,
+  fromEncodedArray,
+  encode,
+  decode,
+  EncodingDecodingContext,
+} from './message';
 import * as API from '../../../../ably';
 import Platform from 'common/platform';
+import PresenceMessage from './presencemessage';
+import { ChannelOptions } from 'common/types/channel';
 
 /**
  `DefaultMessage` is the class returned by `DefaultRest` and `DefaultRealtime`’s `Message` static property. It introduces the static methods described in the `MessageStatic` interface of the public API of the non tree-shakable version of the library.
@@ -12,5 +21,23 @@ export class DefaultMessage extends Message {
 
   static async fromEncodedArray(encodedArray: Array<unknown>, options?: API.Types.ChannelOptions): Promise<Message[]> {
     return fromEncodedArray(Platform.Crypto, encodedArray, options);
+  }
+
+  // Used by tests
+  static fromValues(values: unknown): Message {
+    return Object.assign(new Message(), values);
+  }
+
+  // Used by tests
+  static encode(msg: Message | PresenceMessage, options: CipherOptions, callback: Function): void {
+    encode(msg, options, callback);
+  }
+
+  // Used by tests
+  static async decode(
+    message: Message | PresenceMessage,
+    inputContext: CipherOptions | EncodingDecodingContext | ChannelOptions
+  ): Promise<void> {
+    return decode(message, inputContext);
   }
 }

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -22,7 +22,7 @@ export type CipherOptions = {
   };
 };
 
-type EncodingDecodingContext = {
+export type EncodingDecodingContext = {
   channelOptions: ChannelOptions;
   plugins: {
     vcdiff?: {
@@ -81,12 +81,12 @@ export async function fromEncoded(
   encoded: unknown,
   inputOptions?: API.Types.ChannelOptions
 ): Promise<Message> {
-  const msg = Message.fromValues(encoded);
+  const msg = fromValues(encoded);
   const options = normalizeCipherOptions(Crypto, inputOptions ?? null);
   /* if decoding fails at any point, catch and return the message decoded to
    * the fullest extent possible */
   try {
-    await Message.decode(msg, options);
+    await decode(msg, options);
   } catch (e) {
     Logger.logAction(Logger.LOG_ERROR, 'Message.fromEncoded()', (e as Error).toString());
   }
@@ -103,6 +103,208 @@ export async function fromEncodedArray(
       return fromEncoded(Crypto, encoded, options);
     })
   );
+}
+
+function encrypt(msg: Message | PresenceMessage, options: CipherOptions, callback: Function) {
+  let data = msg.data,
+    encoding = msg.encoding,
+    cipher = options.channelCipher;
+
+  encoding = encoding ? encoding + '/' : '';
+  if (!Platform.BufferUtils.isBuffer(data)) {
+    data = Platform.BufferUtils.utf8Encode(String(data));
+    encoding = encoding + 'utf-8/';
+  }
+  cipher.encrypt(data, function (err: Error, data: unknown) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    msg.data = data;
+    msg.encoding = encoding + 'cipher+' + cipher.algorithm;
+    callback(null, msg);
+  });
+}
+
+export function encode(msg: Message | PresenceMessage, options: CipherOptions, callback: Function): void {
+  const data = msg.data;
+  const nativeDataType =
+    typeof data == 'string' || Platform.BufferUtils.isBuffer(data) || data === null || data === undefined;
+
+  if (!nativeDataType) {
+    if (Utils.isObject(data) || Utils.isArray(data)) {
+      msg.data = JSON.stringify(data);
+      msg.encoding = msg.encoding ? msg.encoding + '/json' : 'json';
+    } else {
+      throw new ErrorInfo('Data type is unsupported', 40013, 400);
+    }
+  }
+
+  if (options != null && options.cipher) {
+    encrypt(msg, options, callback);
+  } else {
+    callback(null, msg);
+  }
+}
+
+export function encodeArray(messages: Array<Message>, options: CipherOptions, callback: Function): void {
+  let processed = 0;
+  for (let i = 0; i < messages.length; i++) {
+    encode(messages[i], options, function (err: Error) {
+      if (err) {
+        callback(err);
+        return;
+      }
+      processed++;
+      if (processed == messages.length) {
+        callback(null, messages);
+      }
+    });
+  }
+}
+
+export const serialize = Utils.encodeBody;
+
+export async function decode(
+  message: Message | PresenceMessage,
+  inputContext: CipherOptions | EncodingDecodingContext | ChannelOptions
+): Promise<void> {
+  const context = normaliseContext(inputContext);
+
+  let lastPayload = message.data;
+  const encoding = message.encoding;
+  if (encoding) {
+    const xforms = encoding.split('/');
+    let lastProcessedEncodingIndex,
+      encodingsToProcess = xforms.length,
+      data = message.data;
+
+    let xform = '';
+    try {
+      while ((lastProcessedEncodingIndex = encodingsToProcess) > 0) {
+        // eslint-disable-next-line security/detect-unsafe-regex
+        const match = xforms[--encodingsToProcess].match(/([-\w]+)(\+([\w-]+))?/);
+        if (!match) break;
+        xform = match[1];
+        switch (xform) {
+          case 'base64':
+            data = Platform.BufferUtils.base64Decode(String(data));
+            if (lastProcessedEncodingIndex == xforms.length) {
+              lastPayload = data;
+            }
+            continue;
+          case 'utf-8':
+            data = Platform.BufferUtils.utf8Decode(data);
+            continue;
+          case 'json':
+            data = JSON.parse(data);
+            continue;
+          case 'cipher':
+            if (
+              context.channelOptions != null &&
+              context.channelOptions.cipher &&
+              context.channelOptions.channelCipher
+            ) {
+              const xformAlgorithm = match[3],
+                cipher = context.channelOptions.channelCipher;
+              /* don't attempt to decrypt unless the cipher params are compatible */
+              if (xformAlgorithm != cipher.algorithm) {
+                throw new Error('Unable to decrypt message with given cipher; incompatible cipher params');
+              }
+              data = await cipher.decrypt(data);
+              continue;
+            } else {
+              throw new Error('Unable to decrypt message; not an encrypted channel');
+            }
+          case 'vcdiff':
+            if (!context.plugins || !context.plugins.vcdiff) {
+              throw new ErrorInfo('Missing Vcdiff decoder (https://github.com/ably-forks/vcdiff-decoder)', 40019, 400);
+            }
+            if (typeof Uint8Array === 'undefined') {
+              throw new ErrorInfo(
+                'Delta decoding not supported on this browser (need ArrayBuffer & Uint8Array)',
+                40020,
+                400
+              );
+            }
+            try {
+              let deltaBase = context.baseEncodedPreviousPayload;
+              if (typeof deltaBase === 'string') {
+                deltaBase = Platform.BufferUtils.utf8Encode(deltaBase);
+              }
+
+              // vcdiff expects Uint8Arrays, can't copy with ArrayBuffers.
+              deltaBase = Platform.BufferUtils.toBuffer(deltaBase as Buffer);
+              data = Platform.BufferUtils.toBuffer(data);
+
+              data = Platform.BufferUtils.arrayBufferViewToBuffer(context.plugins.vcdiff.decode(data, deltaBase));
+              lastPayload = data;
+            } catch (e) {
+              throw new ErrorInfo('Vcdiff delta decode failed with ' + e, 40018, 400);
+            }
+            continue;
+          default:
+            throw new Error('Unknown encoding');
+        }
+      }
+    } catch (e) {
+      const err = e as ErrorInfo;
+      throw new ErrorInfo(
+        'Error processing the ' + xform + ' encoding, decoder returned ‘' + err.message + '’',
+        err.code || 40013,
+        400
+      );
+    } finally {
+      message.encoding =
+        (lastProcessedEncodingIndex as number) <= 0 ? null : xforms.slice(0, lastProcessedEncodingIndex).join('/');
+      message.data = data;
+    }
+  }
+  context.baseEncodedPreviousPayload = lastPayload;
+}
+
+export async function fromResponseBody(
+  body: Array<Message>,
+  options: ChannelOptions | EncodingDecodingContext,
+  MsgPack: MsgPack | null,
+  format?: Utils.Format
+): Promise<Message[]> {
+  if (format) {
+    body = Utils.decodeBody(body, MsgPack, format);
+  }
+
+  for (let i = 0; i < body.length; i++) {
+    const msg = (body[i] = fromValues(body[i]));
+    try {
+      await decode(msg, options);
+    } catch (e) {
+      Logger.logAction(Logger.LOG_ERROR, 'Message.fromResponseBody()', (e as Error).toString());
+    }
+  }
+  return body;
+}
+
+export function fromValues(values: unknown): Message {
+  return Object.assign(new Message(), values);
+}
+
+export function fromValuesArray(values: unknown[]): Message[] {
+  const count = values.length,
+    result = new Array(count);
+  for (let i = 0; i < count; i++) result[i] = fromValues(values[i]);
+  return result;
+}
+
+/* This should be called on encode()d (and encrypt()d) Messages (as it
+ * assumes the data is a string or buffer) */
+export function getMessagesSize(messages: Message[]): number {
+  let msg,
+    total = 0;
+  for (let i = 0; i < messages.length; i++) {
+    msg = messages[i];
+    total += msg.size || (msg.size = getMessageSize(msg));
+  }
+  return total;
 }
 
 class Message {
@@ -169,212 +371,6 @@ class Message {
     if (this.extras) result += '; extras=' + JSON.stringify(this.extras);
     result += ']';
     return result;
-  }
-
-  static encrypt(msg: Message | PresenceMessage, options: CipherOptions, callback: Function) {
-    let data = msg.data,
-      encoding = msg.encoding,
-      cipher = options.channelCipher;
-
-    encoding = encoding ? encoding + '/' : '';
-    if (!Platform.BufferUtils.isBuffer(data)) {
-      data = Platform.BufferUtils.utf8Encode(String(data));
-      encoding = encoding + 'utf-8/';
-    }
-    cipher.encrypt(data, function (err: Error, data: unknown) {
-      if (err) {
-        callback(err);
-        return;
-      }
-      msg.data = data;
-      msg.encoding = encoding + 'cipher+' + cipher.algorithm;
-      callback(null, msg);
-    });
-  }
-
-  static encode(msg: Message | PresenceMessage, options: CipherOptions, callback: Function): void {
-    const data = msg.data;
-    const nativeDataType =
-      typeof data == 'string' || Platform.BufferUtils.isBuffer(data) || data === null || data === undefined;
-
-    if (!nativeDataType) {
-      if (Utils.isObject(data) || Utils.isArray(data)) {
-        msg.data = JSON.stringify(data);
-        msg.encoding = msg.encoding ? msg.encoding + '/json' : 'json';
-      } else {
-        throw new ErrorInfo('Data type is unsupported', 40013, 400);
-      }
-    }
-
-    if (options != null && options.cipher) {
-      Message.encrypt(msg, options, callback);
-    } else {
-      callback(null, msg);
-    }
-  }
-
-  static encodeArray(messages: Array<Message>, options: CipherOptions, callback: Function): void {
-    let processed = 0;
-    for (let i = 0; i < messages.length; i++) {
-      Message.encode(messages[i], options, function (err: Error) {
-        if (err) {
-          callback(err);
-          return;
-        }
-        processed++;
-        if (processed == messages.length) {
-          callback(null, messages);
-        }
-      });
-    }
-  }
-
-  static serialize = Utils.encodeBody;
-
-  static async decode(
-    message: Message | PresenceMessage,
-    inputContext: CipherOptions | EncodingDecodingContext | ChannelOptions
-  ): Promise<void> {
-    const context = normaliseContext(inputContext);
-
-    let lastPayload = message.data;
-    const encoding = message.encoding;
-    if (encoding) {
-      const xforms = encoding.split('/');
-      let lastProcessedEncodingIndex,
-        encodingsToProcess = xforms.length,
-        data = message.data;
-
-      let xform = '';
-      try {
-        while ((lastProcessedEncodingIndex = encodingsToProcess) > 0) {
-          // eslint-disable-next-line security/detect-unsafe-regex
-          const match = xforms[--encodingsToProcess].match(/([-\w]+)(\+([\w-]+))?/);
-          if (!match) break;
-          xform = match[1];
-          switch (xform) {
-            case 'base64':
-              data = Platform.BufferUtils.base64Decode(String(data));
-              if (lastProcessedEncodingIndex == xforms.length) {
-                lastPayload = data;
-              }
-              continue;
-            case 'utf-8':
-              data = Platform.BufferUtils.utf8Decode(data);
-              continue;
-            case 'json':
-              data = JSON.parse(data);
-              continue;
-            case 'cipher':
-              if (
-                context.channelOptions != null &&
-                context.channelOptions.cipher &&
-                context.channelOptions.channelCipher
-              ) {
-                const xformAlgorithm = match[3],
-                  cipher = context.channelOptions.channelCipher;
-                /* don't attempt to decrypt unless the cipher params are compatible */
-                if (xformAlgorithm != cipher.algorithm) {
-                  throw new Error('Unable to decrypt message with given cipher; incompatible cipher params');
-                }
-                data = await cipher.decrypt(data);
-                continue;
-              } else {
-                throw new Error('Unable to decrypt message; not an encrypted channel');
-              }
-            case 'vcdiff':
-              if (!context.plugins || !context.plugins.vcdiff) {
-                throw new ErrorInfo(
-                  'Missing Vcdiff decoder (https://github.com/ably-forks/vcdiff-decoder)',
-                  40019,
-                  400
-                );
-              }
-              if (typeof Uint8Array === 'undefined') {
-                throw new ErrorInfo(
-                  'Delta decoding not supported on this browser (need ArrayBuffer & Uint8Array)',
-                  40020,
-                  400
-                );
-              }
-              try {
-                let deltaBase = context.baseEncodedPreviousPayload;
-                if (typeof deltaBase === 'string') {
-                  deltaBase = Platform.BufferUtils.utf8Encode(deltaBase);
-                }
-
-                // vcdiff expects Uint8Arrays, can't copy with ArrayBuffers.
-                deltaBase = Platform.BufferUtils.toBuffer(deltaBase as Buffer);
-                data = Platform.BufferUtils.toBuffer(data);
-
-                data = Platform.BufferUtils.arrayBufferViewToBuffer(context.plugins.vcdiff.decode(data, deltaBase));
-                lastPayload = data;
-              } catch (e) {
-                throw new ErrorInfo('Vcdiff delta decode failed with ' + e, 40018, 400);
-              }
-              continue;
-            default:
-              throw new Error('Unknown encoding');
-          }
-        }
-      } catch (e) {
-        const err = e as ErrorInfo;
-        throw new ErrorInfo(
-          'Error processing the ' + xform + ' encoding, decoder returned ‘' + err.message + '’',
-          err.code || 40013,
-          400
-        );
-      } finally {
-        message.encoding =
-          (lastProcessedEncodingIndex as number) <= 0 ? null : xforms.slice(0, lastProcessedEncodingIndex).join('/');
-        message.data = data;
-      }
-    }
-    context.baseEncodedPreviousPayload = lastPayload;
-  }
-
-  static async fromResponseBody(
-    body: Array<Message>,
-    options: ChannelOptions | EncodingDecodingContext,
-    MsgPack: MsgPack | null,
-    format?: Utils.Format
-  ): Promise<Message[]> {
-    if (format) {
-      body = Utils.decodeBody(body, MsgPack, format);
-    }
-
-    for (let i = 0; i < body.length; i++) {
-      const msg = (body[i] = Message.fromValues(body[i]));
-      try {
-        await Message.decode(msg, options);
-      } catch (e) {
-        Logger.logAction(Logger.LOG_ERROR, 'Message.fromResponseBody()', (e as Error).toString());
-      }
-    }
-    return body;
-  }
-
-  static fromValues(values: unknown): Message {
-    return Object.assign(new Message(), values);
-  }
-
-  static fromValuesArray(values: unknown[]): Message[] {
-    const count = values.length,
-      result = new Array(count);
-    for (let i = 0; i < count; i++) result[i] = Message.fromValues(values[i]);
-    return result;
-  }
-
-  /* This should be called on encode()d (and encrypt()d) Messages (as it
-   * assumes the data is a string or buffer) */
-  static getMessagesSize(messages: Message[]): number {
-    let msg,
-      total = 0;
-    for (let i = 0; i < messages.length; i++) {
-      msg = messages[i];
-      total += msg.size || (msg.size = getMessageSize(msg));
-    }
-    return total;
   }
 }
 

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -2,10 +2,13 @@ import { MsgPack } from 'common/types/msgpack';
 import { Types } from '../../../../ably';
 import * as Utils from '../util/utils';
 import ErrorInfo from './errorinfo';
-import Message from './message';
-import PresenceMessage, { fromValues as presenceMessageFromValues } from './presencemessage';
+import Message, { fromValues as messageFromValues, fromValuesArray as messagesFromValuesArray } from './message';
+import PresenceMessage, {
+  fromValues as presenceMessageFromValues,
+  fromValuesArray as presenceMessagesFromValuesArray,
+} from './presencemessage';
 
-const actions = {
+export const actions = {
   HEARTBEAT: 0,
   ACK: 1,
   NACK: 2,
@@ -27,7 +30,7 @@ const actions = {
   ACTIVATE: 18,
 };
 
-const ActionName: string[] = [];
+export const ActionName: string[] = [];
 Object.keys(actions).forEach(function (name) {
   ActionName[(actions as { [key: string]: number })[name]] = name;
 });
@@ -58,6 +61,61 @@ function toStringArray(array?: any[]): string {
   return '[ ' + result.join(', ') + ' ]';
 }
 
+export const channelModes = ['PRESENCE', 'PUBLISH', 'SUBSCRIBE', 'PRESENCE_SUBSCRIBE'];
+
+export const serialize = Utils.encodeBody;
+
+export function deserialize(serialized: unknown, MsgPack: MsgPack | null, format?: Utils.Format): ProtocolMessage {
+  const deserialized = Utils.decodeBody<Record<string, unknown>>(serialized, MsgPack, format);
+  return fromDeserialized(deserialized);
+}
+
+export function fromDeserialized(deserialized: Record<string, unknown>): ProtocolMessage {
+  const error = deserialized.error;
+  if (error) deserialized.error = ErrorInfo.fromValues(error as ErrorInfo);
+  const messages = deserialized.messages as Message[];
+  if (messages) for (let i = 0; i < messages.length; i++) messages[i] = messageFromValues(messages[i]);
+  const presence = deserialized.presence as PresenceMessage[];
+  if (presence) for (let i = 0; i < presence.length; i++) presence[i] = presenceMessageFromValues(presence[i], true);
+  return Object.assign(new ProtocolMessage(), deserialized);
+}
+
+export function fromValues(values: unknown): ProtocolMessage {
+  return Object.assign(new ProtocolMessage(), values);
+}
+
+export function stringify(msg: any): string {
+  let result = '[ProtocolMessage';
+  if (msg.action !== undefined) result += '; action=' + ActionName[msg.action] || msg.action;
+
+  const simpleAttributes = ['id', 'channel', 'channelSerial', 'connectionId', 'count', 'msgSerial', 'timestamp'];
+  let attribute;
+  for (let attribIndex = 0; attribIndex < simpleAttributes.length; attribIndex++) {
+    attribute = simpleAttributes[attribIndex];
+    if (msg[attribute] !== undefined) result += '; ' + attribute + '=' + msg[attribute];
+  }
+
+  if (msg.messages) result += '; messages=' + toStringArray(messagesFromValuesArray(msg.messages));
+  if (msg.presence) result += '; presence=' + toStringArray(presenceMessagesFromValuesArray(msg.presence));
+  if (msg.error) result += '; error=' + ErrorInfo.fromValues(msg.error).toString();
+  if (msg.auth && msg.auth.accessToken) result += '; token=' + msg.auth.accessToken;
+  if (msg.flags) result += '; flags=' + flagNames.filter(msg.hasFlag).join(',');
+  if (msg.params) {
+    let stringifiedParams = '';
+    Utils.forInOwnNonNullProperties(msg.params, function (prop: string) {
+      if (stringifiedParams.length > 0) {
+        stringifiedParams += '; ';
+      }
+      stringifiedParams += prop + '=' + msg.params[prop];
+    });
+    if (stringifiedParams.length > 0) {
+      result += '; params=[' + stringifiedParams + ']';
+    }
+  }
+  result += ']';
+  return result;
+}
+
 class ProtocolMessage {
   action?: number;
   flags?: number;
@@ -73,12 +131,6 @@ class ProtocolMessage {
   presence?: PresenceMessage[];
   auth?: unknown;
   connectionDetails?: Record<string, unknown>;
-
-  static Action = actions;
-
-  static channelModes = ['PRESENCE', 'PUBLISH', 'SUBSCRIBE', 'PRESENCE_SUBSCRIBE'];
-
-  static ActionName = ActionName;
 
   hasFlag = (flag: string): boolean => {
     return ((this.flags as number) & flags[flag]) > 0;
@@ -98,66 +150,13 @@ class ProtocolMessage {
 
   decodeModesFromFlags(): string[] | undefined {
     const modes: string[] = [];
-    ProtocolMessage.channelModes.forEach((mode) => {
+    channelModes.forEach((mode) => {
       if (this.hasFlag(mode)) {
         modes.push(mode);
       }
     });
     return modes.length > 0 ? modes : undefined;
   }
-
-  static serialize = Utils.encodeBody;
-
-  static deserialize = function (serialized: unknown, MsgPack: MsgPack | null, format?: Utils.Format): ProtocolMessage {
-    const deserialized = Utils.decodeBody<Record<string, unknown>>(serialized, MsgPack, format);
-    return ProtocolMessage.fromDeserialized(deserialized);
-  };
-
-  static fromDeserialized = function (deserialized: Record<string, unknown>): ProtocolMessage {
-    const error = deserialized.error;
-    if (error) deserialized.error = ErrorInfo.fromValues(error as ErrorInfo);
-    const messages = deserialized.messages as Message[];
-    if (messages) for (let i = 0; i < messages.length; i++) messages[i] = Message.fromValues(messages[i]);
-    const presence = deserialized.presence as PresenceMessage[];
-    if (presence) for (let i = 0; i < presence.length; i++) presence[i] = presenceMessageFromValues(presence[i], true);
-    return Object.assign(new ProtocolMessage(), deserialized);
-  };
-
-  static fromValues(values: unknown): ProtocolMessage {
-    return Object.assign(new ProtocolMessage(), values);
-  }
-
-  static stringify = function (msg: any): string {
-    let result = '[ProtocolMessage';
-    if (msg.action !== undefined) result += '; action=' + ProtocolMessage.ActionName[msg.action] || msg.action;
-
-    const simpleAttributes = ['id', 'channel', 'channelSerial', 'connectionId', 'count', 'msgSerial', 'timestamp'];
-    let attribute;
-    for (let attribIndex = 0; attribIndex < simpleAttributes.length; attribIndex++) {
-      attribute = simpleAttributes[attribIndex];
-      if (msg[attribute] !== undefined) result += '; ' + attribute + '=' + msg[attribute];
-    }
-
-    if (msg.messages) result += '; messages=' + toStringArray(Message.fromValuesArray(msg.messages));
-    if (msg.presence) result += '; presence=' + toStringArray(PresenceMessage.fromValuesArray(msg.presence));
-    if (msg.error) result += '; error=' + ErrorInfo.fromValues(msg.error).toString();
-    if (msg.auth && msg.auth.accessToken) result += '; token=' + msg.auth.accessToken;
-    if (msg.flags) result += '; flags=' + flagNames.filter(msg.hasFlag).join(',');
-    if (msg.params) {
-      let stringifiedParams = '';
-      Utils.forInOwnNonNullProperties(msg.params, function (prop: string) {
-        if (stringifiedParams.length > 0) {
-          stringifiedParams += '; ';
-        }
-        stringifiedParams += prop + '=' + msg.params[prop];
-      });
-      if (stringifiedParams.length > 0) {
-        result += '; params=[' + stringifiedParams + ']';
-      }
-    }
-    result += ']';
-    return result;
-  };
 }
 
 export default ProtocolMessage;

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -58,8 +58,6 @@ function toStringArray(array?: any[]): string {
   return '[ ' + result.join(', ') + ' ]';
 }
 
-const simpleAttributes = 'id channel channelSerial connectionId count msgSerial timestamp'.split(' ');
-
 class ProtocolMessage {
   action?: number;
   flags?: number;
@@ -133,6 +131,7 @@ class ProtocolMessage {
     let result = '[ProtocolMessage';
     if (msg.action !== undefined) result += '; action=' + ProtocolMessage.ActionName[msg.action] || msg.action;
 
+    const simpleAttributes = ['id', 'channel', 'channelSerial', 'connectionId', 'count', 'msgSerial', 'timestamp'];
     let attribute;
     for (let attribIndex = 0; attribIndex < simpleAttributes.length; attribIndex++) {
       attribute = simpleAttributes[attribIndex];

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -3,6 +3,7 @@ import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
+import { fromDeserialized as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
 
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
@@ -51,4 +52,5 @@ export default {
   Rest: DefaultRest,
   Realtime: DefaultRealtime,
   msgpack,
+  protocolMessageFromDeserialized,
 };

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -3,6 +3,7 @@ import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
+import { fromDeserialized as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
 
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
@@ -45,4 +46,5 @@ export default {
   Rest: DefaultRest,
   Realtime: DefaultRealtime,
   msgpack: null,
+  protocolMessageFromDeserialized,
 };

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -3,6 +3,7 @@ import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
+import { fromDeserialized as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
 
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';
@@ -51,4 +52,5 @@ export default {
   Rest: DefaultRest,
   Realtime: DefaultRealtime,
   msgpack,
+  protocolMessageFromDeserialized,
 };

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -3,6 +3,7 @@ import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
+import { fromDeserialized as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
 
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';
@@ -52,7 +53,7 @@ if (Platform.Config.noUpgrade) {
   Platform.Defaults.upgradeTransports = [];
 }
 
-export { DefaultRest as Rest, DefaultRealtime as Realtime, msgpack };
+export { DefaultRest as Rest, DefaultRealtime as Realtime, msgpack, protocolMessageFromDeserialized };
 
 export default {
   ErrorInfo,

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -7,7 +7,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
   var displayError = helper.displayError;
   var closeAndFinish = helper.closeAndFinish;
   var monitorConnection = helper.monitorConnection;
-  var createPM = Ably.Realtime.ProtocolMessage.fromDeserialized;
+  var createPM = Ably.protocolMessageFromDeserialized;
   var testOnAllTransports = helper.testOnAllTransports;
   var whenPromiseSettles = helper.whenPromiseSettles;
   var randomString = helper.randomString;

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -3,7 +3,7 @@
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
   var expect = chai.expect;
   var closeAndFinish = helper.closeAndFinish;
-  var createPM = Ably.Realtime.ProtocolMessage.fromDeserialized;
+  var createPM = Ably.protocolMessageFromDeserialized;
   var displayError = helper.displayError;
   var monitorConnection = helper.monitorConnection;
   var whenPromiseSettles = helper.whenPromiseSettles;

--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -6,7 +6,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
   var utils = helper.Utils;
   var noop = function () {};
   var simulateDroppedConnection = helper.simulateDroppedConnection;
-  var createPM = Ably.Realtime.ProtocolMessage.fromDeserialized;
+  var createPM = Ably.protocolMessageFromDeserialized;
   var availableTransports = helper.availableTransports;
   var whenPromiseSettles = helper.whenPromiseSettles;
 

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -6,7 +6,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
   var utils = helper.Utils;
   let config = Ably.Realtime.Platform.Config;
   var closeAndFinish = helper.closeAndFinish;
-  var createPM = Ably.Realtime.ProtocolMessage.fromDeserialized;
+  var createPM = Ably.protocolMessageFromDeserialized;
   var monitorConnection = helper.monitorConnection;
   var testOnAllTransports = helper.testOnAllTransports;
   var whenPromiseSettles = helper.whenPromiseSettles;

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -3,7 +3,7 @@
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
   var expect = chai.expect;
   var utils = helper.Utils;
-  var createPM = Ably.Realtime.ProtocolMessage.fromDeserialized;
+  var createPM = Ably.protocolMessageFromDeserialized;
   var closeAndFinish = helper.closeAndFinish;
   var monitorConnection = helper.monitorConnection;
   var PresenceMessage = Ably.Realtime.PresenceMessage;

--- a/test/realtime/sync.test.js
+++ b/test/realtime/sync.test.js
@@ -5,7 +5,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
   var displayError = helper.displayError;
   var utils = helper.Utils;
   var closeAndFinish = helper.closeAndFinish;
-  var createPM = Ably.Realtime.ProtocolMessage.fromDeserialized;
+  var createPM = Ably.protocolMessageFromDeserialized;
   var monitorConnection = helper.monitorConnection;
   var whenPromiseSettles = helper.whenPromiseSettles;
 


### PR DESCRIPTION
**Note: This PR is based on top of #1443; please review that one first.**

Replace them by standalone exports, which can be tree-shaken.

(My eye was in particular caught by the `Message.encrypt` function, which I was thinking it would be good to — at some point — bundle only if the `Crypto` module is used. This change isn’t made here though.)