### PR TITLE
consumergroup: emit membership updated event

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -109,7 +109,7 @@ export type ChannelEvent =
 /**
  * Describes the events emitted by a {@link ChannelGroup} object.
  */
-export type ChannelGroupEvent = 'active.updated' | 'assigned.updated';
+export type ChannelGroupEvent = 'active.updated' | 'assigned.updated' | 'membership.updated';
 
 /**
  * The `ConnectionStates` namespace describes the possible values of the {@link ConnectionState} type.

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -210,7 +210,7 @@ class ConsumerGroup extends EventEmitter {
         this.locator.remove(member);
       });
 
-      this.emit('membership');
+      this.emit('membership', memberIds);
       Logger.logAction(
         Logger.LOG_MAJOR,
         'ConsumerGroup.computeMembership()',
@@ -250,7 +250,10 @@ class ChannelGroup extends EventEmitter {
     this.subscriptions = new EventEmitter();
     this.active = channels.get(this.safeChannelName(options?.activeChannel || '$ably:active'));
     this.consumerGroup = new ConsumerGroup(channels, options?.consumerGroup?.name);
-    this.consumerGroup.on('membership', () => this.updateAssignedChannels());
+    this.consumerGroup.on('membership', (memberIds: string[]) => {
+      this.emit('membership.updated', memberIds);
+      this.updateAssignedChannels();
+    });
     this.expression = new RegExp(filter); // eslint-disable-line security/detect-non-literal-regexp
   }
 


### PR DESCRIPTION
Adds `membership.updated` events emitted by the channel group when the set of members in the consumer group changes.