### PR TITLE
Improve deprecation log messages for renamed stuff

### DIFF
--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -328,7 +328,7 @@ class Auth {
   }
 
   authorise(tokenParams: API.Types.TokenParams | null, authOptions: API.Types.AuthOptions, callback: Function): void {
-    Logger.deprecated('Auth.authorise', 'Auth.authorize');
+    Logger.renamedMethod('Auth', 'authorise', 'authorize');
     this.authorize(tokenParams, authOptions, callback);
   }
 

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -508,13 +508,13 @@ class RealtimePresence extends Presence {
 
   /* Deprecated */
   on(...args: unknown[]): void {
-    Logger.deprecated('presence.on', 'presence.subscribe');
+    Logger.renamedMethod('RealtimePresence', 'on', 'subscribe');
     this.subscribe(...args);
   }
 
   /* Deprecated */
   off(...args: unknown[]): void {
-    Logger.deprecated('presence.off', 'presence.unsubscribe');
+    Logger.renamedMethod('RealtimePresence', 'off', 'unsubscribe');
     this.unsubscribe(...args);
   }
 

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -184,15 +184,15 @@ export function objectifyOptions(options: ClientOptions | string): ClientOptions
 export function normaliseOptions(options: DeprecatedClientOptions): NormalisedClientOptions {
   /* Deprecated options */
   if (options.host) {
-    Logger.deprecated('host', 'restHost');
+    Logger.renamedClientOption('host', 'restHost');
     options.restHost = options.host;
   }
   if (options.wsHost) {
-    Logger.deprecated('wsHost', 'realtimeHost');
+    Logger.renamedClientOption('wsHost', 'realtimeHost');
     options.realtimeHost = options.wsHost;
   }
   if (options.queueEvents) {
-    Logger.deprecated('queueEvents', 'queueMessages');
+    Logger.renamedClientOption('queueEvents', 'queueMessages');
     options.queueMessages = options.queueEvents;
   }
   if (options.headers) {
@@ -255,7 +255,9 @@ export function normaliseOptions(options: DeprecatedClientOptions): NormalisedCl
   }
 
   if (options.transports && Utils.arrIn(options.transports, 'xhr')) {
-    Logger.deprecated('transports: ["xhr"]', 'transports: ["xhr_streaming"]');
+    Logger.deprecationWarning(
+      'The "xhr" transport has been renamed to "xhr_streaming". Please update your client options code to use `transports: ["xhr_streaming"]` instead. The ability to use `transports: ["xhr"]` will be removed in a future version.'
+    );
     Utils.arrDeleteValue(options.transports, 'xhr');
     options.transports.push('xhr_streaming');
   }

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -109,12 +109,26 @@ class Logger {
   };
 
   static deprecatedWithMsg = (funcName: string, msg: string) => {
-    if (Logger.shouldLog(LogLevels.Error)) {
-      Logger.logErrorHandler(
-        "Ably: Deprecation warning - '" + funcName + "' is deprecated and will be removed in a future version. " + msg
-      );
-    }
+    Logger.deprecationWarning(`'${funcName}' is deprecated and will be removed in a future version. ${msg}`);
   };
+
+  static renamedClientOption(oldName: string, newName: string) {
+    Logger.deprecationWarning(
+      `The \`${oldName}\` client option has been renamed to \`${newName}\`. Please update your code to use \`${newName}\` instead. \`${oldName}\` will be removed in a future version.`
+    );
+  }
+
+  static renamedMethod(className: string, oldName: string, newName: string) {
+    Logger.deprecationWarning(
+      `\`${className}\`’s \`${oldName}\` method has been renamed to \`${newName}\`. Please update your code to use \`${newName}\` instead. \`${oldName}\` will be removed in a future version.`
+    );
+  }
+
+  static deprecationWarning(message: string) {
+    if (Logger.shouldLog(LogLevels.Error)) {
+      Logger.logErrorHandler(`Ably: Deprecation warning - ${message}`);
+    }
+  }
 
   /* Where a logging operation is expensive, such as serialisation of data, use shouldLog will prevent
 	   the object being serialised if the log level will not output the message */

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -111,7 +111,7 @@ class Logger {
   static deprecatedWithMsg = (funcName: string, msg: string) => {
     if (Logger.shouldLog(LogLevels.Error)) {
       Logger.logErrorHandler(
-        "Ably: Deprecation warning - '" + funcName + "' is deprecated and will be removed from a future version. " + msg
+        "Ably: Deprecation warning - '" + funcName + "' is deprecated and will be removed in a future version. " + msg
       );
     }
   };


### PR DESCRIPTION
**Note: This PR is based on top of #1681; please review that one first.**

Make it explicit that it’s just a rename (the user doesn’t have to waste time thinking about whether some behaviour might have also changed).