### PR TITLE
ci: fix pkg version obtained for attw check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,5 +25,5 @@ jobs:
       - run: npx tsc --noEmit ably.d.ts build/ably-webworker.min.d.ts
       # for some reason, this doesn't work in CI using `npx attw --pack .`
       - run: npm pack
-      - run: npx attw ably-$(npm show ably version).tgz --summary
+      - run: npx attw ably-$(node -e "console.log(require('./package.json').version)").tgz --summary
       - run: npm audit --production


### PR DESCRIPTION
`npm show` just shows the version from NPM rather than the local package, and `npm pkg get version` returns a string with double quotes, so this seems to be the best way to just get the local package version