### PR TITLE
[SDK-4039] Make `modulereport` print gzipped size too

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@babel/parser": "^7.23.6",
         "@babel/traverse": "^7.23.7",
         "@testing-library/react": "^13.3.0",
+        "@types/cli-table": "^0.3.4",
         "@types/jmespath": "^0.15.2",
         "@types/node": "^18.0.0",
         "@types/request": "^2.48.7",
@@ -30,6 +31,7 @@
         "async": "ably-forks/async#requirejs",
         "aws-sdk": "^2.1413.0",
         "chai": "^4.2.0",
+        "cli-table": "^0.3.11",
         "cors": "^2.8.5",
         "esbuild": "^0.18.10",
         "esbuild-plugin-umd-wrapper": "^1.0.7",
@@ -1436,6 +1438,12 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/cli-table": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.4.tgz",
+      "integrity": "sha512-GsALrTL69mlwbAw/MHF1IPTadSLZQnsxe7a80G8l4inN/iEXCOcVeT/S7aRc6hbhqzL9qZ314kHPDQnQ3ev+HA==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.8",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
@@ -2796,6 +2804,27 @@
       "dev": true,
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/cli-table/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/cli-table3": {
@@ -11719,6 +11748,12 @@
         "@types/chai": "*"
       }
     },
+    "@types/cli-table": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.4.tgz",
+      "integrity": "sha512-GsALrTL69mlwbAw/MHF1IPTadSLZQnsxe7a80G8l4inN/iEXCOcVeT/S7aRc6hbhqzL9qZ314kHPDQnQ3ev+HA==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "8.44.8",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
@@ -12756,6 +12791,23 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+          "dev": true
+        }
+      }
     },
     "cli-table3": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/parser": "^7.23.6",
     "@babel/traverse": "^7.23.7",
     "@testing-library/react": "^13.3.0",
+    "@types/cli-table": "^0.3.4",
     "@types/jmespath": "^0.15.2",
     "@types/node": "^18.0.0",
     "@types/request": "^2.48.7",
@@ -62,6 +63,7 @@
     "async": "ably-forks/async#requirejs",
     "aws-sdk": "^2.1413.0",
     "chai": "^4.2.0",
+    "cli-table": "^0.3.11",
     "cors": "^2.8.5",
     "esbuild": "^0.18.10",
     "esbuild-plugin-umd-wrapper": "^1.0.7",
