### PR TITLE
[SDK-4048] Document that `queryTime` auth option requires `Rest` module

### DIFF
--- a/modules.d.ts
+++ b/modules.d.ts
@@ -46,6 +46,9 @@ import {
   Push,
   RealtimeChannel,
   Connection,
+  // The ESLint warning is triggered because we only use this type in a documentation comment.
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  AuthOptions,
 } from './ably';
 
 export declare const generateRandomKey: CryptoClass['generateRandomKey'];
@@ -72,6 +75,7 @@ export declare const constructPresenceMessage: PresenceMessageStatic['fromValues
  *
  * - { @link ably!Push | push admin }
  * - { @link BaseRealtime.time | retrieving Ably service time }
+ * - { @link ably!Auth.createTokenRequest | creating a token request } using the { @link ably!AuthOptions.queryTime } option
  * - { @link BaseRealtime.stats | retrieving your application’s usage statistics }
  * - { @link BaseRealtime.request | making arbitrary REST requests }
  * - { @link BaseRealtime.batchPublish | batch publishing of messages }

--- a/test/browser/modules.test.js
+++ b/test/browser/modules.test.js
@@ -62,6 +62,14 @@ function registerAblyModulesTests(helper, registerDeltaTests) {
           action: (client) => client.push.admin.publish({ clientId: 'foo' }, { data: { bar: 'baz' } }),
         },
         { description: 'call `time()`', action: (client) => client.time() },
+        {
+          description: 'call `auth.createTokenRequest()` with `queryTime` option enabled',
+          action: (client) =>
+            client.auth.createTokenRequest(undefined, {
+              key: getTestApp().keys[0].keyStr /* if passing authOptions you have to explicitly pass the key */,
+              queryTime: true,
+            }),
+        },
         { description: 'call `stats()`', action: (client) => client.stats() },
         { description: 'call `request(...)`', action: (client) => client.request('get', '/channels/channel', 2) },
         {
@@ -151,6 +159,13 @@ function registerAblyModulesTests(helper, registerDeltaTests) {
 
           const receivedMessage = await recievedMessagePromise;
           expect(receivedMessage.data).to.eql({ foo: 'bar' });
+        });
+
+        it('allows `auth.createTokenRequest()` without `queryTime` option enabled', async () => {
+          const client = new BaseRealtime(ablyClientOptions(), { WebSocketTransport, FetchRequest });
+
+          const tokenRequest = await client.auth.createTokenRequest();
+          expect(tokenRequest).to.be.an('object');
         });
 
         for (const scenario of restScenarios) {


### PR DESCRIPTION
Because this option causes `time()` to be called internally.

Resolves #1592.