### PR TITLE
types/capability: allow wildcard capability when presented in object form, add privileged-headers capability

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -683,7 +683,8 @@ export type capabilityOp =
   | 'stats'
   | 'channel-metadata'
   | 'push-subscribe'
-  | 'push-admin';
+  | 'push-admin'
+  | 'privileged-headers';
 
 /**
  * Capabilities which are available for use within {@link TokenParams}.

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -684,6 +684,7 @@ export type capabilityOp =
   | 'channel-metadata'
   | 'push-subscribe'
   | 'push-admin';
+
 /**
  * Capabilities which are available for use within {@link TokenParams}.
  */
@@ -698,7 +699,7 @@ export interface TokenParams {
    *
    * @defaultValue `'{"*":["*"]}'`
    */
-  capability?: { [key: string]: capabilityOp[] } | string;
+  capability?: { [key: string]: capabilityOp[] | ['*'] } | string;
   /**
    * A client ID, used for identifying this client when publishing messages or for presence purposes. The `clientId` can be any non-empty string, except it cannot contain a `*`. This option is primarily intended to be used in situations where the library is instantiated with a key. Note that a `clientId` may also be implicit in a token used to instantiate the library. An error is raised if a `clientId` specified here conflicts with the `clientId` implicit in the token. Find out more about [identified clients](https://ably.com/docs/core-features/authentication#identified-clients).
    */


### PR DESCRIPTION
At the moment, it's not possible (according to TypeScript) to specify a capability as `{"resource": ["*"]}` using the map-form - which is still valid. This change also allows the explicit specification of a wildcard.