### PR TITLE
Use correct request headers in `Resource` after re-auth

### DIFF
--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -247,7 +247,7 @@ class Resource {
         function (
           err: ErrorInfo | ErrnoException | null | undefined,
           res: any,
-          headers: Record<string, string>,
+          resHeaders: Record<string, string>,
           unpacked?: boolean,
           statusCode?: number
         ) {
@@ -263,7 +263,7 @@ class Resource {
             });
             return;
           }
-          callback(err as ErrorInfo, res, headers, unpacked, statusCode);
+          callback(err as ErrorInfo, res, resHeaders, unpacked, statusCode);
         }
       );
     }


### PR DESCRIPTION
It was incorrectly using the headers from the response that triggered the re-auth, instead of the request headers provided by the user. This regression was introduced in 601ebfe.

Resolves #1566.