### PR TITLE
[ECO-4645] Move `React.createContext` outside of components in react-hooks

### DIFF
--- a/src/platform/react-hooks/src/AblyContext.tsx
+++ b/src/platform/react-hooks/src/AblyContext.tsx
@@ -1,0 +1,39 @@
+import * as Ably from 'ably';
+import React from 'react';
+
+// We need to make sure we never create more than one Ably React context.
+// This might happen when exporting a context directly from a module -
+// there's a risk of creating multiple instances of the same context
+// if there are misconfigurations in module bundler or package manager on the consumer side of Ably Context.
+// This can lead to problems like having an Ably Channel instance added
+// in one context, and then attempting to retrieve it from another different context.
+// This is why a single Ably context is created and stored in the global state.
+const contextKey = Symbol.for('__ABLY_CONTEXT__');
+
+const globalObjectForContext: { [contextKey]?: React.Context<AblyContextType> } =
+  typeof globalThis !== 'undefined' ? (globalThis as any) : {};
+
+// Ably context contains an object which stores all provider options indexed by provider id,
+// which is used to get options set by specific `AblyProvider` after calling `React.useContext`.
+export type AblyContextType = Record<string, AblyContextProviderProps>;
+
+export interface AblyContextProviderProps {
+  client: Ably.RealtimeClient;
+  _channelNameToChannelContext: Record<string, ChannelContextProps>;
+}
+
+export interface ChannelContextProps {
+  channel: Ably.RealtimeChannel;
+  derived?: boolean;
+}
+
+function getContext(): React.Context<AblyContextType> {
+  let context = globalObjectForContext[contextKey];
+  if (!context) {
+    context = globalObjectForContext[contextKey] = React.createContext<AblyContextType>({});
+  }
+
+  return context;
+}
+
+export const AblyContext = getContext();

--- a/src/platform/react-hooks/src/AblyContext.tsx
+++ b/src/platform/react-hooks/src/AblyContext.tsx
@@ -10,12 +10,12 @@ import React from 'react';
 // This is why a single Ably context is created and stored in the global state.
 const contextKey = Symbol.for('__ABLY_CONTEXT__');
 
-const globalObjectForContext: { [contextKey]?: React.Context<AblyContextType> } =
+const globalObjectForContext: { [contextKey]?: React.Context<AblyContextValue> } =
   typeof globalThis !== 'undefined' ? (globalThis as any) : {};
 
 // Ably context contains an object which stores all provider options indexed by provider id,
 // which is used to get options set by specific `AblyProvider` after calling `React.useContext`.
