### PR TITLE
Make `FetchRequest` not try and parse a 204 response body

### DIFF
--- a/src/platform/web/lib/http/request/fetchrequest.ts
+++ b/src/platform/web/lib/http/request/fetchrequest.ts
@@ -69,6 +69,10 @@ export default async function fetchRequest(
 
       clearTimeout(timeout!);
 
+      if (res.status == 204) {
+        return { error: null, statusCode: res.status };
+      }
+
       const contentType = res.headers.get('Content-Type');
       let body;
       if (contentType && contentType.indexOf('application/x-msgpack') > -1) {


### PR DESCRIPTION
It currently checks for the presence of a `Content-Type` response header and if present assumes that trying to parse the response will succeed.

Realtime currently sends a `204 No Content` with a `Content-Type` header from the `POST rest.ably.io/push/publish` endpoint when using HTTP 1.1 (see REA-1924).

(This bug hasn't been caught by the tests because I guess most of the time they use HTTP 2 in browsers, and also we don't use FetchRequest in the tests except briefly in those for the modular variant of the library. I’ve created #1772 for improving this situation).

The 204 handling approach is copied from that which we already have in `XHRRequest`.

Resolves #1771.