### PR TITLE
Make LogInfo["level"] more stricter

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -1133,7 +1133,7 @@ declare namespace Types {
     /**
      * Controls the verbosity of the logs output from the library. Valid values are: 0 (no logs), 1 (errors only), 2 (errors plus connection and channel state changes), 3 (high-level debug output), and 4 (full debug output).
      */
-    level?: number;
+    level?: 0 | 1 | 2 | 3 | 4;
 
     /**
      * Controls the log output of the library. This is a function to handle each line of log output. If you do not set this value, then `console.log` will be used.


### PR DESCRIPTION
Makes LogInfo["level"] more stricter

[TS Playground example](https://www.typescriptlang.org/play?ssl=6&ssc=8&pln=6&pc=80#code/PQKhCgAIUhlBTALoglgOwOYGdIHcAWKAxvpEQPZqIBO5ANpIvvJHeRpOQK6IAOPnAGaNmrFACNqAQ2oBPAHRQQwcOkTxqgqURYAZdgEk0g8pADeUSFdAQrdmAGFKNejiYsAbhvHksKRLJCIixs2Jw8-IiQgrQAtsFikjIKkABqUnQoACaQHhlc8Dgy8ABckAAMkAAUaKahWACUADSQAIzVGrTUOJR0ss2QAEwd1F04vHRcOBRoaPBEqJSQUmg5JCtzDFiIUupk+CsYhQMAzNWEGPgAtHTwXgxZ8OJcHNx8PAMrOQAs1YJcdAeTxe4XeiAaijsVmUlist3uAH4ypUAD5tSBo4Zos5o74AbnAsMgNiJ0EgTiotDoblEoVBkSC7kS0jk8kgABVCDgUEVolw0AsUEtEKYDqtbpB4NpSJk5kE6W9ImyDMJZNxIFlTLUolgkCIebl8vAWu40JAAAYzLD0eDyULmvAoQGQcQsKbwLKQqG2b2QAACvBkUnisSwHCuHNp7EgsUKWCkR0lsX86hy4kCTMySVZpJhULFWVu1CR1VDGDK22o6AwDUgAF4AHy5cjZAkAX0JVqioSMJnr5iJ8PgdDKAFZwG3IPHUFhBChCpB9Bhe+Q8UA)