### PR TITLE
Fixes bug in Ably Provider where client does not update

### DIFF
--- a/src/platform/react-hooks/src/AblyProvider.tsx
+++ b/src/platform/react-hooks/src/AblyProvider.tsx
@@ -33,12 +33,10 @@ export const AblyProvider = ({ client, children, id = 'default' }: AblyProviderP
     throw new Error('AblyProvider: the `client` prop must take an instance of Ably.Realtime.Promise');
   }
 
-  const realtime = useMemo(() => client, [client]);
-
   let context = getContext(id);
   if (!context) {
-    context = ctxMap[id] = React.createContext(realtime);
+    context = ctxMap[id] = React.createContext(client);
   }
 
-  return <context.Provider value={realtime}>{children}</context.Provider>;
+  return <context.Provider value={client}>{children}</context.Provider>;
 };


### PR DESCRIPTION
There is a bug in AblyProvider where if the client is updated, the provider context is not updated, and so the old client lives in perpetuity.

Unfortunately, I wasn't able to test this because the repo doesn't support installing from git when using React, it appears. However, in this PR you can see what might likely fix the issue.

The bigger problem I am running into is that at a certain lifecycle in my React Native app, I do not have the token necessary to authenticate with Ably. Thus I cannot instantiate a client. However, if I don't have a client, I cannot use the AblyProvider, and errors get thrown all over the place. (I think this assumption is a critical flaw in the design of this library). If a client without a token is loaded up and given to the provider, then when I change it to a new client has a valid token, the rest of the app does not seem to see this new client and I can still see the old client continually try to connect and fail.