### PR TITLE
[ECO-4681] Remove incorrect deprecation of `ClientOptions.maxMessageSize`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -573,6 +573,13 @@ declare namespace Types {
        */
       vcdiff?: any;
     };
+
+    /**
+     * The maximum message size is an attribute of an Ably account which represents the largest permitted payload size of a single message or set of messages published in a single operation. Publish requests whose payload exceeds this limit are rejected by the server. `maxMessageSize` enables the client to enforce, or further restrict, the maximum size of a single message or set of messages published via REST. The default value is `65536` (64 KiB). In the case of a realtime connection, the server may indicate the associated maximum message size on connection establishment; this value takes precedence over the client's default `maxMessageSize`.
+     *
+     * @defaultValue 65536
+     */
+    maxMessageSize?: number;
   }
 
   /**

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -20,7 +20,6 @@ export type DeprecatedClientOptions = Modify<
     queueEvents?: boolean;
     promises?: boolean;
     headers?: Record<string, string>;
-    maxMessageSize?: number;
   }
 >;
 


### PR DESCRIPTION
This client option still exists in the spec ([TO3l8](https://sdk.ably.com/builds/ably/specification/main/features/#TO3l8)). Looks like when we added it in 228eabf we forgot to add it to the typings, which I guess is why it then ended up being added to `DeprecatedClientOptions` in 4f66064.

So, add it to the public typings.

Documentation taken from sdk-api-reference at commit `a8fdd42` (see https://github.com/ably/sdk-api-reference/pull/39).

Part of #1677.