### PR TITLE
Exclude `PresenceMessage` from `BaseRealtime` bundle

### DIFF
--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -9,8 +9,7 @@ import ProtocolMessage from '../types/protocolmessage';
 import { ChannelOptions } from '../../types/channel';
 import ClientOptions from '../../types/ClientOptions';
 import * as API from '../../../../ably';
-import { ModulesMap } from './modulesmap';
-import RealtimePresence from './realtimepresence';
+import { ModulesMap, RealtimePresenceModule } from './modulesmap';
 import { TransportNames } from 'common/constants/TransportName';
 import { TransportImplementations } from 'common/platform';
 
@@ -18,7 +17,7 @@ import { TransportImplementations } from 'common/platform';
  `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
  */
 class BaseRealtime extends BaseClient {
-  readonly _RealtimePresence: typeof RealtimePresence | null;
+  readonly _RealtimePresence: RealtimePresenceModule | null;
   // Extra transport implementations available to this client, in addition to those in Platform.Transports.bundledImplementations
   readonly _additionalTransportImplementations: TransportImplementations;
   _channels: any;

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -11,6 +11,10 @@ import RealtimePresence from './realtimepresence';
 import { DefaultPresenceMessage } from '../types/defaultpresencemessage';
 import initialiseWebSocketTransport from '../transport/websockettransport';
 import { FilteredSubscriptions } from './filteredsubscriptions';
+import {
+  fromValues as presenceMessageFromValues,
+  fromValuesArray as presenceMessagesFromValuesArray,
+} from '../types/presencemessage';
 
 /**
  `DefaultRealtime` is the class that the non tree-shakable version of the SDK exports as `Realtime`. It ensures that this version of the SDK includes all of the functionality which is optionally available in the tree-shakable version.
@@ -26,7 +30,11 @@ export class DefaultRealtime extends BaseRealtime {
       ...allCommonModules,
       Crypto: DefaultRealtime.Crypto ?? undefined,
       MsgPack,
-      RealtimePresence,
+      RealtimePresence: {
+        RealtimePresence,
+        presenceMessageFromValues,
+        presenceMessagesFromValuesArray,
+      },
       WebSocketTransport: initialiseWebSocketTransport,
       MessageInteractions: FilteredSubscriptions,
     });

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -6,12 +6,25 @@ import { TransportInitialiser } from '../transport/connectionmanager';
 import XHRRequest from 'platform/web/lib/http/request/xhrrequest';
 import fetchRequest from 'platform/web/lib/http/request/fetchrequest';
 import { FilteredSubscriptions } from './filteredsubscriptions';
+import {
+  fromValues as presenceMessageFromValues,
+  fromValuesArray as presenceMessagesFromValuesArray,
+} from '../types/presencemessage';
+
+export interface PresenceMessageModule {
+  presenceMessageFromValues: typeof presenceMessageFromValues;
+  presenceMessagesFromValuesArray: typeof presenceMessagesFromValuesArray;
+}
+
+export type RealtimePresenceModule = PresenceMessageModule & {
+  RealtimePresence: typeof RealtimePresence;
+};
 
 export interface ModulesMap {
   Rest?: typeof Rest;
   Crypto?: IUntypedCryptoStatic;
   MsgPack?: MsgPack;
-  RealtimePresence?: typeof RealtimePresence;
+  RealtimePresence?: RealtimePresenceModule;
   WebSocketTransport?: TransportInitialiser;
   XHRPolling?: TransportInitialiser;
   XHRStreaming?: TransportInitialiser;

--- a/src/common/lib/transport/comettransport.ts
+++ b/src/common/lib/transport/comettransport.ts
@@ -348,7 +348,10 @@ abstract class CometTransport extends Transport {
     try {
       const items = this.decodeResponse(responseData);
       if (items && items.length)
-        for (let i = 0; i < items.length; i++) this.onProtocolMessage(protocolMessageFromDeserialized(items[i]));
+        for (let i = 0; i < items.length; i++)
+          this.onProtocolMessage(
+            protocolMessageFromDeserialized(items[i], this.connectionManager.realtime._RealtimePresence)
+          );
     } catch (e) {
       Logger.logAction(
         Logger.LOG_ERROR,

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1914,7 +1914,11 @@ class ConnectionManager extends EventEmitter {
       return;
     }
     if (Logger.shouldLog(Logger.LOG_MICRO)) {
-      Logger.logAction(Logger.LOG_MICRO, 'ConnectionManager.send()', 'queueing msg; ' + stringifyProtocolMessage(msg));
+      Logger.logAction(
+        Logger.LOG_MICRO,
+        'ConnectionManager.send()',
+        'queueing msg; ' + stringifyProtocolMessage(msg, this.realtime._RealtimePresence)
+      );
     }
     this.queue(msg, callback);
   }

--- a/src/common/lib/transport/protocol.ts
+++ b/src/common/lib/transport/protocol.ts
@@ -74,7 +74,8 @@ class Protocol extends EventEmitter {
       Logger.logAction(
         Logger.LOG_MICRO,
         'Protocol.send()',
-        'sending msg; ' + stringifyProtocolMessage(pendingMessage.message)
+        'sending msg; ' +
+          stringifyProtocolMessage(pendingMessage.message, this.transport.connectionManager.realtime._RealtimePresence)
       );
     }
     pendingMessage.sendAttempted = true;

--- a/src/common/lib/transport/transport.ts
+++ b/src/common/lib/transport/transport.ts
@@ -123,7 +123,7 @@ abstract class Transport extends EventEmitter {
         'received on ' +
           this.shortName +
           ': ' +
-          stringifyProtocolMessage(message) +
+          stringifyProtocolMessage(message, this.connectionManager.realtime._RealtimePresence) +
           '; connectionId = ' +
           this.connectionManager.connectionId
       );

--- a/src/common/lib/transport/websockettransport.ts
+++ b/src/common/lib/transport/websockettransport.ts
@@ -125,7 +125,14 @@ class WebSocketTransport extends Transport {
       'data received; length = ' + data.length + '; type = ' + typeof data
     );
     try {
-      this.onProtocolMessage(deserializeProtocolMessage(data, this.connectionManager.realtime._MsgPack, this.format));
+      this.onProtocolMessage(
+        deserializeProtocolMessage(
+          data,
+          this.connectionManager.realtime._MsgPack,
+          this.connectionManager.realtime._RealtimePresence,
+          this.format
+        )
+      );
     } catch (e) {
       Logger.logAction(
         Logger.LOG_ERROR,

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -1,5 +1,6 @@
 import { MsgPack } from 'common/types/msgpack';
 import { Types } from '../../../../ably';
+import { PresenceMessageModule } from '../client/modulesmap';
 import * as Utils from '../util/utils';
 import ErrorInfo from './errorinfo';
 import Message, { fromValues as messageFromValues, fromValuesArray as messagesFromValuesArray } from './message';
@@ -65,26 +66,46 @@ export const channelModes = ['PRESENCE', 'PUBLISH', 'SUBSCRIBE', 'PRESENCE_SUBSC
 
 export const serialize = Utils.encodeBody;
 
-export function deserialize(serialized: unknown, MsgPack: MsgPack | null, format?: Utils.Format): ProtocolMessage {
+export function deserialize(
+  serialized: unknown,
+  MsgPack: MsgPack | null,
+  presenceMessageModule: PresenceMessageModule | null,
+  format?: Utils.Format
+): ProtocolMessage {
   const deserialized = Utils.decodeBody<Record<string, unknown>>(serialized, MsgPack, format);
-  return fromDeserialized(deserialized);
+  return fromDeserialized(deserialized, presenceMessageModule);
 }
 
-export function fromDeserialized(deserialized: Record<string, unknown>): ProtocolMessage {
+export function fromDeserialized(
+  deserialized: Record<string, unknown>,
+  presenceMessageModule: PresenceMessageModule | null
+): ProtocolMessage {
   const error = deserialized.error;
   if (error) deserialized.error = ErrorInfo.fromValues(error as ErrorInfo);
   const messages = deserialized.messages as Message[];
   if (messages) for (let i = 0; i < messages.length; i++) messages[i] = messageFromValues(messages[i]);
-  const presence = deserialized.presence as PresenceMessage[];
-  if (presence) for (let i = 0; i < presence.length; i++) presence[i] = presenceMessageFromValues(presence[i], true);
-  return Object.assign(new ProtocolMessage(), deserialized);
+
+  const presence = presenceMessageModule ? (deserialized.presence as PresenceMessage[]) : undefined;
+  if (presenceMessageModule) {
+    if (presence && presenceMessageModule)
+      for (let i = 0; i < presence.length; i++)
+        presence[i] = presenceMessageModule.presenceMessageFromValues(presence[i], true);
+  }
+  return Object.assign(new ProtocolMessage(), { ...deserialized, presence });
+}
+
+/**
+ * Used by the tests.
+ */
+export function fromDeserializedIncludingDependencies(deserialized: Record<string, unknown>): ProtocolMessage {
+  return fromDeserialized(deserialized, { presenceMessageFromValues, presenceMessagesFromValuesArray });
 }
 
 export function fromValues(values: unknown): ProtocolMessage {
   return Object.assign(new ProtocolMessage(), values);
 }
 
-export function stringify(msg: any): string {
+export function stringify(msg: any, presenceMessageModule: PresenceMessageModule | null): string {
   let result = '[ProtocolMessage';
   if (msg.action !== undefined) result += '; action=' + ActionName[msg.action] || msg.action;
 
@@ -96,7 +117,8 @@ export function stringify(msg: any): string {
   }
 
   if (msg.messages) result += '; messages=' + toStringArray(messagesFromValuesArray(msg.messages));
-  if (msg.presence) result += '; presence=' + toStringArray(presenceMessagesFromValuesArray(msg.presence));
+  if (msg.presence && presenceMessageModule)
+    result += '; presence=' + toStringArray(presenceMessageModule.presenceMessagesFromValuesArray(msg.presence));
   if (msg.error) result += '; error=' + ErrorInfo.fromValues(msg.error).toString();
   if (msg.auth && msg.auth.accessToken) result += '; token=' + msg.auth.accessToken;
   if (msg.flags) result += '; flags=' + flagNames.filter(msg.hasFlag).join(',');
@@ -128,6 +150,7 @@ class ProtocolMessage {
   channelSerial?: string | null;
   msgSerial?: number;
   messages?: Message[];
+  // This will be undefined if we skipped decoding this property due to user not requesting presence functionality — see `fromDeserialized`
   presence?: PresenceMessage[];
   auth?: unknown;
   connectionDetails?: Record<string, unknown>;

--- a/src/platform/nativescript/index.ts
+++ b/src/platform/nativescript/index.ts
@@ -3,7 +3,7 @@ import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
-import { fromDeserialized as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
+import { fromDeserializedIncludingDependencies as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
 
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';

--- a/src/platform/nodejs/index.ts
+++ b/src/platform/nodejs/index.ts
@@ -3,7 +3,7 @@ import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
-import { fromDeserialized as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
+import { fromDeserializedIncludingDependencies as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
 
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -3,7 +3,7 @@ import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
-import { fromDeserialized as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
+import { fromDeserializedIncludingDependencies as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
 
 // Platform Specific
 import BufferUtils from '../web/lib/util/bufferutils';

--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -3,7 +3,7 @@ import { DefaultRest } from '../../common/lib/client/defaultrest';
 import { DefaultRealtime } from '../../common/lib/client/defaultrealtime';
 import Platform from '../../common/platform';
 import ErrorInfo from '../../common/lib/types/errorinfo';
-import { fromDeserialized as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
+import { fromDeserializedIncludingDependencies as protocolMessageFromDeserialized } from '../../common/lib/types/protocolmessage';
 
 // Platform Specific
 import BufferUtils from './lib/util/bufferutils';

--- a/src/platform/web/modules/realtimepresence.ts
+++ b/src/platform/web/modules/realtimepresence.ts
@@ -1,1 +1,14 @@
-export { default as RealtimePresence } from '../../../common/lib/client/realtimepresence';
+import { RealtimePresenceModule } from 'common/lib/client/modulesmap';
+import { default as realtimePresenceClass } from '../../../common/lib/client/realtimepresence';
+import {
+  fromValues as presenceMessageFromValues,
+  fromValuesArray as presenceMessagesFromValuesArray,
+} from '../../../common/lib/types/presencemessage';
+
+const RealtimePresence: RealtimePresenceModule = {
+  RealtimePresence: realtimePresenceClass,
+  presenceMessageFromValues,
+  presenceMessagesFromValuesArray,
+};
+
+export { RealtimePresence };


### PR DESCRIPTION
**Note: This PR is based on top of #1503; please review that one first.**

Now `PresenceMessage` only gets included if you provide the `RealtimePresence` module.