### PR TITLE
Add stats to list of functionality gated off by `Rest` module

### DIFF
--- a/modules.d.ts
+++ b/modules.d.ts
@@ -24,6 +24,7 @@ export declare const constructPresenceMessage: Types.PresenceMessageStatic['from
  *
  * - { @link Types.Push | push admin }
  * - { @link BaseRealtime.time | retrieving Ably service time }
+ * - { @link BaseRealtime.stats | retrieving your application’s usage statistics }
  * - { @link BaseRealtime.request | making arbitrary REST requests }
  * - { @link BaseRealtime.batchPublish | batch publishing of messages }
  * - { @link BaseRealtime.batchPresence | batch retrieval of channel presence state }

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -68,6 +68,7 @@ describe('browser/modules', function () {
         action: (client) => client.push.admin.publish({ clientId: 'foo' }, { data: { bar: 'baz' } }),
       },
       { description: 'call `time()`', action: (client) => client.time() },
+      { description: 'call `stats()`', action: (client) => client.stats() },
       { description: 'call `request(...)`', action: (client) => client.request('get', '/channels/channel', 2) },
       {
         description: 'call `batchPublish(...)`',


### PR DESCRIPTION
Missed this in 01775fd.