### PR TITLE
Support optional multiple recovery scopes

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -464,6 +464,18 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
   recover?: string | recoverConnectionCallback;
 
   /**
+   * If specified, the SDK's internal persistence mechanism for storing the recovery key
+   * over page loads (see the `recover` client option) will store the recovery key under
+   * this identifier (in sessionstorage), so only another library instance which specifies
+   * the same recoveryKeyStorageName will attempt to recover from it. This is useful if you have
+   * multiple ably-js instances sharing a given origin (the origin being the scope of
+   * sessionstorage), as otherwise the multiple instances will overwrite each other's
+   * recovery keys, and after a reload they will all try and recover the same connection,
+   * which is not permitted and will cause broken behaviour.
+   */
+  recoveryKeyStorageName?: string;
+
+  /**
    * When `false`, the client will use an insecure connection. The default is `true`, meaning a TLS connection will be used to connect to Ably.
    *
    * @defaultValue `true`

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -31,17 +31,6 @@ const haveSessionStorage = () => typeof Platform.WebStorage !== 'undefined' && P
 const noop = function () {};
 const transportPreferenceName = 'ably-transport-preference';
 
-const sessionRecoveryName = 'ably-connection-recovery';
-function getSessionRecoverData() {
-  return haveSessionStorage() && Platform.WebStorage?.getSession?.(sessionRecoveryName);
-}
-function setSessionRecoverData(value: any) {
-  return haveSessionStorage() && Platform.WebStorage?.setSession?.(sessionRecoveryName, value);
-}
-function clearSessionRecoverData() {
-  return haveSessionStorage() && Platform.WebStorage?.removeSession?.(sessionRecoveryName);
-}
-
 function bundleWith(dest: ProtocolMessage, src: ProtocolMessage, maxSize: number) {
   let action;
   if (dest.channel !== src.channel) {
@@ -431,12 +420,15 @@ class ConnectionManager extends EventEmitter {
       }
 
       const recoverFn = this.options.recover,
-        lastSessionData = getSessionRecoverData();
+        lastSessionData = this.getSessionRecoverData(),
+        sessionRecoveryName = this.sessionRecoveryName();
       if (lastSessionData && typeof recoverFn === 'function') {
         Logger.logAction(
           Logger.LOG_MINOR,
           'ConnectionManager.getTransportParams()',
-          'Calling clientOptions-provided recover function with last session data',
+          'Calling clientOptions-provided recover function with last session data (recovery scope: ' +
+            sessionRecoveryName +
+            ')',
         );
         recoverFn(lastSessionData, (shouldRecover?: boolean) => {
           if (shouldRecover) {
@@ -893,7 +885,7 @@ class ConnectionManager extends EventEmitter {
     if (haveSessionStorage()) {
       const recoveryKey = this.createRecoveryKey();
       if (recoveryKey) {
-        setSessionRecoverData({
+        this.setSessionRecoverData({
           recoveryKey: recoveryKey,
           disconnectedAt: Date.now(),
           location: globalObject.location,
@@ -908,7 +900,7 @@ class ConnectionManager extends EventEmitter {
    * state for later recovery. Only applicable in the browser context.
    */
   unpersistConnection(): void {
-    clearSessionRecoverData();
+    this.clearSessionRecoverData();
   }
 
   /*********************
@@ -1959,6 +1951,20 @@ class ConnectionManager extends EventEmitter {
         }
       };
     });
+  }
+
+  sessionRecoveryName() {
+    return this.options.recoveryKeyStorageName || 'ably-connection-recovery';
+  }
+
+  getSessionRecoverData() {
+    return haveSessionStorage() && Platform.WebStorage?.getSession?.(this.sessionRecoveryName());
+  }
+  setSessionRecoverData(value: any) {
+    return haveSessionStorage() && Platform.WebStorage?.setSession?.(this.sessionRecoveryName(), value);
+  }
+  clearSessionRecoverData() {
+    return haveSessionStorage() && Platform.WebStorage?.removeSession?.(this.sessionRecoveryName());
   }
 }
 


### PR DESCRIPTION
New `recoveryScope` client option where, if specified, the SDK's recovery key will be persisted under that identifier (in sessionstorage), so only another library instance which specifies the same recoveryScope will attempt to recover from it. This is useful if you have multiple ably-js instances sharing a given origin (the origin being the scope of sessionstorage), as otherwise the multiple instances will overwrite each other's recovery keys, and after a reload they will all try and recover the same connection, which is not permitted and will cause broken behaviour.

Not entirely happy with `recoveryScope` but I can't think of anything better (considered: recoveryKeyKey, recoveryKeyIdentifier, recoveryDiscriminator, recoveryTag, recoveryMarker, ...)