### PR TITLE
Add `globalObject: 'global'` for react native webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,6 +76,7 @@ const reactNativeConfig = {
   output: {
     ...baseConfig.output,
     filename: 'ably-reactnative.js',
+    globalObject: 'global',
   },
   entry: {
     index: platformPath('react-native'),


### PR DESCRIPTION
When running Jest tests with the 'react-native' preset (the default preset used when app is created with `react-native init`), tests are run in a Node.js environment ([from docs](https://jestjs.io/docs/tutorial-react-native#environment)). There are some slight differences, such as the `this` global variable being an empty object, and the 'window' global variable is present.

When running Jest tests with the 'react-native' preset, [it supports the `exports` field in the package.json file](https://reactnative.dev/blog/2023/06/21/package-exports-support#:~:text=Remember%20to%20use%20the%20React%20Native%20Jest%20preset!%20Jest%20includes%20support%20for%20Package%20Exports%20by%20default). It resolves libraries with an `exports` field using the `react-native` condition.

Our `react-native` exports condition exports an `ably-reactnative.js` bundle, which is built using webpack v5. By default, webpack v5 sets the globalObject to `self`. In Node.js environments, the `self` global property does not exist, so our React Native bundle fails with a `ReferenceError: self is not defined` when we try to run Jest tests.

This issue does not occur for ably-js v1 because we don't use `exports` in the package.json file, and Jest, for some reason, doesn't recognize the root `react-native` field in package.json. So, instead, when running Jest tests for React Native with ably-js v1, it uses our Node.js bundle, which has `global` for its globalObject.

To fix the `ReferenceError: self is not defined` error for ably-js v2, we should change the globalObject to something supported both in Node.js environments when running Jest tests for React Native and in React Native itself. In ably-js v1, our bundles used the following global objects:

- `ably-node` used 'global'
- `ably-reactnative` used 'window'

Based on my tests, `window === global` both when running Jest tests for React Native and when running a React Native app. So, we can use `globalObject: 'global'` for our React Native bundle in ably-js v2.

---
**NOTE**
Even though this resolves the `ReferenceError: self is not defined` error for Jest tests, they will still fail with other errors like `ReferenceError: WebSocket is not defined`. This is because Jest with 'react-native' preset is using a node environment, which [doesn't load any DOM or browser APIs](https://jestjs.io/docs/tutorial-react-native#environment:~:text=Because%20it%20doesn%27t%20load%20any%20DOM%20or%20browser%20APIs%2C%20it%20greatly%20improves%20Jest%27s%20startup%20time), but our `ably-reactnative.js` bundle expects certain browser APIs like `WebSocket` to be available in the global scope.
This is not something we can resolve directly, so users would need to either mock the Ably client or provide mocks for such browser APIs when running Jest tests (example [here](https://stackoverflow.com/a/46468142)), or force Jest to use the ably-js node.js bundle by adding the following config to their `jest.config.js`:
```javascript
moduleNameMapper: {
    ably: require.resolve('ably'),
},
```
Or users can [force Jest to resolve the `exports` field using the `node` condition](https://jestjs.io/docs/configuration#testenvironmentoptions-object) for all bundles (although this is the least ideal solution):
```javascript
testEnvironmentOptions: {
    customExportConditions: ['node'],
},
```