### PR TITLE
[ECO-4666] feat: add `publish` to the `useChannel` hook

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -8,7 +8,7 @@ Use Ably in your React application using idiomatic, easy to use, React Hooks!
 Using this module you can:
 
 - Interact with [Ably channels](https://ably.com/docs/channels) using a React Hook.
-- [Publish messages](https://ably.com/docs/channels#publish) via Ably using the channel instances the hooks provide
+- [Publish messages](https://ably.com/docs/channels#publish) via Ably using publish function the hooks provide
 - Get notifications of user [presence on channels](https://ably.com/docs/presence-occupancy/presence)
 - Send presence updates
 
@@ -94,20 +94,27 @@ const messagePreviews = messages.map((msg, index) => <li key={index}>{msg.data.s
 `useChannel` supports all of the parameter combinations of a regular call to `channel.subscribe`, so you can filter the messages you subscribe to by providing a `message type` to the `useChannel` function:
 
 ```javascript
-const { channel } = useChannel("your-channel-name", "test-message", (message) => {
+useChannel("your-channel-name", "test-message", (message) => {
     console.log(message); // Only logs messages sent using the `test-message` message type
 });
 ```
 
-The `channel` instance returned by `useChannel` can be used to send messages to the channel. It's just a regular Ably JavaScript SDK `channel` instance.
+#### useChannel `publish` function
+
+The `publish` function returned by `useChannel` can be used to send messages to the channel.
 
 ```javascript
-channel.publish("test-message", { text: "message text" });
+const { publish } = useChannel("your-channel-name")
+publish("test-message", { text: "message text" });
 ```
 
-Because we're returning the channel instance, and Ably SDK instance from our `useChannel` hook, you can subsequently use these to perform any operations you like on the channel.
+#### useChannel `channel` instance
 
-For example, you could retrieve history like this:
+The `useChannel` hook returns an instance of the channel, which is part of the Ably JavaScript SDK. This allows you to access the standard Ably JavaScript SDK functionalities associated with channels.
+
+By providing both the channel instance and the Ably SDK instance through our useChannel hook, you gain the flexibility to execute various operations on the channel.
+
+For instance, you can easily fetch the history of the channel using the following method:
 
 ```javascript
 const { channel } = useChannel("your-channel-name", (message) => {
@@ -134,24 +141,12 @@ const { channel } = useChannel({ channelName: "your-channel-name", options: { pa
 
 ```javascript
 const deriveOptions = { filter: 'headers.email == `"rob.pike@domain.com"` || headers.company == `"domain"`' }
-const { channel } = useChannel({ channelName: "your-derived-channel-name", options: { ... }, deriveOptions }, (message) => {
+const { publish } = useChannel({ channelName: "your-derived-channel-name", options: { ... }, deriveOptions }, (message) => {
     ...
 });
 ```
 
-Please note that attempts to publish to a derived channel (the one created or retrieved with a filter expression) will fail. In order to send messages to the channel called _"your-derived-channel-name"_ from the example above, you will need to create another channel instance without a filter expression.
-
-```javascript
-const channelName = "your-derived-channel-name";
-const options = { ... };
-const deriveOptions = { filter: 'headers.email == `"rob.pike@domain.com"` || headers.company == `"domain"`' }
-const callback = (message) => { ... };
-
-const { channel: readOnlyChannelInstance } = useChannel({ channelName, options, deriveOptions }, callback);
-const { channel: readWriteChannelInstance } = useChannel({ channelName, options }, callback); // NB! No 'deriveOptions' passed here
-
-readWriteChannelInstance.publish("test-message", { text: "message text" });
-```
+Please note that attempts to publish to a derived channel (the one created or retrieved with a filter expression) using channel instance will fail, since derived channels support only `subscribe` capability. Use `publish` function returned by `useChannel` hook instead.
 
 ---
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -8,7 +8,7 @@ Use Ably in your React application using idiomatic, easy to use, React Hooks!
 Using this module you can:
 
 - Interact with [Ably channels](https://ably.com/docs/channels) using a React Hook.
-- [Publish messages](https://ably.com/docs/channels#publish) via Ably using publish function the hooks provide
+- [Publish messages](https://ably.com/docs/channels#publish) via Ably using the publish function the hooks provide
 - Get notifications of user [presence on channels](https://ably.com/docs/presence-occupancy/presence)
 - Send presence updates
 

--- a/src/platform/react-hooks/sample-app/src/App.tsx
+++ b/src/platform/react-hooks/sample-app/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
   const [frontOficeOnlyMessages, updateFrontOfficeOnlyMessages] = useState<Ably.Message[]>([]);
 
   const [skip, setSkip] = useState(false);
-  const { channel, ably } = useChannel({ channelName: 'your-channel-name', skip }, (message) => {
+  const { publish, ably } = useChannel({ channelName: 'your-channel-name', skip }, (message) => {
     updateMessages((prev) => [...prev, message]);
   });
 
@@ -39,7 +39,7 @@ function App() {
     }
   );
 
-  const { channel: anotherChannelPublisher } = useChannel({
+  const { publish: anotherChannelPublish } = useChannel({
     channelName: 'your-derived-channel-name',
   });
 
@@ -89,7 +89,7 @@ function App() {
       <div>
         <button
           onClick={() => {
-            channel.publish('test-message', {
+            publish('test-message', {
               text: 'message text',
             });
           }}
@@ -105,7 +105,7 @@ function App() {
         </button>
         <button
           onClick={() => {
-            anotherChannelPublisher.publish({
+            anotherChannelPublish({
               name: 'test-message',
               data: {
                 text: 'This is a message for Rob',
@@ -122,7 +122,7 @@ function App() {
         </button>
         <button
           onClick={() => {
-            anotherChannelPublisher.publish({
+            anotherChannelPublish({
               name: 'test-message',
               data: {
                 text: 'This is a company-wide message',
@@ -139,7 +139,7 @@ function App() {
         </button>
         <button
           onClick={() => {
-            anotherChannelPublisher.publish({
+            anotherChannelPublish({
               name: 'test-message',
               data: {
                 text: 'This is a message for front office employees only',

--- a/src/platform/react-hooks/src/AblyProvider.tsx
+++ b/src/platform/react-hooks/src/AblyProvider.tsx
@@ -11,7 +11,12 @@ interface AblyProviderProps {
 
 export interface AblyContextProps {
   client: Ably.RealtimeClient;
-  _channelNameToInstance: Record<string, Ably.RealtimeChannel>;
+  _channelNameToChannelContext: Record<string, ChannelContextProps>;
+}
+
+export interface ChannelContextProps {
+  channel: Ably.RealtimeChannel;
+  derived?: boolean;
 }
 
 type AblyContextType = React.Context<AblyContextProps>;
@@ -32,7 +37,7 @@ export const AblyProvider = ({ client, children, id = 'default' }: AblyProviderP
   const value: AblyContextProps = useMemo(
     () => ({
       client,
-      _channelNameToInstance: {},
+      _channelNameToChannelContext: {},
     }),
     [client]
   );
@@ -43,7 +48,7 @@ export const AblyProvider = ({ client, children, id = 'default' }: AblyProviderP
 
   let context = getContext(id);
   if (!context) {
-    context = ctxMap[id] = React.createContext({ client, _channelNameToInstance: {} });
+    context = ctxMap[id] = React.createContext({ client, _channelNameToChannelContext: {} });
   }
 
   return <context.Provider value={value}>{children}</context.Provider>;

--- a/src/platform/react-hooks/src/ChannelProvider.tsx
+++ b/src/platform/react-hooks/src/ChannelProvider.tsx
@@ -19,25 +19,27 @@ export const ChannelProvider = ({
   children,
 }: ChannelProviderProps) => {
   const context = getContext(id);
-  const { client, _channelNameToInstance } = React.useContext(context);
+  const { client, _channelNameToChannelContext } = React.useContext(context);
 
-  if (_channelNameToInstance[channelName]) {
+  if (_channelNameToChannelContext[channelName]) {
     throw new Error('You can not use more than one `ChannelProvider` with the same channel name');
   }
 
-  const channel = deriveOptions
-    ? client.channels.getDerived(channelName, deriveOptions)
-    : client.channels.get(channelName);
+  const derived = Boolean(deriveOptions);
+  const channel = derived ? client.channels.getDerived(channelName, deriveOptions) : client.channels.get(channelName);
 
   const value: AblyContextProps = useMemo(() => {
     return {
       client,
-      _channelNameToInstance: {
-        ..._channelNameToInstance,
-        [channelName]: channel,
+      _channelNameToChannelContext: {
+        ..._channelNameToChannelContext,
+        [channelName]: {
+          channel,
+          derived,
+        },
       },
     };
-  }, [client, channel, channelName, _channelNameToInstance]);
+  }, [derived, client, channel, channelName, _channelNameToChannelContext]);
 
   useEffect(() => {
     channel.setOptions(channelOptionsWithAgent(options));

--- a/src/platform/react-hooks/src/fakes/ably.ts
+++ b/src/platform/react-hooks/src/fakes/ably.ts
@@ -116,7 +116,7 @@ export class ClientChannelsCollection {
 
     const channel = this.channels.get(name);
     channelConnection = new ClientSingleDerivedChannelConnection(this.client, channel, options, name);
-    this._channelConnections.set(name, channelConnection);
+    this._channelConnections.set(`[derived]${name}`, channelConnection);
     return channelConnection;
   }
 }
@@ -194,6 +194,10 @@ export class ClientSingleDerivedChannelConnection extends EventEmitter {
 
   public async setOptions() {
     // do nothing
+  }
+
+  public async publish() {
+    throw Error('no publish for derived channel');
   }
 }
 

--- a/src/platform/react-hooks/src/hooks/useChannel.test.tsx
+++ b/src/platform/react-hooks/src/hooks/useChannel.test.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { it, beforeEach, describe, expect, vi } from 'vitest';
 import { useChannel } from './useChannel.js';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { FakeAblySdk, FakeAblyChannels } from '../fakes/ably.js';
 import * as Ably from 'ably';
 import { act } from 'react-dom/test-utils';
@@ -203,6 +203,23 @@ describe('useChannel with deriveOptions', () => {
     const messageUl = screen.getAllByRole('derived-channel-messages')[0];
 
     expect(messageUl.childElementCount).toBe(0);
+  });
+
+  it('component can use "publish" for channel with "deriveOptions"', async () => {
+    const { result } = renderHook(() => useChannel('blah'), {
+      wrapper: ({ children }) => (
+        <AblyProvider client={ablyClient as unknown as Ably.RealtimeClient}>
+          <ChannelProvider channelName="blah" deriveOptions={{ filter: 'headers.user == `"robert.pike@domain.io"`' }}>
+            {children}
+          </ChannelProvider>
+        </AblyProvider>
+      ),
+    });
+
+    const { channel, publish } = result.current;
+
+    await expect(channel.publish('test', 'test')).rejects.toThrow();
+    await publish('test', 'test');
   });
 
   it('component updates when new message arrives', async () => {

--- a/src/platform/react-hooks/src/hooks/useChannelInstance.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelInstance.ts
@@ -1,14 +1,14 @@
 import React from 'react';
-import { getContext } from '../AblyProvider.js';
+import { ChannelContextProps, getContext } from '../AblyProvider.js';
 
-export function useChannelInstance(id: string, channelName: string) {
-  const channel = React.useContext(getContext(id))._channelNameToInstance[channelName];
+export function useChannelInstance(id: string, channelName: string): ChannelContextProps {
+  const channelContext = React.useContext(getContext(id))._channelNameToChannelContext[channelName];
 
-  if (!channel) {
+  if (!channelContext) {
     throw new Error(
       `Could not find a parent ChannelProvider in the component tree for channelName="${channelName}". Make sure your channel based hooks (usePresence, useChannel, useChannelStateListener) are called inside a <ChannelProvider> component`
     );
   }
 
-  return channel;
+  return channelContext;
 }

--- a/src/platform/react-hooks/src/hooks/useChannelStateListener.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelStateListener.ts
@@ -24,7 +24,7 @@ export function useChannelStateListener(
 
   const { channelName } = channelHookOptions;
 
-  const channel = useChannelInstance(id, channelName);
+  const { channel } = useChannelInstance(id, channelName);
 
   const _listener = typeof listener === 'function' ? listener : (stateOrListener as ChannelStateListener);
 

--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -28,7 +28,7 @@ export function usePresence<T = any>(
       : { channelName: channelNameOrNameAndOptions };
 
   const ably = useAbly(params.id);
-  const channel = useChannelInstance(params.id, params.channelName);
+  const { channel } = useChannelInstance(params.id, params.channelName);
 
   const subscribeOnly = typeof channelNameOrNameAndOptions === 'string' ? false : params.subscribeOnly;
 


### PR DESCRIPTION
Using publish method you can send messages to the derived channels (channels with filter qualifier, without attaching to the channel or using other workarounds)