### PR TITLE
Remove some lingering `any` from `stats()` param type

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2686,7 +2686,7 @@ export declare class Rest implements RestClient {
     body?: any[] | any,
     headers?: any,
   ): Promise<HttpPaginatedResponse<T>>;
-  stats(params?: StatsParams | any): Promise<PaginatedResult<Stats>>;
+  stats(params?: StatsParams): Promise<PaginatedResult<Stats>>;
   time(): Promise<number>;
   batchPublish(spec: BatchPublishSpec): Promise<BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>>;
   batchPublish(
@@ -2741,7 +2741,7 @@ export declare class Realtime implements RealtimeClient {
     body?: any[] | any,
     headers?: any,
   ): Promise<HttpPaginatedResponse<T>>;
-  stats(params?: StatsParams | any): Promise<PaginatedResult<Stats>>;
+  stats(params?: StatsParams): Promise<PaginatedResult<Stats>>;
   time(): Promise<number>;
   batchPublish(spec: BatchPublishSpec): Promise<BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>>;
   batchPublish(

--- a/modular.d.ts
+++ b/modular.d.ts
@@ -290,7 +290,7 @@ export declare class BaseRest implements RestClient {
     body?: any[] | any,
     headers?: any,
   ): Promise<HttpPaginatedResponse<T>>;
-  stats(params?: StatsParams | any): Promise<PaginatedResult<Stats>>;
+  stats(params?: StatsParams): Promise<PaginatedResult<Stats>>;
   time(): Promise<number>;
   batchPublish(spec: BatchPublishSpec): Promise<BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>>;
   batchPublish(
@@ -343,7 +343,7 @@ export declare class BaseRealtime implements RealtimeClient {
     body?: any[] | any,
     headers?: any,
   ): Promise<HttpPaginatedResponse<T>>;
-  stats(params?: StatsParams | any): Promise<PaginatedResult<Stats>>;
+  stats(params?: StatsParams): Promise<PaginatedResult<Stats>>;
   time(): Promise<number>;
   batchPublish(spec: BatchPublishSpec): Promise<BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>>;
   batchPublish(


### PR DESCRIPTION
This appears to be the result of me not incorporating e524d68’s changes into ff7cb41, probably a botched merge conflict resolution.