### PR TITLE
[CHA-138] paginatedresource: allow for no content

### DIFF
--- a/src/common/lib/client/paginatedresource.ts
+++ b/src/common/lib/client/paginatedresource.ts
@@ -4,6 +4,7 @@ import Resource from './resource';
 import { IPartialErrorInfo } from '../types/errorinfo';
 import { PaginatedResultCallback } from '../../types/utils';
 import Rest from './rest';
+import HttpStatusCodes from '../../constants/HttpStatusCodes';
 
 export type BodyHandler = (body: unknown, headers: Record<string, string>, unpacked?: boolean) => any;
 
@@ -151,7 +152,7 @@ class PaginatedResource {
     }
     let items, linkHeader, relParams;
     try {
-      items = this.bodyHandler(body, headers || {}, unpacked);
+      items = statusCode == HttpStatusCodes.NoContent ? [] : this.bodyHandler(body, headers || {}, unpacked);
     } catch (e) {
       /* If we got an error, the failure to parse the body is almost certainly
        * due to that, so callback with that in preference over the parse error */

--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -36,7 +36,7 @@ function unenvelope<T>(callback: ResourceCallback<T>, format: Utils.Format | nul
     }
 
     if (outerStatusCode === httpStatusCodes.NoContent) {
-      callback(err, [] as any, [] as any, true, outerStatusCode);
+      callback(err, [] as any, outerHeaders, true, outerStatusCode);
       return;
     }
 

--- a/src/common/lib/client/resource.ts
+++ b/src/common/lib/client/resource.ts
@@ -6,6 +6,7 @@ import HttpMethods from '../../constants/HttpMethods';
 import ErrorInfo, { IPartialErrorInfo, PartialErrorInfo } from '../types/errorinfo';
 import Rest from './rest';
 import { ErrnoException } from '../../types/http';
+import httpStatusCodes from '../../constants/HttpStatusCodes';
 
 function withAuthDetails(
   rest: Rest,
@@ -31,6 +32,11 @@ function unenvelope<T>(callback: ResourceCallback<T>, format: Utils.Format | nul
   return (err, body, outerHeaders, unpacked, outerStatusCode) => {
     if (err && !body) {
       callback(err);
+      return;
+    }
+
+    if (outerStatusCode === httpStatusCodes.NoContent) {
+      callback(err, [] as any, [] as any, true, outerStatusCode);
       return;
     }
 

--- a/test/rest/http.test.js
+++ b/test/rest/http.test.js
@@ -67,7 +67,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       //Intercept Http.do with test
 
       function testRequestHandler(_, __, ___, ____, _____, ______, callback) {
-        callback(null, null, null, false, 204);
+        callback(null, null, { 'X-Ably-Foo': 'headerValue' }, false, 204);
       }
 
       rest.http.do = testRequestHandler;
@@ -77,6 +77,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           expect(error).to.be.null;
           expect(response.statusCode).to.equal(204);
           expect(response.items).to.be.empty;
+          expect(response.headers).to.deep.equal({ 'X-Ably-Foo': 'headerValue' });
           done();
         } catch (err) {
           done(err);

--- a/test/rest/http.test.js
+++ b/test/rest/http.test.js
@@ -62,5 +62,26 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       done();
     });
+
+    it('Should handle no content responses', function (done) {
+      //Intercept Http.do with test
+
+      function testRequestHandler(_, __, ___, ____, _____, ______, callback) {
+        callback(null, null, null, false, 204);
+      }
+
+      rest.http.do = testRequestHandler;
+
+      rest.request('GET', '/foo', {}, null, {}, (error, response) => {
+        try {
+          expect(error).to.be.null;
+          expect(response.statusCode).to.equal(204);
+          expect(response.items).to.be.empty;
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
Handles the situation whereby an endpoint returns 204 that caused paginatedresource to throw an error. This does not check for the body actually being empty, but at least handles the situation whereby the response is obviously trying not to return one.

This does not fully address #676 in that it does not check the body itself for being empty and is not robust in this sense. However it at least respects the 204 status code - which will unblock other teams using the SDK.