### PR TITLE
Use `useLayoutEffect` when calling `.setOptions()` in `ChannelProvider`

### DIFF
--- a/src/platform/react-hooks/src/ChannelProvider.tsx
+++ b/src/platform/react-hooks/src/ChannelProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useLayoutEffect, useMemo } from 'react';
 import * as Ably from 'ably';
 import { type AblyContextValue, AblyContext } from './AblyContext.js';
 import { channelOptionsWithAgent } from './AblyReactHooks.js';
@@ -44,7 +44,7 @@ export const ChannelProvider = ({
     };
   }, [derived, client, channel, channelName, _channelNameToChannelContext, ablyId, context]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     channel.setOptions(channelOptionsWithAgent(options));
   }, [channel, options]);
 


### PR DESCRIPTION
This is a temporary fix for #1704. This does not fix the underlying problem of ably-js sending two `ATTACH` messages with the same options when we call `.setOptions()` in `ChannelProvider`.

What `useLayoutEffect` accomplishes is it runs before children components' `useEffect` hooks, thus it sets options for a channel before attachment process starts, so there will be no need for reattachment and sending a second `ATTACH` message.