### PR TITLE
consumergroup: replace consistent hash package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ ably-js.iml
 node_modules
 npm-debug.log
 .tool-versions
+*.swp
+*.swo
 build/
 react/
 typedoc/generated/

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -1426,6 +1426,13 @@ export interface TokenRevocationFailureResult {
  */
 export type messageCallback<T> = (message: T) => void;
 /**
+ * A callback which returns a channel and message argument, used for {@link ChannelGroup} subscriptions.
+ *
+ * @param channel - The channel name on which the message was received.
+ * @param message - The message which triggered the callback.
+ */
+export type channelAndMessageCallback<T> = (channel: string, message: T) => void;
+/**
  * The callback used for the events emitted by {@link RealtimeChannel}.
  *
  * @param changeStateChange - The state change that occurred.
@@ -1958,6 +1965,18 @@ export declare interface Channel {
 }
 
 /**
+ * Enables messages to be subscribed to on a group of channels.
+ */
+export declare interface ChannelGroup {
+  /**
+   * Registers a listener for messages on this channel group. The caller supplies a listener function, which is called each time one or more messages arrives on the channels in the group.
+   *
+   * @param callback - An event listener function.
+   */
+  subscribe(callback: channelAndMessageCallback<InboundMessage>): void;
+}
+
+/**
  * Enables messages to be published and subscribed to. Also enables historic messages to be retrieved and provides access to the {@link RealtimePresence} object of a channel.
  */
 export declare interface RealtimeChannel extends EventEmitter<channelEventCallback, ChannelStateChange, ChannelEvent> {
@@ -2187,6 +2206,20 @@ export declare interface Channels<T> {
    * @param name - The channel name.
    */
   release(name: string): void;
+}
+
+/**
+ * Creates and destroys {@link ChannelGroup} objects.
+ */
+export declare interface ChannelGroups {
+  /**
+   * Creates a new {@link ChannelGroup} object, with the specified {@link ChannelGroupOptions}, or returns the existing channel group object.
+   *
+   * @param filter - A regular expression defining the channel group. Only wildcards are supported.
+   * @param options - A {@link ChannelGroupOptions} object.
+   * @returns A {@link ChannelGroup} object.
+   */
+  get(filter: string, options?: ChannelGroupOptions): Promise<ChannelGroup>;
 }
 
 /**
@@ -2728,6 +2761,7 @@ export declare class Realtime implements RealtimeClient {
   connect(): void;
   auth: Auth;
   channels: Channels<RealtimeChannel>;
+  channelGroups: ChannelGroups;
   connection: Connection;
   request<T = any>(
     method: string,

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -327,6 +327,14 @@ export interface ChannelStatus {
   occupancy: ChannelOccupancy;
 }
 
+  interface ConsumerGroupOptions {
+    name: string;
+  }
+
+  interface ChannelGroupOptions {
+    consumerGroup?: ConsumerGroupOptions;
+  }
+
 /**
  * Contains the metrics of a {@link Channel} or {@link RealtimeChannel} object.
  */

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -327,14 +327,6 @@ export interface ChannelStatus {
   occupancy: ChannelOccupancy;
 }
 
-  interface ConsumerGroupOptions {
-    name: string;
-  }
-
-  interface ChannelGroupOptions {
-    consumerGroup?: ConsumerGroupOptions;
-  }
-
 /**
  * Contains the metrics of a {@link Channel} or {@link RealtimeChannel} object.
  */
@@ -850,6 +842,20 @@ export interface ChannelOptions {
    * An array of {@link ChannelMode} objects.
    */
   modes?: ChannelMode[];
+}
+
+/**
+ * Describes the consumer group. Consumers in the same group will partition the channels of that group.
+ */
+interface ConsumerGroupOptions {
+  name: string;
+}
+
+/**
+ * Allows specifying properties of a {@link ChannelGroup}
+ */
+interface ChannelGroupOptions {
+  consumerGroup?: ConsumerGroupOptions;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",
+        "@types/hashring": "^3.2.5",
         "got": "^11.8.5",
+        "hashring": "^3.2.0",
         "ws": "^8.14.2"
       },
       "devDependencies": {
@@ -2838,6 +2840,14 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "node_modules/@types/hashring": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/hashring/-/hashring-3.2.5.tgz",
+      "integrity": "sha512-Y80Bt3Y9Z6erq9bGvwbxLD8z0XGLxK41XXeAJtaX4BbVUvStqhfGjKtXNVNISfBVxE/hndVw6aQ3EdOIVcwIFg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -4407,7 +4417,39 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/connection-parse": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+      "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
+    },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "node_modules/content-disposition": {
@@ -7300,6 +7342,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
+      "dependencies": {
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
       }
     },
     "node_modules/he": {
@@ -10582,6 +10633,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "node_modules/simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
     },
     "node_modules/skin-tone": {
       "version": "2.0.0",
@@ -14491,6 +14553,14 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "@types/hashring": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/hashring/-/hashring-3.2.5.tgz",
+      "integrity": "sha512-Y80Bt3Y9Z6erq9bGvwbxLD8z0XGLxK41XXeAJtaX4BbVUvStqhfGjKtXNVNISfBVxE/hndVw6aQ3EdOIVcwIFg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -15683,7 +15753,36 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "connection-parse": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+      "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
+    },
+    "console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "content-disposition": {
@@ -17806,6 +17905,15 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
+      }
+    },
+    "hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
+      "requires": {
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
       }
     },
     "he": {
@@ -20204,6 +20312,17 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "simple-lru-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
     },
     "skin-tone": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4420,37 +4420,10 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/connection-parse": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
       "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
