### PR TITLE
fix: react-native TextEncoder/TextDecoder polyfill + restore package.json react-native field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
         "got": "^11.8.5",
         "ws": "^8.14.2"
       },
@@ -4644,6 +4645,11 @@
       "engines": {
         "node": ">= 4.9.1"
       }
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "node_modules/fastq": {
       "version": "1.16.0",
@@ -14061,6 +14067,11 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true
+    },
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "fastq": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "@ably/msgpack-js": "^0.4.0",
+    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "got": "^11.8.5",
     "ws": "^8.14.2"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/ably/ably-js/issues",
     "email": "support@ably.com"
   },
+  "react-native": "./build/ably-reactnative.js",
   "exports": {
     ".": {
       "types": "./ably.d.ts",

--- a/src/platform/react-native/index.ts
+++ b/src/platform/react-native/index.ts
@@ -20,6 +20,9 @@ import PlatformDefaults from '../web/lib/util/defaults';
 import msgpack from '../web/lib/util/msgpack';
 import { defaultBundledRequestImplementations } from '../web/lib/http/request';
 
+// lightweight polyfill for TextEncoder/TextDecoder
+import 'fastestsmallesttextencoderdecoder';
+
 const Config = configFactory(BufferUtils);
 
 const Crypto = createCryptoClass(Config, BufferUtils);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,6 +91,7 @@ const reactNativeConfig = {
     request: false,
     ws: false,
     'react-native': true,
+    fastestsmallesttextencoderdecoder: 'fastestsmallesttextencoderdecoder',
   },
   optimization: {
     minimize: false,


### PR DESCRIPTION
Resolves #1712, #1711 

Contains two fixes for react-native support in v2:
- React Native does not currently support "exports" field in package.json by default when consuming npm packages ([source](https://reactnative.dev/blog/2023/06/21/package-exports-support)) - which we started using in v2. It is still an experimental feature and not enabled by default in new React Native apps. We restore root "react-native" field in package.json to fix this issue.
- React Native does not have support for TextEncoder/TextDecoder API, so we provide polyfills for them.