### PR TITLE
Bring `whenState` in line with spec

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2097,11 +2097,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   publish(message: Message): Promise<void>;
   /**
-   * Returns a promise which is resolved when the channel reaches the specified {@link ChannelState}. If the channel is already in the specified state, the promise is resolved immediately.
+   * If the channel is already in the given state, returns a promise which immediately resolves to `null`. Else, calls {@link EventEmitter.once | `once()`} to return a promise which resolves the next time the channel transitions to the given state.
    *
-   * @param targetState - The state which should be reached.
+   * @param targetState - The channel state to wait for.
    */
-  whenState(targetState: ChannelState): Promise<ChannelStateChange>;
+  whenState(targetState: ChannelState): Promise<ChannelStateChange | null>;
 }
 
 /**
@@ -2398,11 +2398,11 @@ export declare interface Connection
    */
   ping(): Promise<number>;
   /**
-   * Returns a promise which is resolved when the connection reaches the specified {@link ConnectionState}. If the connection is already in the specified state, the promise is resolved immediately.
+   * If the connection is already in the given state, returns a promise which immediately resolves to `null`. Else, calls {@link EventEmitter.once | `once()`} to return a promise which resolves the next time the connection transitions to the given state.
    *
-   * @param targetState - The state which should be reached.
+   * @param targetState - The connection state to wait for.
    */
-  whenState(targetState: ConnectionState): Promise<ConnectionStateChange>;
+  whenState(targetState: ConnectionState): Promise<ConnectionStateChange | null>;
 }
 
 /**

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -37,14 +37,8 @@ class Connection extends EventEmitter {
     });
   }
 
-  whenState = ((state: string, listener: Function) => {
-    return EventEmitter.prototype.whenState.call(
-      this,
-      state,
-      this.state,
-      listener,
-      new ConnectionStateChange(undefined, state),
-    );
+  whenState = ((state: string) => {
+    return EventEmitter.prototype.whenState.call(this, state, this.state, new ConnectionStateChange(undefined, state));
   }) as any;
 
   connect(): void {

--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -38,7 +38,7 @@ class Connection extends EventEmitter {
   }
 
   whenState = ((state: string) => {
-    return EventEmitter.prototype.whenState.call(this, state, this.state, new ConnectionStateChange(undefined, state));
+    return EventEmitter.prototype.whenState.call(this, state, this.state);
   }) as any;
 
   connect(): void {

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -875,8 +875,8 @@ class RealtimeChannel extends EventEmitter {
     return restMixin.history(this, params);
   } as any;
 
-  whenState = ((state: string, listener: ErrCallback) => {
-    return EventEmitter.prototype.whenState.call(this, state, this.state, listener);
+  whenState = ((state: string) => {
+    return EventEmitter.prototype.whenState.call(this, state, this.state);
   }) as any;
 
   /* @returns null (if can safely be released) | ErrorInfo (if cannot) */

--- a/src/common/lib/util/eventemitter.ts
+++ b/src/common/lib/util/eventemitter.ts
@@ -286,19 +286,16 @@ class EventEmitter {
   }
 
   /**
-   * Private API
-   *
    * Listen for a single occurrence of a state event and fire immediately if currentState matches targetState
    * @param targetState the name of the state event to listen to
    * @param currentState the name of the current state of this object
-   * @param returnValue
    */
