### PR TITLE
Correct `tsc` module settings for `test:package`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "exports": {
     ".": {
+      "types": "./ably.d.ts",
       "node": "./build/ably-node.js",
       "react-native": "./build/ably-reactnative.js",
       "default": "./build/ably.js"

--- a/test/package/browser/template/package.json
+++ b/test/package/browser/template/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "esbuild --bundle src/index-default.ts --outdir=dist && esbuild --bundle src/index-modules.ts --outdir=dist",
-    "typecheck": "tsc -noEmit",
+    "typecheck": "tsc --project src -noEmit",
     "test-support:server": "ts-node server/server.ts",
     "test": "playwright test",
     "test:install-deps": "playwright install chromium"

--- a/test/package/browser/template/src/tsconfig.json
+++ b/test/package/browser/template/src/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["**/*.ts"],
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  }
+}

--- a/test/package/browser/template/tsconfig.json
+++ b/test/package/browser/template/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  "include": ["src/**/*.ts"],
   "compilerOptions": {
-    "resolveJsonModule": true,
     "esModuleInterop": true
   }
 }


### PR DESCRIPTION
I noticed that, when I tried changing the structure of our package to put the type declarations in a subdirectory (not part of this commit), `test:package` started failing, claiming that `ably/modules` didn’t exist.

Changing the module settings per [this documentation](https://www.typescriptlang.org/docs/handbook/modules/reference.html#summary-1) fixes this, and sounds like it’s the way it should have been configured in the first place:

> Use `esnext` with `--moduleResolution bundler` for bundlers, Bun, and tsx.

(Not sure _why_ putting the types in a subdirectory triggered this…)

I noticed that making this change caused VS Code to start displaying the following error against the Ably import in `index-default.ts` (although weirdly, not causing `tsc` to fail):

> Could not find a declaration file for module 'ably'. '/Users/lawrence/code/work/ably/ably-js/test/package/browser/build/node_modules/ably/build/ably.js' implicitly has an 'any' type.
>
> There are types at '/Users/lawrence/code/work/ably/ably-js/test/package/browser/build/node_modules/ably/ably.d.ts', but this result could not be resolved when respecting package.json "exports". The 'ably' library may need to update its package.json or typings.ts (7016)

So I’ve added typings against the `"."` `package.json` export. I think I should have done this in de5ddfa.