### PR TITLE
[ECO-4667] Add spec-conforming logging API to v1

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -392,7 +392,21 @@ declare namespace Types {
     environment?: string;
 
     /**
+     * Controls the verbosity of the logs output from the library. Valid values are: 0 (no logs), 1 (errors only), 2 (errors plus connection and channel state changes), 3 (high-level debug output), and 4 (full debug output).
+     */
+    logLevel?: number;
+
+    /**
+     * Controls the log output of the library. This is a function to handle each line of log output. If you do not set this value, then `console.log` will be used.
+     *
+     * @param msg - The log message emitted by the library.
+     */
+    logHandler?: (msg: string) => void;
+
+    /**
      * Parameters to control the log output of the library, such as the log handler and log level.
+     *
+     * @deprecated This property is deprecated and will be removed in a future version. Use the {@link ClientOptions.logLevel} and {@link ClientOptions.logHandler} client options instead.
      */
     log?: LogInfo;
 
@@ -1128,15 +1142,21 @@ declare namespace Types {
 
   /**
    * Settings which control the log output of the library.
+   *
+   * @deprecated This type is deprecated and will be removed in a future version. Use the {@link ClientOptions.logLevel} and {@link ClientOptions.logHandler} client options instead.
    */
   interface LogInfo {
     /**
      * Controls the verbosity of the logs output from the library. Valid values are: 0 (no logs), 1 (errors only), 2 (errors plus connection and channel state changes), 3 (high-level debug output), and 4 (full debug output).
+     *
+     * @deprecated This property is deprecated and will be removed in a future version. Use the {@link ClientOptions.logLevel} client option instead.
      */
     level?: number;
 
     /**
      * Controls the log output of the library. This is a function to handle each line of log output. If you do not set this value, then `console.log` will be used.
+     *
+     * @deprecated This property is deprecated and will be removed in a future version. Use the {@link ClientOptions.logHandler} client option instead.
      *
      * @param msg - The log message emitted by the library.
      */

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -53,7 +53,11 @@ class Rest {
 
     if (optionsObj.log) {
       Logger.setLog(optionsObj.log.level, optionsObj.log.handler);
+      Logger.deprecated('the `log` client option', 'the `logLevel` and `logHandler` client options');
+    } else {
+      Logger.setLog(optionsObj.logLevel, optionsObj.logHandler);
     }
+
     Logger.logAction(Logger.LOG_MICRO, 'Rest()', 'initialized with clientOptions ' + Platform.Config.inspect(options));
 
     const normalOptions = (this.options = Defaults.normaliseOptions(optionsObj));

--- a/test/common/globals/environment.js
+++ b/test/common/globals/environment.js
@@ -41,15 +41,13 @@ define(function (require) {
     port: port,
     tlsPort: tlsPort,
     tls: tls,
-    log: {
-      level: logLevel,
-      handler: function (msg) {
-        var time = new Date();
-        console.log(
-          time.getHours() + ':' + time.getMinutes() + ':' + time.getSeconds() + '.' + time.getMilliseconds(),
-          msg
-        );
-      },
+    logLevel: logLevel,
+    logHandler: function (msg) {
+      var time = new Date();
+      console.log(
+        time.getHours() + ':' + time.getMinutes() + ':' + time.getSeconds() + '.' + time.getMilliseconds(),
+        msg
+      );
     },
   });
 });

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -1337,7 +1337,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     /* Check that only the last authorize matters */
     it('multiple_concurrent_authorize', function (done) {
       var realtime = helper.AblyRealtime({
-        log: { level: 4 },
+        logLevel: 4,
         useTokenAuth: true,
         defaultTokenParams: { capability: { wrong: ['*'] } },
       });

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -65,7 +65,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('connectionAttributes', function (done) {
       var realtime;
       try {
-        realtime = helper.AblyRealtime({ log: { level: 4 } });
+        realtime = helper.AblyRealtime({ logLevel: 4 });
         realtime.connection.on('connected', function () {
           try {
             const recoveryContext = JSON.parse(realtime.connection.recoveryKey);

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1979,9 +1979,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * and only members that changed between ATTACHED states should result in
      * presence events */
     it('suspended_preserves_presence', function (done) {
-      var mainRealtime = helper.AblyRealtime({ clientId: 'main', log: { level: 4 } }),
-        continuousRealtime = helper.AblyRealtime({ clientId: 'continuous', log: { level: 4 } }),
-        leavesRealtime = helper.AblyRealtime({ clientId: 'leaves', log: { level: 4 } }),
+      var mainRealtime = helper.AblyRealtime({ clientId: 'main', logLevel: 4 }),
+        continuousRealtime = helper.AblyRealtime({ clientId: 'continuous', logLevel: 4 }),
+        leavesRealtime = helper.AblyRealtime({ clientId: 'leaves', logLevel: 4 }),
         channelName = 'suspended_preserves_presence',
         mainChannel = mainRealtime.channels.get(channelName);
 

--- a/test/rest/fallbacks.test.js
+++ b/test/rest/fallbacks.test.js
@@ -25,7 +25,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
         restHost: helper.unroutableHost,
         fallbackHosts: [goodHost],
         httpRequestTimeout: 3000,
-        log: { level: 4 },
+        logLevel: 4,
       });
       var validUntil;
       async.series(


### PR DESCRIPTION
Cherry-picked from commit eaee6f6 in the `integration/v2` branch, but preserving the old API with a deprecation warning. Message of that commit:

> Conform to spec for logging configuration
>
> Replace the ClientOptions.log property with separate logLevel and
> logHandler properties, to conform with TO3b and TO3c.
>
> Resolves #642.

Decided to add the new API to v1 so that we can add a deprecation warning to the old one before removing it in v2. This will then allow the first step of our v2 migration guide to simply be “upgrade to the latest version of v1 and address all the deprecation warnings”.

Part of #1666.