### PR TITLE
[ECO-4737, ECO-4756] Fix auth token encoding in React Native

### DIFF
--- a/src/common/types/IBufferUtils.ts
+++ b/src/common/types/IBufferUtils.ts
@@ -2,7 +2,9 @@ export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput> {
   base64CharSet: string;
   hexCharSet: string;
   isBuffer: (buffer: unknown) => buffer is Bufferlike;
-  // On browser this returns a Uint8Array, on node a Buffer
+  /**
+   * On browser this returns a Uint8Array, on node a Buffer
+   */
   toBuffer: (buffer: Bufferlike) => ToBufferOutput;
   toArrayBuffer: (buffer: Bufferlike) => ArrayBuffer;
   base64Encode: (buffer: Bufferlike) => string;
@@ -13,6 +15,9 @@ export default interface IBufferUtils<Bufferlike, Output, ToBufferOutput> {
   utf8Decode: (buffer: Bufferlike) => string;
   areBuffersEqual: (buffer1: Bufferlike, buffer2: Bufferlike) => boolean;
   byteLength: (buffer: Bufferlike) => number;
+  /**
+   * Returns ArrayBuffer on browser and Buffer on Node.js
+   */
   arrayBufferViewToBuffer: (arrayBufferView: ArrayBufferView) => Bufferlike;
   hmacSha256(message: Bufferlike, key: Bufferlike): Output;
 }

--- a/src/platform/nodejs/lib/util/bufferutils.ts
+++ b/src/platform/nodejs/lib/util/bufferutils.ts
@@ -56,7 +56,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
   }
 
   arrayBufferViewToBuffer(arrayBufferView: ArrayBufferView): Buffer {
-    return this.toBuffer(arrayBufferView.buffer);
+    return this.toBuffer(arrayBufferView);
   }
 
   utf8Decode(buffer: Bufferlike): string {

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -15,7 +15,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
   hexCharSet = '0123456789abcdef';
 
   // // https://gist.githubusercontent.com/jonleighton/958841/raw/f200e30dfe95212c0165ccf1ae000ca51e9de803/gistfile1.js
-  uint8ViewToBase64(bytes: Uint8Array) {
+  private uint8ViewToBase64(bytes: Uint8Array) {
     let base64 = '';
     const encodings = this.base64CharSet;
 
@@ -66,7 +66,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     return base64;
   }
 
-  base64ToArrayBuffer(base64: string) {
+  private base64ToArrayBuffer(base64: string) {
     const binary_string = atob?.(base64) as string; // this will always be defined in browser so it's safe to cast
     const len = binary_string.length;
     const bytes = new Uint8Array(len);

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -3,8 +3,7 @@ import IBufferUtils from 'common/types/IBufferUtils';
 import { hmac as hmacSha256 } from './hmac-sha256';
 
 /* Most BufferUtils methods that return a binary object return an ArrayBuffer
- * The exception is toBuffer, which returns a Uint8Array (and won't work on
- * browsers too old to support it) */
+ * The exception is toBuffer, which returns a Uint8Array */
 
 export type Bufferlike = BufferSource;
 export type Output = Bufferlike;
@@ -14,7 +13,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
   base64CharSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
   hexCharSet = '0123456789abcdef';
 
-  // // https://gist.githubusercontent.com/jonleighton/958841/raw/f200e30dfe95212c0165ccf1ae000ca51e9de803/gistfile1.js
+  // https://gist.githubusercontent.com/jonleighton/958841/raw/f200e30dfe95212c0165ccf1ae000ca51e9de803/gistfile1.js
   private uint8ViewToBase64(bytes: Uint8Array): string {
     let base64 = '';
     const encodings = this.base64CharSet;
@@ -81,7 +80,6 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     return buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer);
   }
 
-  /* In browsers, returns a Uint8Array */
   toBuffer(buffer: Bufferlike): ToBufferOutput {
     if (!ArrayBuffer) {
       throw new Error("Can't convert to Buffer: browser does not support the necessary types");
@@ -193,7 +191,6 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     return -1;
   }
 
-  /* Returns ArrayBuffer on browser and Buffer on Node.js */
   arrayBufferViewToBuffer(arrayBufferView: ArrayBufferView): ArrayBuffer {
     return this.toArrayBuffer(arrayBufferView);
   }

--- a/src/platform/web/lib/util/bufferutils.ts
+++ b/src/platform/web/lib/util/bufferutils.ts
@@ -15,7 +15,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
   hexCharSet = '0123456789abcdef';
 
   // // https://gist.githubusercontent.com/jonleighton/958841/raw/f200e30dfe95212c0165ccf1ae000ca51e9de803/gistfile1.js
-  private uint8ViewToBase64(bytes: Uint8Array) {
+  private uint8ViewToBase64(bytes: Uint8Array): string {
     let base64 = '';
     const encodings = this.base64CharSet;
 
@@ -66,7 +66,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     return base64;
   }
 
-  private base64ToArrayBuffer(base64: string) {
+  private base64ToArrayBuffer(base64: string): Output {
     const binary_string = atob?.(base64) as string; // this will always be defined in browser so it's safe to cast
     const len = binary_string.length;
     const bytes = new Uint8Array(len);
@@ -105,7 +105,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     return this.toBuffer(buffer).buffer;
   }
 
-  base64Encode(buffer: Bufferlike) {
+  base64Encode(buffer: Bufferlike): string {
     return this.uint8ViewToBase64(this.toBuffer(buffer));
   }
 
@@ -117,7 +117,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     }
   }
 
-  hexEncode(buffer: Bufferlike) {
+  hexEncode(buffer: Bufferlike): string {
     const arrayBuffer =
       buffer instanceof ArrayBuffer
         ? buffer
@@ -126,7 +126,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     return uint8Array.reduce((accum, byte) => accum + byte.toString(16).padStart(2, '0'), '');
   }
 
-  hexDecode(hexEncodedBytes: string) {
+  hexDecode(hexEncodedBytes: string): Output {
     if (hexEncodedBytes.length % 2 !== 0) {
       throw new Error("Can't create a byte array from a hex string of odd length");
     }
@@ -140,7 +140,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     return uint8Array.buffer.slice(uint8Array.byteOffset, uint8Array.byteOffset + uint8Array.byteLength);
   }
 
-  utf8Encode(string: string) {
+  utf8Encode(string: string): Output {
     if (Platform.Config.TextEncoder) {
       return new Platform.Config.TextEncoder().encode(string).buffer;
     } else {
@@ -153,7 +153,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
    * can take (in particular allowing strings, which are just interpreted as
    * binary); here we ensure that the input is actually a buffer since trying
    * to utf8-decode a string to another string is almost certainly a mistake */
-  utf8Decode(buffer: Bufferlike) {
+  utf8Decode(buffer: Bufferlike): string {
     if (!this.isBuffer(buffer)) {
       throw new Error('Expected input of utf8decode to be an arraybuffer or typed array');
     }
@@ -164,7 +164,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     }
   }
 
-  areBuffersEqual(buffer1: Bufferlike, buffer2: Bufferlike) {
+  areBuffersEqual(buffer1: Bufferlike, buffer2: Bufferlike): boolean {
     if (!buffer1 || !buffer2) return false;
     const arrayBuffer1 = this.toArrayBuffer(buffer1);
     const arrayBuffer2 = this.toArrayBuffer(buffer2);
@@ -180,7 +180,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
     return true;
   }
 
-  byteLength(buffer: Bufferlike) {
+  byteLength(buffer: Bufferlike): number {
     if (buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer)) {
       return buffer.byteLength;
     }
@@ -188,7 +188,7 @@ class BufferUtils implements IBufferUtils<Bufferlike, Output, ToBufferOutput> {
   }
 
   /* Returns ArrayBuffer on browser and Buffer on Node.js */
-  arrayBufferViewToBuffer(arrayBufferView: ArrayBufferView) {
+  arrayBufferViewToBuffer(arrayBufferView: ArrayBufferView): ArrayBuffer {
     return arrayBufferView.buffer;
   }
 


### PR DESCRIPTION
Resolves #1730 , resolves #1749 

Fixes incorrect usage of the underlying ArrayBuffer buffer in web BufferUtils, where we didn't account for the `byteOffset` and `byteLength` of the original array buffer view. This resulted in us incorrectly encoding auth tokens in the React Native bundle, where we use a polyfill for the TextEncoder class, which returned Uint8Array as a subarray of the underlying ArrayBuffer (see [polyfill's code](https://github.com/anonyco/FastestSmallestTextEncoderDecoder/blob/f04c88cf11024672e4d3e3dd59b9530b50eefbed/EncoderDecoderTogether.src.js#L268)).