### PR TITLE
Merge `main` into `integration/v2`

### DIFF
--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -59,7 +59,9 @@ class Connection extends EventEmitter {
   }
 
   get recoveryKey(): string | null {
-    Logger.deprecated('Connection.recoveryKey attribute', 'Connection.createRecoveryKey() method');
+    Logger.deprecationWarning(
+      'The `Connection.recoveryKey` attribute has been replaced by the `Connection.createRecoveryKey()` method. Replace your usage of `recoveryKey` with the return value of `createRecoveryKey()`. `recoveryKey` will be removed in a future version.',
+    );
     return this.createRecoveryKey();
   }
 

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -108,20 +108,27 @@ class Logger {
     }
   }
 
-  static deprecated = function (original: string, replacement: string) {
-    Logger.deprecatedWithMsg(original, "Please use '" + replacement + "' instead.");
+  static deprecated = (description: string, msg: string) => {
+    Logger.deprecationWarning(`${description} is deprecated and will be removed in a future version. ${msg}`);
   };
 
-  static deprecatedWithMsg = (funcName: string, msg: string) => {
+  static renamedClientOption(oldName: string, newName: string) {
+    Logger.deprecationWarning(
+      `The \`${oldName}\` client option has been renamed to \`${newName}\`. Please update your code to use \`${newName}\` instead. \`${oldName}\` will be removed in a future version.`,
+    );
+  }
+
+  static renamedMethod(className: string, oldName: string, newName: string) {
+    Logger.deprecationWarning(
+      `\`${className}\`’s \`${oldName}\` method has been renamed to \`${newName}\`. Please update your code to use \`${newName}\` instead. \`${oldName}\` will be removed in a future version.`,
+    );
+  }
+
+  static deprecationWarning(message: string) {
     if (Logger.shouldLog(LogLevels.Error)) {
-      Logger.logErrorHandler(
-        "Ably: Deprecation warning - '" +
-          funcName +
-          "' is deprecated and will be removed from a future version. " +
-          msg,
-      );
+      Logger.logErrorHandler(`Ably: Deprecation warning - ${message}`);
     }
-  };
+  }
 
   /* Where a logging operation is expensive, such as serialisation of data, use shouldLog will prevent
 	   the object being serialised if the log level will not output the message */


### PR DESCRIPTION
The conflicts here all resulted from the tweaks to deprecation messages (messages which v2 already removes) in `main`.

I’ve also changed the `Connection.recoveryKey` deprecation warning to be consistent with the warnings that are on `main`, and to account for 76200a6’s change to the output of the `Logger.deprecated` method.