### PR TITLE
[ECO-4721] Fix rest fallback behavior

### DIFF
--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -23,6 +23,7 @@ type CompleteDefaults = IDefaults & {
     disconnectedRetryTimeout: number;
     suspendedRetryTimeout: number;
     httpRequestTimeout: number;
+    httpMaxRetryDuration: number;
     channelRetryTimeout: number;
     fallbackRetryTimeout: number;
     connectionStateTtl: number;
@@ -74,6 +75,7 @@ const Defaults = {
     suspendedRetryTimeout: 30000,
     /* Undocumented, but part of the api and can be used by customers: */
     httpRequestTimeout: 10000,
+    httpMaxRetryDuration: 15000,
     channelRetryTimeout: 15000,
     fallbackRetryTimeout: 600000,
     /* For internal / test use only: */

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -73,7 +73,7 @@ const Defaults = {
     disconnectedRetryTimeout: 15000,
     suspendedRetryTimeout: 30000,
     /* Undocumented, but part of the api and can be used by customers: */
-    httpRequestTimeout: 15000,
+    httpRequestTimeout: 10000,
     channelRetryTimeout: 15000,
     fallbackRetryTimeout: 600000,
     /* For internal / test use only: */

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -238,6 +238,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           disconnectedRetryTimeout: 123,
           suspendedRetryTimeout: 456,
           httpRequestTimeout: 789,
+          httpMaxRetryDuration: 321,
         });
         /* Note: uses internal knowledge of connectionManager */
         try {
@@ -251,7 +252,11 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           );
           expect(realtime.connection.connectionManager.options.timeouts.httpRequestTimeout).to.equal(
             789,
-            'Verify suspended retry frequency is settable',
+            'Verify http request timeout is settable',
+          );
+          expect(realtime.connection.connectionManager.options.timeouts.httpMaxRetryDuration).to.equal(
+            321,
+            'Verify http max retry duration is settable',
           );
         } catch (err) {
           closeAndFinish(done, realtime, err);


### PR DESCRIPTION
Resolves #1717 

Fixes incorrect default value for `httpRequestTimeout` client option. It should be 10 seconds according to [TO3l4](https://sdk.ably.com/builds/ably/specification/main/features/#TO3l4).
Implements missing `httpMaxRetryDuration` functionality and adds tests for it per [TO3l6](https://sdk.ably.com/builds/ably/specification/main/features/#TO3l6).