### PR TITLE
Typings: update v2 typings to use createRecoveryKey() instead of recoveryKey

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2386,17 +2386,13 @@ export declare interface Connection
    */
   id?: string;
   /**
-   * A unique private connection key used to recover or resume a connection, assigned by Ably. When recovering a connection explicitly, the `recoveryKey` is used in the recover client options as it contains both the key and the last message serial. This private connection key can also be used by other REST clients to publish on behalf of this client. See the [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf) for more info.
+   * A unique private connection key used to recover or resume a connection, assigned by Ably. This private connection key can also be used by other REST clients to publish on behalf of this client. See the [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf) for more info. (If you want to explicitly recover a connection in a different SDK instance, see createRecoveryKey() instead)
    */
   key?: string;
   /**
-   * The recovery key string can be used by another client to recover this connection's state in the recover client options property. See [connection state recover options](https://ably.com/docs/realtime/connection#connection-state-recover-options) for more information.
+   * createRecoveryKey method returns a string that can be used by another client to recover this connection's state in the recover client options property. See [connection state recover options](https://ably.com/docs/connect/states?lang=javascript#connection-state-recovery) for more information.
    */
-  recoveryKey: string | null;
-  /**
-   * The serial number of the last message to be received on this connection, used automatically by the library when recovering or resuming a connection. When recovering a connection explicitly, the `recoveryKey` is used in the recover client options as it contains both the key and the last message serial.
-   */
-  serial: number;
+  createRecoveryKey(): string | null;
   /**
    * The current {@link ConnectionState} of the connection.
    */

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -65,6 +65,7 @@ class Connection extends EventEmitter {
   }
 
   get recoveryKey(): string | null {
+    Logger.deprecated('Connection.recoveryKey attribute', 'Connection.createRecoveryKey() method');
     return this.createRecoveryKey();
   }
 

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -116,6 +116,18 @@ class Logger {
     }
   }
 
+  static deprecated = function (original: string, replacement: string) {
+    Logger.deprecatedWithMsg(original, "Please use '" + replacement + "' instead.");
+  };
+
+  static deprecatedWithMsg = (funcName: string, msg: string) => {
+    if (Logger.shouldLog(LogLevels.Error)) {
+      Logger.logErrorHandler(
+        "Ably: Deprecation warning - '" + funcName + "' is deprecated and will be removed from a future version. " + msg
+      );
+    }
+  };
+
   /* Where a logging operation is expensive, such as serialisation of data, use shouldLog will prevent
 	   the object being serialised if the log level will not output the message */
   static shouldLog = (level: LogLevels) => {


### PR DESCRIPTION
(leave the recoveryKey getter there just so as not to unnecessarily break the code of people who don't use typescript, doesn't cost us much)