### PR TITLE
[ECO-4696] Fix typing and deprecation warning for `Crypto.getDefaultParams()`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3340,9 +3340,9 @@ declare namespace Types {
      * Returns a {@link CipherParams} object, using the default values for any fields not supplied by the {@link CipherParamOptions} object.
      *
      * @param params - A {@link CipherParamOptions} object.
-     * @param callback - A function which, upon success, will be called with a {@link CipherParams} object, using the default values for any fields not supplied. Upon failure, the function will be called with information about the error.
+     * @returns A {@link CipherParams} object, using the default values for any fields not supplied.
      */
-    getDefaultParams(params: CipherParamOptions, callback: Types.StandardCallback<CipherParams>): void;
+    getDefaultParams(params: CipherParamOptions): CipherParams;
   }
 
   /**

--- a/src/platform/nodejs/lib/util/crypto.js
+++ b/src/platform/nodejs/lib/util/crypto.js
@@ -130,14 +130,25 @@ var Crypto = (function () {
     /* Backward compatibility */
     if (typeof params === 'function' || typeof params === 'string') {
       Logger.deprecated(
-        'The ability to pass the encryption key as the first argument of `Crypto.getDefaultParams()`',
-        'Please update your code so that it instead passes an object whose `key` property contains the key. That is, replace `Crypto.getDefaultParams(key)` with `Crypto.getDefaultParams({ key })`.'
+        'The ability to pass a callback to `Crypto.getDefaultParams()`',
+        'This method now directly returns its result, instead of returning it asynchronously via a callback. Please update your code so that it uses the return value of this method instead of passing a callback.'
       );
+
       if (typeof params === 'function') {
+        // Called with (callback)
+        Logger.deprecated(
+          'The ability to call `Crypto.getDefaultParams()` without specifying an encryption key',
+          'Please update your code so that it instead passes an object whose `key` property contains an encryption key. That is, replace `Crypto.getDefaultParams()` with `Crypto.getDefaultParams({ key })`, where `key` is an encryption key that you have generated (for example from the `Crypto.generateRandomKey()` method).'
+        );
         Crypto.generateRandomKey(function (key) {
           params(null, Crypto.getDefaultParams({ key: key }));
         });
       } else if (typeof arguments[1] === 'function') {
+        // Called with (key, callback)
+        Logger.deprecated(
+          'The ability to pass the encryption key as the first argument of `Crypto.getDefaultParams()`',
+          'Please update your code so that it instead passes an object whose `key` property contains the key. That is, replace `Crypto.getDefaultParams(key)` with `Crypto.getDefaultParams({ key })`.'
+        );
         arguments[1](null, Crypto.getDefaultParams({ key: params }));
       } else {
         throw new Error('Invalid arguments for Crypto.getDefaultParams');

--- a/src/platform/web/lib/util/crypto.js
+++ b/src/platform/web/lib/util/crypto.js
@@ -161,14 +161,25 @@ var CryptoFactory = function (config, bufferUtils) {
     /* Backward compatibility */
     if (typeof params === 'function' || typeof params === 'string') {
       Logger.deprecated(
-        'The ability to pass the encryption key as the first argument of `Crypto.getDefaultParams()`',
-        'Please update your code so that it instead passes an object whose `key` property contains the key. That is, replace `Crypto.getDefaultParams(key)` with `Crypto.getDefaultParams({ key })`.'
+        'The ability to pass a callback to `Crypto.getDefaultParams()`',
+        'This method now directly returns its result, instead of returning it asynchronously via a callback. Please update your code so that it uses the return value of this method instead of passing a callback.'
       );
+
       if (typeof params === 'function') {
+        // Called with (callback)
+        Logger.deprecated(
+          'The ability to call `Crypto.getDefaultParams()` without specifying an encryption key',
+          'Please update your code so that it instead passes an object whose `key` property contains an encryption key. That is, replace `Crypto.getDefaultParams()` with `Crypto.getDefaultParams({ key })`, where `key` is an encryption key that you have generated (for example from the `Crypto.generateRandomKey()` method).'
+        );
         Crypto.generateRandomKey(function (key) {
           params(null, Crypto.getDefaultParams({ key: key }));
         });
       } else if (typeof arguments[1] === 'function') {
+        // Called with (key, callback)
+        Logger.deprecated(
+          'The ability to pass the encryption key as the first argument of `Crypto.getDefaultParams()`',
+          'Please update your code so that it instead passes an object whose `key` property contains the key. That is, replace `Crypto.getDefaultParams(key)` with `Crypto.getDefaultParams({ key })`.'
+        );
         arguments[1](null, Crypto.getDefaultParams({ key: params }));
       } else {
         throw new Error('Invalid arguments for Crypto.getDefaultParams');


### PR DESCRIPTION
See commit messages for more details.

Resolves #1692.