### PR TITLE
[SDK-3937] Create a tree-shakable module for realtime publishing

### DIFF
--- a/modules.d.ts
+++ b/modules.d.ts
@@ -163,6 +163,20 @@ export declare const FetchRequest: unknown;
 export declare const MessageInteractions: unknown;
 
 /**
+ * Provides a {@link BaseRealtime} instance with the ability to publish messages.
+ *
+ * To create a client that includes this module, include it in the `ModulesMap` that you pass to the {@link BaseRealtime.constructor}:
+ *
+ * ```javascript
+ * import { BaseRealtime, WebSocketTransport, FetchRequest, RealtimePublishing } from 'ably/modules';
+ * const realtime = new BaseRealtime(options, { WebSocketTransport, FetchRequest, RealtimePublishing });
+ * ```
+ *
+ * If this module is not provided, then calling {@link Types.RealtimeChannel.publish} on a channel will cause a runtime error.
+ */
+export declare const RealtimePublishing: unknown;
+
+/**
  * Pass a `ModulesMap` to { @link BaseRest.constructor | the constructor of BaseRest } or {@link BaseRealtime.constructor | that of BaseRealtime} to specify which functionality should be made available to that client.
  */
 export interface ModulesMap {
@@ -215,6 +229,11 @@ export interface ModulesMap {
    * See {@link MessageInteractions | documentation for the `MessageInteractions` module}.
    */
   MessageInteractions?: typeof MessageInteractions;
+
+  /**
+   * See {@link RealtimePublishing | documentation for the `RealtimePublishing` module}.
+   */
+  RealtimePublishing?: typeof RealtimePublishing;
 }
 
 /**

--- a/scripts/moduleReport.js
+++ b/scripts/moduleReport.js
@@ -1,0 +1,108 @@
+const esbuild = require('esbuild');
+
+// List of all modules accepted in ModulesMap
+const moduleNames = [
+  'Rest',
+  'Crypto',
+  'MsgPack',
+  'RealtimePresence',
+  'XHRPolling',
+  'XHRStreaming',
+  'WebSocketTransport',
+  'XHRRequest',
+  'FetchRequest',
+  'MessageInteractions',
+  'RealtimePublishing',
+];
+
+// List of all free-standing functions exported by the library along with the
+// ModulesMap entries that we expect them to transitively import
+const functions = [
+  { name: 'generateRandomKey', transitiveImports: ['Crypto'] },
+  { name: 'getDefaultCryptoParams', transitiveImports: ['Crypto'] },
+  { name: 'decodeMessage', transitiveImports: [] },
+  { name: 'decodeEncryptedMessage', transitiveImports: ['Crypto'] },
+  { name: 'decodeMessages', transitiveImports: [] },
+  { name: 'decodeEncryptedMessages', transitiveImports: ['Crypto'] },
+  { name: 'decodePresenceMessage', transitiveImports: [] },
+  { name: 'decodePresenceMessages', transitiveImports: [] },
+  { name: 'constructPresenceMessage', transitiveImports: [] },
+];
+
+function formatBytes(bytes) {
+  const kibibytes = bytes / 1024;
+  const formatted = kibibytes.toFixed(2);
+  return `${formatted} KiB`;
+}
+
+// Gets the bundled size in bytes of an array of named exports from 'ably/modules'
+function getImportSize(modules) {
+  const outfile = modules.join('');
+  const result = esbuild.buildSync({
+    stdin: {
+      contents: `export { ${modules.join(', ')} } from './build/modules'`,
+      resolveDir: '.',
+    },
+    metafile: true,
+    minify: true,
+    bundle: true,
+    outfile,
+    write: false,
+  });
+
+  return result.metafile.outputs[outfile].bytes;
+}
+
+const errors = [];
+
+['BaseRest', 'BaseRealtime'].forEach((baseClient) => {
+  const baseClientSize = getImportSize([baseClient]);
+
+  // First display the size of the base client
+  console.log(`${baseClient}: ${formatBytes(baseClientSize)}`);
+
+  // Then display the size of each export together with the base client
+  [...moduleNames, ...Object.values(functions).map((functionData) => functionData.name)].forEach((exportName) => {
+    const size = getImportSize([baseClient, exportName]);
+    console.log(`${baseClient} + ${exportName}: ${formatBytes(size)}`);
+
+    if (!(baseClientSize < size) && !(baseClient === 'BaseRest' && exportName === 'Rest')) {
+      // Emit an error if adding the module does not increase the bundle size
+      // (this means that the module is not being tree-shaken correctly).
+      errors.push(new Error(`Adding ${exportName} to ${baseClient} does not increase the bundle size.`));
+    }
+  });
+});
+
+for (const functionData of functions) {
+  const { name: functionName, transitiveImports } = functionData;
+
+  // First display the size of the function
+  const standaloneSize = getImportSize([functionName]);
+  console.log(`${functionName}: ${formatBytes(standaloneSize)}`);
+
+  // Then display the size of the function together with the modules we expect
+  // it to transitively import
+  if (transitiveImports.length > 0) {
+    const withTransitiveImportsSize = getImportSize([functionName, ...transitiveImports]);
+    console.log(`${functionName} + ${transitiveImports.join(' + ')}: ${formatBytes(withTransitiveImportsSize)}`);
+
+    if (withTransitiveImportsSize > standaloneSize) {
+      // Emit an error if the bundle size is increased by adding the modules
+      // that we expect this function to have transitively imported anyway.
+      // This seemed like a useful sense check, but it might need tweaking in
+      // the future if we make future optimisations that mean that the
+      // standalone functions don’t necessarily import the whole module.
+      errors.push(
+        new Error(`Adding ${transitiveImports.join(' + ')} to ${functionName} unexpectedly increases the bundle size.`)
+      );
+    }
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.log(error.message);
+  }
+  process.exit(1);
+}

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -17,6 +17,7 @@ const moduleNames = [
   'XHRRequest',
   'FetchRequest',
   'MessageInteractions',
+  'RealtimePublishing',
 ];
 
 // List of all free-standing functions exported by the library along with the

--- a/src/common/lib/client/acks.ts
+++ b/src/common/lib/client/acks.ts
@@ -1,0 +1,110 @@
+import ErrorInfo from '../types/errorinfo';
+import MessageQueue from '../transport/messagequeue';
+import Protocol, { PendingMessage } from '../transport/protocol';
+import Transport from '../transport/transport';
+import Logger from '../util/logger';
+import * as Utils from '../util/utils';
+import { ErrCallback } from '../../types/utils';
+import ConnectionManager from '../transport/connectionmanager';
+import Platform from 'common/platform';
+
+export class Acks {
+  messageQueue: MessageQueue;
+
+  constructor(transport: Transport) {
+    this.messageQueue = new MessageQueue();
+    transport.on('ack', (serial: number, count: number) => {
+      this.onAck(serial, count);
+    });
+    transport.on('nack', (serial: number, count: number, err: ErrorInfo) => {
+      this.onNack(serial, count, err);
+    });
+  }
+
+  onAck(serial: number, count: number): void {
+    Logger.logAction(Logger.LOG_MICRO, 'Protocol.onAck()', 'serial = ' + serial + '; count = ' + count);
+    this.messageQueue.completeMessages(serial, count);
+  }
+
+  onNack(serial: number, count: number, err: ErrorInfo): void {
+    Logger.logAction(
+      Logger.LOG_ERROR,
+      'Protocol.onNack()',
+      'serial = ' + serial + '; count = ' + count + '; err = ' + Utils.inspectError(err)
+    );
+    if (!err) {
+      err = new ErrorInfo('Unable to send message; channel not responding', 50001, 500);
+    }
+    this.messageQueue.completeMessages(serial, count, err);
+  }
+
+  onceIdle(listener: ErrCallback): void {
+    const messageQueue = this.messageQueue;
+    if (messageQueue.count() === 0) {
+      listener();
+      return;
+    }
+    messageQueue.once('idle', listener);
+  }
+
+  onProtocolWillSend(pendingMessage: PendingMessage) {
+    if (pendingMessage.ackRequired) {
+      this.messageQueue.push(pendingMessage);
+    }
+  }
+
+  getPendingMessages(): PendingMessage[] {
+    return this.messageQueue.copyAll();
+  }
+
+  clearPendingMessages(): void {
+    return this.messageQueue.clear();
+  }
+
+  thingMovedFromActivateTransport(existingActiveProtocol: Protocol, transport: Transport) {
+    if (this.messageQueue.count() > 0) {
+      /* We could just requeue pending messages on the new transport, but
+       * actually this should never happen: transports should only take over
+       * from other active transports when upgrading, and upgrading waits for
+       * the old transport to be idle. So log an error. */
+      Logger.logAction(
+        Logger.LOG_ERROR,
+        'ConnectionManager.activateTransport()',
+        'Previous active protocol (for transport ' +
+          existingActiveProtocol.transport.shortName +
+          ', new one is ' +
+          transport.shortName +
+          ') finishing with ' +
+          existingActiveProtocol.acks!.messageQueue.count() +
+          ' messages still pending'
+      );
+    }
+  }
+
+  thingMovedFromDeactivateTransport(connectionManager: ConnectionManager, currentProtocol: Protocol) {
+    Logger.logAction(
+      Logger.LOG_MICRO,
+      'ConnectionManager.deactivateTransport()',
+      'Getting, clearing, and requeuing ' + currentProtocol.acks!.messageQueue.count() + ' pending messages'
+    );
+    this.queuePendingMessages(connectionManager, this.getPendingMessages());
+    /* Clear any messages we requeue to allow the protocol to become idle.
+     * In case of an upgrade, this will trigger an immediate activation of
+     * the upgrade transport, so delay a tick so this transport can finish
+     * deactivating */
+    Platform.Config.nextTick(() => {
+      this.clearPendingMessages();
+    });
+  }
+
+  queuePendingMessages(connectionManager: ConnectionManager, pendingMessages: Array<PendingMessage>): void {
+    if (pendingMessages && pendingMessages.length) {
+      Logger.logAction(
+        Logger.LOG_MICRO,
+        'ConnectionManager.queuePendingMessages()',
+        'queueing ' + pendingMessages.length + ' pending messages'
+      );
+      connectionManager.queuedMessages.prepend(pendingMessages);
+    }
+  }
+}

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -13,12 +13,14 @@ import { ModulesMap, RealtimePresenceModule } from './modulesmap';
 import { TransportNames } from 'common/constants/TransportName';
 import { TransportImplementations } from 'common/platform';
 import { RealtimePublishing } from './realtimepublishing';
