### PR TITLE
Document IXHRRequest’s emitted events

### DIFF
--- a/src/common/lib/transport/comettransport.ts
+++ b/src/common/lib/transport/comettransport.ts
@@ -118,7 +118,7 @@ abstract class CometTransport extends Transport {
         }
         this.onData(data);
       });
-      connectRequest.on('complete', (err: ErrorInfo) => {
+      connectRequest.on('complete', (err: ErrorInfo | null) => {
         if (!this.recvRequest) {
           /* the transport was disposed before we connected */
           err = err || new ErrorInfo('Request cancelled', 80003, 400);

--- a/src/common/types/IXHRRequest.d.ts
+++ b/src/common/types/IXHRRequest.d.ts
@@ -2,6 +2,20 @@ import EventEmitter from '../lib/util/eventemitter';
 
 /**
  * A common interface shared by the browser and NodeJS XHRRequest implementations
+ *
+ * Expected to emit the following events:
+ *
+ * - 'data': When a new chunk is received. A _chunk_ is extracted from the response data by reading until a "\n" is encountered.
+ *
+ *   Event args:
+ *
+ *   - data (string | Record<string, any>): The received chunk. This should be either a string containing a JSON-serialized object, or an object which is the result of deserializing the chunk.
+ *
+ * - 'complete': When the entire response has been received, or an error has occurred. May be preceded by one or more 'data' events.
+ *
+ *   Event args:
+ *
+ *   - err (ErrorInfo | null): Any error that occurred. Either a protocol error received from Realtime, or a network/XHR error.
  */
 export default interface IXHRRequest extends EventEmitter {
   exec(): void;

--- a/src/platform/nodejs/lib/transport/nodecomettransport.js
+++ b/src/platform/nodejs/lib/transport/nodecomettransport.js
@@ -159,7 +159,7 @@ var NodeCometTransport = function (connectionManager) {
       if (statusCode == HttpStatusCodes.NoContent) {
         /* cause the stream to flow, and thus end */
         res.resume();
-        self.complete();
+        self.complete(null);
         return;
       }
 
@@ -314,7 +314,7 @@ var NodeCometTransport = function (connectionManager) {
       req.abort();
       this.req = null;
     }
-    this.complete({ statusCode: 400, code: 80003, message: 'Cancelled' });
+    this.complete(new ErrorInfo('Cancelled', 80003, 400));
   };
 
   return NodeCometTransport;

--- a/src/platform/web/lib/transport/xhrrequest.ts
+++ b/src/platform/web/lib/transport/xhrrequest.ts
@@ -129,7 +129,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
   }
 
   complete(
-    err?: IPartialErrorInfo | null,
+    err: IPartialErrorInfo | null,
     body?: unknown,
     headers?: Record<string, string> | null,
     unpacked?: boolean | null,
@@ -317,7 +317,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
       onProgress();
       this.streamComplete = true;
       Platform.Config.nextTick(() => {
-        this.complete();
+        this.complete(null);
       });
     };
 


### PR DESCRIPTION
Needed to understand them for something I was investigating, thought it worth documenting my findings.

Also made the arg types consistent between those expected by CometTransport and those emitted by the XHR implementations.

TODO still a bit wip — need to double check the params to all of the on('complete') and on('data'), and also switch to IPartialErrorInfo