### PR TITLE
[ECO-4138] Fix `ably/modular` can't be imported in node environment

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,7 @@ jobs:
       # for some reason, this doesn't work in CI using `npx attw --pack .`
       - run: npm pack
       - run: npx attw ably-$(node -e "console.log(require('./package.json').version)").tgz --summary --exclude-entrypoints 'ably/modular'
-      # TODO understand this unexpected-module-syntax error (https://github.com/ably/ably-js/issues/1546)
-      - run: npx attw ably-$(node -e "console.log(require('./package.json').version)").tgz --summary --entrypoints 'ably/modular' --ignore-rules unexpected-module-syntax
+      # see https://github.com/ably/ably-js/issues/1546 for why we ignore 'false-cjs' currently.
+      # should remove when switched to auto-generated type declaration files for modular variant of the library.
+      - run: npx attw ably-$(node -e "console.log(require('./package.json').version)").tgz --summary --entrypoints 'ably/modular' --ignore-rules false-cjs
       - run: npm audit --production

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -123,7 +123,7 @@ module.exports = function (grunt) {
         // which we don’t want here.
         ...createBaseConfig(),
         entryPoints: ['src/platform/web/modular.ts'],
-        outfile: 'build/modular/index.js',
+        outfile: 'build/modular/index.mjs',
         format: 'esm',
         plugins: [stripLogsPlugin],
       };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "./modular": {
       "types": "./modular.d.ts",
-      "default": "./build/modular/index.js"
+      "import": "./build/modular/index.mjs"
     },
     "./react": {
       "require": "./react/cjs/index.js",

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -70,7 +70,7 @@ function getBundleInfo(exports: string[]): BundleInfo {
   const outfile = exports.join('');
   const result = esbuild.buildSync({
     stdin: {
-      contents: `export { ${exports.join(', ')} } from './build/modular'`,
+      contents: `export { ${exports.join(', ')} } from './build/modular/index.mjs'`,
       resolveDir: '.',
     },
     metafile: true,

--- a/test/browser/modular.test.js
+++ b/test/browser/modular.test.js
@@ -20,7 +20,7 @@ import {
   FetchRequest,
   XHRRequest,
   MessageInteractions,
-} from '../../build/modular/index.js';
+} from '../../build/modular/index.mjs';
 
 function registerAblyModularTests(helper) {
   describe('browser/modular', function () {


### PR DESCRIPTION
Resolves #1546