### PR TITLE
[ECO-4121] Publicly document v2 platform compatibility and update CI accordingly

### DIFF
--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -17,10 +17,10 @@ jobs:
         run: >
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
-      - name: Use Node.js 14.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 20.x
       - run: npm ci
       - name: Build bundle reports
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,10 +14,10 @@ jobs:
         run: >
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
-      - name: Use Node.js 14.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 20.x
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Package Dependencies
         run: npm ci

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -23,9 +23,9 @@ jobs:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/prod-ably-sdk-cdn
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
-      - name: Use Node.js 14.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 20.x
       - run: npm ci
       - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.event.inputs.version }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
       - run: npm run format:check
       - run: npm run test:react

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -20,10 +20,10 @@ jobs:
         run: >
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: npm ci
       - name: Install Playwright browsers and dependencies
         run: npx playwright install --with-deps

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: npm ci
       - run: npm run test:package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@
 
 ## Building the library
 
-To build the library, simply run `npm run build`. Building the library currently requires NodeJS <= v16.
+To build the library, simply run `npm run build`. Building the library currently requires NodeJS >= v16.
 
 Since webpack builds are slow, commands are also available to only build the output for specific platforms (eg `npm run build:node`), see [package.json](./package.json) for the full list of available commands
 
@@ -51,11 +51,11 @@ Or run just one test file
 
 Or run just one test
 
-    npm run test:node -- --file=test/rest/status.test.js --grep=test_name_here 
+    npm run test:node -- --file=test/rest/status.test.js --grep=test_name_here
 
 Or run test skipping the build
 
-    npm run test:node:skip-build -- --file=test/rest/status.test.js --grep=test_name_here 
+    npm run test:node:skip-build -- --file=test/rest/status.test.js --grep=test_name_here
 
 ### Debugging the mocha tests locally with a debugger
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,7 +120,7 @@ module.exports = function (grunt) {
         format: 'umd',
         banner: { js: '/*' + banner + '*/' },
         plugins: [umdWrapper.default({ libraryName: 'Ably', amdNamedModule: false })],
-        target: 'es6',
+        target: 'es2017',
       };
     }
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ This library currently targets the [Ably client library features spec](https://w
 
 This SDK supports the following platforms:
 
-**Browsers:** All major desktop and mobile browsers, including (but not limited to) Chrome, Firefox, IE (only version 9 or newer), Safari on iOS and macOS, Opera, and Android browsers.
+**Browsers:** All major desktop and mobile browsers, including (but not limited to) Chrome, Firefox, Edge, Safari on iOS and macOS, Opera, and Android browsers. IE is not supported. See compatibility table below for more information on minimum supported versions for major browsers:
+
+| Browser       | Minimum supported version | Release date  |
+| ------------- |:-------------------------:| -------------:|
+| Chrome        | 58                        | Apr 19, 2017  |
+| Firefox       | 52                        | Mar 7, 2017   |
+| Edge          | 79                        | Dec 15, 2020  |
+| Safari        | 11                        | Sep 19, 2017  |
+| Opera         | 45                        | May 10, 2017  |
 
 **Webpack:** see [using Webpack in browsers](#using-webpack), or [our guide for serverside Webpack](#serverside-usage-with-webpack)
 
-**Node.js:** version 8.17 or newer. (1.1.x versions work on Node.js 4.5 or newer). We do not currently provide an ESM bundle, please [contact us](https://www.ably.com/contact) if you would would like to use ably-js in a NodeJS ESM project.
+**Node.js:** version 16.x or newer. (1.1.x versions work on Node.js 4.5 or newer, 1.2.x versions work on Node.js 8.17 or newer). We do not currently provide an ESM bundle, please [contact us](https://www.ably.com/contact) if you would would like to use ably-js in a NodeJS ESM project.
 
 **React (release candidate):** We offer a set of React Hooks which make it seamless to use ably-js in your React application. See the [React Hooks documentation](./docs/react.md) for more details.
 
@@ -30,7 +38,9 @@ This SDK supports the following platforms:
 
 **WebWorkers:** The browser bundle supports running in a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) context. You can also use the [modular variant](#modular-tree-shakable-variant) of the library in Web Workers.
 
-We regression-test the library against a selection of those (which will change over time, but usually consists of the versions that are supported upstream, plus old versions of IE).
+We test the library against a selection of browsers using their latest versions. Please refer to [the test-browser GitHub workflow](./.github/workflows/test-browser.yml) for the set of browsers that currently undergo CI testing.
+
+We regression-test the library against a selection of Node.js version, which will change over time. We will always support and test against current LTS Node.js versions, and optionally some older versions that are supported upstream. We reserve the right to drop support for non-LTS versions in a non-major release. We will update the `engines` field in [package.json](./package.json) whenever we change the Node.js versions supported by the project. Please refer to [the test-node GitHub workflow](./.github/workflows/test-node.yml) for the set of versions that currently undergo CI testing.
 
 However, we aim to be compatible with a much wider set of platforms and browsers than we can possibly test on. That means we'll happily support (and investigate reported problems with) any reasonably-widely-used browser. So if you find any compatibility issues, please do [raise an issue](https://github.com/ably/ably-js/issues) in this repository or [contact Ably customer support](https://support.ably.com) for advice.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": ">=5.10.x"
+        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "engines": {
-    "node": ">=5.10.x"
+    "node": ">=16"
   },
   "repository": "ably/ably-js",
   "jspm": {

--- a/src/platform/react-hooks/tsconfig.json
+++ b/src/platform/react-hooks/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["./src/**/*.ts", "./ably.d.ts"],
   "exclude": ["./src/**/*.test.tsx", "./src/fakes/**/*.ts"],
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2017",
     "rootDir": "./src",
     "sourceMap": true,
     "strict": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "module": "commonjs",
-    "lib": ["ES5", "DOM", "DOM.Iterable", "webworker"],
+    "lib": ["ES2017", "DOM", "DOM.Iterable", "webworker"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ const baseConfig = {
       { test: /\.ts$/, loader: 'ts-loader' },
     ],
   },
-  target: ['web', 'es5'],
+  target: ['web', 'es2017'],
   externals: {
     request: false,
     ws: false,
@@ -54,7 +54,7 @@ const nodeConfig = {
     ...baseConfig.output,
     filename: 'ably-node.js',
   },
-  target: ['node', 'es5'],
+  target: ['node', 'es2017'],
   externals: {
     got: true,
     ws: true,


### PR DESCRIPTION
Resolves #1605 

Changes:
- Use Node.js 20 in github workflows
- Run CI tests for node on Node.js 16, 18, 20
- Update engines in package.json to node >=16
- Update platform compatibility statements in README and CONTRIBUTING
- Change build/bundle ES target to ES2017