-  async whenState(targetState: string, currentState: string, returnValue?: unknown) {
+  async whenState(targetState: string, currentState: string) {
     if (typeof targetState !== 'string' || typeof currentState !== 'string') {
       throw new Error('whenState requires a valid state String argument');
     }
     if (targetState === currentState) {
-      return returnValue;
+      return null;
     } else {
       return this.once(targetState);
     }

--- a/src/common/lib/util/eventemitter.ts
+++ b/src/common/lib/util/eventemitter.ts
@@ -291,27 +291,16 @@ class EventEmitter {
    * Listen for a single occurrence of a state event and fire immediately if currentState matches targetState
    * @param targetState the name of the state event to listen to
    * @param currentState the name of the current state of this object
-   * @param listener the listener to be called
-   * @param listenerArgs
+   * @param returnValue
    */
-  whenState(targetState: string, currentState: string, listener: Function, ...listenerArgs: unknown[]) {
-    const eventThis = { event: targetState };
-
+  async whenState(targetState: string, currentState: string, returnValue?: unknown) {
     if (typeof targetState !== 'string' || typeof currentState !== 'string') {
       throw new Error('whenState requires a valid state String argument');
     }
-    if (typeof listener !== 'function') {
-      return new Promise((resolve) => {
-        EventEmitter.prototype.whenState.apply(
-          this,
-          [targetState, currentState, resolve].concat(listenerArgs as any[]) as any,
-        );
-      });
-    }
     if (targetState === currentState) {
-      callListener(eventThis, listener, listenerArgs);
+      return returnValue;
     } else {
-      this.once(targetState, listener);
+      return this.once(targetState);
     }
   }
 }

--- a/src/common/lib/util/eventemitter.ts
+++ b/src/common/lib/util/eventemitter.ts
@@ -298,7 +298,7 @@ class EventEmitter {
     const eventThis = { event: targetState };
 
     if (typeof targetState !== 'string' || typeof currentState !== 'string') {
-      throw 'whenState requires a valid event String argument';
+      throw new Error('whenState requires a valid event String argument');
     }
     if (typeof listener !== 'function') {
       return new Promise((resolve) => {

--- a/src/common/lib/util/eventemitter.ts
+++ b/src/common/lib/util/eventemitter.ts
@@ -298,7 +298,7 @@ class EventEmitter {
     const eventThis = { event: targetState };
 
     if (typeof targetState !== 'string' || typeof currentState !== 'string') {
-      throw new Error('whenState requires a valid event String argument');
+      throw new Error('whenState requires a valid state String argument');
     }
     if (typeof listener !== 'function') {
       return new Promise((resolve) => {

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -42,6 +42,15 @@ define([
     });
   }
 
+  async function monitorConnectionAsync(action, realtime, states) {
+    const monitoringResultPromise = new Promise((resolve, reject) => {
+      monitorConnection((err) => (err ? reject(err) : resolve()), realtime, states);
+    });
+    const actionResultPromise = Promise.resolve(action());
+
+    return Promise.race([monitoringResultPromise, actionResultPromise]);
+  }
+
   function closeAndFinish(done, realtime, err) {
     if (typeof realtime === 'undefined') {
       // Likely called in a catch block for an exception
@@ -58,6 +67,12 @@ define([
     }
     callbackOnClose(realtime, function () {
       done(err);
+    });
+  }
+
+  async function closeAndFinishAsync(realtime, err) {
+    return new Promise((resolve, reject) => {
+      closeAndFinish((err) => (err ? reject(err) : resolve()), realtime, err);
     });
   }
 
@@ -238,7 +253,9 @@ define([
 
     displayError: displayError,
     monitorConnection: monitorConnection,
+    monitorConnectionAsync: monitorConnectionAsync,
     closeAndFinish: closeAndFinish,
+    closeAndFinishAsync: closeAndFinishAsync,
     simulateDroppedConnection: simulateDroppedConnection,
     becomeSuspended: becomeSuspended,
     testOnAllTransports: testOnAllTransports,

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -447,10 +447,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     /*
      * Attach then later call whenState which fires immediately
      */
-    it('channelattachOnceOrIfAfter', function (done) {
+    it('channelattachWhenState', function (done) {
       try {
         var realtime = helper.AblyRealtime(),
-          channel = realtime.channels.get('channelattachOnceOrIf'),
+          channel = realtime.channels.get('channelattachWhenState'),
           firedImmediately = false;
 
         whenPromiseSettles(channel.attach(), function (err) {

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -450,19 +450,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('channelattachWhenState', function (done) {
       try {
         var realtime = helper.AblyRealtime(),
-          channel = realtime.channels.get('channelattachWhenState'),
-          firedImmediately = false;
+          channel = realtime.channels.get('channelattachWhenState');
 
         whenPromiseSettles(channel.attach(), function (err) {
-          channel.whenState('attached', function () {
-            firedImmediately = true;
-          });
-          try {
-            expect(firedImmediately, 'whenState fired immediately as attached').to.be.ok;
-            closeAndFinish(done, realtime);
-          } catch (err) {
+          whenPromiseSettles(channel.whenState('attached'), function () {
             closeAndFinish(done, realtime, err);
-          }
+          });
         });
         monitorConnection(done, realtime);
       } catch (err) {
@@ -480,7 +473,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           firedImmediately = false;
 
         channel.attach();
-        channel.whenState('attached', function () {
+        whenPromiseSettles(channel.whenState('attached'), function () {
           firedImmediately = true;
           try {
             expect(channel.state).to.equal('attached', 'whenState fired when attached');
@@ -1651,7 +1644,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       const realtime = helper.AblyRealtime();
       const channel = realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
       channel.attach();
-      channel.whenState('attaching', function () {
+      whenPromiseSettles(channel.whenState('attaching'), function () {
         try {
           realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
           closeAndFinish(done, realtime);

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -105,7 +105,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   return;
                 }
                 realtime.connection.close();
-                realtime.connection.whenState('closed', function () {
+                whenPromiseSettles(realtime.connection.whenState('closed'), function () {
                   try {
                     expect(realtime.connection.recoveryKey).to.equal(null, 'verify recovery key null after close');
                     closeAndFinish(done, realtime);

--- a/test/realtime/history.test.js
+++ b/test/realtime/history.test.js
@@ -56,7 +56,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       parallelPublishMessages(done, restChannel, preAttachMessages, function () {
         /* second, connect and attach to the channel */
         try {
-          realtime.connection.whenState('connected', function () {
+          whenPromiseSettles(realtime.connection.whenState('connected'), function () {
             var rtChannel = realtime.channels.get('persisted:history_until_attach');
             whenPromiseSettles(rtChannel.attach(), function (err) {
               if (err) {

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1104,7 +1104,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               return;
             }
             clientRealtime.close();
-            clientRealtime.connection.whenState('closed', function () {
+            whenPromiseSettles(clientRealtime.connection.whenState('closed'), function () {
               clientRealtime.connection.once('connected', function () {
                 //Should automatically reattach
                 whenPromiseSettles(clientChannel.presence.enter('second'), function (err) {
@@ -1774,7 +1774,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       async.series(
         [
           function (cb) {
-            continuousRealtime.connection.whenState('connected', function () {
+            whenPromiseSettles(continuousRealtime.connection.whenState('connected'), function () {
               cb();
             });
           },
@@ -1785,7 +1785,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             whenPromiseSettles(continuousChannel.presence.enter(), cb);
           },
           function (cb) {
-            realtime.connection.whenState('connected', function () {
+            whenPromiseSettles(realtime.connection.whenState('connected'), function () {
               cb();
             });
           },
@@ -1885,7 +1885,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       async.series(
         [
           function (cb) {
-            realtime.connection.whenState('connected', function () {
+            whenPromiseSettles(realtime.connection.whenState('connected'), function () {
               cb();
             });
           },
@@ -1982,7 +1982,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           async.series(
             [
               function (cb) {
-                rt.connection.whenState('connected', function () {
+                whenPromiseSettles(rt.connection.whenState('connected'), function () {
                   cb();
                 });
               },
@@ -2059,7 +2059,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            leavesRealtime.connection.whenState('closed', function () {
+            whenPromiseSettles(leavesRealtime.connection.whenState('closed'), function () {
               cb();
             });
             leavesRealtime.close();


### PR DESCRIPTION
Updates the `whenState` methods to conform to https://github.com/ably/specification/pull/183. See commit messages for more details.

Resolves #1597.
https://ably.atlassian.net/browse/ECO-4662