### PR TITLE
Add try/catch to `_multiple_send` to allow fast fail in case of errors

### DIFF
--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -468,7 +468,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         function recvAll(recvCb) {
           var received = 0;
           channel.subscribe('event0', function (msg) {
-            expect(msg.data == messageText).to.be.ok;
+            try {
+              expect(msg.data == messageText).to.be.ok;
+            } catch (error) {
+              recvCb(error);
+            }
             if (++received == iterations) recvCb(null);
           });
         }


### PR DESCRIPTION
This allows multiple_send_* tests to fast fail and show an actual assertion arrow, instead of waiting for a timeout and showing a timeout exceeded error.

See #1557 for an example how it behaves currently.