### PR TITLE
Change `PresenceEnterResult` to `PresenceResult` in react hooks

### DIFF
--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -5,7 +5,7 @@ import { useAbly } from './useAbly.js';
 import { useChannelInstance } from './useChannelInstance.js';
 import { useStateErrors } from './useStateErrors.js';
 
-export interface PresenceEnterResult<T> {
+export interface PresenceResult<T> {
   updateStatus: (messageOrPresenceObject: T) => void;
   connectionError: Ably.ErrorInfo | null;
   channelError: Ably.ErrorInfo | null;
@@ -16,7 +16,7 @@ const INACTIVE_CONNECTION_STATES: Ably.ConnectionState[] = ['suspended', 'closin
 export function usePresence<T = any>(
   channelNameOrNameAndOptions: ChannelParameters,
   messageOrPresenceObject?: T,
-): PresenceEnterResult<T> {
+): PresenceResult<T> {
   const params =
     typeof channelNameOrNameAndOptions === 'object'
       ? channelNameOrNameAndOptions


### PR DESCRIPTION
This was wrongfully renamed in 730c621d6de3f76be727c18e528071937936a967. It is a remnant of a `usePresenceEnter` name for the new hook, which was temporary used during development in https://github.com/ably/ably-js/pull/1674, but we decided to keep the name `usePresence`.