### PR TITLE
[ECO-4115] Split `usePresence` hook into different hooks for entering presence and subscribing to presence events

### DIFF
--- a/src/platform/react-hooks/sample-app/src/App.tsx
+++ b/src/platform/react-hooks/sample-app/src/App.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import {
   useChannel,
   usePresence,
+  usePresenceListener,
   useConnectionStateListener,
   useChannelStateListener,
   useAbly,
@@ -15,7 +16,7 @@ function App() {
   const [frontOficeOnlyMessages, updateFrontOfficeOnlyMessages] = useState<Ably.Message[]>([]);
 
   const [skip, setSkip] = useState(false);
-  const { publish, ably } = useChannel({ channelName: 'your-channel-name', skip }, (message) => {
+  const { channel, publish, ably } = useChannel({ channelName: 'your-channel-name', skip }, (message) => {
     updateMessages((prev) => [...prev, message]);
   });
 
@@ -43,13 +44,10 @@ function App() {
     channelName: 'your-derived-channel-name',
   });
 
-  const { presenceData, updateStatus } = usePresence(
-    { channelName: 'your-channel-name', skip },
-    { foo: 'bar' },
-    (update) => {
-      console.log(update);
-    },
-  );
+  const { updateStatus } = usePresence({ channelName: 'your-channel-name', skip }, { foo: 'bar' });
+  const { presenceData } = usePresenceListener({ channelName: 'your-channel-name', skip }, (update) => {
+    console.log(update);
+  });
 
   const [, setConnectionState] = useState(ably.connection.state);
 
@@ -79,7 +77,8 @@ function App() {
 
   const presentClients = presenceData.map((msg, index) => (
     <li key={index}>
-      {msg.clientId}: {JSON.stringify(msg.data)}
+      {/* PresenceMessage type is not correctly resolved and is missing 'clientId' property due to fail to load 'ably' type declarations in this test file */}
+      {(msg as any).clientId}: {JSON.stringify(msg.data)}
     </li>
   ));
 
@@ -101,7 +100,7 @@ function App() {
             updateStatus({ foo: 'baz' });
           }}
         >
-          Update status to hello
+          Update presence status to baz
         </button>
         <button
           onClick={() => {

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -3,7 +3,6 @@ import * as Ably from 'ably';
 export type ChannelNameAndOptions = {
   channelName: string;
   ablyId?: string;
-  subscribeOnly?: boolean;
   skip?: boolean;
 
   onConnectionError?: (error: Ably.ErrorInfo) => unknown;

--- a/src/platform/react-hooks/src/fakes/ably.ts
+++ b/src/platform/react-hooks/src/fakes/ably.ts
@@ -219,8 +219,8 @@ export class ClientPresenceConnection {
     this.presence.update(this.client.clientId, message);
   }
 
-  public subscribe(key: string, callback: CallableFunction) {
-    this.presence.subscribe(this.client.clientId, key, callback);
+  public subscribe(key: string | string[], callback: CallableFunction) {
+    (Array.isArray(key) ? key : [key]).forEach((x) => this.presence.subscribe(this.client.clientId, x, callback));
   }
 
   public leave(data?: any) {
@@ -233,8 +233,8 @@ export class ClientPresenceConnection {
     this.presence.enter(this.client.clientId, message);
   }
 
-  public unsubscribe(key: string, listener?: any) {
-    this.presence.unsubscribe(this.client.clientId, key, listener);
+  public unsubscribe(key: string | string[], listener?: any) {
+    (Array.isArray(key) ? key : [key]).forEach((x) => this.presence.unsubscribe(this.client.clientId, x, listener));
   }
 
   private toPressenceMessage(data: any) {
@@ -404,8 +404,8 @@ export class ChannelPresence {
   }
 
   private triggerSubs(subType: string, data: any) {
-    for (const [, subscriptions] of this.subscriptionsPerClient.entries()) {
-      const subs = subscriptions.get(subType);
+    for (const subscriptions of this.subscriptionsPerClient.values()) {
+      const subs = subscriptions.get(subType) ?? [];
       for (const callback of subs) {
         callback(data);
       }

--- a/src/platform/react-hooks/src/hooks/usePresence.test.tsx
+++ b/src/platform/react-hooks/src/hooks/usePresence.test.tsx
@@ -28,83 +28,80 @@ describe('usePresence', () => {
     otherClient = new FakeAblySdk().connectTo(channels);
   });
 
-  it('presence data is not visible on first render as it runs in an effect', async () => {
+  it('presence is entered after effect runs', async () => {
+    const enterListener = vi.fn();
+    ablyClient.channels.get(testChannelName).presence.subscribe(['enter'], enterListener);
+
     renderInCtxProvider(ablyClient, <UsePresenceComponent></UsePresenceComponent>);
 
-    const values = screen.getByRole('presence').innerHTML;
-    expect(values).toBe('');
-
-    await act(async () => {
-      await wait(2);
-      // To let react run its updates so we don't see warnings in the test output
+    await waitFor(() => {
+      expect(enterListener).toHaveBeenCalledWith(expect.objectContaining({ data: 'bar' }));
     });
-  });
-
-  it('presence data available after effect runs', async () => {
-    renderInCtxProvider(ablyClient, <UsePresenceComponent></UsePresenceComponent>);
-
-    await act(async () => {
-      await wait(2);
-    });
-
-    const values = screen.getByRole('presence').innerHTML;
-    expect(values).toContain(`"bar"`);
   });
 
   it('presence data updates when update function is triggered', async () => {
+    const updateListener = vi.fn();
+    ablyClient.channels.get(testChannelName).presence.subscribe(['update'], updateListener);
+
     renderInCtxProvider(ablyClient, <UsePresenceComponent></UsePresenceComponent>);
 
     await act(async () => {
       const button = screen.getByText(/Update/i);
       button.click();
+      await wait(2);
     });
 
-    const values = screen.getByRole('presence').innerHTML;
-    expect(values).toContain(`"baz"`);
-  });
-
-  it('presence data respects updates made by other clients', async () => {
-    renderInCtxProvider(ablyClient, <UsePresenceComponent></UsePresenceComponent>);
-
-    await act(async () => {
-      otherClient.channels.get(testChannelName).presence.enter('boop');
+    await waitFor(() => {
+      expect(updateListener).toHaveBeenCalledWith(expect.objectContaining({ data: 'baz' }));
     });
-
-    const presenceElement = screen.getByRole('presence');
-    const values = presenceElement.innerHTML;
-    expect(presenceElement.children.length).toBe(2);
-    expect(values).toContain(`"bar"`);
-    expect(values).toContain(`"boop"`);
   });
 
   it('presence API works with type information provided', async () => {
-    renderInCtxProvider(
-      ablyClient,
-      <ChannelProvider channelName="testChannelName">
-        <TypedUsePresenceComponent></TypedUsePresenceComponent>
-      </ChannelProvider>,
-    );
+    const enterListener = vi.fn();
+    const updateListener = vi.fn();
+    ablyClient.channels.get(testChannelName).presence.subscribe('enter', enterListener);
+    ablyClient.channels.get(testChannelName).presence.subscribe('update', updateListener);
+
+    renderInCtxProvider(ablyClient, <TypedUsePresenceComponent></TypedUsePresenceComponent>);
+
+    // Wait for `usePresence` to be rendered and entered presence
+    await waitFor(() => {
+      expect(enterListener).toHaveBeenCalledWith(expect.objectContaining({ data: { foo: 'bar' } }));
+    });
 
     await act(async () => {
+      const button = screen.getByText(/Update/i);
+      button.click();
       await wait(2);
     });
 
-    const values = screen.getByRole('presence').innerHTML;
-    expect(values).toContain(`"data":{"foo":"bar"}`);
+    // Wait for presence data be updated
+    await waitFor(() => {
+      expect(updateListener).toHaveBeenCalledWith(expect.objectContaining({ data: { foo: 'baz' } }));
+    });
   });
 
-  it('skip param', async () => {
+  it('`skip` param prevents mounting and entering presence', async () => {
+    const enterListener = vi.fn();
+    ablyClient.channels.get(testChannelName).presence.subscribe('enter', enterListener);
+
     renderInCtxProvider(ablyClient, <UsePresenceComponent skip={true}></UsePresenceComponent>);
 
+    // wait for component to be rendered
     await act(async () => {
       await wait(2);
     });
 
-    const values = screen.getByRole('presence').innerHTML;
-    expect(values).to.not.contain(`"bar"`);
+    // expect presence not to be entered
+    await waitFor(() => {
+      expect(enterListener).not.toHaveBeenCalled();
+    });
   });
 
   it('usePresence works with multiple clients', async () => {
+    const updateListener = vi.fn();
+    ablyClient.channels.get(testChannelName).presence.subscribe('update', updateListener);
+
     renderInCtxProvider(
       ablyClient,
       <AblyProvider ablyId="otherClient" client={otherClient as unknown as Ably.RealtimeClient}>
@@ -120,9 +117,10 @@ describe('usePresence', () => {
       await wait(2);
     });
 
-    const values = screen.getByRole('presence').innerHTML;
-    expect(values).toContain(`"data":"baz1"`);
-    expect(values).toContain(`"data":"baz2"`);
+    await waitFor(() => {
+      expect(updateListener).toHaveBeenCalledWith(expect.objectContaining({ data: 'baz1' }));
+      expect(updateListener).toHaveBeenCalledWith(expect.objectContaining({ data: 'baz2' }));
+    });
   });
 
   it('handles channel errors', async () => {
@@ -207,15 +205,7 @@ describe('usePresence', () => {
 });
 
 const UsePresenceComponent = ({ skip }: { skip?: boolean }) => {
-  const { presenceData, updateStatus } = usePresence({ channelName: testChannelName, skip }, 'bar');
-
-  const presentUsers = presenceData.map((presence, index) => {
-    return (
-      <li key={index}>
-        {presence.clientId} - {JSON.stringify(presence)}
-      </li>
-    );
-  });
+  const { updateStatus } = usePresence({ channelName: testChannelName, skip }, 'bar');
 
   return (
     <>
@@ -226,22 +216,13 @@ const UsePresenceComponent = ({ skip }: { skip?: boolean }) => {
       >
         Update
       </button>
-      <ul role="presence">{presentUsers}</ul>
     </>
   );
 };
 
 const UsePresenceComponentMultipleClients = () => {
-  const { presenceData: val1, updateStatus: update1 } = usePresence({ channelName: testChannelName }, 'foo');
+  const { updateStatus: update1 } = usePresence({ channelName: testChannelName }, 'foo');
   const { updateStatus: update2 } = usePresence({ channelName: testChannelName, ablyId: 'otherClient' }, 'bar');
-
-  const presentUsers = val1.map((presence, index) => {
-    return (
-      <li key={index}>
-        {presence.clientId} - {JSON.stringify(presence)}
-      </li>
-    );
-  });
 
   return (
     <>
@@ -253,7 +234,6 @@ const UsePresenceComponentMultipleClients = () => {
       >
         Update
       </button>
-      <ul role="presence">{presentUsers}</ul>
     </>
   );
 };
@@ -286,11 +266,19 @@ interface MyPresenceType {
 }
 
 const TypedUsePresenceComponent = () => {
-  const { presenceData } = usePresence<MyPresenceType>('testChannelName', {
-    foo: 'bar',
-  });
+  const { updateStatus } = usePresence<MyPresenceType>(testChannelName, { foo: 'bar' });
 
-  return <div role="presence">{JSON.stringify(presenceData)}</div>;
+  return (
+    <div role="presence">
+      <button
+        onClick={() => {
+          updateStatus({ foo: 'baz' });
+        }}
+      >
+        Update
+      </button>
+    </div>
+  );
 };
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -1,5 +1,5 @@
 import type * as Ably from 'ably';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { ChannelParameters } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly.js';
 import { useChannelInstance } from './useChannelInstance.js';
@@ -26,27 +26,37 @@ export function usePresence<T = any>(
   const ably = useAbly(params.ablyId);
   const { channel } = useChannelInstance(params.ablyId, params.channelName);
   const { connectionError, channelError } = useStateErrors(params);
+  // we can't simply add messageOrPresenceObject to dependency list in our useCallback/useEffect hooks,
+  // since it will most likely cause an infinite loop of updates in cases when user calls this hook
+  // with an object literal instead of a state or memoized object.
+  // to prevent this from happening we store messageOrPresenceObject in a ref, and use that instead.
+  // note that it still prevents us from automatically re-entering presence with new messageOrPresenceObject if it changes.
+  // one of the options to fix this, is to use deep equals to check if the object has actually changed. see https://github.com/ably/ably-js/issues/1688.
+  const messageOrPresenceObjectRef = useRef(messageOrPresenceObject);
 
-  const onMount = async () => {
-    await channel.presence.enter(messageOrPresenceObject);
-  };
+  useEffect(() => {
+    messageOrPresenceObjectRef.current = messageOrPresenceObject;
+  }, [messageOrPresenceObject]);
 
-  const onUnmount = () => {
+  const onMount = useCallback(async () => {
+    await channel.presence.enter(messageOrPresenceObjectRef.current);
+  }, [channel.presence]);
+
+  const onUnmount = useCallback(() => {
     // if connection is in one of inactive states, leave call will produce exception
     if (channel.state === 'attached' && !INACTIVE_CONNECTION_STATES.includes(ably.connection.state)) {
       channel.presence.leave();
     }
-  };
+  }, [channel, ably.connection.state]);
 
-  const useEffectHook = () => {
-    if (!skip) onMount();
+  useEffect(() => {
+    if (skip) return;
+
+    onMount();
     return () => {
       onUnmount();
     };
-  };
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(useEffectHook, [skip]);
+  }, [skip, onMount, onUnmount]);
 
   const updateStatus = useCallback(
     (messageOrPresenceObject: T) => {

--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -5,6 +5,10 @@ import { useAbly } from './useAbly.js';
 import { useStateErrors } from './useStateErrors.js';
 import { useChannelInstance } from './useChannelInstance.js';
 
+interface PresenceMessage<T = any> extends Ably.PresenceMessage {
+  data: T;
+}
+
 export interface PresenceResult<T> {
   presenceData: PresenceMessage<T>[];
   updateStatus: (messageOrPresenceObject: T) => void;
@@ -88,14 +92,4 @@ export function usePresence<T = any>(
   );
 
   return { presenceData, updateStatus, connectionError, channelError };
-}
-
-interface PresenceMessage<T = any> {
-  action: Ably.PresenceAction;
-  clientId: string;
-  connectionId: string;
-  data: T;
-  encoding: string;
-  id: string;
-  timestamp: number;
 }

--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -46,9 +46,7 @@ export function usePresence<T = any>(
   };
 
   const onMount = async () => {
-    channel.presence.subscribe('enter', updatePresence);
-    channel.presence.subscribe('leave', updatePresence);
-    channel.presence.subscribe('update', updatePresence);
+    channel.presence.subscribe(['enter', 'leave', 'update'], updatePresence);
 
     if (!subscribeOnly) {
       await channel.presence.enter(messageOrPresenceObject);
@@ -65,9 +63,7 @@ export function usePresence<T = any>(
         channel.presence.leave();
       }
     }
-    channel.presence.unsubscribe('enter', updatePresence);
-    channel.presence.unsubscribe('leave', updatePresence);
-    channel.presence.unsubscribe('update', updatePresence);
+    channel.presence.unsubscribe(['enter', 'leave', 'update'], updatePresence);
   };
 
   const useEffectHook = () => {

--- a/src/platform/react-hooks/src/hooks/usePresenceListener.test.tsx
+++ b/src/platform/react-hooks/src/hooks/usePresenceListener.test.tsx
@@ -1,0 +1,318 @@
+import React from 'react';
+import type * as Ably from 'ably';
+import { it, beforeEach, describe, expect, vi } from 'vitest';
+import { usePresenceListener } from './usePresenceListener.js';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { FakeAblySdk, FakeAblyChannels } from '../fakes/ably.js';
+import { AblyProvider } from '../AblyProvider.js';
+import { ChannelProvider } from '../ChannelProvider.js';
+
+const testChannelName = 'testChannel';
+
+function renderInCtxProvider(client: FakeAblySdk, children: React.ReactNode | React.ReactNode[]) {
+  return render(
+    <AblyProvider client={client as unknown as Ably.RealtimeClient}>
+      <ChannelProvider channelName={testChannelName}>{children}</ChannelProvider>
+    </AblyProvider>,
+  );
+}
+
+describe('usePresenceListener', () => {
+  let channels: FakeAblyChannels;
+  let ablyClient: FakeAblySdk;
+  let otherClient: FakeAblySdk;
+
+  beforeEach(() => {
+    channels = new FakeAblyChannels([testChannelName]);
+    ablyClient = new FakeAblySdk().connectTo(channels);
+    otherClient = new FakeAblySdk().connectTo(channels);
+  });
+
+  it('presence data is not visible on first render as it runs in an effect', async () => {
+    // enter presence before rendering the component
+    ablyClient.channels.get(testChannelName).presence.enter('bar');
+
+    renderInCtxProvider(ablyClient, <UsePresenceListenerComponent></UsePresenceListenerComponent>);
+
+    const values = screen.getByRole('presence').innerHTML;
+    expect(values).toBe('');
+
+    await act(async () => {
+      await wait(2);
+      // To let react run its updates so we don't see warnings in the test output
+    });
+  });
+
+  it('presence data available after effect runs', async () => {
+    // enter presence before rendering the component
+    ablyClient.channels.get(testChannelName).presence.enter('bar');
+
+    renderInCtxProvider(ablyClient, <UsePresenceListenerComponent></UsePresenceListenerComponent>);
+
+    await act(async () => {
+      await wait(2);
+    });
+
+    const values = screen.getByRole('presence').innerHTML;
+    expect(values).toContain(`"bar"`);
+  });
+
+  it('presence data in component updates when presence was updated', async () => {
+    ablyClient.channels.get(testChannelName).presence.enter('bar');
+
+    renderInCtxProvider(ablyClient, <UsePresenceListenerComponent></UsePresenceListenerComponent>);
+
+    await act(async () => {
+      ablyClient.channels.get(testChannelName).presence.update('baz');
+    });
+
+    const values = screen.getByRole('presence').innerHTML;
+    expect(values).toContain(`"baz"`);
+  });
+
+  it('presence data respects updates made by other clients', async () => {
+    ablyClient.channels.get(testChannelName).presence.enter('bar');
+
+    renderInCtxProvider(ablyClient, <UsePresenceListenerComponent></UsePresenceListenerComponent>);
+
+    await act(async () => {
+      otherClient.channels.get(testChannelName).presence.enter('baz');
+    });
+
+    const presenceElement = screen.getByRole('presence');
+    const values = presenceElement.innerHTML;
+    expect(presenceElement.children.length).toBe(2);
+    expect(values).toContain(`"bar"`);
+    expect(values).toContain(`"baz"`);
+  });
+
+  it('presence API works with type information provided', async () => {
+    const data: MyPresenceType = { foo: 'bar' };
+    ablyClient.channels.get(testChannelName).presence.enter(data);
+
+    renderInCtxProvider(ablyClient, <TypedUsePresenceListenerComponent></TypedUsePresenceListenerComponent>);
+
+    await act(async () => {
+      await wait(2);
+    });
+
+    const values = screen.getByRole('presence').innerHTML;
+    expect(values).toContain(`"data":${JSON.stringify(data)}`);
+  });
+
+  it('`skip` param prevents mounting and subscribing to presence events', async () => {
+    // can't really test 'leave' event, since if 'skip' works as expected then we won't have any data available to check that it's gone
+    ablyClient.channels.get(testChannelName).presence.enter('bar');
+    ablyClient.channels.get(testChannelName).presence.update('baz');
+
+    renderInCtxProvider(ablyClient, <UsePresenceListenerComponent skip={true}></UsePresenceListenerComponent>);
+
+    await act(async () => {
+      await wait(2);
+    });
+
+    const values = screen.getByRole('presence').innerHTML;
+    expect(values).to.not.contain(`"bar"`);
+    expect(values).to.not.contain(`"baz"`);
+  });
+
+  it('usePresenceListener works with multiple clients', async () => {
+    ablyClient.channels.get(testChannelName).presence.enter('bar1');
+    otherClient.channels.get(testChannelName).presence.enter('bar2');
+
+    renderInCtxProvider(
+      ablyClient,
+      <AblyProvider ablyId="otherClient" client={otherClient as unknown as Ably.RealtimeClient}>
+        <ChannelProvider channelName={testChannelName} ablyId="otherClient">
+          <UsePresenceListenerComponentMultipleClients />
+        </ChannelProvider>
+      </AblyProvider>,
+    );
+
+    await act(async () => {
+      ablyClient.channels.get(testChannelName).presence.update('baz1');
+      otherClient.channels.get(testChannelName).presence.update('baz2');
+    });
+
+    const values1 = screen.getByRole('presence1').innerHTML;
+    expect(values1).toContain(`"data":"baz1"`);
+    expect(values1).toContain(`"data":"baz2"`);
+
+    const values2 = screen.getByRole('presence2').innerHTML;
+    expect(values2).toContain(`"data":"baz1"`);
+    expect(values2).toContain(`"data":"baz2"`);
+  });
+
+  it('handles channel errors', async () => {
+    const onChannelError = vi.fn();
+    const reason = { message: 'foo' };
+
+    renderInCtxProvider(
+      ablyClient,
+      <ChannelProvider channelName="blah">
+        <UsePresenceListenerStateErrorsComponent
+          onChannelError={onChannelError}
+        ></UsePresenceListenerStateErrorsComponent>
+      </ChannelProvider>,
+    );
+
+    const channelErrorElem = screen.getByRole('channelError');
+    expect(onChannelError).toHaveBeenCalledTimes(0);
+    expect(channelErrorElem.innerHTML).toEqual('');
+
+    await act(async () => {
+      ablyClient.channels.get('blah').emit('failed', {
+        reason,
+      });
+    });
+
+    expect(channelErrorElem.innerHTML).toEqual(reason.message);
+    expect(onChannelError).toHaveBeenCalledTimes(1);
+    expect(onChannelError).toHaveBeenCalledWith(reason);
+  });
+
+  it('handles connection errors', async () => {
+    const onConnectionError = vi.fn();
+    const reason = { message: 'foo' };
+
+    renderInCtxProvider(
+      ablyClient,
+      <ChannelProvider channelName="blah">
+        <UsePresenceListenerStateErrorsComponent
+          onConnectionError={onConnectionError}
+        ></UsePresenceListenerStateErrorsComponent>
+      </ChannelProvider>,
+    );
+
+    const connectionErrorElem = screen.getByRole('connectionError');
+    expect(onConnectionError).toHaveBeenCalledTimes(0);
+    expect(connectionErrorElem.innerHTML).toEqual('');
+
+    await act(async () => {
+      ablyClient.connection.emit('failed', {
+        reason,
+      });
+    });
+
+    expect(connectionErrorElem.innerHTML).toEqual(reason.message);
+    expect(onConnectionError).toHaveBeenCalledTimes(1);
+    expect(onConnectionError).toHaveBeenCalledWith(reason);
+  });
+
+  it('should not affect existing presence listeners when hook unmounts', async () => {
+    const enterListener = vi.fn();
+    ablyClient.channels.get(testChannelName).presence.subscribe('enter', enterListener);
+
+    // enter presence
+    ablyClient.channels.get(testChannelName).presence.enter('bar');
+
+    const { unmount } = renderInCtxProvider(ablyClient, <UsePresenceListenerComponent></UsePresenceListenerComponent>);
+
+    // wait for 'usePresenceListener' to render
+    await act(async () => {
+      await wait(2);
+    });
+
+    // expect existing listener and component to have presence data
+    const values = screen.getByRole('presence').innerHTML;
+    expect(values).toContain(`"bar"`);
+    expect(enterListener).toHaveBeenCalledWith(expect.objectContaining({ data: 'bar' }));
+
+    unmount();
+
+    // Wait for `usePresenceListener` to be fully unmounted and effect's clean-ups applied
+    await act(async () => {
+      await wait(2);
+    });
+
+    ablyClient.channels.get(testChannelName).presence.enter('baz');
+
+    // Check that listener still exists
+    await waitFor(() => {
+      expect(enterListener).toHaveBeenCalledWith(expect.objectContaining({ data: 'baz' }));
+    });
+  });
+});
+
+const UsePresenceListenerComponent = ({ skip }: { skip?: boolean }) => {
+  const { presenceData } = usePresenceListener({ channelName: testChannelName, skip });
+
+  const presentUsers = presenceData.map((presence, index) => {
+    return (
+      <li key={index}>
+        {/* PresenceMessage type is not correctly resolved and is missing 'clientId' property due to fail to load 'ably' type declarations in this test file */}
+        {(presence as any).clientId} - {JSON.stringify(presence)}
+      </li>
+    );
+  });
+
+  return (
+    <>
+      <ul role="presence">{presentUsers}</ul>
+    </>
+  );
+};
+
+const UsePresenceListenerComponentMultipleClients = () => {
+  const { presenceData: presenceData1 } = usePresenceListener({ channelName: testChannelName });
+  const { presenceData: presenceData2 } = usePresenceListener({ channelName: testChannelName, ablyId: 'otherClient' });
+
+  const presentUsers1 = presenceData1.map((presence, index) => {
+    return (
+      <li key={index}>
+        {/* PresenceMessage type is not correctly resolved and is missing 'clientId' property due to fail to load 'ably' type declarations in this test file */}
+        {(presence as any).clientId} - {JSON.stringify(presence)}
+      </li>
+    );
+  });
+  const presentUsers2 = presenceData2.map((presence, index) => {
+    return (
+      <li key={index}>
+        {/* PresenceMessage type is not correctly resolved and is missing 'clientId' property due to fail to load 'ably' type declarations in this test file */}
+        {(presence as any).clientId} - {JSON.stringify(presence)}
+      </li>
+    );
+  });
+
+  return (
+    <>
+      <ul role="presence1">{presentUsers1}</ul>
+      <ul role="presence2">{presentUsers2}</ul>
+    </>
+  );
+};
+
+interface UsePresenceListenerStateErrorsComponentProps {
+  onConnectionError?: (err: Ably.ErrorInfo) => unknown;
+  onChannelError?: (err: Ably.ErrorInfo) => unknown;
+}
+
+const UsePresenceListenerStateErrorsComponent = ({
+  onConnectionError,
+  onChannelError,
+}: UsePresenceListenerStateErrorsComponentProps) => {
+  const { connectionError, channelError } = usePresenceListener({
+    channelName: 'blah',
+    onConnectionError,
+    onChannelError,
+  });
+
+  return (
+    <>
+      <p role="connectionError">{connectionError?.message}</p>
+      <p role="channelError">{channelError?.message}</p>
+    </>
+  );
+};
+
+interface MyPresenceType {
+  foo: string;
+}
+
+const TypedUsePresenceListenerComponent = () => {
+  const { presenceData } = usePresenceListener<MyPresenceType>(testChannelName);
+
+  return <div role="presence">{JSON.stringify(presenceData)}</div>;
+};
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/platform/react-hooks/src/hooks/usePresenceListener.ts
+++ b/src/platform/react-hooks/src/hooks/usePresenceListener.ts
@@ -1,0 +1,61 @@
+import type * as Ably from 'ably';
+import { useEffect, useState } from 'react';
+import { ChannelParameters } from '../AblyReactHooks.js';
+import { useChannelInstance } from './useChannelInstance.js';
+import { useStateErrors } from './useStateErrors.js';
+
+interface PresenceMessage<T = any> extends Ably.PresenceMessage {
+  data: T;
+}
+
+export interface PresenceListenerResult<T> {
+  presenceData: PresenceMessage<T>[];
+  connectionError: Ably.ErrorInfo | null;
+  channelError: Ably.ErrorInfo | null;
+}
+
+export type OnPresenceMessageReceived<T> = (presenceData: PresenceMessage<T>) => void;
+
+export function usePresenceListener<T = any>(
+  channelNameOrNameAndOptions: ChannelParameters,
+  onPresenceMessageReceived?: OnPresenceMessageReceived<T>,
+): PresenceListenerResult<T> {
+  const params =
+    typeof channelNameOrNameAndOptions === 'object'
+      ? channelNameOrNameAndOptions
+      : { channelName: channelNameOrNameAndOptions };
+  const skip = params.skip;
+
+  const { channel } = useChannelInstance(params.ablyId, params.channelName);
+  const { connectionError, channelError } = useStateErrors(params);
+  const [presenceData, updatePresenceData] = useState<Array<PresenceMessage<T>>>([]);
+
+  const updatePresence = async (message?: Ably.PresenceMessage) => {
+    const snapshot = await channel.presence.get();
+    updatePresenceData(snapshot);
+
+    onPresenceMessageReceived?.call(this, message);
+  };
+
+  const onMount = async () => {
+    channel.presence.subscribe(['enter', 'leave', 'update'], updatePresence);
+    const snapshot = await channel.presence.get();
+    updatePresenceData(snapshot);
+  };
+
+  const onUnmount = () => {
+    channel.presence.unsubscribe(['enter', 'leave', 'update'], updatePresence);
+  };
+
+  const useEffectHook = () => {
+    if (!skip) onMount();
+    return () => {
+      onUnmount();
+    };
+  };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(useEffectHook, [skip]);
+
+  return { presenceData, connectionError, channelError };
+}

--- a/src/platform/react-hooks/src/index.ts
+++ b/src/platform/react-hooks/src/index.ts
@@ -1,6 +1,7 @@
 export * from './AblyReactHooks.js';
 export * from './hooks/useChannel.js';
 export * from './hooks/usePresence.js';
+export * from './hooks/usePresenceListener.js';
 export * from './hooks/useAbly.js';
 export * from './AblyProvider.js';
 export * from './hooks/useChannelStateListener.js';


### PR DESCRIPTION
Resolves #1621 

See commit messages for more details