### PR TITLE
fix: should reattach channel logic

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,12 +31,12 @@ module.exports = {
     {
       files: ["**/*.{ts,tsx}"],
       rules: {
-	"comma-dangle": ["error", "only-multiline"],
-	"@typescript-eslint/no-unused-vars": ["error"],
-
-	// TypeScript already enforces these rules better than any eslint setup can
-	"no-undef": "off",
-	"no-dupe-class-members": "off",
+        "comma-dangle": ["error", "only-multiline"],
+        "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_" }],
+        // TypeScript already enforces these rules better than any eslint setup can
+        "no-undef": "off",
+        "no-dupe-class-members": "off",
+        "no-unused-vars": "off",
       },
     },
     {

--- a/src/common/lib/client/realtime.ts
+++ b/src/common/lib/client/realtime.ts
@@ -149,7 +149,7 @@ class Channels extends EventEmitter {
     if (!channel) {
       channel = this.all[name] = new RealtimeChannel(this.realtime, name, channelOptions);
     } else if (channelOptions) {
-      if (channel._shouldReattachToSetOptions(channelOptions)) {
+      if (channel._shouldReattachToSetOptions(channelOptions, channel.channelOptions)) {
         throw new ErrorInfo(
           'Channels.get() cannot be used to set channel options that would cause the channel to reattach. Please, use RealtimeChannel.setOptions() instead.',
           40000,

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1698,6 +1698,5 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         }
       });
     });
-
   });
 });

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1684,5 +1684,20 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         });
       });
     });
+
+    it('should not throw exception then run RealtimeChannels.get() with same options', function (done) {
+      const realtime = helper.AblyRealtime();
+      const channel = realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
+      channel.attach();
+      channel.whenState('attaching', function () {
+        try {
+          realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
+          closeAndFinish(done, realtime);
+        } catch (err) {
+          closeAndFinish(done, realtime, err);
+        }
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Resolves https://github.com/ably/ably-js/issues/1609
Jira links [SDK-4075](https://ably.atlassian.net/browse/SDK-4075)

`_shouldReattachToSetOptions` used `this.params` and `this.modes` when checking channel options, but these fields are only set after the channel is attached. This created a bug when `RealtimeChannels.get()` is invoked during `attaching` state.

[SDK-4075]: https://ably.atlassian.net/browse/SDK-4075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