-    },
-    "node_modules/console-browserify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
-      "dev": true
-    },
-    "node_modules/constants-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -7332,6 +7305,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashring": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
+      "dependencies": {
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -7342,15 +7324,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hashring": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
-      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
-      "dependencies": {
-        "connection-parse": "0.0.x",
-        "simple-lru-cache": "0.0.x"
       }
     },
     "node_modules/he": {
@@ -10633,12 +10606,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
     },
     "node_modules/simple-lru-cache": {
       "version": "0.0.2",
@@ -15756,34 +15723,10 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "connection-parse": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
       "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
-    },
-    "console-browserify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
-      "dev": true
-    },
-    "constants-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -17898,15 +17841,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.2"
-      }
-    },
     "hashring": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
@@ -17914,6 +17848,15 @@
       "requires": {
         "connection-parse": "0.0.x",
         "simple-lru-cache": "0.0.x"
+      }
+    },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "he": {
@@ -20312,12 +20255,6 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
-    },
-    "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
     },
     "simple-lru-cache": {
       "version": "0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",
         "@types/hashring": "^3.2.5",
+        "consistent-hash": "^1.2.2",
         "got": "^11.8.5",
-        "hashring": "^3.2.0",
         "ws": "^8.14.2"
       },
       "devDependencies": {
@@ -4420,10 +4420,10 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "node_modules/connection-parse": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
-      "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
+    "node_modules/consistent-hash": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/consistent-hash/-/consistent-hash-1.2.2.tgz",
+      "integrity": "sha512-xKAVji9aC80uN/h5u4XXwJ8otOh/D/cm8aryKa7+I0qwoBwxYOYkTiyvgwjUBRn+7CRVEvn/DvJtX1YsEugr0w=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -7303,15 +7303,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hashring": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
-      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
-      "dependencies": {
-        "connection-parse": "0.0.x",
-        "simple-lru-cache": "0.0.x"
       }
     },
     "node_modules/hasown": {
@@ -10606,11 +10597,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/simple-lru-cache": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
-      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
     },
     "node_modules/skin-tone": {
       "version": "2.0.0",
@@ -15723,10 +15709,10 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "connection-parse": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
-      "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
+    "consistent-hash": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/consistent-hash/-/consistent-hash-1.2.2.tgz",
+      "integrity": "sha512-xKAVji9aC80uN/h5u4XXwJ8otOh/D/cm8aryKa7+I0qwoBwxYOYkTiyvgwjUBRn+7CRVEvn/DvJtX1YsEugr0w=="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -17839,15 +17825,6 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
-      }
-    },
-    "hashring": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
-      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
-      "requires": {
-        "connection-parse": "0.0.x",
-        "simple-lru-cache": "0.0.x"
       }
     },
     "hasown": {
@@ -20255,11 +20232,6 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
-    },
-    "simple-lru-cache": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
-      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
     },
     "skin-tone": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "dependencies": {
     "@ably/msgpack-js": "^0.4.0",
     "@types/hashring": "^3.2.5",
+    "consistent-hash": "^1.2.2",
     "got": "^11.8.5",
-    "hashring": "^3.2.0",
     "ws": "^8.14.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   ],
   "dependencies": {
     "@ably/msgpack-js": "^0.4.0",
+    "@types/hashring": "^3.2.5",
     "got": "^11.8.5",
+    "hashring": "^3.2.0",
     "ws": "^8.14.2"
   },
   "peerDependencies": {

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -60,7 +60,7 @@ class BaseRealtime extends BaseClient {
   }
 
   get channelGroups() {
-    return this._channelGroups
+    return this._channelGroups;
   }
 
   connect(): void {

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -24,6 +24,7 @@ class BaseRealtime extends BaseClient {
   readonly _additionalTransportImplementations: TransportImplementations;
   _channels: any;
   connection: Connection;
+  readonly _channelGroups;
 
   constructor(options: ClientOptions, modules: ModulesMap) {
     super(options, modules);
@@ -33,6 +34,7 @@ class BaseRealtime extends BaseClient {
     this._decodeVcdiff = (modules.Vcdiff ?? (Platform.Vcdiff.supported && Platform.Vcdiff.bundledDecode)) || null;
     this.connection = new Connection(this, this.options);
     this._channels = new Channels(this);
+    this._channelGroups = new ChannelGroups(this.channels);
     if (options.autoConnect !== false) this.connect();
   }
 
@@ -56,6 +58,10 @@ class BaseRealtime extends BaseClient {
     return this._channels;
   }
 
+  get channelGroups() {
+    return this._channelGroups
+  }
+
   connect(): void {
     Logger.logAction(Logger.LOG_MINOR, 'Realtime.connect()', '');
     this.connection.connect();
@@ -64,6 +70,88 @@ class BaseRealtime extends BaseClient {
   close(): void {
     Logger.logAction(Logger.LOG_MINOR, 'Realtime.close()', '');
     this.connection.close();
+  }
+}
+
+class ChannelGroups {
+  groups: Record<string, ChannelGroup> = {};
+
+  constructor(readonly channels: Channels) {}
+
+  get(filter: string): ChannelGroup {
+    let group = this.groups[filter];
+
+    if (group) {
+      return group;
+    }
+
+    return (this.groups[filter] = new ChannelGroup(this.channels, filter));
+  }
+}
+
+class ChannelGroup {
+  currentChannels: string[];
+  active: RealtimeChannel;
+  subsciptions: EventEmitter;
+  subscribedChannels: Record<string, RealtimeChannel> = {};
+  expression: RegExp;
+
+  constructor(readonly channels: Channels, filter: string) {
+    this.currentChannels = [];
+    this.subsciptions = new EventEmitter();
+    this.active = channels.get('active', { params: { rewind: '1' } });
+    this.active.subscribe((msg: any) => this.updateActiveChannels(msg.data));
+    this.expression = new RegExp(filter);
+  }
+
+  private updateActiveChannels(data: any) {
+    const activeChannels = data as { active: string[] };
+    Logger.logAction(Logger.LOG_DEBUG, 'ChannelGroups.setActiveChannels', 'received active channels ' + data);
+
+    const matched = activeChannels.active.filter((x) => this.expression.test(x));
+
+    const { add, remove } = this.diffSets(this.currentChannels, matched);
+    this.currentChannels = matched;
+
+    Logger.logAction(Logger.LOG_DEBUG, 'ChannelGroups.setActiveChannels', 'computed channel diffs ' + { add, remove });
+
+    this.removeSubscriptions(remove);
+    this.addSubscrptions(add);
+  }
+
+  private diffSets(current: string[], updated: string[]): { add: string[]; remove: string[] } {
+    const remove = current.filter((x) => !updated.includes(x));
+    const add = updated.filter((x) => !current.includes(x));
+
+    return { add, remove };
+  }
+
+  private addSubscrptions(channels: string[]) {
+    channels.forEach((channel) => {
+      if (this.subscribedChannels[channel]) {
+        return;
+      }
+
+      this.subscribedChannels[channel] = this.channels.get(channel, { params: { rewind: '5s' } });
+      this.subscribedChannels[channel].subscribe((msg: any) => {
+        this.subsciptions.emit('message', channel, msg);
+      });
+    });
+  }
+
+  private removeSubscriptions(channels: string[]) {
+    channels.forEach((channel) => {
+      if (!this.subscribedChannels[channel]) {
+        return;
+      }
+
+      this.subscribedChannels[channel].unsubscribe();
+      delete this.subscribedChannels[channel];
+    });
+  }
+
+  subscribe(cb: (channel: string, msg: any) => void) {
+    this.subsciptions.on('message', cb);
   }
 }
 

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -25,7 +25,7 @@ class BaseRealtime extends BaseClient {
   readonly _additionalTransportImplementations: TransportImplementations;
   _channels: Channels;
   connection: Connection;
-  readonly _channelGroups;
+  readonly _channelGroups: ChannelGroups | null;
 
   constructor(options: ClientOptions, modules: ModulesMap) {
     super(options, modules);
@@ -35,7 +35,7 @@ class BaseRealtime extends BaseClient {
     this._decodeVcdiff = (modules.Vcdiff ?? (Platform.Vcdiff.supported && Platform.Vcdiff.bundledDecode)) || null;
     this.connection = new Connection(this, this.options);
     this._channels = new Channels(this);
-    this._channelGroups = new ChannelGroups(this.channels);
+    this._channelGroups = modules.ChannelGroups ? new modules.ChannelGroups(this._channels) : null;
     if (options.autoConnect !== false) this.connect();
   }
 
@@ -88,7 +88,6 @@ class ChannelGroups {
 
     group = this.groups[filter] = new ChannelGroup(this.channels, filter, options);
     await group.join();
-
 
     return group;
   }
@@ -381,4 +380,4 @@ class Channels extends EventEmitter {
 }
 
 export default BaseRealtime;
-export type RealtimeChannelGroups = typeof ChannelGroups;
+export { ChannelGroups };

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -13,7 +13,7 @@ import { ModulesMap, RealtimePresenceModule } from './modulesmap';
 import { TransportNames } from 'common/constants/TransportName';
 import Platform, { TransportImplementations } from 'common/platform';
 import { VcdiffDecoder } from '../types/message';
-import HashRing from 'hashring';
+import ConsistentHash from 'consistent-hash';
 
 /**
  `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
@@ -96,7 +96,7 @@ class ChannelGroups {
 class ConsumerGroup extends EventEmitter {
   private channel?: RealtimeChannel;
   private currentMembers: string[] = [];
-  private hashring?: HashRing;
+  private hashring?: ConsistentHash;
   private myClientId?: string;
 
   constructor(readonly channels: Channels, readonly consumerGroupName?: string) {
@@ -113,7 +113,8 @@ class ConsumerGroup extends EventEmitter {
 
     this.channel = this.channels.get(this.consumerGroupName, { params: { rewind: '1' } });
     this.myClientId = this.channels.realtime.options.clientId!;
-    this.hashring = new HashRing(this.myClientId!);
+    this.hashring = new ConsistentHash();
+    this.hashring.add(this.myClientId);
 
     try {
       await this.channel.presence.enter(null);

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -13,6 +13,7 @@ import { ModulesMap, RealtimePresenceModule } from './modulesmap';
 import { TransportNames } from 'common/constants/TransportName';
 import Platform, { TransportImplementations } from 'common/platform';
 import { VcdiffDecoder } from '../types/message';
+import HashRing from 'hashring';
 
 /**
  `BaseRealtime` is an export of the tree-shakable version of the SDK, and acts as the base class for the `DefaultRealtime` class exported by the non tree-shakable version.
@@ -78,14 +79,96 @@ class ChannelGroups {
 
   constructor(readonly channels: Channels) {}
 
-  get(filter: string): ChannelGroup {
+  async get(filter: string, options?: API.Types.ChannelGroupOptions): Promise<ChannelGroup> {
     let group = this.groups[filter];
 
     if (group) {
       return group;
     }
 
-    return (this.groups[filter] = new ChannelGroup(this.channels, filter));
+    group = this.groups[filter] = new ChannelGroup(this.channels, filter, options);
+    await group.join();
+
+    return group;
+  }
+}
+
+class ConsumerGroup extends EventEmitter {
+  private channel?: RealtimeChannel;
+  private currentMembers: string[] = [];
+  private hashring?: HashRing;
+  private myClientId?: string;
+
+  constructor(readonly channels: Channels, readonly consumerGroupName?: string) {
+    super();
+  }
+
+  async join() {
+    if (!this.consumerGroupName) {
+      // If no name is specified, then don't enforce the consumer group
+      // this is the equivalent of a no-op group where every channel
+      // is considered to be assigned to this client.
+      return;
+    }
+
+    this.channel = this.channels.get(this.consumerGroupName, { params: { rewind: '1' } });
+    this.myClientId = this.channels.realtime.options.clientId!;
+    this.hashring = new HashRing(this.myClientId!);
+
+    await this.channel.presence.enter(null, (err) => {
+      if (err) {
+        Logger.logAction(
+          Logger.LOG_ERROR,
+          'ConsumerGroup.join()',
+          'failed to enter presence set on consumer group channel:' + err
+        );
+      }
+    });
+
+    this.channel!.presence!.subscribe(() => {
+      this.computeMembership();
+    });
+  }
+
+  computeMembership() {
+    this.channel!.presence.get({ waitForSync: true }, (err, result) => {
+      if (err) {
+        Logger.logAction(
+          Logger.LOG_ERROR,
+          'ConsumerGroup.computeMembership()',
+          'failed to get presence set on consumer group channel:' + err
+        );
+        return;
+      }
+
+      const memberIds = result?.filter((member) => member.clientId).map((member) => member.clientId!) || [];
+      const { add, remove } = diffSets(this.currentMembers, memberIds);
+
+      Logger.logAction(
+        Logger.LOG_DEBUG,
+        'ConsumerGroup.computeMembership()',
+        'computed member diffs ' + { add, remove }
+      );
+
+      add.forEach((member) => {
+        this.hashring!.add(member);
+      });
+
+      remove.forEach((member) => {
+        this.hashring!.remove(member);
+      });
+
+      this.emit('membership');
+    });
+  }
+
+  assigned(channel: string): boolean {
+    if (!this.consumerGroupName) {
+      // Consumer group is not enabled, every channel
+      // is considered assigned to this client
+      return true;
+    }
+    return this.myClientId === this.hashring!.get(channel);
   }
 }
 
@@ -95,35 +178,34 @@ class ChannelGroup {
   subsciptions: EventEmitter;
   subscribedChannels: Record<string, RealtimeChannel> = {};
   expression: RegExp;
+  consumerGroup: ConsumerGroup;
 
-  constructor(readonly channels: Channels, filter: string) {
+  constructor(readonly channels: Channels, filter: string, options?: API.Types.ChannelGroupOptions) {
     this.currentChannels = [];
     this.subsciptions = new EventEmitter();
     this.active = channels.get('active', { params: { rewind: '1' } });
-    this.active.subscribe((msg: any) => this.updateActiveChannels(msg.data));
+    this.consumerGroup = new ConsumerGroup(channels, options?.consumerGroup?.name);
+    this.consumerGroup.on('membership', () => this.updateActiveChannels(this.currentChannels));
     this.expression = new RegExp(filter);
   }
 
-  private updateActiveChannels(data: any) {
-    const activeChannels = data as { active: string[] };
-    Logger.logAction(Logger.LOG_DEBUG, 'ChannelGroups.setActiveChannels', 'received active channels ' + data);
+  async join() {
+    await this.consumerGroup.join();
+    this.active.subscribe((msg: any) => this.updateActiveChannels(msg.data.active));
+  }
 
-    const matched = activeChannels.active.filter((x) => this.expression.test(x));
+  private updateActiveChannels(activeChannels: string[]) {
+    Logger.logAction(Logger.LOG_DEBUG, 'ChannelGroups.setActiveChannels', 'received active channels ' + activeChannels);
 
-    const { add, remove } = this.diffSets(this.currentChannels, matched);
+    const matched = activeChannels.filter((x) => this.expression.test(x)).filter((x) => this.consumerGroup.assigned(x));
+
+    const { add, remove } = diffSets(this.currentChannels, matched);
     this.currentChannels = matched;
 
     Logger.logAction(Logger.LOG_DEBUG, 'ChannelGroups.setActiveChannels', 'computed channel diffs ' + { add, remove });
 
     this.removeSubscriptions(remove);
     this.addSubscrptions(add);
-  }
-
-  private diffSets(current: string[], updated: string[]): { add: string[]; remove: string[] } {
-    const remove = current.filter((x) => !updated.includes(x));
-    const add = updated.filter((x) => !current.includes(x));
-
-    return { add, remove };
   }
 
   private addSubscrptions(channels: string[]) {
@@ -153,6 +235,13 @@ class ChannelGroup {
   subscribe(cb: (channel: string, msg: any) => void) {
     this.subsciptions.on('message', cb);
   }
+}
+
+function diffSets(current: string[], updated: string[]): { add: string[]; remove: string[] } {
+  const remove = current.filter((x) => !updated.includes(x));
+  const add = updated.filter((x) => !current.includes(x));
+
+  return { add, remove };
 }
 
 class Channels extends EventEmitter {

--- a/src/common/lib/client/defaultrealtime.ts
+++ b/src/common/lib/client/defaultrealtime.ts
@@ -1,4 +1,4 @@
-import BaseRealtime from './baserealtime';
+import BaseRealtime, { ChannelGroups } from './baserealtime';
 import ClientOptions from '../../types/ClientOptions';
 import { allCommonModules } from './modulesmap';
 import * as Utils from '../util/utils';
@@ -38,6 +38,7 @@ export class DefaultRealtime extends BaseRealtime {
       },
       WebSocketTransport: initialiseWebSocketTransport,
       MessageInteractions: FilteredSubscriptions,
+      ChannelGroups: ChannelGroups,
     });
   }
 

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -11,6 +11,7 @@ import {
   fromValuesArray as presenceMessagesFromValuesArray,
 } from '../types/presencemessage';
 import { VcdiffDecoder } from '../types/message';
+  import {RealtimeChannelGroups} from './baserealtime';
 
 export interface PresenceMessageModule {
   presenceMessageFromValues: typeof presenceMessageFromValues;
@@ -33,6 +34,7 @@ export interface ModulesMap {
   FetchRequest?: typeof fetchRequest;
   MessageInteractions?: typeof FilteredSubscriptions;
   Vcdiff?: VcdiffDecoder;
+  ChannelGroups?: RealtimeChannelGroups
 }
 
 export const allCommonModules: ModulesMap = { Rest };

--- a/src/common/lib/client/modulesmap.ts
+++ b/src/common/lib/client/modulesmap.ts
@@ -11,7 +11,7 @@ import {
   fromValuesArray as presenceMessagesFromValuesArray,
 } from '../types/presencemessage';
 import { VcdiffDecoder } from '../types/message';
-  import {RealtimeChannelGroups} from './baserealtime';
+import { ChannelGroups } from './baserealtime';
 
 export interface PresenceMessageModule {
   presenceMessageFromValues: typeof presenceMessageFromValues;
@@ -34,7 +34,7 @@ export interface ModulesMap {
   FetchRequest?: typeof fetchRequest;
   MessageInteractions?: typeof FilteredSubscriptions;
   Vcdiff?: VcdiffDecoder;
-  ChannelGroups?: RealtimeChannelGroups
+  ChannelGroups?: typeof ChannelGroups;
 }
 
 export const allCommonModules: ModulesMap = { Rest };

--- a/src/common/types/consistent-hash.d.ts
+++ b/src/common/types/consistent-hash.d.ts
@@ -1,0 +1,23 @@
+declare module 'consistent-hash' {
+  interface ConsistentHashOptions {
+    range?: number;
+    weight?: number;
+    distribution?: 'uniform';
+    orderNodes?: (nodes: any[]) => any[];
+  }
+
+  class ConsistentHash {
+    constructor(options?: ConsistentHashOptions);
+
+    nodeCount: number;
+    keyCount: number;
+
+    add(node: string, weight?: number, points?: number[]): ConsistentHash;
+    remove(node: string): ConsistentHash;
+    get(name: string | number, count?: number): string;
+    getNodes(): string[];
+    getPoints(node: any): number[] | undefined;
+  }
+
+  export = ConsistentHash;
+}

--- a/test/realtime/channelgroup.test.js
+++ b/test/realtime/channelgroup.test.js
@@ -1,0 +1,182 @@
+'use strict';
+
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+  var expect = chai.expect;
+  var displayError = helper.displayError;
+  var utils = helper.Utils;
+  let config = Ably.Realtime.Platform.Config;
+  var closeAndFinish = helper.closeAndFinish;
+  var createPM = Ably.Realtime.ProtocolMessage.fromDeserialized;
+  var monitorConnection = helper.monitorConnection;
+
+  describe('realtime/channelgroup', function () {
+    this.timeout(60 * 1000);
+    before(function (done) {
+      helper.setupApp(function (err) {
+        if (err) {
+          done(err);
+        }
+        done();
+      });
+    });
+
+    it('subscribes to active', function (done) {
+      try {
+        /* set up realtime */
+        var realtime = helper.AblyRealtime();
+
+        /* connect and attach */
+        realtime.connection.on('connected', function () {
+          const channelGroup = realtime.channelGroups.get('.*');
+
+          var testMsg = { active: ['channel1', 'channel2', 'channel3'] };
+          var activeChannel = realtime.channels.get('active');
+          var dataChannel1 = realtime.channels.get('channel1');
+          var dataChannel2 = realtime.channels.get('channel2');
+
+          activeChannel.attach(function (err) {
+            if (err) {
+              closeAndFinish(done, realtime, err);
+              return;
+            }
+
+            var events = 1;
+
+            /* subscribe to channel group */
+            channelGroup.subscribe((channel, msg) => {
+              try {
+                expect(msg.data).to.equal('test data ' + events, 'Unexpected msg text received');
+                expect(channel).to.equal('channel' + events, 'Unexpected channel name');
+              } catch (err) {
+                closeAndFinish(done, realtime, err);
+                return;
+              }
+
+              if (events == 1) {
+                dataChannel2.publish('event0', 'test data 2');
+                events++;
+                return;
+              }
+
+              closeAndFinish(done, realtime);
+            });
+
+            /* publish active channels */
+            activeChannel.publish('event0', testMsg);
+            dataChannel1.publish('event0', 'test data 1');
+          });
+        });
+        monitorConnection(done, realtime);
+      } catch (err) {
+        closeAndFinish(done, realtime, err);
+      }
+    });
+
+    it('ignores channels not matched on filter', function (done) {
+      try {
+        /* set up realtime */
+        var realtime = helper.AblyRealtime();
+
+        /* connect and attach */
+        realtime.connection.on('connected', function () {
+          const channelGroup = realtime.channelGroups.get('include:.*');
+
+          var testMsg = { active: ['include:channel1', 'stream3'] };
+          var activeChannel = realtime.channels.get('active');
+          var dataChannel1 = realtime.channels.get('include:channel1');
+          var streamChannel3 = realtime.channels.get('stream3');
+
+          activeChannel.attach(function (err) {
+            if (err) {
+              closeAndFinish(done, realtime, err);
+              return;
+            }
+
+            /* subscribe to channel group */
+            channelGroup.subscribe((channel, msg) => {
+              try {
+                expect(msg.data).to.equal('test data 1', 'Unexpected msg text received');
+                expect(channel).to.equal('include:channel1', 'Unexpected channel name');
+              } catch (err) {
+                closeAndFinish(done, realtime, err);
+                return;
+              }
+
+              closeAndFinish(done, realtime);
+            });
+
+            /* publish active channels */
+            activeChannel.publish('event0', testMsg);
+            streamChannel3.publish('event0', 'should not be subscribed to this message');
+            dataChannel1.publish('event0', 'test data 1');
+          });
+        });
+        monitorConnection(done, realtime);
+      } catch (err) {
+        closeAndFinish(done, realtime, err);
+      }
+    });
+
+    it('reacts to changing active channels', function (done) {
+      try {
+        /* set up realtime */
+        var realtime = helper.AblyRealtime();
+
+        /* connect and attach */
+        realtime.connection.on('connected', function () {
+          const channelGroup = realtime.channelGroups.get('group:.*');
+
+          var testMsg = { active: ['group:channel1', 'group:channel2', 'group:channel3'] };
+          var activeChannel = realtime.channels.get('active');
+          var dataChannel1 = realtime.channels.get('group:channel1');
+          var dataChannel2 = realtime.channels.get('group:channel2');
+          var dataChannel4 = realtime.channels.get('group:channel4');
+          var dataChannel5 = realtime.channels.get('group:channel5');
+
+          activeChannel.attach(function (err) {
+            if (err) {
+              closeAndFinish(done, realtime, err);
+              return;
+            }
+
+            var events = 1;
+
+            /* subscribe to channel group */
+            channelGroup.subscribe(async (channel, msg) => {
+              try {
+                expect(msg.data).to.equal('test data ' + events, 'Unexpected msg text received');
+                expect(channel).to.equal('group:channel' + events, 'Unexpected channel name');
+              } catch (err) {
+                closeAndFinish(done, realtime, err);
+                return;
+              }
+
+              if (events == 1) {
+                activeChannel.publish('event0', { active: ['group:channel4', 'group:channel5'] });
+                dataChannel4.publish('event0', 'test data 4');
+                events = 4;
+                return;
+              }
+
+              if (events == 4) {
+                await dataChannel2.publish('event 0', 'should be ignored test dat');
+                await dataChannel5.publish('event0', 'test data 5');
+                events++;
+                return;
+              }
+
+              closeAndFinish(done, realtime);
+            });
+
+            /* publish active channels */
+            activeChannel.publish('event0', testMsg);
+            dataChannel1.publish('event0', 'test data 1');
+          });
+        });
+        monitorConnection(done, realtime);
+      } catch (err) {
+        closeAndFinish(done, realtime, err);
+      }
+    });
+  });
+});


### PR DESCRIPTION
The `hashring` package is node-only as it depends on the native `crypto` package. Replaced with a dep-free alternative.