### PR TITLE
[SDK-4003] Fix `multiple_send_binary_2_200` is failing intermittently in browser on v2 branch

### DIFF
--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -33,8 +33,8 @@ var createCryptoClass = function (config: IPlatformConfig, bufferUtils: typeof B
   if (config.getRandomArrayBuffer) {
     generateRandom = config.getRandomArrayBuffer;
   } else if (typeof Uint32Array !== 'undefined' && config.getRandomValues) {
-    var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
     generateRandom = function (bytes, callback) {
+      var blockRandomArray = new Uint32Array(DEFAULT_BLOCKLENGTH_WORDS);
       var words = bytes / 4,
         nativeArray = words == DEFAULT_BLOCKLENGTH_WORDS ? blockRandomArray : new Uint32Array(words);
       config.getRandomValues!(nativeArray, function (err) {

--- a/src/platform/web/lib/util/crypto.ts
+++ b/src/platform/web/lib/util/crypto.ts
@@ -300,9 +300,6 @@ var createCryptoClass = function (config: IPlatformConfig, bufferUtils: typeof B
         return;
       }
 
-      /* Since the iv for a new block is the ciphertext of the last, this
-       * sets a new iv (= aes(randomBlock XOR lastCipherText)) as well as
-       * returning it */
       generateRandom(DEFAULT_BLOCKLENGTH, function (err, randomBlock) {
         if (err) {
           callback(err, null);

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -501,6 +501,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       _multiple_send(done, true, 20, 100);
     });
 
+    it('multiple_send_binary_10_10', function (done) {
+      _multiple_send(done, false, 10, 10);
+    });
+
+    it('multiple_send_text_10_10', function (done) {
+      _multiple_send(done, true, 10, 10);
+    });
+
     function _single_send_separate_realtimes(done, txOpts, rxOpts) {
       if (!Crypto) {
         done(new Error('Encryption not supported'));


### PR DESCRIPTION
Fixes race condition error caused by byte array being shared in memory between different operations in web crypto.
Adds new tests to cover the case like this.
See commits for more details.

Resolves #1557 