### PR TITLE
Merge `main` into `integration/v2`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -574,6 +574,13 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
    * A map between a plugin type and a plugin object.
    */
   plugins?: Plugins;
+
+  /**
+   * The maximum message size is an attribute of an Ably account which represents the largest permitted payload size of a single message or set of messages published in a single operation. Publish requests whose payload exceeds this limit are rejected by the server. `maxMessageSize` enables the client to enforce, or further restrict, the maximum size of a single message or set of messages published via REST. The default value is `65536` (64 KiB). In the case of a realtime connection, the server may indicate the associated maximum message size on connection establishment; this value takes precedence over the client's default `maxMessageSize`.
+   *
+   * @defaultValue 65536
+   */
+  maxMessageSize?: number;
 }
 
 /**

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -3,7 +3,7 @@ import * as Utils from './utils';
 import Logger from './logger';
 import ErrorInfo from 'common/lib/types/errorinfo';
 import { version } from '../../../../package.json';
-import ClientOptions, { InternalClientOptions, NormalisedClientOptions } from 'common/types/ClientOptions';
+import ClientOptions, { NormalisedClientOptions } from 'common/types/ClientOptions';
 import IDefaults from '../../types/IDefaults';
 import { MsgPack } from 'common/types/msgpack';
 import { IUntypedCryptoStatic } from 'common/types/ICryptoStatic';
@@ -45,7 +45,7 @@ type CompleteDefaults = IDefaults & {
   checkHost(host: string): void;
   getRealtimeHost(options: ClientOptions, production: boolean, environment: string): string;
   objectifyOptions(options: ClientOptions | string, modularPluginsToInclude?: ModularPlugins): ClientOptions;
-  normaliseOptions(options: InternalClientOptions, MsgPack: MsgPack | null): NormalisedClientOptions;
+  normaliseOptions(options: ClientOptions, MsgPack: MsgPack | null): NormalisedClientOptions;
   defaultGetHeaders(options: NormalisedClientOptions, headersOptions?: HeadersOptions): Record<string, string>;
   defaultPostHeaders(options: NormalisedClientOptions, headersOptions?: HeadersOptions): Record<string, string>;
 };
@@ -196,7 +196,7 @@ export function objectifyOptions(
   return optionsObj;
 }
 
-export function normaliseOptions(options: InternalClientOptions, MsgPack: MsgPack | null): NormalisedClientOptions {
+export function normaliseOptions(options: ClientOptions, MsgPack: MsgPack | null): NormalisedClientOptions {
   if (typeof options.recover === 'function' && options.closeOnUnload === true) {
     Logger.logAction(
       Logger.LOG_ERROR,
@@ -267,7 +267,7 @@ export function normaliseOptions(options: InternalClientOptions, MsgPack: MsgPac
     ...options,
     realtimeHost,
     restHost,
-    maxMessageSize: options.internal?.maxMessageSize || Defaults.maxMessageSize,
+    maxMessageSize: options.maxMessageSize || Defaults.maxMessageSize,
     timeouts,
     connectivityCheckParams,
     connectivityCheckUrl,

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -13,20 +13,8 @@ export default interface ClientOptions extends API.ClientOptions<API.CorePlugins
   agents?: Record<string, string | undefined>;
 }
 
-/**
- * Properties which internal and test code wish to be able to pass to the public constructor of `Rest` and `Realtime` in order to modify the behaviour of those classes.
- */
-export type InternalClientOptions = Modify<
-  ClientOptions,
-  {
-    internal?: {
-      maxMessageSize?: number;
-    };
-  }
->;
-
 export type NormalisedClientOptions = Modify<
-  InternalClientOptions,
+  ClientOptions,
   {
     realtimeHost: string;
     restHost: string;

--- a/test/rest/message.test.js
+++ b/test/rest/message.test.js
@@ -99,7 +99,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     /* TO3l8; CD2C; RSL1i */
     it('Should error when publishing message larger than maxMessageSize', async function () {
       /* No connectionDetails mechanism for REST, so just pass the override into the constructor */
-      var realtime = helper.AblyRest({ internal: { maxMessageSize: 64 } }),
+      var realtime = helper.AblyRest({ maxMessageSize: 64 }),
         channel = realtime.channels.get('maxMessageSize');
 
       try {


### PR DESCRIPTION
Here’s how we handle the following commits that merge commit 1262a77 brings in from `main`:

- 36162c4: The content of this commit already exists on v2 (in commit eaee6f6), except for the deprecation warnings for the old API, which we remove in the current commit.

- 8f725ee: This commit un-deprecates the `maxMessageSize` client option, so we undo the part of fe3c9ce that relates to this option (as described in #1677).