### PR TITLE
[SDK-3990] Fix `PaginatedResult.next()` behaviour when no next page

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3460,13 +3460,13 @@ declare namespace Types {
      *
      * @param results - A function which, upon success, will be fulfilled with a page of results for message and presence history, stats, and REST presence requests. Upon failure, the function will be called with information about the error.
      */
-    next(results: paginatedResultCallback<T>): void;
+    next(results: StandardCallback<PaginatedResult<T> | null>): void;
     /**
      * Returns a new `PaginatedResult` loaded with the next page of results. If there are no further pages, then `null` is returned.
      *
      * @returns A promise which, upon success, will be fulfilled with a page of results for message and presence history, stats, and REST presence requests. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
      */
-    next(): Promise<PaginatedResult<T>>;
+    next(): Promise<PaginatedResult<T> | null>;
     /**
      * Returns the `PaginatedResult` for the current page of results.
      *

--- a/src/common/lib/client/paginatedresource.ts
+++ b/src/common/lib/client/paginatedresource.ts
@@ -209,7 +209,7 @@ export class PaginatedResult<T> {
         if ('next' in relParams) {
           self.get(relParams.next, callback);
         } else {
-          callback(null);
+          callback(null, null);
         }
       };
 

--- a/src/common/lib/client/paginatedresource.ts
+++ b/src/common/lib/client/paginatedresource.ts
@@ -1,7 +1,7 @@
 import * as Utils from '../util/utils';
 import Logger from '../util/logger';
 import Resource from './resource';
-import ErrorInfo, { IPartialErrorInfo } from '../types/errorinfo';
+import { IPartialErrorInfo } from '../types/errorinfo';
 import { PaginatedResultCallback } from '../../types/utils';
 import Rest from './rest';
 
@@ -187,7 +187,7 @@ export class PaginatedResult<T> {
     const self = this;
     if (relParams) {
       if ('first' in relParams) {
-        this.first = function (callback: (result?: ErrorInfo | null) => void) {
+        this.first = function (callback) {
           if (!callback && self.resource.rest.options.promises) {
             return Utils.promisify(self, 'first', []);
           }
@@ -195,14 +195,14 @@ export class PaginatedResult<T> {
         };
       }
       if ('current' in relParams) {
-        this.current = function (callback: (results?: ErrorInfo | null) => void) {
+        this.current = function (callback) {
           if (!callback && self.resource.rest.options.promises) {
             return Utils.promisify(self, 'current', []);
           }
           self.get(relParams.current, callback);
         };
       }
-      this.next = function (callback: (results?: ErrorInfo | null) => void) {
+      this.next = function (callback) {
         if (!callback && self.resource.rest.options.promises) {
           return Utils.promisify(self, 'next', []);
         }

--- a/test/rest/history.test.js
+++ b/test/rest/history.test.js
@@ -444,6 +444,26 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       }
     });
 
+    restTestOnJsonMsgpack('history_no_next_page', function (done, rest, channelName) {
+      const channel = rest.channels.get(channelName);
+
+      channel.history(function (err, firstPage) {
+        if (err) {
+          done(err);
+          return;
+        }
+        firstPage.next(function (err, secondPage) {
+          if (err) {
+            done(err);
+            return;
+          }
+
+          expect(secondPage).to.equal(null);
+          done();
+        });
+      });
+    });
+
     if (typeof Promise !== 'undefined') {
       it('historyPromise', function (done) {
         var rest = helper.AblyRest({ promises: true });


### PR DESCRIPTION
It's meant to return `null`, not `undefined`. See commit messages for more details.

Resolves #1542.