### PR TITLE
fix: export ErrorInfo as named export in web entrypoint

### DIFF
--- a/src/platform/web/index.ts
+++ b/src/platform/web/index.ts
@@ -45,7 +45,7 @@ if (Platform.Config.agent) {
   Platform.Defaults.agent += ' ' + Platform.Config.agent;
 }
 
-export { DefaultRest as Rest, DefaultRealtime as Realtime, msgpack, protocolMessageFromDeserialized };
+export { DefaultRest as Rest, DefaultRealtime as Realtime, msgpack, protocolMessageFromDeserialized, ErrorInfo };
 
 export default {
   ErrorInfo,


### PR DESCRIPTION
this allows the ErrorInfo export to be accessed as a named export in ESM and when using commonjs interop