### PR TITLE
build: use `Ably` as UMD lib name

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,7 +119,7 @@ module.exports = function (grunt) {
         sourcemap: true,
         format: 'umd',
         banner: { js: '/*' + banner + '*/' },
-        plugins: [umdWrapper.default()],
+        plugins: [umdWrapper.default({ libraryName: 'Ably' })],
         target: 'es6',
       };
     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,7 +119,7 @@ module.exports = function (grunt) {
         sourcemap: true,
         format: 'umd',
         banner: { js: '/*' + banner + '*/' },
-        plugins: [umdWrapper.default({ libraryName: 'Ably' })],
+        plugins: [umdWrapper.default({ libraryName: 'Ably', amdNamedModule: false })],
         target: 'es6',
       };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "cli-table": "^0.3.11",
         "cors": "^2.8.5",
         "esbuild": "^0.18.10",
-        "esbuild-plugin-umd-wrapper": "^1.0.7",
+        "esbuild-plugin-umd-wrapper": "ably-forks/esbuild-plugin-umd-wrapper#1.0.7-optional-amd-named-module",
         "esbuild-runner": "^2.2.2",
         "eslint": "^7.13.0",
         "eslint-plugin-import": "^2.28.0",
@@ -5370,9 +5370,9 @@
     },
     "node_modules/esbuild-plugin-umd-wrapper": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-umd-wrapper/-/esbuild-plugin-umd-wrapper-1.0.7.tgz",
-      "integrity": "sha512-Jo1S3rczXupUzPGt4eXF643FF/J7nDkwwwHH2PS6ic1l0ye7kTS0plAJQoD9u349ybLyt4wyG9fFa/RCuI2dXw==",
-      "dev": true
+      "resolved": "git+ssh://git@github.com/ably-forks/esbuild-plugin-umd-wrapper.git#6eef42a607a9192960706d31e444a2c79a2daeb0",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild-runner": {
       "version": "2.2.2",
@@ -16350,10 +16350,9 @@
       "optional": true
     },
     "esbuild-plugin-umd-wrapper": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-umd-wrapper/-/esbuild-plugin-umd-wrapper-1.0.7.tgz",
-      "integrity": "sha512-Jo1S3rczXupUzPGt4eXF643FF/J7nDkwwwHH2PS6ic1l0ye7kTS0plAJQoD9u349ybLyt4wyG9fFa/RCuI2dXw==",
-      "dev": true
+      "version": "git+ssh://git@github.com/ably-forks/esbuild-plugin-umd-wrapper.git#6eef42a607a9192960706d31e444a2c79a2daeb0",
+      "dev": true,
+      "from": "esbuild-plugin-umd-wrapper@ably-forks/esbuild-plugin-umd-wrapper#1.0.7-optional-amd-named-module"
     },
     "esbuild-runner": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "cli-table": "^0.3.11",
     "cors": "^2.8.5",
     "esbuild": "^0.18.10",
-    "esbuild-plugin-umd-wrapper": "^1.0.7",
+    "esbuild-plugin-umd-wrapper": "ably-forks/esbuild-plugin-umd-wrapper#1.0.7-optional-amd-named-module",
     "esbuild-runner": "^2.2.2",
     "eslint": "^7.13.0",
     "eslint-plugin-import": "^2.28.0",


### PR DESCRIPTION
Fixes a regression in which, when using UMD without commonjs/amd, the esbuild UMD wrapper would add each named export of ably to the global namespace rather than adding it in an object called `Ably` (as it did in v1).