### PR TITLE
[ECO-4667] Add a deprecation warning for the `headers` client option

### DIFF
--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -195,6 +195,12 @@ export function normaliseOptions(options: DeprecatedClientOptions): NormalisedCl
     Logger.deprecated('queueEvents', 'queueMessages');
     options.queueMessages = options.queueEvents;
   }
+  if (options.headers) {
+    Logger.deprecatedWithMsg(
+      'the `headers` client option',
+      '' /* there is no replacement; see DeprecatedClientOptions.headers */
+    );
+  }
 
   if (options.fallbackHostsUseDefault) {
     /* fallbackHostsUseDefault and fallbackHosts are mutually exclusive as per TO3k7 */

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -19,6 +19,9 @@ export type DeprecatedClientOptions = Modify<
     wsHost?: string;
     queueEvents?: boolean;
     promises?: boolean;
+    /**
+     * This option dates back to the initial commit of the repo but was never in the specification and sounds like nobody is depending on it; Paddy said we can remove in v2 (see https://ably-real-time.slack.com/archives/CURL4U2FP/p1709909310332169?thread_ts=1709908997.753599&cid=CURL4U2FP)
+     */
     headers?: Record<string, string>;
     maxMessageSize?: number;
   }


### PR DESCRIPTION
Along with an explanation of why it’s in `DeprecatedClientOptions`.

We’ve removed this client option in commit d7aaf34 on the `integration/v2` branch. It sounds unlikely this will affect anyone, but add a deprecation warning just in case, and to be consistent with our approach to other deprecated client options.

Part of #1666.