### PR TITLE
consumergroup: use modulo-based hashing scheme

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -1973,7 +1973,7 @@ export declare interface ChannelGroup {
    *
    * @param callback - An event listener function.
    */
-  subscribe(callback: channelAndMessageCallback<InboundMessage>): void;
+  subscribe(callback: channelAndMessageCallback<InboundMessage>): Promise<void>;
 }
 
 /**
@@ -2219,7 +2219,7 @@ export declare interface ChannelGroups {
    * @param options - A {@link ChannelGroupOptions} object.
    * @returns A {@link ChannelGroup} object.
    */
-  get(filter: string, options?: ChannelGroupOptions): Promise<ChannelGroup>;
+  get(filter: string, options?: ChannelGroupOptions): ChannelGroup;
 }
 
 /**

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -848,6 +848,10 @@ export interface ChannelOptions {
  * Describes the consumer group. Consumers in the same group will partition the channels of that group.
  */
 interface ConsumerGroupOptions {
+  /**
+   * The name of the consumer group.
+   * Channels will be partitioned across consumers in the same group identified by this name.
+   */
   name: string;
 }
 
@@ -855,6 +859,9 @@ interface ConsumerGroupOptions {
  * Allows specifying properties of a {@link ChannelGroup}
  */
 interface ChannelGroupOptions {
+  /**
+   * Options for a consumer group used to partition the channels in the channel group across consumers in the consumer group.
+   */
   consumerGroup?: ConsumerGroupOptions;
 }
 
@@ -1965,6 +1972,8 @@ export declare interface Channel {
 }
 
 /**
+ * This is a preview feature and may change in a future non-major release.
+ *
  * Enables messages to be subscribed to on a group of channels.
  */
 export declare interface ChannelGroup {
@@ -2186,7 +2195,8 @@ export declare interface Channels<T> {
    */
   get(name: string, channelOptions?: ChannelOptions): T;
   /**
-   * @experimental This is a preview feature and may change in a future non-major release.
+   * This is a preview feature and may change in a future non-major release.
+   *
    * This experimental method allows you to create custom realtime data feeds by selectively subscribing
    * to receive only part of the data from the channel.
    * See the [announcement post](https://pages.ably.com/subscription-filters-preview) for more information.
@@ -2209,6 +2219,8 @@ export declare interface Channels<T> {
 }
 
 /**
+ * This is a preview feature and may change in a future non-major release.
+ *
  * Creates and destroys {@link ChannelGroup} objects.
  */
 export declare interface ChannelGroups {
@@ -2761,6 +2773,9 @@ export declare class Realtime implements RealtimeClient {
   connect(): void;
   auth: Auth;
   channels: Channels<RealtimeChannel>;
+  /**
+   * This is a preview feature and may change in a future non-major release.
+   */
   channelGroups: ChannelGroups;
   connection: Connection;
   request<T = any>(

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@ably/msgpack-js": "^0.4.0",
         "@types/hashring": "^3.2.5",
         "got": "^11.8.5",
-        "hashring": "^3.2.0",
         "ws": "^8.14.2"
       },
       "devDependencies": {
@@ -4420,11 +4419,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "node_modules/connection-parse": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
-      "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -7303,15 +7297,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hashring": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
-      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
-      "dependencies": {
-        "connection-parse": "0.0.x",
-        "simple-lru-cache": "0.0.x"
       }
     },
     "node_modules/hasown": {
@@ -10606,11 +10591,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/simple-lru-cache": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
-      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
     },
     "node_modules/skin-tone": {
       "version": "2.0.0",
@@ -15723,11 +15703,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "connection-parse": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
-      "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
-    },
     "content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -17839,15 +17814,6 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
-      }
-    },
-    "hashring": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
-      "integrity": "sha512-xCMovURClsQZ+TR30icCZj+34Fq1hs0y6YCASD6ZqdRfYRybb5Iadws2WS+w09mGM/kf9xyA5FCdJQGcgcraSA==",
-      "requires": {
-        "connection-parse": "0.0.x",
-        "simple-lru-cache": "0.0.x"
       }
     },
     "hasown": {
@@ -20255,11 +20221,6 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
-    },
-    "simple-lru-cache": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
-      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
     },
     "skin-tone": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@ably/msgpack-js": "^0.4.0",
     "@types/hashring": "^3.2.5",
     "got": "^11.8.5",
-    "hashring": "^3.2.0",
     "ws": "^8.14.2"
   },
   "peerDependencies": {

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -118,7 +118,11 @@ class ConsumerGroup extends EventEmitter {
     }
 
     try {
-      Logger.logAction(Logger.LOG_MAJOR, 'ConsumerGroup.join()', 'joining consumer group ' + this.consumerGroupName + ' as ' + this.consumerId);
+      Logger.logAction(
+        Logger.LOG_MAJOR,
+        'ConsumerGroup.join()',
+        'joining consumer group ' + this.consumerGroupName + ' as ' + this.consumerId
+      );
       this.channel = this.channels.get(this.consumerGroupName, { params: { rewind: '1' } });
       await this.channel.presence.enter(null);
       await this.channel.presence.subscribe(async () => {
@@ -189,7 +193,7 @@ class ChannelGroup {
     this.active = channels.get('active', { params: { rewind: '1' } });
     this.consumerGroup = new ConsumerGroup(channels, options?.consumerGroup?.name);
     this.consumerGroup.on('membership', () => this.updateActiveChannels(this.currentChannels));
-    this.expression = new RegExp(filter);
+    this.expression = new RegExp(filter); // eslint-disable-line security/detect-non-literal-regexp
   }
 
   async join() {
@@ -205,7 +209,11 @@ class ChannelGroup {
     const { add, remove } = diffSets(this.currentChannels, matched);
     this.currentChannels = matched;
 
-    Logger.logAction(Logger.LOG_DEBUG, 'ChannelGroups.setActiveChannels', 'computed channel diffs: add=' + add + ' remove=' + remove);
+    Logger.logAction(
+      Logger.LOG_DEBUG,
+      'ChannelGroups.setActiveChannels',
+      'computed channel diffs: add=' + add + ' remove=' + remove
+    );
 
     this.removeSubscriptions(remove);
     this.addSubscriptions(add);
@@ -219,13 +227,20 @@ class ChannelGroup {
       }
 
       this.subscribedChannels[channel] = this.channels.get(channel);
-      this.subscribedChannels[channel].setOptions({ params: { rewind: '5s' } }).then(() => {
-        this.subscribedChannels[channel].subscribe((msg: any) => {
-          this.subscriptions.emit('message', channel, msg);
+      this.subscribedChannels[channel]
+        .setOptions({ params: { rewind: '5s' } })
+        .then(() => {
+          this.subscribedChannels[channel].subscribe((msg: any) => {
+            this.subscriptions.emit('message', channel, msg);
+          });
+        })
+        .catch((err) => {
+          Logger.logAction(
+            Logger.LOG_ERROR,
+            'ChannelGroups.addSubscriptions()',
+            'failed to set rewind options on channel ' + channel + ': ' + err
+          );
         });
-      }).catch((err) => {
-        Logger.logAction(Logger.LOG_ERROR, 'ChannelGroups.addSubscriptions()', 'failed to set rewind options on channel ' + channel + ': ' + err);
-      });
     });
   }
 

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -80,18 +80,13 @@ class ChannelGroups {
 
   constructor(readonly channels: Channels) {}
 
-  // TODO(mschristensen) make this non async
-  async get(filter: string, options?: API.ChannelGroupOptions): Promise<ChannelGroup> {
+  get(filter: string, options?: API.ChannelGroupOptions): ChannelGroup {
     let group = this.groups[filter];
-
     if (group) {
       return group;
     }
-
-    group = this.groups[filter] = new ChannelGroup(this.channels, filter, options);
-    await group.join();
-
-    return group;
+    this.groups[filter] = new ChannelGroup(this.channels, filter, options);
+    return this.groups[filter];
   }
 }
 
@@ -241,7 +236,8 @@ class ChannelGroup {
     });
   }
 
-  subscribe(cb: (channel: string, msg: any) => void) {
+  async subscribe(cb: (channel: string, msg: any) => void): Promise<void> {
+    await this.join();
     this.subscriptions.on('message', cb);
   }
 }

--- a/src/common/lib/util/hashring.ts
+++ b/src/common/lib/util/hashring.ts
@@ -3,42 +3,42 @@
 // TODO(mschristensen): use consistent hashing instead of modulo-based hashing
 // to avoid re-assigning all keys when nodes are added or removed.
 export default class HashRing {
-	private nodes: string[] = [];
-	
-	constructor(nodes?: string[]) {
-		if (nodes) {
-			this.nodes = nodes;
-		}
-	}
+  private nodes: string[] = [];
 
-	add(node: string): void {
-		if (this.nodes.includes(node)) {
-			return;
-		}
-		this.nodes.push(node);
-		this.nodes.sort();
-	}
+  constructor(nodes?: string[]) {
+    if (nodes) {
+      this.nodes = nodes;
+    }
+  }
 
-	remove(node: string): void {
-		this.nodes = this.nodes.filter((n) => n !== node);
-	}
+  add(node: string): void {
+    if (this.nodes.includes(node)) {
+      return;
+    }
+    this.nodes.push(node);
+    this.nodes.sort();
+  }
 
-	get(key: string): string {
-		const hash = this.hash(key);
-		const index = hash % this.nodes.length;
-		return this.nodes[index];
-	}
+  remove(node: string): void {
+    this.nodes = this.nodes.filter((n) => n !== node);
+  }
 
-	hash(key: string): number {
-		let hash = 0;
-		for (let i = 0; i < key.length; i++) {
-			hash = (hash << 5) - hash + key.charCodeAt(i);
-			hash = hash >>> 0; // convert to 32 bit unsigned integer
-		}
-		return hash;
-	}
+  get(key: string): string {
+    const hash = this.hash(key);
+    const index = hash % this.nodes.length;
+    return this.nodes[index];
+  }
 
-	getNodes(): string[] {
-		return this.nodes;
-	}
+  hash(key: string): number {
+    let hash = 0;
+    for (let i = 0; i < key.length; i++) {
+      hash = (hash << 5) - hash + key.charCodeAt(i);
+      hash = hash >>> 0; // convert to 32 bit unsigned integer
+    }
+    return hash;
+  }
+
+  getNodes(): string[] {
+    return this.nodes;
+  }
 }

--- a/src/common/lib/util/hashring.ts
+++ b/src/common/lib/util/hashring.ts
@@ -1,0 +1,44 @@
+// HashRing currently implements a modulo-based hash partitioning scheme.
+// It is used to distribute keys across a set of nodes.
+// TODO(mschristensen): use consistent hashing instead of modulo-based hashing
+// to avoid re-assigning all keys when nodes are added or removed.
+export default class HashRing {
+	private nodes: string[] = [];
+	
+	constructor(nodes?: string[]) {
+		if (nodes) {
+			this.nodes = nodes;
+		}
+	}
+
+	add(node: string): void {
+		if (this.nodes.includes(node)) {
+			return;
+		}
+		this.nodes.push(node);
+		this.nodes.sort();
+	}
+
+	remove(node: string): void {
+		this.nodes = this.nodes.filter((n) => n !== node);
+	}
+
+	get(key: string): string {
+		const hash = this.hash(key);
+		const index = hash % this.nodes.length;
+		return this.nodes[index];
+	}
+
+	hash(key: string): number {
+		let hash = 0;
+		for (let i = 0; i < key.length; i++) {
+			hash = (hash << 5) - hash + key.charCodeAt(i);
+			hash = hash >>> 0; // convert to 32 bit unsigned integer
+		}
+		return hash;
+	}
+
+	getNodes(): string[] {
+		return this.nodes;
+	}
+}

--- a/test/realtime/channelgroup.test.js
+++ b/test/realtime/channelgroup.test.js
@@ -24,7 +24,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         /* connect and attach */
         realtime.connection.on('connected', async function () {
-          const channelGroup = await realtime.channelGroups.get('.*');
+          const channelGroup = realtime.channelGroups.get('.*');
 
           var testMsg = { active: ['channel1', 'channel2', 'channel3'] };
           var activeChannel = realtime.channels.get('active');
@@ -35,7 +35,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             var events = 1;
 
             /* subscribe to channel group */
-            channelGroup.subscribe((channel, msg) => {
+            await channelGroup.subscribe((channel, msg) => {
               try {
                 expect(msg.data).to.equal('test data ' + events, 'Unexpected msg text received');
                 expect(channel).to.equal('channel' + events, 'Unexpected channel name');
@@ -75,7 +75,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         /* connect and attach */
         realtime.connection.on('connected', async function () {
-          const channelGroup = await realtime.channelGroups.get('include:.*');
+          const channelGroup = realtime.channelGroups.get('include:.*');
 
           var testMsg = { active: ['include:channel1', 'stream3'] };
           var activeChannel = realtime.channels.get('active');
@@ -85,7 +85,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           try {
             await activeChannel.attach();
             /* subscribe to channel group */
-            channelGroup.subscribe((channel, msg) => {
+            await channelGroup.subscribe((channel, msg) => {
               try {
                 expect(msg.data).to.equal('test data 1', 'Unexpected msg text received');
                 expect(channel).to.equal('include:channel1', 'Unexpected channel name');
@@ -120,7 +120,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         /* connect and attach */
         realtime.connection.on('connected', async function () {
-          const channelGroup = await realtime.channelGroups.get('group:.*');
+          const channelGroup = realtime.channelGroups.get('group:.*');
 
           var testMsg = { active: ['group:channel1', 'group:channel2', 'group:channel3'] };
           var activeChannel = realtime.channels.get('active');
@@ -134,7 +134,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             var events = 1;
 
             /* subscribe to channel group */
-            channelGroup.subscribe(async (channel, msg) => {
+            await channelGroup.subscribe(async (channel, msg) => {
               try {
                 expect(msg.data).to.equal('test data ' + events, 'Unexpected msg text received');
                 expect(channel).to.equal('group:channel' + events, 'Unexpected channel name');
@@ -151,8 +151,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               }
 
               if (events == 4) {
-                await dataChannel2.publish('event 0', 'should be ignored test dat');
-                await dataChannel5.publish('event0', 'test data 5');
+                dataChannel2.publish('event 0', 'should be ignored test dat');
+                dataChannel5.publish('event0', 'test data 5');
                 events++;
                 return;
               }
@@ -192,8 +192,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         // create 2 consumers in one group
         const consumers = [
-          await realtime2.channelGroups.get('partition:.*', { consumerGroup: { name: 'testgroup' } }),
-          await realtime3.channelGroups.get('partition:.*', { consumerGroup: { name: 'testgroup' } }),
+          realtime2.channelGroups.get('partition:.*', { consumerGroup: { name: 'testgroup' } }),
+          realtime3.channelGroups.get('partition:.*', { consumerGroup: { name: 'testgroup' } }),
         ];
 
         // create 5 channels
@@ -239,7 +239,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         // subscribe each consumer and collect results
         const results = Array.from({ length: consumers.length }, () => []);
         for (let i = 0; i < consumers.length; i++) {
-          consumers[i].subscribe((channel, msg) => {
+          await consumers[i].subscribe((channel, msg) => {
             results[i].push({ channel, name: msg.name, data: msg.data });
             if (results.flat().length === 2 * channels.length) {
               assertResult(results);


### PR DESCRIPTION
The `hashring` package is node-only as it depends on the native `crypto` package. Replaced with a simple modulo hash scheme for now.

Fixes the case where the channel is already attached and the channel is obtained with new rewind options that require a re-attach.

Updates the consumer group partitioning test to more robustly assert that channels are partitioned across consumers.