### PR TITLE
[ECO-4122] v2.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,92 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.0.0](https://github.com/ably/ably-js/tree/2.0.0) (2024-03-21)
+
+The 2.0.0 release introduces a number of new features and QoL improvements, including a new way to remove bloat and reduce the bundle size of your ably-js client, first-class support for Promises, a more idiomatic approach to using ably-js' React Hooks, enhancements to TypeScript typings, and more.
+
+Below is an overview of the major changes in this release.
+
+Please refer to the ably-js v2 [lib migration guide](./docs/migration-guides/v2/lib.md) and [React Hooks migration guide](./docs/migration-guides/v2/react-hooks.md) for the full details, including a list of all breaking changes and instructions on how to address them.
+
+### Bundle Size Reduction
+
+The default bundle size for the web has been reduced by ~32% compared to v1 - from 234.11 KiB to 159.32 KiB. When calculated with gzip compression, the reduction is ~30%, from 82.54 KiB to 57.9 KiB.
+
+Additionally, by utilizing the new modular variant of the library (see below) and JavaScript tree shaking, you can create your own minimal useful `Realtime` client and achieve a bundle size reduction of ~60.5% compared to v1 - from 234.11 KiB to 92.38 KiB (or ~66% for gzip: from 82.54 KiB to 28.18 KiB).
+
+### Modular variant of the library
+
+An ESM variant of the library is now available for browsers (but not for Node.js) via import from `ably/modular`. This modular variant of the library supports tree shaking, allowing for a reduction in the Ably bundle size within your application and improving the user experience. It can also be used by Web Workers.
+
+### React Hooks changes
+
+React Hooks, exported at `ably/react`, now require the new `ChannelProvider` component to define the channels you wish to use and the options for them. This addresses the complexities previously encountered with `useChannel` and `usePresence` hooks when attempting to dynamically change options for a channel and provides a more straightforward approach to set and manage these options.
+
+The functionality of the `usePresence` hook has been split into two separate hooks: `usePresence`, which is now used only to enter presence, and `usePresenceListener`, which is used to listen for presence updates. These new hooks offer better control over the desired presence behavior in your React components.
+
+### First-class support for Promises
+
+The callbacks API has been entirely removed, and the library now supports promises for all its asynchronous operations by default.
+
+### TypeScript typings
+
+The Types namespace has been removed. All types it contained are now exported at the top level.
+
+### Browser and Web Worker bundles
+
+- The browser bundle now relies on the native Web Crypto API instead of CryptoJS. The `ably/build/ably.noencryption` bundle has been removed, as it is no longer necessary.
+- The browser bundle can now be directly used by Web Workers. The `ably/build/ably-webworker` bundle has been removed, as it is no longer necessary.
+
+### Supported platforms changes
+
+- Support for Internet Explorer has been dropped.
+- Support for Node.js versions lower than 16 has been dropped. The supported Node.js versions are now 16, 18, and 20.
+- The minimum supported versions for major browsers are: Chrome 58, Firefox 52, Edge 79, Safari 11, and Opera 45.
+
+<details>
+<summary><b>View merged Pull Requests</b></summary>
+
+### Breaking Changes
+
+- Add `ChannelProvider` component to React Hooks [\#1620](https://github.com/ably/ably-js/pull/1620), [\#1654](https://github.com/ably/ably-js/pull/1654)
+- Add untyped stats API [\#1522](https://github.com/ably/ably-js/pull/1522)
+- Add type definitions for key returned by `generateRandomKey` [\#1320](https://github.com/ably/ably-js/pull/1320)
+- Add mandatory `version` param to `Rest.request` [\#1231](https://github.com/ably/ably-js/pull/1231)
+- Change `id` field to be named `ablyId` in React Hooks [\#1676](https://github.com/ably/ably-js/pull/1676)
+- Change `usePresence` hook to two different hooks: for entering presence and subscribing to presence updates [\#1674](https://github.com/ably/ably-js/pull/1674)
+- Change naming for enum-like namespaces in type declarations and change meaning for public `ChannelModes` type [\#1601](https://github.com/ably/ably-js/pull/1601)
+- Change publishing methods to accept a `Message`-shaped object [\#1515](https://github.com/ably/ably-js/pull/1515)
+- Change `Crypto.generateRandomKey` API to use Promises [\#1351](https://github.com/ably/ably-js/pull/1351)
+- Change `fromEncoded()` and `fromEncodedArray()` methods on `Message` and `PresenceMessage` to be async [\#1311](https://github.com/ably/ably-js/pull/1311)
+- Remove `XHRStreaming` transport support [\#1645](https://github.com/ably/ably-js/pull/1645)
+- Remove code that's supporting older platforms [\#1629](https://github.com/ably/ably-js/pull/1629), [\#1633](https://github.com/ably/ably-js/pull/1633), [\#1641](https://github.com/ably/ably-js/pull/1641)
+- Remove `recoveryKey` in favour of `createRecoveryKey()` on `Connection` [\#1613](https://github.com/ably/ably-js/pull/1613)
+- Remove `any` from `stats()` param type [\#1561](https://github.com/ably/ably-js/pull/1561)
+- Remove the dedicated Web Worker bundle `ably/build/ably-webworker` and add support for using `ably` and `ably/modular` in Web Workers [\#1550](https://github.com/ably/ably-js/pull/1550)
+- Remove false class exports in type declarations [\#1524](https://github.com/ably/ably-js/pull/1524)
+- Remove the `Types` namespace [\#1518](https://github.com/ably/ably-js/pull/1518)
+- Remove `noencryption` variant of the library [\#1500](https://github.com/ably/ably-js/pull/1500)
+- Remove public callbacks API [\#1358](https://github.com/ably/ably-js/pull/1358)
+- Remove CryptoJS library and replace it with the Web Crypto API in web bundle [\#1299](https://github.com/ably/ably-js/pull/1299), [\#1325](https://github.com/ably/ably-js/pull/1325), [\#1333](https://github.com/ably/ably-js/pull/1333)
+- Remove `ably-commonjs*.js` files [\#1229](https://github.com/ably/ably-js/pull/1229)
+- Remove deprecated APIs [\#1227](https://github.com/ably/ably-js/pull/1227)
+- Remove deprecated `fromEncoded*` type declarations [\#1222](https://github.com/ably/ably-js/pull/1222)
+- Remove deprecated `ClientOptions` parameters [\#1221](https://github.com/ably/ably-js/pull/1221)
+- Remove the `ClientOptions.log` property and replace it with separate `logLevel` and `logHandler` properties [\#1216](https://github.com/ably/ably-js/pull/1216)
+- Remove support for JSONP [\#1215](https://github.com/ably/ably-js/pull/1215)
+- Fix `whenState` inconsistent behavior in `Connection` and `RealtimeChannel` [\#1640](https://github.com/ably/ably-js/pull/1640)
+- Fix the type definition of `Crypto.getDefaultParams` [\#1352](https://github.com/ably/ably-js/pull/1352)
+
+### Features
+
+- Add `publish` function to the `useChannel` hook [\#1658](https://github.com/ably/ably-js/pull/1658)
+- Add logs to all HTTP activity [\#1581](https://github.com/ably/ably-js/pull/1581)
+
+</details>
+
+[Full Changelog](https://github.com/ably/ably-js/compare/1.2.50...2.0.0)
+
 ## [1.2.49](https://github.com/ably/ably-js/tree/1.2.49) (2024-02-07)
 
 - \[React-Hooks\] `usePresence` unsubscribes all listeners on unmount and run `Presence.leave` even if connection has been terminated [\#1610](https://github.com/ably/ably-js/issues/1610)


### PR DESCRIPTION
Changelog is based on changes between https://github.com/ably/ably-js/compare/e71ed5febf98e7e73683088c7f5c98b2f5cb721b...c02ec568b51be10f0e4c70805f36a01514b8fcac (latest `main` and `integration/v2` diff as of March 21).

PRs that need to be added to the changelog when finished/reviewed and merged:
- [x] https://github.com/ably/ably-js/pull/1613 - breaking API change
- [x] https://github.com/ably/ably-js/pull/1633 - platform compatibility PR
- [x] https://github.com/ably/ably-js/pull/1640 - API change
- [x] https://github.com/ably/ably-js/pull/1645 - breaking API change, removes `xhr_streaming` Transport
- [x] https://github.com/ably/ably-js/issues/1621 - breaking API change
- [x] https://github.com/ably/ably-js/issues/1637 - breaking API change
- [x] https://github.com/ably/ably-js/pull/1663 - breaking API change
- [x] https://github.com/ably/ably-js/pull/1658 - new API feature
- [x] https://github.com/ably/ably-js/pull/1654 - `ChannelProvider` documentation
- [x] https://github.com/ably/ably-js/pull/1675 - falls under refactoring

Please note that this is not an exhaustive list of tasks that need to be completed before the v2 release. This list contains only the user-facing PRs/tasks that must be added to the changelog.

Pull requests not included in this changelog (I considered them as Miscellaneous / Extras, non-user facing):
- Use useLayoutEffect when calling .setOptions() in ChannelProvider [\#1706](https://github.com/ably/ably-js/pull/1706)
- Remove some lingering any from stats() param type [\#1705](https://github.com/ably/ably-js/pull/1705)
- Improve errors for incorrect constructor args [\#1702](https://github.com/ably/ably-js/pull/1702)
- Fix stray second arg to modular constructor [\#1701](https://github.com/ably/ably-js/pull/1701)
- Add migration guide for react hooks for ably-js v2 [\#1698](https://github.com/ably/ably-js/pull/1698)
- Change PresenceEnterResult to PresenceResult in react hooks [\#1697](https://github.com/ably/ably-js/pull/1697)
- Fix ably/modular can't be imported in node environment [\#1696](https://github.com/ably/ably-js/pull/1696)
- Fix lint warnings [\#1694](https://github.com/ably/ably-js/pull/1694)
- build: use esbuild for nodejs bundle [\#1691](https://github.com/ably/ably-js/pull/1691)
- Add documentation for `skip` parameter for hooks to React docs [\#1675](https://github.com/ably/ably-js/pull/1675)
- Add migration guide for v2 [\#1670](https://github.com/ably/ably-js/pull/1670)
- Document fallback transport mechanism in the context of network conditions for v2 [\#1664](https://github.com/ably/ably-js/pull/1664)
- Restore ClientOptions.plugins mechanism and use it for modular variant [\#1663](https://github.com/ably/ably-js/pull/1663)
- ci: don't check formatting in react workflow [\#1653](https://github.com/ably/ably-js/pull/1653)
- test: test ux improvements [\#1652](https://github.com/ably/ably-js/pull/1652)
- Move React.createContext outside of components in react-hooks [\#1643](https://github.com/ably/ably-js/pull/1643)
- Improve logs for react package test in test:package [\#1639](https://github.com/ably/ably-js/pull/1639)
- Document our continued support for v1 [\#1634](https://github.com/ably/ably-js/pull/1634)
- Refactor nodejs http util class [\#1627](https://github.com/ably/ably-js/pull/1627)
- Fix missing ably/react export from ably package on v2 branch [\#1625](https://github.com/ably/ably-js/pull/1625)
- Fix ably import in react hooks [\#1624](https://github.com/ably/ably-js/pull/1624)
- Convert HTTP code to use promises [\#1603](https://github.com/ably/ably-js/pull/1603)
- Add better error handling for incorrect PLAYWRIGHT_BROWSER in runPlaywrightTests script [\#1595](https://github.com/ably/ably-js/pull/1595)
- Document that queryTime auth option requires Rest module [\#1593](https://github.com/ably/ably-js/pull/1593)
- Make modulereport print gzipped size too [\#1586](https://github.com/ably/ably-js/pull/1586)
- Add try/catch to _multiple_send to allow fast fail in case of errors [\#1585](https://github.com/ably/ably-js/pull/1585)
- Fix mocha web server process keeps running after failed playwright tests [\#1584](https://github.com/ably/ably-js/pull/1584)
- Fix multiple_send_binary_2_200 is failing intermittently in browser on v2 branch [\#1583](https://github.com/ably/ably-js/pull/1583)
- Improve IPlatformConfig [\#1563](https://github.com/ably/ably-js/pull/1563)
- build: use Ably as UMD lib name [\#1558](https://github.com/ably/ably-js/pull/1558)
- Remove callbacks part 1 [\#1541](https://github.com/ably/ably-js/pull/1541)
- Strip logging from modular variant of the SDK [\#1536](https://github.com/ably/ably-js/pull/1536)
- Correct tsc module settings for test:package [\#1521](https://github.com/ably/ably-js/pull/1521)
- Add stats to list of functionality gated off by Rest module [\#1517](https://github.com/ably/ably-js/pull/1517)
- Remove the existing plugins mechanism [\#1512](https://github.com/ably/ably-js/pull/1512)
- Add some regression testing for bundle size and included files [\#1507](https://github.com/ably/ably-js/pull/1507)
- Exclude PresenceMessage from BaseRealtime bundle [\#1505](https://github.com/ably/ably-js/pull/1505)
- Remove static stuff from *Message classes [\#1503](https://github.com/ably/ably-js/pull/1503)
- Add documentation for modular variant of library [\#1502](https://github.com/ably/ably-js/pull/1502)
- Add typings for the tree-shakable version of the library [\#1498](https://github.com/ably/ably-js/pull/1498)
- Remove remaining REST code from BaseRealtime [\#1496](https://github.com/ably/ably-js/pull/1496)
- Don’t populate DeviceDetails.toRequestBody by assignment [\#1494](https://github.com/ably/ably-js/pull/1494)
- Do e013cc0’s typescript-eslint version bumps in package.json [\#1490](https://github.com/ably/ably-js/pull/1490)
- Add a basic test of NPM package [\#1476](https://github.com/ably/ably-js/pull/1476)
- Make MessageFilter subscription filtering tree-shakable[\#1473](https://github.com/ably/ably-js/pull/1473)
- Make HTTP request implementations tree-shakable [\#1438](https://github.com/ably/ably-js/pull/1438)
- Make realtime transports tree-shakable [\#1432](https://github.com/ably/ably-js/pull/1432)
- Remove PresenceMessage-related static things in tree-shakable library [\#1429](https://github.com/ably/ably-js/pull/1429)
- Make realtime presence functionality tree-shakable [\#1428](https://github.com/ably/ably-js/pull/1428)
- Create tree-shakable MsgPack module [\#1425](https://github.com/ably/ably-js/pull/1425)
- Create tree-shakable Crypto module [\#1419](https://github.com/ably/ably-js/pull/1419)
- Add tree-shakable Base* and Rest exports [\#1417](https://github.com/ably/ably-js/pull/1417)
- refactor: convert web comet transports to typescript [\#1379](https://github.com/ably/ably-js/pull/1379)
- build: use esbuild for web bundles [\#1369](https://github.com/ably/ably-js/pull/1369)
- Update the tests to use the Promise-based API [\#1349](https://github.com/ably/ably-js/pull/1349)
- Make ErrorInfo.fromValues’s signature correspond to its expectations [\#1322](https://github.com/ably/ably-js/pull/1322)
- Fix TypeScript 4.9.5 upgrade mistakes [\#1267](https://github.com/ably/ably-js/pull/1267)
- Upgrade TypeScript to 4.9.5 [\#1258](https://github.com/ably/ably-js/pull/1258)
- Update docstrings for Rest.request version param [\#1255](https://github.com/ably/ably-js/pull/1255)
- Convert platform crypto.js files to TypeScript [\#1246](https://github.com/ably/ably-js/pull/1246)
- Upgrade webpack to version 5 [\#1201](https://github.com/ably/ably-js/pull/1201)

Resolves #1604 