### PR TITLE
[ECO-4116] Fix `ably` import in react hooks

### DIFF
--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -1,4 +1,4 @@
-import * as Ably from '../../../../ably.js';
+import * as Ably from 'ably';
 
 export type ChannelNameAndOptions = {
   channelName: string;

--- a/src/platform/react-hooks/src/hooks/useChannel.test.tsx
+++ b/src/platform/react-hooks/src/hooks/useChannel.test.tsx
@@ -3,7 +3,7 @@ import { it, beforeEach, describe, expect, vi } from 'vitest';
 import { useChannel } from './useChannel.js';
 import { render, screen, waitFor } from '@testing-library/react';
 import { FakeAblySdk, FakeAblyChannels } from '../fakes/ably.js';
-import * as Ably from '../../../../../ably.js';
+import * as Ably from 'ably';
 import { act } from 'react-dom/test-utils';
 import { AblyProvider } from '../AblyProvider.js';
 

--- a/src/platform/react-hooks/src/hooks/useChannel.ts
+++ b/src/platform/react-hooks/src/hooks/useChannel.ts
@@ -1,4 +1,4 @@
-import * as Ably from '../../../../../ably.js';
+import * as Ably from 'ably';
 import { useEffect, useMemo, useRef } from 'react';
 import { channelOptionsWithAgent, ChannelParameters } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly.js';

--- a/src/platform/react-hooks/src/hooks/useChannelStateListener.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelStateListener.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import * as Ably from '../../../../../ably.js';
+import * as Ably from 'ably';
 import { ChannelNameAndId, ChannelNameAndOptions, channelOptionsWithAgent } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly.js';
 import { useEventListener } from './useEventListener.js';

--- a/src/platform/react-hooks/src/hooks/useConnectionStateListener.ts
+++ b/src/platform/react-hooks/src/hooks/useConnectionStateListener.ts
@@ -1,4 +1,4 @@
-import * as Ably from '../../../../../ably.js';
+import * as Ably from 'ably';
 import { useAbly } from './useAbly.js';
 import { useEventListener } from './useEventListener.js';
 

--- a/src/platform/react-hooks/src/hooks/useEventListener.ts
+++ b/src/platform/react-hooks/src/hooks/useEventListener.ts
@@ -1,4 +1,4 @@
-import * as Ably from '../../../../../ably.js';
+import * as Ably from 'ably';
 import { useEffect, useRef } from 'react';
 
 type EventListener<T> = (stateChange: T) => any;

--- a/src/platform/react-hooks/src/hooks/useStateErrors.ts
+++ b/src/platform/react-hooks/src/hooks/useStateErrors.ts
@@ -1,4 +1,4 @@
-import { ErrorInfo } from '../../../../../ably.js';
+import { ErrorInfo } from 'ably';
 import { useState } from 'react';
 import { useConnectionStateListener } from './useConnectionStateListener.js';
 import { useChannelStateListener } from './useChannelStateListener.js';


### PR DESCRIPTION
This reapplies 7af5a4b07721da42c42b46983fd89d2aa5ed3a03 which apparently got lost at some point during merge commits from `main` into `integration/v2`.

Resolves #1619