-export type AblyContextType = Record<string, AblyContextProviderProps>;
+export type AblyContextValue = Record<string, AblyContextProviderProps>;
 
 export interface AblyContextProviderProps {
   client: Ably.RealtimeClient;
@@ -27,10 +27,10 @@ export interface ChannelContextProps {
   derived?: boolean;
 }
 
-function getContext(): React.Context<AblyContextType> {
+function getContext(): React.Context<AblyContextValue> {
   let context = globalObjectForContext[contextKey];
   if (!context) {
-    context = globalObjectForContext[contextKey] = React.createContext<AblyContextType>({});
+    context = globalObjectForContext[contextKey] = React.createContext<AblyContextValue>({});
   }
 
   return context;

--- a/src/platform/react-hooks/src/AblyProvider.tsx
+++ b/src/platform/react-hooks/src/AblyProvider.tsx
@@ -7,6 +7,22 @@ interface AblyProviderProps {
   ablyId?: string;
 }
 
+// We need to make sure we never create more than one Ably React context.
+// This might happen when exporting a context directly from a module -
+// there's a risk of creating multiple instances of the same context
+// if there are misconfigurations in module bundler or package manager on the consumer side of Ably Context.
+// This can lead to problems like having an Ably Channel instance added
+// in one context, and then attempting to retrieve it from another different context.
+// This is why a single Ably context is created and stored in the global state.
+const contextKey = Symbol.for('__ABLY_CONTEXT__');
+
+const globalObjectForContext: { [contextKey]?: React.Context<AblyContextType> } =
+  typeof globalThis !== 'undefined' ? (globalThis as any) : {};
+
+// Ably context contains an object which stores all provider options indexed by provider id,
+// which is used to get options set by specific `AblyProvider` after calling `React.useContext`.
+export type AblyContextType = Record<string, AblyContextProviderProps>;
+
 export interface AblyContextProviderProps {
   client: Ably.RealtimeClient;
   _channelNameToChannelContext: Record<string, ChannelContextProps>;
@@ -17,11 +33,16 @@ export interface ChannelContextProps {
   derived?: boolean;
 }
 
-// An object which stores all provider options indexed by provider id,
-// which is used to get options set by specific `AblyProvider` after calling `React.useContext`.
-export type AblyContextType = Record<string, AblyContextProviderProps>;
+function getContext(): React.Context<AblyContextType> {
+  let context = globalObjectForContext[contextKey];
+  if (!context) {
+    context = globalObjectForContext[contextKey] = React.createContext<AblyContextType>({});
+  }
 
-export const AblyContext = React.createContext<AblyContextType>({});
+  return context;
+}
+
+export const AblyContext = getContext();
 
 export const AblyProvider = ({ client, children, ablyId = 'default' }: AblyProviderProps) => {
   if (!client) {

--- a/src/platform/react-hooks/src/AblyProvider.tsx
+++ b/src/platform/react-hooks/src/AblyProvider.tsx
@@ -1,15 +1,13 @@
 import * as Ably from 'ably';
 import React, { useMemo } from 'react';
 
-const canUseSymbol = typeof Symbol === 'function' && typeof Symbol.for === 'function';
-
 interface AblyProviderProps {
   children?: React.ReactNode | React.ReactNode[] | null;
   client?: Ably.RealtimeClient;
   ablyId?: string;
 }
 
-export interface AblyContextProps {
+export interface AblyContextProviderProps {
   client: Ably.RealtimeClient;
   _channelNameToChannelContext: Record<string, ChannelContextProps>;
 }
@@ -19,37 +17,22 @@ export interface ChannelContextProps {
   derived?: boolean;
 }
 
-type AblyContextType = React.Context<AblyContextProps>;
+// An object which stores all provider options indexed by provider id,
+// which is used to get options set by specific `AblyProvider` after calling `React.useContext`.
+export type AblyContextType = Record<string, AblyContextProviderProps>;
 
-// An object is appended to `React.createContext` which stores all contexts
-// indexed by id, which is used by useAbly to find the correct context when an
-// id is provided.
-type ContextMap = Record<string, AblyContextType>;
-export const contextKey = canUseSymbol ? Symbol.for('__ABLY_CONTEXT__') : '__ABLY_CONTEXT__';
-
-const ctxMap: ContextMap = typeof globalThis !== 'undefined' ? (globalThis[contextKey] = {}) : {};
-
-export function getContext(ctxId = 'default'): AblyContextType {
-  return ctxMap[ctxId];
-}
+export const AblyContext = React.createContext<AblyContextType>({});
 
 export const AblyProvider = ({ client, children, ablyId = 'default' }: AblyProviderProps) => {
-  const value: AblyContextProps = useMemo(
-    () => ({
-      client,
-      _channelNameToChannelContext: {},
-    }),
-    [client],
-  );
-
   if (!client) {
     throw new Error('AblyProvider: the `client` prop is required');
   }
 
-  let context = getContext(ablyId);
-  if (!context) {
-    context = ctxMap[ablyId] = React.createContext({ client, _channelNameToChannelContext: {} });
-  }
+  const context = React.useContext(AblyContext);
 
-  return <context.Provider value={value}>{children}</context.Provider>;
+  const value: AblyContextType = useMemo(() => {
+    return { ...context, [ablyId]: { client, _channelNameToChannelContext: {} } };
+  }, [context, client, ablyId]);
+
+  return <AblyContext.Provider value={value}>{children}</AblyContext.Provider>;
 };

--- a/src/platform/react-hooks/src/AblyProvider.tsx
+++ b/src/platform/react-hooks/src/AblyProvider.tsx
@@ -1,48 +1,12 @@
 import * as Ably from 'ably';
 import React, { useMemo } from 'react';
+import { AblyContext, AblyContextType } from './AblyContext.js';
 
 interface AblyProviderProps {
   children?: React.ReactNode | React.ReactNode[] | null;
   client?: Ably.RealtimeClient;
   ablyId?: string;
 }
-
-// We need to make sure we never create more than one Ably React context.
-// This might happen when exporting a context directly from a module -
-// there's a risk of creating multiple instances of the same context
-// if there are misconfigurations in module bundler or package manager on the consumer side of Ably Context.
-// This can lead to problems like having an Ably Channel instance added
-// in one context, and then attempting to retrieve it from another different context.
-// This is why a single Ably context is created and stored in the global state.
-const contextKey = Symbol.for('__ABLY_CONTEXT__');
-
-const globalObjectForContext: { [contextKey]?: React.Context<AblyContextType> } =
-  typeof globalThis !== 'undefined' ? (globalThis as any) : {};
-
-// Ably context contains an object which stores all provider options indexed by provider id,
-// which is used to get options set by specific `AblyProvider` after calling `React.useContext`.
-export type AblyContextType = Record<string, AblyContextProviderProps>;
-
-export interface AblyContextProviderProps {
-  client: Ably.RealtimeClient;
-  _channelNameToChannelContext: Record<string, ChannelContextProps>;
-}
-
-export interface ChannelContextProps {
-  channel: Ably.RealtimeChannel;
-  derived?: boolean;
-}
-
-function getContext(): React.Context<AblyContextType> {
-  let context = globalObjectForContext[contextKey];
-  if (!context) {
-    context = globalObjectForContext[contextKey] = React.createContext<AblyContextType>({});
-  }
-
-  return context;
-}
-
-export const AblyContext = getContext();
 
 export const AblyProvider = ({ client, children, ablyId = 'default' }: AblyProviderProps) => {
   if (!client) {

--- a/src/platform/react-hooks/src/AblyProvider.tsx
+++ b/src/platform/react-hooks/src/AblyProvider.tsx
@@ -1,6 +1,6 @@
 import * as Ably from 'ably';
 import React, { useMemo } from 'react';
-import { AblyContext, AblyContextType } from './AblyContext.js';
+import { AblyContext, AblyContextValue } from './AblyContext.js';
 
 interface AblyProviderProps {
   children?: React.ReactNode | React.ReactNode[] | null;
@@ -15,7 +15,7 @@ export const AblyProvider = ({ client, children, ablyId = 'default' }: AblyProvi
 
   const context = React.useContext(AblyContext);
 
-  const value: AblyContextType = useMemo(() => {
+  const value: AblyContextValue = useMemo(() => {
     return { ...context, [ablyId]: { client, _channelNameToChannelContext: {} } };
   }, [context, client, ablyId]);
 

--- a/src/platform/react-hooks/src/ChannelProvider.tsx
+++ b/src/platform/react-hooks/src/ChannelProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import * as Ably from 'ably';
-import { type AblyContextType, AblyContext } from './AblyProvider.js';
+import { type AblyContextType, AblyContext } from './AblyContext.js';
 import { channelOptionsWithAgent } from './AblyReactHooks.js';
 
 interface ChannelProviderProps {

--- a/src/platform/react-hooks/src/ChannelProvider.tsx
+++ b/src/platform/react-hooks/src/ChannelProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import * as Ably from 'ably';
-import { type AblyContextType, AblyContext } from './AblyContext.js';
+import { type AblyContextValue, AblyContext } from './AblyContext.js';
 import { channelOptionsWithAgent } from './AblyReactHooks.js';
 
 interface ChannelProviderProps {
@@ -28,7 +28,7 @@ export const ChannelProvider = ({
   const derived = Boolean(deriveOptions);
   const channel = derived ? client.channels.getDerived(channelName, deriveOptions) : client.channels.get(channelName);
 
-  const value: AblyContextType = useMemo(() => {
+  const value: AblyContextValue = useMemo(() => {
     return {
       ...context,
       [ablyId]: {

--- a/src/platform/react-hooks/src/hooks/useAbly.ts
+++ b/src/platform/react-hooks/src/hooks/useAbly.ts
@@ -1,9 +1,9 @@
 import React from 'react';
-import { getContext } from '../AblyProvider.js';
+import { AblyContext } from '../AblyProvider.js';
 import * as API from 'ably';
 
 export function useAbly(ablyId = 'default'): API.RealtimeClient {
-  const client = React.useContext(getContext(ablyId)).client;
+  const client = React.useContext(AblyContext)[ablyId].client;
 
   if (!client) {
     throw new Error(

--- a/src/platform/react-hooks/src/hooks/useAbly.ts
+++ b/src/platform/react-hooks/src/hooks/useAbly.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AblyContext } from '../AblyProvider.js';
+import { AblyContext } from '../AblyContext.js';
 import * as API from 'ably';
 
 export function useAbly(ablyId = 'default'): API.RealtimeClient {

--- a/src/platform/react-hooks/src/hooks/useChannelInstance.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelInstance.ts
@@ -1,8 +1,8 @@
 import React from 'react';
-import { ChannelContextProps, getContext } from '../AblyProvider.js';
+import { AblyContext, ChannelContextProps } from '../AblyProvider.js';
 
-export function useChannelInstance(ablyId: string, channelName: string): ChannelContextProps {
-  const channelContext = React.useContext(getContext(ablyId))._channelNameToChannelContext[channelName];
+export function useChannelInstance(ablyId = 'default', channelName: string): ChannelContextProps {
+  const channelContext = React.useContext(AblyContext)[ablyId]._channelNameToChannelContext[channelName];
 
   if (!channelContext) {
     throw new Error(

--- a/src/platform/react-hooks/src/hooks/useChannelInstance.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelInstance.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AblyContext, ChannelContextProps } from '../AblyProvider.js';
+import { AblyContext, ChannelContextProps } from '../AblyContext.js';
 
 export function useChannelInstance(ablyId = 'default', channelName: string): ChannelContextProps {
   const channelContext = React.useContext(AblyContext)[ablyId]._channelNameToChannelContext[channelName];

--- a/src/platform/react-hooks/src/index.ts
+++ b/src/platform/react-hooks/src/index.ts
@@ -6,3 +6,4 @@ export * from './AblyProvider.js';
 export * from './hooks/useChannelStateListener.js';
 export * from './hooks/useConnectionStateListener.js';
 export { ChannelProvider } from './ChannelProvider.js';
+export * from './AblyContext.js';


### PR DESCRIPTION
Resolves #1638