+import { Acks } from './acks';
 
 /**
  `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
  */
 class BaseRealtime extends BaseClient {
   readonly _RealtimePresence: RealtimePresenceModule | null;
+  readonly _Acks: typeof Acks | null;
   readonly __RealtimePublishing: typeof RealtimePublishing | null;
   // Extra transport implementations available to this client, in addition to those in Platform.Transports.bundledImplementations
   readonly _additionalTransportImplementations: TransportImplementations;
@@ -30,6 +32,7 @@ class BaseRealtime extends BaseClient {
     Logger.logAction(Logger.LOG_MINOR, 'Realtime()', '');
     this._additionalTransportImplementations = BaseRealtime.transportImplementationsFromModules(modules);
     this._RealtimePresence = modules.RealtimePresence ?? null;
+    this._Acks = modules.RealtimePublishing?.Acks ?? modules.RealtimePresence?.Acks ?? null;
     this.__RealtimePublishing = modules.RealtimePublishing ?? null;
     this.connection = new Connection(this, this.options);
     this._channels = new Channels(this);

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -12,12 +12,14 @@ import * as API from '../../../../ably';
 import { ModulesMap, RealtimePresenceModule } from './modulesmap';
 import { TransportNames } from 'common/constants/TransportName';
 import { TransportImplementations } from 'common/platform';
+import { RealtimePublishing } from './realtimepublishing';
 
 /**
  `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
  */
 class BaseRealtime extends BaseClient {
   readonly _RealtimePresence: RealtimePresenceModule | null;
+  readonly __RealtimePublishing: typeof RealtimePublishing | null;
   // Extra transport implementations available to this client, in addition to those in Platform.Transports.bundledImplementations
   readonly _additionalTransportImplementations: TransportImplementations;
   _channels: any;
@@ -28,6 +30,7 @@ class BaseRealtime extends BaseClient {
     Logger.logAction(Logger.LOG_MINOR, 'Realtime()', '');
     this._additionalTransportImplementations = BaseRealtime.transportImplementationsFromModules(modules);
     this._RealtimePresence = modules.RealtimePresence ?? null;
+    this.__RealtimePublishing = modules.RealtimePublishing ?? null;
     this.connection = new Connection(this, this.options);
     this._channels = new Channels(this);
     if (options.autoConnect !== false) this.connect();
@@ -51,6 +54,13 @@ class BaseRealtime extends BaseClient {
 
   get channels() {
     return this._channels;
+  }
+
+  get _RealtimePublishing(): typeof RealtimePublishing {
+    if (!this.__RealtimePublishing) {
+      Utils.throwMissingModuleError('RealtimePublishing');
+    }
+    return this.__RealtimePublishing;
   }
 
   connect(): void {

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -15,6 +15,7 @@ import {
   fromValues as presenceMessageFromValues,
   fromValuesArray as presenceMessagesFromValuesArray,
 } from '../types/presencemessage';
+import { RealtimePublishing } from './realtimepublishing';
 
 /**
  `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -37,6 +38,7 @@ export class DefaultRealtime extends BaseRealtime {
       },
       WebSocketTransport: initialiseWebSocketTransport,
       MessageInteractions: FilteredSubscriptions,
+      RealtimePublishing: RealtimePublishing,
     });
   }
 

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -16,6 +16,7 @@ import {
   fromValuesArray as presenceMessagesFromValuesArray,
 } from '../types/presencemessage';
 import { RealtimePublishing } from './realtimepublishing';
+import { Acks } from './acks';
 
 /**
  `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -35,6 +36,7 @@ export class DefaultRealtime extends BaseRealtime {
         RealtimePresence,
         presenceMessageFromValues,
         presenceMessagesFromValuesArray,
+        Acks,
       },
       WebSocketTransport: initialiseWebSocketTransport,
       MessageInteractions: FilteredSubscriptions,

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -10,6 +10,7 @@ import {
   fromValues as presenceMessageFromValues,
   fromValuesArray as presenceMessagesFromValuesArray,
 } from '../types/presencemessage';
+import { RealtimePublishing } from './realtimepublishing';
 
 export interface PresenceMessageModule {
   presenceMessageFromValues: typeof presenceMessageFromValues;
@@ -31,6 +32,7 @@ export interface ModulesMap {
   XHRRequest?: typeof XHRRequest;
   FetchRequest?: typeof fetchRequest;
   MessageInteractions?: typeof FilteredSubscriptions;
+  RealtimePublishing?: typeof RealtimePublishing;
 }
 
 export const allCommonModules: ModulesMap = { Rest };

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -11,6 +11,7 @@ import {
   fromValuesArray as presenceMessagesFromValuesArray,
 } from '../types/presencemessage';
 import { RealtimePublishing } from './realtimepublishing';
+import { Acks } from './acks';
 
 export interface PresenceMessageModule {
   presenceMessageFromValues: typeof presenceMessageFromValues;
@@ -19,6 +20,7 @@ export interface PresenceMessageModule {
 
 export type RealtimePresenceModule = PresenceMessageModule & {
   RealtimePresence: typeof RealtimePresence;
+  Acks: typeof Acks;
 };
 
 export interface ModulesMap {

--- a/src/common/lib/client/realtimepublishing.ts
+++ b/src/common/lib/client/realtimepublishing.ts
@@ -11,8 +11,13 @@ import Message, {
 } from '../types/message';
 import ErrorInfo from '../types/errorinfo';
 import { ErrCallback } from '../../types/utils';
+import { Acks } from './acks';
 
 export class RealtimePublishing {
+  static get Acks(): typeof Acks {
+    return Acks;
+  }
+
   static publish(channel: RealtimeChannel, ...args: any[]): void | Promise<void> {
     let messages = args[0];
     let argCount = args.length;

--- a/src/common/lib/client/realtimepublishing.ts
+++ b/src/common/lib/client/realtimepublishing.ts
@@ -1,0 +1,85 @@
+import RealtimeChannel from './realtimechannel';
+import ProtocolMessage, { actions } from '../types/protocolmessage';
+import * as Utils from '../util/utils';
+import Logger from '../util/logger';
+import Message, {
+  fromValues as messageFromValues,
+  fromValuesArray as messagesFromValuesArray,
+  encodeArray as encodeMessagesArray,
+  getMessagesSize,
+  CipherOptions,
+} from '../types/message';
+import ErrorInfo from '../types/errorinfo';
+import { ErrCallback } from '../../types/utils';
+
+export class RealtimePublishing {
+  static publish(channel: RealtimeChannel, ...args: any[]): void | Promise<void> {
+    let messages = args[0];
+    let argCount = args.length;
+    let callback = args[argCount - 1];
+
+    if (typeof callback !== 'function') {
+      return Utils.promisify(this, 'publish', arguments);
+    }
+    if (!channel.connectionManager.activeState()) {
+      callback(channel.connectionManager.getError());
+      return;
+    }
+    if (argCount == 2) {
+      if (Utils.isObject(messages)) messages = [messageFromValues(messages)];
+      else if (Utils.isArray(messages)) messages = messagesFromValuesArray(messages);
+      else
+        throw new ErrorInfo(
+          'The single-argument form of publish() expects a message object or an array of message objects',
+          40013,
+          400
+        );
+    } else {
+      messages = [messageFromValues({ name: args[0], data: args[1] })];
+    }
+    const maxMessageSize = channel.client.options.maxMessageSize;
+    encodeMessagesArray(messages, channel.channelOptions as CipherOptions, (err: Error | null) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+      /* RSL1i */
+      const size = getMessagesSize(messages);
+      if (size > maxMessageSize) {
+        callback(
+          new ErrorInfo(
+            'Maximum size of messages that can be published at once exceeded ( was ' +
+              size +
+              ' bytes; limit is ' +
+              maxMessageSize +
+              ' bytes)',
+            40009,
+            400
+          )
+        );
+        return;
+      }
+      this._publish(channel, messages, callback);
+    });
+  }
+
+  static _publish(channel: RealtimeChannel, messages: Array<Message>, callback: ErrCallback) {
+    Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.publish()', 'message count = ' + messages.length);
+    const state = channel.state;
+    switch (state) {
+      case 'failed':
+      case 'suspended':
+        callback(ErrorInfo.fromValues(channel.invalidStateError()));
+        break;
+      default: {
+        Logger.logAction(Logger.LOG_MICRO, 'RealtimeChannel.publish()', 'sending message; channel state is ' + state);
+        const msg = new ProtocolMessage();
+        msg.action = actions.MESSAGE;
+        msg.channel = channel.name;
+        msg.messages = messages;
+        channel.sendMessage(msg, callback);
+        break;
+      }
+    }
+  }
+}

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -992,9 +992,7 @@ class ConnectionManager extends EventEmitter {
       Logger.logAction(
         Logger.LOG_MICRO,
         'ConnectionManager.deactivateTransport()',
-        'Getting, clearing, and requeuing ' +
-          (this.activeProtocol as Protocol).messageQueue.count() +
-          ' pending messages'
+        'Getting, clearing, and requeuing ' + (currentProtocol as Protocol).messageQueue.count() + ' pending messages'
       );
       this.queuePendingMessages((currentProtocol as Protocol).getPendingMessages());
       /* Clear any messages we requeue to allow the protocol to become idle.

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -992,15 +992,15 @@ class ConnectionManager extends EventEmitter {
       Logger.logAction(
         Logger.LOG_MICRO,
         'ConnectionManager.deactivateTransport()',
-        'Getting, clearing, and requeuing ' + (currentProtocol as Protocol).messageQueue.count() + ' pending messages'
+        'Getting, clearing, and requeuing ' + currentProtocol!.messageQueue.count() + ' pending messages'
       );
-      this.queuePendingMessages((currentProtocol as Protocol).getPendingMessages());
+      this.queuePendingMessages(currentProtocol!.getPendingMessages());
       /* Clear any messages we requeue to allow the protocol to become idle.
        * In case of an upgrade, this will trigger an immediate activation of
        * the upgrade transport, so delay a tick so this transport can finish
        * deactivating */
       Platform.Config.nextTick(function () {
-        (currentProtocol as Protocol).clearPendingMessages();
+        currentProtocol!.clearPendingMessages();
       });
       this.activeProtocol = this.host = null;
     }
@@ -1689,7 +1689,7 @@ class ConnectionManager extends EventEmitter {
     /* returns the subset of upgradeTransports to the right of the current
      * transport in upgradeTransports (if it's in there - if not, currentSerial
      * will be -1, so return upgradeTransports.slice(0) == upgradeTransports */
-    const current = (this.activeProtocol as Protocol).getTransport().shortName;
+    const current = this.activeProtocol!.getTransport().shortName;
     const currentSerial = Utils.arrIndexOf(this.upgradeTransports, current);
     return this.upgradeTransports.slice(currentSerial + 1);
   }
@@ -1764,7 +1764,7 @@ class ConnectionManager extends EventEmitter {
           this.state !== this.states.synchronizing
         ) {
           this.disconnectAllTransports(/* exceptActive: */ true);
-          const transportParams = (this.activeProtocol as Protocol).getTransport().params;
+          const transportParams = this.activeProtocol!.getTransport().params;
           Platform.Config.nextTick(() => {
             if (this.state.state === 'connected') {
               this.upgradeIfNeeded(transportParams);
@@ -1929,7 +1929,7 @@ class ConnectionManager extends EventEmitter {
       msg.msgSerial = this.msgSerial++;
     }
     try {
-      (this.activeProtocol as Protocol).send(pendingMessage);
+      this.activeProtocol!.send(pendingMessage);
     } catch (e) {
       Logger.logAction(
         Logger.LOG_ERROR,
@@ -2102,11 +2102,11 @@ class ConnectionManager extends EventEmitter {
     };
 
     this.on('transport.active', onTransportActive);
-    this.ping((this.activeProtocol as Protocol).getTransport(), onPingComplete);
+    this.ping(this.activeProtocol!.getTransport(), onPingComplete);
   }
 
   abort(error: ErrorInfo): void {
-    (this.activeProtocol as Protocol).getTransport().fail(error);
+    this.activeProtocol!.getTransport().fail(error);
   }
 
   registerProposedTransport(transport: Transport): void {

--- a/src/common/lib/transport/messagequeue.ts
+++ b/src/common/lib/transport/messagequeue.ts
@@ -39,6 +39,7 @@ class MessageQueue extends EventEmitter {
     this.messages.unshift.apply(this.messages, messages);
   }
 
+  // TODO maybe we could move this into Acks and then inline completeAllMessages, I think the savings would be minimal though
   completeMessages(serial: number, count: number, err?: ErrorInfo | null): void {
     Logger.logAction(Logger.LOG_MICRO, 'MessageQueue.completeMessages()', 'serial = ' + serial + '; count = ' + count);
     err = err || null;

--- a/src/common/lib/transport/protocol.ts
+++ b/src/common/lib/transport/protocol.ts
@@ -1,11 +1,9 @@
 import ProtocolMessage, { actions, stringify as stringifyProtocolMessage } from '../types/protocolmessage';
-import * as Utils from '../util/utils';
 import EventEmitter from '../util/eventemitter';
 import Logger from '../util/logger';
-import MessageQueue from './messagequeue';
-import ErrorInfo from '../types/errorinfo';
 import Transport from './transport';
 import { ErrCallback } from '../../types/utils';
+import type { Acks } from '../client/acks';
 
 export class PendingMessage {
   message: ProtocolMessage;
@@ -20,56 +18,32 @@ export class PendingMessage {
     this.merged = false;
     const action = message.action;
     this.sendAttempted = false;
+    // TODO should this come out or would it do more harm than good?
     this.ackRequired = action == actions.MESSAGE || action == actions.PRESENCE;
   }
 }
 
 class Protocol extends EventEmitter {
   transport: Transport;
-  messageQueue: MessageQueue;
+  acks: Acks | null;
 
   constructor(transport: Transport) {
     super();
     this.transport = transport;
-    this.messageQueue = new MessageQueue();
-    transport.on('ack', (serial: number, count: number) => {
-      this.onAck(serial, count);
-    });
-    transport.on('nack', (serial: number, count: number, err: ErrorInfo) => {
-      this.onNack(serial, count, err);
-    });
-  }
-
-  onAck(serial: number, count: number): void {
-    Logger.logAction(Logger.LOG_MICRO, 'Protocol.onAck()', 'serial = ' + serial + '; count = ' + count);
-    this.messageQueue.completeMessages(serial, count);
-  }
-
-  onNack(serial: number, count: number, err: ErrorInfo): void {
-    Logger.logAction(
-      Logger.LOG_ERROR,
-      'Protocol.onNack()',
-      'serial = ' + serial + '; count = ' + count + '; err = ' + Utils.inspectError(err)
-    );
-    if (!err) {
-      err = new ErrorInfo('Unable to send message; channel not responding', 50001, 500);
-    }
-    this.messageQueue.completeMessages(serial, count, err);
+    const Acks = transport.connectionManager.realtime._Acks;
+    this.acks = Acks ? new Acks(transport) : null;
   }
 
   onceIdle(listener: ErrCallback): void {
-    const messageQueue = this.messageQueue;
-    if (messageQueue.count() === 0) {
+    if (this.acks) {
+      this.acks?.onceIdle(listener);
+    } else {
       listener();
-      return;
     }
-    messageQueue.once('idle', listener);
   }
 
   send(pendingMessage: PendingMessage): void {
-    if (pendingMessage.ackRequired) {
-      this.messageQueue.push(pendingMessage);
-    }
+    this.acks?.onProtocolWillSend(pendingMessage);
     if (Logger.shouldLog(Logger.LOG_MICRO)) {
       Logger.logAction(
         Logger.LOG_MICRO,
@@ -84,14 +58,6 @@ class Protocol extends EventEmitter {
 
   getTransport(): Transport {
     return this.transport;
-  }
-
-  getPendingMessages(): PendingMessage[] {
-    return this.messageQueue.copyAll();
-  }
-
-  clearPendingMessages(): void {
-    return this.messageQueue.clear();
   }
 
   finish(): void {

--- a/src/platform/web/modules.ts
+++ b/src/platform/web/modules.ts
@@ -51,4 +51,5 @@ export * from './modules/transports';
 export * from './modules/http';
 export { Rest } from '../../common/lib/client/rest';
 export { FilteredSubscriptions as MessageInteractions } from '../../common/lib/client/filteredsubscriptions';
+export { RealtimePublishing } from '../../common/lib/client/realtimepublishing';
 export { BaseRest, BaseRealtime, ErrorInfo };

--- a/src/platform/web/modules/realtimepresence.ts
+++ b/src/platform/web/modules/realtimepresence.ts
@@ -1,3 +1,4 @@
+import { Acks } from 'common/lib/client/acks';
 import { RealtimePresenceModule } from 'common/lib/client/modulesmap';
 import { default as realtimePresenceClass } from '../../../common/lib/client/realtimepresence';
 import {
@@ -7,6 +8,7 @@ import {
 
 const RealtimePresence: RealtimePresenceModule = {
   RealtimePresence: realtimePresenceClass,
+  Acks,
   presenceMessageFromValues,
   presenceMessagesFromValuesArray,
 };

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -20,6 +20,7 @@ import {
   FetchRequest,
   XHRRequest,
   MessageInteractions,
+  RealtimePublishing,
 } from '../../build/modules/index.js';
 
 describe('browser/modules', function () {
@@ -141,7 +142,7 @@ describe('browser/modules', function () {
 
     describe('BaseRealtime without Rest', () => {
       it('still allows publishing and subscribing', async () => {
-        const client = new BaseRealtime(ablyClientOptions(), { WebSocketTransport, FetchRequest });
+        const client = new BaseRealtime(ablyClientOptions(), { WebSocketTransport, FetchRequest, RealtimePublishing });
 
         const channel = client.channels.get('channel');
         await channel.attach();
@@ -368,7 +369,7 @@ describe('browser/modules', function () {
 
       for (const clientClassConfig of [
         { clientClass: BaseRest },
-        { clientClass: BaseRealtime, additionalModules: { WebSocketTransport } },
+        { clientClass: BaseRealtime, additionalModules: { WebSocketTransport, RealtimePublishing } },
       ]) {
         describe(clientClassConfig.clientClass.name, () => {
           it('is able to publish encrypted messages', async () => {
@@ -478,6 +479,7 @@ describe('browser/modules', function () {
           WebSocketTransport,
           FetchRequest,
           RealtimePresence,
+          RealtimePublishing,
         });
         const txChannel = txClient.channels.get('channel');
 
@@ -629,7 +631,11 @@ describe('browser/modules', function () {
     describe('BaseRealtime', () => {
       describe('without MessageInteractions', () => {
         it('is able to subscribe to and unsubscribe from channel events, as long as a MessageFilter isn’t passed', async () => {
-          const realtime = new BaseRealtime(ablyClientOptions(), { WebSocketTransport, FetchRequest });
+          const realtime = new BaseRealtime(ablyClientOptions(), {
+            WebSocketTransport,
+            FetchRequest,
+            RealtimePublishing,
+          });
           const channel = realtime.channels.get('channel');
           await channel.attach();
 
@@ -642,7 +648,11 @@ describe('browser/modules', function () {
         });
 
         it('throws an error when attempting to subscribe to channel events using a MessageFilter', async () => {
-          const realtime = new BaseRealtime(ablyClientOptions(), { WebSocketTransport, FetchRequest });
+          const realtime = new BaseRealtime(ablyClientOptions(), {
+            WebSocketTransport,
+            FetchRequest,
+            RealtimePublishing,
+          });
           const channel = realtime.channels.get('channel');
 
           let thrownError = null;
@@ -662,6 +672,7 @@ describe('browser/modules', function () {
           const realtime = new BaseRealtime(ablyClientOptions(), {
             WebSocketTransport,
             FetchRequest,
+            RealtimePublishing,
             MessageInteractions,
           });
           const channel = realtime.channels.get('channel');
@@ -708,6 +719,35 @@ describe('browser/modules', function () {
           await unfilteredSubscriptionReceivedNextMessagePromise;
 
           expect(filteredSubscriptionReceivedMessages.length).to./* (still) */ equal(1);
+        });
+      });
+    });
+  });
+
+  describe('RealtimePublishing', () => {
+    describe('BaseRealtime', () => {
+      describe('without RealtimePublishing', () => {
+        it('throws an error when attempting to publish a message', async () => {
+          const realtime = new BaseRealtime(ablyClientOptions(), {
+            WebSocketTransport,
+            FetchRequest,
+          });
+
+          const channel = realtime.channels.get('channel');
+          expect(() => channel.publish('message', { foo: 'bar' })).to.throw('RealtimePublishing module not provided');
+        });
+      });
+
+      describe('with RealtimePublishing', () => {
+        it('can publish a message', async () => {
+          const realtime = new BaseRealtime(ablyClientOptions(), {
+            WebSocketTransport,
+            FetchRequest,
+            RealtimePublishing,
+          });
+
+          const channel = realtime.channels.get('channel');
+          await channel.publish('message', { foo: 'bar' });
         });
       });
     });

--- a/test/package/browser/template/src/index-modules.ts
+++ b/test/package/browser/template/src/index-modules.ts
@@ -1,4 +1,11 @@
-import { BaseRealtime, Types, WebSocketTransport, FetchRequest, generateRandomKey } from 'ably/modules';
+import {
+  BaseRealtime,
+  Types,
+  WebSocketTransport,
+  FetchRequest,
+  RealtimePublishing,
+  generateRandomKey,
+} from 'ably/modules';
 import { createSandboxAblyAPIKey } from './sandbox';
 
 // This function exists to check that we can import the Types namespace and refer to its types.
@@ -17,7 +24,10 @@ async function checkStandaloneFunction() {
 globalThis.testAblyPackage = async function () {
   const key = await createSandboxAblyAPIKey();
 
-  const realtime = new BaseRealtime({ key, environment: 'sandbox' }, { WebSocketTransport, FetchRequest });
+  const realtime = new BaseRealtime(
+    { key, environment: 'sandbox' },
+    { WebSocketTransport, FetchRequest, RealtimePublishing }
+  );
 
   const channel = realtime.channels.get('channel');
   await attachChannel(channel);


### PR DESCRIPTION
@owenpearson mentioned that we have many browser use cases which only require subscriptions, and no publishing. He suggested that we create a separate tree-shakable module for this functionality.

This commit introduces the API, but the bundle size savings are minimal since it only pulls out the very low-hanging fruit. I think that we could return to this at some point to see what further size savings we could achieve, but I didn’t want to spend too much time on this now.

Resolves #1491.