### PR TITLE
[SDK-4078] fix: `usePresence` clean up functions

### DIFF
--- a/src/platform/react-hooks/src/fakes/ably.ts
+++ b/src/platform/react-hooks/src/fakes/ably.ts
@@ -216,8 +216,8 @@ export class ClientPresenceConnection {
     this.presence.enter(this.client.clientId, message);
   }
 
-  public unsubscribe(key: string) {
-    this.presence.unsubscribe(this.client.clientId, key);
+  public unsubscribe(key: string, listener?: any) {
+    this.presence.unsubscribe(this.client.clientId, key, listener);
   }
 
   private toPressenceMessage(data: any) {
@@ -373,9 +373,13 @@ export class ChannelPresence {
     this.triggerSubs('enter', data);
   }
 
-  public unsubscribe(clientId: string, key: string) {
+  public unsubscribe(clientId: string, key: string, listener?: any) {
     const subsForClient = this.subscriptionsPerClient.get(clientId);
-    subsForClient?.set(key, []);
+    if (listener) {
+      subsForClient?.set(key, subsForClient?.get(key)?.filter((l) => l !== listener) ?? []);
+    } else {
+      subsForClient?.set(key, []);
+    }
   }
 
   private triggerSubs(subType: string, data: any) {

--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -1,4 +1,4 @@
-import { Types } from 'ably';
+import { type Types } from 'ably';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { channelOptionsWithAgent, ChannelParameters } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly.js';
@@ -13,6 +13,8 @@ export interface PresenceResult<T> {
 
 export type OnPresenceMessageReceived<T> = (presenceData: PresenceMessage<T>) => void;
 export type UseStatePresenceUpdate = (presenceData: Types.PresenceMessage[]) => void;
+
+const INACTIVE_CONNECTION_STATES: Types.ConnectionState[] = ['suspended', 'closing', 'closed', 'failed'];
 
 export function usePresence<T = any>(
   channelNameOrNameAndOptions: ChannelParameters,
@@ -69,14 +71,15 @@ export function usePresence<T = any>(
   };
 
   const onUnmount = () => {
-    if (channel.state == 'attached') {
+    // if connection is in one of inactive states, leave call will produce exception
+    if (channel.state === 'attached' && !INACTIVE_CONNECTION_STATES.includes(ably.connection.state)) {
       if (!subscribeOnly) {
         channel.presence.leave();
       }
     }
-    channel.presence.unsubscribe('enter');
-    channel.presence.unsubscribe('leave');
-    channel.presence.unsubscribe('update');
+    channel.presence.unsubscribe('enter', updatePresence);
+    channel.presence.unsubscribe('leave', updatePresence);
+    channel.presence.unsubscribe('update', updatePresence);
   };
 
   const useEffectHook = () => {


### PR DESCRIPTION
Resolves https://github.com/ably/ably-js/issues/1610
Jira issue [SDK-4078](https://ably.atlassian.net/browse/SDK-4078)

* fixed `usePresence` clean up functions to remove only listeners attached inside the hook

* check connection status before running`Presence.leave`

[SDK-4078]: https://ably.atlassian.net/browse/SDK-4078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