@@ -138,7 +140,7 @@
     "format": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modules.d.ts webpack.config.js Gruntfile.js scripts/*.[jt]s docs/chrome-mv3.md grunt",
     "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modules.d.ts webpack.config.js Gruntfile.js scripts/*.[jt]s grunt",
     "sourcemap": "source-map-explorer build/ably.min.js",
-    "modulereport": "tsc --noEmit scripts/moduleReport.ts && esr scripts/moduleReport.ts",
+    "modulereport": "tsc --noEmit --esModuleInterop scripts/moduleReport.ts && esr scripts/moduleReport.ts",
     "docs": "typedoc"
   }
 }

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -101,7 +101,7 @@ function printAndCheckModuleSizes() {
     console.log(`${baseClient}: ${formatBytes(baseClientSize)}`);
 
     // Then display the size of each export together with the base client
-    [...moduleNames, ...Object.values(functions).map((functionData) => functionData.name)].forEach((exportName) => {
+    [...moduleNames, ...functions.map((functionData) => functionData.name)].forEach((exportName) => {
       const size = getImportSize([baseClient, exportName]);
       console.log(`${baseClient} + ${exportName}: ${formatBytes(size)}`);
 


### PR DESCRIPTION
It’s quite likely that some of our users will be serving their bundles with gzip encoding, so this is useful information to have.

<details>
<summary>
Example output
</summary>

```
> ably@1.2.48 modulereport
> tsc --noEmit scripts/moduleReport.ts && esr scripts/moduleReport.ts

Minimal useful Realtime (BaseRealtime + FetchRequest + WebSocketTransport): raw: 107.68 KiB; gzip: 31.15 KiB
BaseRest: raw: 59.12 KiB; gzip: 18.52 KiB
BaseRest + Rest: raw: 59.12 KiB; gzip: 18.52 KiB
BaseRest + Crypto: raw: 62.66 KiB; gzip: 19.76 KiB
BaseRest + MsgPack: raw: 67.88 KiB; gzip: 20.62 KiB
BaseRest + RealtimePresence: raw: 86.54 KiB; gzip: 25.73 KiB
BaseRest + XHRPolling: raw: 77.17 KiB; gzip: 23.75 KiB
BaseRest + XHRStreaming: raw: 77.17 KiB; gzip: 23.75 KiB
BaseRest + WebSocketTransport: raw: 72.06 KiB; gzip: 22.08 KiB
BaseRest + XHRRequest: raw: 66.24 KiB; gzip: 20.80 KiB
BaseRest + FetchRequest: raw: 60.16 KiB; gzip: 18.96 KiB
BaseRest + MessageInteractions: raw: 60.36 KiB; gzip: 18.93 KiB
BaseRest + Vcdiff: raw: 66.55 KiB; gzip: 20.63 KiB
BaseRest + generateRandomKey: raw: 62.69 KiB; gzip: 19.77 KiB
BaseRest + getDefaultCryptoParams: raw: 62.69 KiB; gzip: 19.77 KiB
BaseRest + decodeMessage: raw: 59.46 KiB; gzip: 18.63 KiB
BaseRest + decodeEncryptedMessage: raw: 62.99 KiB; gzip: 19.85 KiB
BaseRest + decodeMessages: raw: 59.56 KiB; gzip: 18.65 KiB
BaseRest + decodeEncryptedMessages: raw: 63.10 KiB; gzip: 19.88 KiB
BaseRest + decodePresenceMessage: raw: 59.30 KiB; gzip: 18.56 KiB
BaseRest + decodePresenceMessages: raw: 59.40 KiB; gzip: 18.58 KiB
BaseRest + constructPresenceMessage: raw: 59.13 KiB; gzip: 18.53 KiB
BaseRealtime: raw: 103.10 KiB; gzip: 29.69 KiB
BaseRealtime + Rest: raw: 122.58 KiB; gzip: 34.47 KiB
BaseRealtime + Crypto: raw: 106.64 KiB; gzip: 30.93 KiB
BaseRealtime + MsgPack: raw: 111.86 KiB; gzip: 31.78 KiB
BaseRealtime + RealtimePresence: raw: 113.14 KiB; gzip: 32.19 KiB
BaseRealtime + XHRPolling: raw: 111.61 KiB; gzip: 32.36 KiB
BaseRealtime + XHRStreaming: raw: 111.61 KiB; gzip: 32.36 KiB
BaseRealtime + WebSocketTransport: raw: 106.63 KiB; gzip: 30.70 KiB
BaseRealtime + XHRRequest: raw: 106.83 KiB; gzip: 31.05 KiB
BaseRealtime + FetchRequest: raw: 104.14 KiB; gzip: 30.13 KiB
BaseRealtime + MessageInteractions: raw: 104.34 KiB; gzip: 30.08 KiB
BaseRealtime + Vcdiff: raw: 110.53 KiB; gzip: 31.79 KiB
BaseRealtime + generateRandomKey: raw: 106.67 KiB; gzip: 30.95 KiB
BaseRealtime + getDefaultCryptoParams: raw: 106.67 KiB; gzip: 30.95 KiB
BaseRealtime + decodeMessage: raw: 103.44 KiB; gzip: 29.80 KiB
BaseRealtime + decodeEncryptedMessage: raw: 106.98 KiB; gzip: 31.04 KiB
BaseRealtime + decodeMessages: raw: 103.54 KiB; gzip: 29.82 KiB
BaseRealtime + decodeEncryptedMessages: raw: 107.08 KiB; gzip: 31.06 KiB
BaseRealtime + decodePresenceMessage: raw: 104.60 KiB; gzip: 29.98 KiB
BaseRealtime + decodePresenceMessages: raw: 104.70 KiB; gzip: 30.01 KiB
BaseRealtime + constructPresenceMessage: raw: 104.43 KiB; gzip: 29.95 KiB
generateRandomKey: raw: 38.94 KiB; gzip: 13.60 KiB
generateRandomKey + Crypto: raw: 38.94 KiB; gzip: 13.59 KiB
getDefaultCryptoParams: raw: 38.94 KiB; gzip: 13.59 KiB
getDefaultCryptoParams + Crypto: raw: 38.94 KiB; gzip: 13.59 KiB
decodeMessage: raw: 38.34 KiB; gzip: 13.31 KiB
decodeEncryptedMessage: raw: 41.88 KiB; gzip: 14.56 KiB
decodeEncryptedMessage + Crypto: raw: 41.88 KiB; gzip: 14.56 KiB
decodeMessages: raw: 38.45 KiB; gzip: 13.35 KiB
decodeEncryptedMessages: raw: 41.98 KiB; gzip: 14.59 KiB
decodeEncryptedMessages + Crypto: raw: 41.98 KiB; gzip: 14.58 KiB
decodePresenceMessage: raw: 38.51 KiB; gzip: 13.42 KiB
decodePresenceMessages: raw: 38.61 KiB; gzip: 13.44 KiB
constructPresenceMessage: raw: 36.51 KiB; gzip: 12.68 KiB
```
</details>

Resolves #1580.