### PR TITLE
[SDK-3943] Add some regression testing for bundle size and included files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "cors": "^2.8.5",
         "esbuild": "^0.18.10",
         "esbuild-plugin-umd-wrapper": "^1.0.7",
+        "esbuild-runner": "^2.2.2",
         "eslint": "^7.13.0",
         "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-jsdoc": "^40.0.0",
@@ -3772,6 +3773,28 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/esbuild-plugin-umd-wrapper/-/esbuild-plugin-umd-wrapper-1.0.7.tgz",
       "integrity": "sha512-Jo1S3rczXupUzPGt4eXF643FF/J7nDkwwwHH2PS6ic1l0ye7kTS0plAJQoD9u349ybLyt4wyG9fFa/RCuI2dXw==",
+      "dev": true
+    },
+    "node_modules/esbuild-runner": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/esbuild-runner/-/esbuild-runner-2.2.2.tgz",
+      "integrity": "sha512-fRFVXcmYVmSmtYm2mL8RlUASt2TDkGh3uRcvHFOKNr/T58VrfVeKD9uT9nlgxk96u0LS0ehS/GY7Da/bXWKkhw==",
+      "dev": true,
+      "dependencies": {
+        "source-map-support": "0.5.21",
+        "tslib": "2.4.0"
+      },
+      "bin": {
+        "esr": "bin/esr.js"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/esbuild-runner/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/esbuild-sunos-64": {
@@ -13282,6 +13305,24 @@
       "resolved": "https://registry.npmjs.org/esbuild-plugin-umd-wrapper/-/esbuild-plugin-umd-wrapper-1.0.7.tgz",
       "integrity": "sha512-Jo1S3rczXupUzPGt4eXF643FF/J7nDkwwwHH2PS6ic1l0ye7kTS0plAJQoD9u349ybLyt4wyG9fFa/RCuI2dXw==",
       "dev": true
+    },
+    "esbuild-runner": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/esbuild-runner/-/esbuild-runner-2.2.2.tgz",
+      "integrity": "sha512-fRFVXcmYVmSmtYm2mL8RlUASt2TDkGh3uRcvHFOKNr/T58VrfVeKD9uT9nlgxk96u0LS0ehS/GY7Da/bXWKkhw==",
+      "dev": true,
+      "requires": {
+        "source-map-support": "0.5.21",
+        "tslib": "2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
     },
     "esbuild-sunos-64": {
       "version": "0.15.18",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "cors": "^2.8.5",
     "esbuild": "^0.18.10",
     "esbuild-plugin-umd-wrapper": "^1.0.7",
+    "esbuild-runner": "^2.2.2",
     "eslint": "^7.13.0",
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-jsdoc": "^40.0.0",
@@ -128,10 +129,10 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "prepare": "npm run build",
-    "format": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modules.d.ts webpack.config.js Gruntfile.js scripts/*.js docs/chrome-mv3.md",
-    "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modules.d.ts webpack.config.js Gruntfile.js scripts/*.js",
+    "format": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modules.d.ts webpack.config.js Gruntfile.js scripts/*.[jt]s docs/chrome-mv3.md",
+    "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modules.d.ts webpack.config.js Gruntfile.js scripts/*.[jt]s",
     "sourcemap": "source-map-explorer build/ably.min.js",
-    "modulereport": "node scripts/moduleReport.js",
+    "modulereport": "tsc --noEmit scripts/moduleReport.ts && esr scripts/moduleReport.ts",
     "docs": "typedoc --entryPoints ably.d.ts --out typedoc/generated/default --readme typedoc/landing-pages/default.md && typedoc --entryPoints modules.d.ts --out typedoc/generated/modules --name \"ably (modular version)\" --readme typedoc/landing-pages/modules.md && cp typedoc/landing-pages/choose-library.html typedoc/generated/index.html"
   }
 }

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -1,4 +1,4 @@
-const esbuild = require('esbuild');
+import * as esbuild from 'esbuild';
 
 // List of all modules accepted in ModulesMap
 const moduleNames = [
@@ -28,14 +28,14 @@ const functions = [
   { name: 'constructPresenceMessage', transitiveImports: [] },
 ];
 
-function formatBytes(bytes) {
+function formatBytes(bytes: number) {
   const kibibytes = bytes / 1024;
   const formatted = kibibytes.toFixed(2);
   return `${formatted} KiB`;
 }
 
 // Gets the bundled size in bytes of an array of named exports from 'ably/modules'
-function getImportSize(modules) {
+function getImportSize(modules: string[]) {
   const outfile = modules.join('');
   const result = esbuild.buildSync({
     stdin: {
@@ -52,7 +52,7 @@ function getImportSize(modules) {
   return result.metafile.outputs[outfile].bytes;
 }
 
-const errors = [];
+const errors: Error[] = [];
 
 ['BaseRest', 'BaseRealtime'].forEach((baseClient) => {
   const baseClientSize = getImportSize([baseClient]);

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -111,14 +111,16 @@ function printAndCheckFunctionSizes() {
   return errors;
 }
 
-const errors: Error[] = [];
+(function run() {
+  const errors: Error[] = [];
 
-errors.push(...printAndCheckModuleSizes());
-errors.push(...printAndCheckFunctionSizes());
+  errors.push(...printAndCheckModuleSizes());
+  errors.push(...printAndCheckFunctionSizes());
 
-if (errors.length > 0) {
-  for (const error of errors) {
-    console.log(error.message);
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.log(error.message);
+    }
+    process.exit(1);
   }
-  process.exit(1);
-}
+})();

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -1,4 +1,6 @@
 import * as esbuild from 'esbuild';
+import * as path from 'path';
+import { explore } from 'source-map-explorer';
 
 // List of all modules accepted in ModulesMap
 const moduleNames = [
@@ -34,8 +36,14 @@ function formatBytes(bytes: number) {
   return `${formatted} KiB`;
 }
 
-// Gets the bundled size in bytes of an array of named exports from 'ably/modules'
-function getImportSize(modules: string[]) {
+interface BundleInfo {
+  byteSize: number;
+  code: Uint8Array;
+  sourceMap: Uint8Array;
+}
+
+// Uses esbuild to create a bundle containing the named exports from 'ably/modules'
+function getBundleInfo(modules: string[]): BundleInfo {
   const outfile = modules.join('');
   const result = esbuild.buildSync({
     stdin: {
@@ -47,9 +55,36 @@ function getImportSize(modules: string[]) {
     bundle: true,
     outfile,
     write: false,
+    sourcemap: 'external',
   });
 
-  return result.metafile.outputs[outfile].bytes;
+  const pathHasBase = (component: string) => {
+    return (outputFile: esbuild.OutputFile) => {
+      return path.parse(outputFile.path).base === component;
+    };
+  };
+
+  const codeOutputFile = result.outputFiles.find(pathHasBase(outfile))!;
+  const sourceMapOutputFile = result.outputFiles.find(pathHasBase(`${outfile}.map`))!;
+
+  return {
+    byteSize: result.metafile.outputs[outfile].bytes,
+    code: codeOutputFile.contents,
+    sourceMap: sourceMapOutputFile.contents,
+  };
+}
+
+// Gets the bundled size in bytes of an array of named exports from 'ably/modules'
+function getImportSize(modules: string[]) {
+  const bundleInfo = getBundleInfo(modules);
+  return bundleInfo.byteSize;
+}
+
+async function runSourceMapExplorer(bundleInfo: BundleInfo) {
+  return explore({
+    code: Buffer.from(bundleInfo.code),
+    map: Buffer.from(bundleInfo.sourceMap),
+  });
 }
 
 function printAndCheckModuleSizes() {
@@ -111,11 +146,95 @@ function printAndCheckFunctionSizes() {
   return errors;
 }
 
-(function run() {
+// Performs a sense check that there are no unexpected files making a large contribution to the BaseRealtime bundle size.
+async function checkBaseRealtimeFiles() {
+  const baseRealtimeBundleInfo = getBundleInfo(['BaseRealtime']);
+  const exploreResult = await runSourceMapExplorer(baseRealtimeBundleInfo);
+
+  const files = exploreResult.bundles[0].files;
+  delete files['[sourceMappingURL]'];
+  delete files['[unmapped]'];
+  delete files['[EOLs]'];
+
+  const thresholdBytes = 100;
+  const filesAboveThreshold = Object.entries(files).filter((file) => file[1].size >= thresholdBytes);
+
+  // These are the files that are allowed to contribute >= `threshold` bytes to the BaseRealtime bundle.
+  //
+  // The threshold is chosen pretty arbitrarily. There are some files (e.g. presencemessage.ts) whose bulk should not be included in the BaseRealtime bundle, but which make a small contribution to the bundle (probably because we make use of one exported constant or something; I haven’t looked into it).
+  const allowedFiles = new Set([
+    'src/common/constants/HttpStatusCodes.ts',
+    'src/common/constants/TransportName.ts',
+    'src/common/constants/XHRStates.ts',
+    'src/common/lib/client/auth.ts',
+    'src/common/lib/client/baseclient.ts',
+    'src/common/lib/client/baserealtime.ts',
+    'src/common/lib/client/channelstatechange.ts',
+    'src/common/lib/client/connection.ts',
+    'src/common/lib/client/connectionstatechange.ts',
+    'src/common/lib/client/realtimechannel.ts',
+    'src/common/lib/transport/connectionerrors.ts',
+    'src/common/lib/transport/connectionmanager.ts',
+    'src/common/lib/transport/messagequeue.ts',
+    'src/common/lib/transport/protocol.ts',
+    'src/common/lib/transport/transport.ts',
+    'src/common/lib/types/errorinfo.ts',
+    'src/common/lib/types/message.ts',
+    'src/common/lib/types/protocolmessage.ts',
+    'src/common/lib/types/pushchannelsubscription.ts', // TODO why? https://github.com/ably/ably-js/issues/1506
+    'src/common/lib/util/defaults.ts',
+    'src/common/lib/util/eventemitter.ts',
+    'src/common/lib/util/logger.ts',
+    'src/common/lib/util/multicaster.ts',
+    'src/common/lib/util/utils.ts',
+    'src/platform/web/config.ts',
+    'src/platform/web/lib/http/http.ts',
+    'src/platform/web/lib/util/bufferutils.ts',
+    'src/platform/web/lib/util/defaults.ts',
+    'src/platform/web/lib/util/hmac-sha256.ts',
+    'src/platform/web/lib/util/webstorage.ts',
+    'src/platform/web/modules.ts',
+  ]);
+
+  const errors: Error[] = [];
+
+  // Check that no files other than those allowed above make a large contribution to the bundle size
+  for (const file of filesAboveThreshold) {
+    if (!allowedFiles.has(file[0])) {
+      errors.push(
+        new Error(
+          `Unexpected file ${file[0]}, contributes ${file[1].size}B to BaseRealtime, more than allowed ${thresholdBytes}B`
+        )
+      );
+    }
+  }
+
+  // Check that there are no stale entries in the allowed list
+  for (const allowedFile of Array.from(allowedFiles)) {
+    const file = files[allowedFile];
+
+    if (file) {
+      if (file.size < thresholdBytes) {
+        errors.push(
+          new Error(
+            `File ${allowedFile} contributes ${file.size}B, which is less than the expected minimum of ${thresholdBytes}B. Remove it from the \`allowedFiles\` list.`
+          )
+        );
+      }
+    } else {
+      errors.push(new Error(`File ${allowedFile} is referenced in \`allowedFiles\` but does not contribute to bundle`));
+    }
+  }
+
+  return errors;
+}
+
+(async function run() {
   const errors: Error[] = [];
 
   errors.push(...printAndCheckModuleSizes());
   errors.push(...printAndCheckFunctionSizes());
+  errors.push(...(await checkBaseRealtimeFiles()));
 
   if (errors.length > 0) {
     for (const error of errors) {


### PR DESCRIPTION
**Note: This PR is based on top of #1505; please review that one first.**

This enhances the `modulereport` script, which gets run in CI, to do the following:

- check which files make a non-trivial contribution to `BaseRealtime` bundle size (against a hardcoded allow list)
- check that the bundle size of a minimal useful Realtime client (i.e. one that can subscribe) does not exceed a hardcoded threshold

The idea being to have some safeguards against accidental regressions in bundle size.

Resolves #1497.