### PR TITLE
[REA-1702] feat: web push

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,7 +73,7 @@ module.exports = function (grunt) {
     });
   });
 
-  grunt.registerTask('build', ['checkGitSubmodules', 'webpack:all', 'build:browser', 'build:node']);
+  grunt.registerTask('build', ['checkGitSubmodules', 'webpack:all', 'build:browser', 'build:node', 'build:push']);
 
   grunt.registerTask('all', ['build', 'requirejs']);
 
@@ -122,8 +122,22 @@ module.exports = function (grunt) {
       });
   });
 
+  grunt.registerTask('build:push', function () {
+    var done = this.async();
+
+    esbuild
+      .build(esbuildConfig.pushPluginConfig)
+      .then(() => {
+        done(true);
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
   grunt.registerTask('test:webserver', 'Launch the Mocha test web server on http://localhost:3000/', [
     'build:browser',
+    'build:push',
     'checkGitSubmodules',
     'mocha:webserver',
   ]);

--- a/README.md
+++ b/README.md
@@ -488,6 +488,60 @@ const nextPage = await statsPage.next();        // retrieves the next page as Pa
 const time = await client.time(); // time is in ms since epoch
 ```
 
+### Push activation
+
+Push activation is supported for browser clients, via the Push plugin. In order to use push activation, you must pass in the plugin via client options.
+
+You also need to provide a path to a service worker which will be registered when the client is activated, and will handle receipt of push notifications.
+
+```javascript
+import * as Ably from 'ably';
+import Push from 'ably/push';
+
+const client = new Ably.Rest({
+    ...options,
+    pushServiceWorkerUrl: '/my_service_worker.js',
+    plugins: { Push }
+});
+```
+
+Example service worker:
+
+```javascript
+// my_service_worker.js
+self.addEventListener("push", async (event) => {
+  const { notification } = event.data.json();
+  self.registration.showNotification(notification.title, notification);
+});
+```
+
+To register the device to receive push notifications, you must call the `activate` method:
+
+```javascript
+await client.push.activate();
+```
+
+Once the client is activated, you can subscribe to receive push notifcations on a channel:
+
+```javascript
+const channel = client.channels.get('my_push_channel');
+
+// Subscribe the device to receive push notifcations for a channel...
+await channel.push.subscribeDevice();
+
+// ...or subscribe all devices associated with the client's cliendId to receive notifcations from the channel
+await channel.push.subscribeClient();
+
+// When you no longer need to be subscribed to push notifcations, you can remove the subscription:
+await channel.push.unsubscribeDevice();
+// Or:
+await channel.push.unsubscribeClient();
+```
+
+Push activation works with the [Modular variant](#modular-tree-shakable-variant) of the library, but requires you to be using the Rest plugin.
+
+For more information on publishing push notifcations over Ably, see the [Ably push documentation](https://ably.com/docs/push).
+
 ## Delta Plugin
 
 From version 1.2 this client library supports subscription to a stream of Vcdiff formatted delta messages from the Ably service. For certain applications this can bring significant data efficiency savings.
@@ -502,10 +556,6 @@ Please visit http://support.ably.com/ for access to our knowledgebase and to ask
 You can also view the [community reported Github issues](https://github.com/ably/ably-js/issues).
 
 To see what has changed in recent versions, see the [CHANGELOG](CHANGELOG.md).
-
-## Known Limitations
-
-This library currently does not support being the [target of a push notification](https://www.ably.com/docs/general/push/activate-subscribe) (i.e. web push).
 
 #### Browser-specific issues
 

--- a/grunt/esbuild/build.js
+++ b/grunt/esbuild/build.js
@@ -54,9 +54,18 @@ const nodeConfig = {
   external: ['ws', 'got'],
 };
 
+const pushPluginConfig = {
+  ...createBaseConfig(),
+  entryPoints: ['src/plugins/push/index.ts'],
+  plugins: [umdWrapper.default({ libraryName: 'AblyPushPlugin', amdNamedModule: false })],
+  outfile: 'build/push.js',
+  external: ['ulid'],
+};
+
 module.exports = {
   webConfig,
   minifiedWebConfig,
   modularConfig,
   nodeConfig,
+  pushPluginConfig,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ably/msgpack-js": "^0.4.0",
         "fastestsmallesttextencoderdecoder": "^1.0.22",
         "got": "^11.8.5",
+        "ulid": "^2.3.0",
         "ws": "^8.17.1"
       },
       "devDependencies": {
@@ -9731,6 +9732,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ulid": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
+      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
+      "bin": {
+        "ulid": "bin/cli.js"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -17826,6 +17835,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
+    },
+    "ulid": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
+      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,16 @@
     "./react": {
       "require": "./react/cjs/index.js",
       "import": "./react/mjs/index.js"
+    },
+    "./push": {
+      "types": "./push.d.ts",
+      "import": "./build/push.js"
     }
   },
   "files": [
     "build/**",
     "ably.d.ts",
+    "push.d.ts",
     "modular.d.ts",
     "resources/**",
     "src/**",
@@ -131,7 +136,7 @@
     "start:react": "npx vite serve",
     "grunt": "grunt",
     "test": "npm run test:node",
-    "test:node": "npm run build:node && mocha",
+    "test:node": "npm run build:node && npm run build:push && mocha",
     "test:node:skip-build": "mocha",
     "test:webserver": "grunt test:webserver",
     "test:playwright": "node test/support/runPlaywrightTests.js",
@@ -144,6 +149,7 @@
     "build:react": "npm run build:react:mjs && npm run build:react:cjs && cp src/platform/react-hooks/res/package.react.json react/package.json",
     "build:react:mjs": "tsc --project src/platform/react-hooks/tsconfig.mjs.json && cp src/platform/react-hooks/res/package.mjs.json react/mjs/package.json",
     "build:react:cjs": "tsc --project src/platform/react-hooks/tsconfig.cjs.json && cp src/platform/react-hooks/res/package.cjs.json react/cjs/package.json",
+    "build:push": "grunt build:push",
     "requirejs": "grunt requirejs",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@ably/msgpack-js": "^0.4.0",
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "got": "^11.8.5",
+    "ulid": "^2.3.0",
     "ws": "^8.17.1"
   },
   "peerDependencies": {

--- a/push.d.ts
+++ b/push.d.ts
@@ -1,0 +1,28 @@
+// The ESLint warning is triggered because we only use these types in a documentation comment.
+/* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
+import { RealtimeClient, RestClient } from './ably';
+import { BaseRest, BaseRealtime, Rest } from './modular';
+/* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
+
+/**
+ * Provides a {@link RestClient} or {@link RealtimeClient} instance with the ability to be activated as a target for push notifications.
+ *
+ * To create a client that includes this plugin, include it in the client options that you pass to the {@link RestClient.constructor} or {@link RealtimeClient.constructor}:
+ *
+ * ```javascript
+ * import { Realtime } from 'ably';
+ * import Push from 'ably/push';
+ * const realtime = new Realtime({ ...options, plugins: { Push } });
+ * ```
+ *
+ * The Push plugin can also be used with a {@link BaseRest} or {@link BaseRealtime} client, with the additional requirement that you must also use the {@link Rest} plugin
+ *
+ * ```javascript
+ * import { BaseRealtime, Rest, WebSocketTransport, FetchRequest } from 'ably/modular';
+ * import Push from 'ably/push';
+ * const realtime = new BaseRealtime({ ...options, plugins: { Rest, WebSocketTransport, FetchRequest, Push } });
+ * ```
+ */
+declare const Push: any;
+
+export = Push;

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -6,7 +6,7 @@ import { gzip } from 'zlib';
 import Table from 'cli-table';
 
 // The maximum size we allow for a minimal useful Realtime bundle (i.e. one that can subscribe to a channel)
-const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 96, gzip: 29 };
+const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 98, gzip: 30 };
 
 const baseClientNames = ['BaseRest', 'BaseRealtime'];
 

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -65,11 +65,17 @@ interface Output {
 }
 
 // Uses esbuild to create a bundle containing the named exports from 'ably/modular'
-function getBundleInfo(exports: string[]): BundleInfo {
-  const outfile = exports.join('');
+function getModularBundleInfo(exports: string[]): BundleInfo {
+  return getBundleInfo('./build/modular/index.mjs', exports);
+}
+
+// Uses esbuild to create a bundle containing the named exports from a given module
+function getBundleInfo(modulePath: string, exports?: string[]): BundleInfo {
+  const outfile = exports ? exports.join('') : 'all';
+  const exportTarget = exports ? `{ ${exports.join(', ')} }` : '*';
   const result = esbuild.buildSync({
     stdin: {
-      contents: `export { ${exports.join(', ')} } from './build/modular/index.mjs'`,
+      contents: `export ${exportTarget} from '${modulePath}'`,
       resolveDir: '.',
     },
     metafile: true,
@@ -78,6 +84,7 @@ function getBundleInfo(exports: string[]): BundleInfo {
     outfile,
     write: false,
     sourcemap: 'external',
+    external: ['ulid'],
   });
 
   const pathHasBase = (component: string) => {
@@ -97,8 +104,8 @@ function getBundleInfo(exports: string[]): BundleInfo {
 }
 
 // Gets the bundled size in bytes of an array of named exports from 'ably/modular'
-async function getImportSizes(exports: string[]): Promise<ByteSizes> {
-  const bundleInfo = getBundleInfo(exports);
+async function getModularImportSizes(exports: string[]): Promise<ByteSizes> {
+  const bundleInfo = getModularBundleInfo(exports);
 
   return {
     rawByteSize: bundleInfo.byteSize,
@@ -118,14 +125,14 @@ async function calculateAndCheckExportSizes(): Promise<Output> {
   const output: Output = { tableRows: [], errors: [] };
 
   for (const baseClient of baseClientNames) {
-    const baseClientSizes = await getImportSizes([baseClient]);
+    const baseClientSizes = await getModularImportSizes([baseClient]);
 
     // First output the size of the base client
     output.tableRows.push({ description: baseClient, sizes: baseClientSizes });
 
     // Then output the size of each export together with the base client
     for (const exportName of [...pluginNames, ...functions.map((functionData) => functionData.name)]) {
-      const sizes = await getImportSizes([baseClient, exportName]);
+      const sizes = await getModularImportSizes([baseClient, exportName]);
       output.tableRows.push({ description: `${baseClient} + ${exportName}`, sizes });
 
       if (!(baseClientSizes.rawByteSize < sizes.rawByteSize) && !(baseClient === 'BaseRest' && exportName === 'Rest')) {
@@ -146,13 +153,13 @@ async function calculateAndCheckFunctionSizes(): Promise<Output> {
     const { name: functionName, transitiveImports } = functionData;
 
     // First output the size of the function
-    const standaloneSizes = await getImportSizes([functionName]);
+    const standaloneSizes = await getModularImportSizes([functionName]);
     output.tableRows.push({ description: functionName, sizes: standaloneSizes });
 
     // Then output the size of the function together with the plugin we expect
     // it to transitively import
     if (transitiveImports.length > 0) {
-      const withTransitiveImportsSizes = await getImportSizes([functionName, ...transitiveImports]);
+      const withTransitiveImportsSizes = await getModularImportSizes([functionName, ...transitiveImports]);
       output.tableRows.push({
         description: `${functionName} + ${transitiveImports.join(' + ')}`,
         sizes: withTransitiveImportsSizes,
@@ -176,11 +183,27 @@ async function calculateAndCheckFunctionSizes(): Promise<Output> {
   return output;
 }
 
+async function calculatePushPluginSize(): Promise<Output> {
+  const output: Output = { tableRows: [], errors: [] };
+  const pushPluginBundleInfo = getBundleInfo('./build/push.js');
+  const sizes = {
+    rawByteSize: pushPluginBundleInfo.byteSize,
+    gzipEncodedByteSize: (await promisify(gzip)(pushPluginBundleInfo.code)).byteLength,
+  };
+
+  output.tableRows.push({
+    description: 'Push',
+    sizes: sizes,
+  });
+
+  return output;
+}
+
 async function calculateAndCheckMinimalUsefulRealtimeBundleSize(): Promise<Output> {
   const output: Output = { tableRows: [], errors: [] };
 
   const exports = ['BaseRealtime', 'FetchRequest', 'WebSocketTransport'];
-  const sizes = await getImportSizes(exports);
+  const sizes = await getModularImportSizes(exports);
 
   output.tableRows.push({ description: `Minimal useful Realtime (${exports.join(' + ')})`, sizes });
 
@@ -209,27 +232,19 @@ async function calculateAndCheckMinimalUsefulRealtimeBundleSize(): Promise<Outpu
 
 async function calculateAllExportsBundleSize(): Promise<Output> {
   const exports = [...baseClientNames, ...pluginNames, ...functions.map((val) => val.name)];
-  const sizes = await getImportSizes(exports);
+  const sizes = await getModularImportSizes(exports);
 
   return { tableRows: [{ description: 'All exports', sizes }], errors: [] };
 }
 
 // Performs a sense check that there are no unexpected files making a large contribution to the BaseRealtime bundle size.
 async function checkBaseRealtimeFiles() {
-  const baseRealtimeBundleInfo = getBundleInfo(['BaseRealtime']);
-  const exploreResult = await runSourceMapExplorer(baseRealtimeBundleInfo);
+  const baseRealtimeBundleInfo = getModularBundleInfo(['BaseRealtime']);
 
-  const files = exploreResult.bundles[0].files;
-  delete files['[sourceMappingURL]'];
-  delete files['[unmapped]'];
-  delete files['[EOLs]'];
-
+  // The threshold is chosen pretty arbitrarily. There are some files (e.g. presencemessage.ts) whose bulk should not be included in the BaseRealtime bundle, but which make a small contribution to the bundle (probably because we make use of one exported constant or something; I haven’t looked into it).
   const thresholdBytes = 100;
-  const filesAboveThreshold = Object.entries(files).filter((file) => file[1].size >= thresholdBytes);
 
   // These are the files that are allowed to contribute >= `threshold` bytes to the BaseRealtime bundle.
-  //
-  // The threshold is chosen pretty arbitrarily. There are some files (e.g. presencemessage.ts) whose bulk should not be included in the BaseRealtime bundle, but which make a small contribution to the bundle (probably because we make use of one exported constant or something; I haven’t looked into it).
   const allowedFiles = new Set([
     'src/common/constants/HttpStatusCodes.ts',
     'src/common/constants/XHRStates.ts',
@@ -264,6 +279,33 @@ async function checkBaseRealtimeFiles() {
     'src/platform/web/modular.ts',
   ]);
 
+  return checkBundleFiles(baseRealtimeBundleInfo, allowedFiles, thresholdBytes);
+}
+
+async function checkPushPluginFiles() {
+  const pushPluginBundleInfo = getBundleInfo('./build/push.js');
+
+  // These are the files that are allowed to contribute >= `threshold` bytes to the Push bundle.
+  const allowedFiles = new Set([
+    'src/plugins/push/index.ts',
+    'src/plugins/push/pushchannel.ts',
+    'src/plugins/push/getW3CDeviceDetails.ts',
+    'src/plugins/push/pushactivation.ts',
+  ]);
+
+  return checkBundleFiles(pushPluginBundleInfo, allowedFiles, 100);
+}
+
+async function checkBundleFiles(bundleInfo: BundleInfo, allowedFiles: Set<string>, thresholdBytes: number) {
+  const exploreResult = await runSourceMapExplorer(bundleInfo);
+
+  const files = exploreResult.bundles[0].files;
+  delete files['[sourceMappingURL]'];
+  delete files['[unmapped]'];
+  delete files['[EOLs]'];
+
+  const filesAboveThreshold = Object.entries(files).filter((file) => file[1].size >= thresholdBytes);
+
   const errors: Error[] = [];
 
   // Check that no files other than those allowed above make a large contribution to the bundle size
@@ -271,7 +313,7 @@ async function checkBaseRealtimeFiles() {
     if (!allowedFiles.has(file[0])) {
       errors.push(
         new Error(
-          `Unexpected file ${file[0]}, contributes ${file[1].size}B to BaseRealtime, more than allowed ${thresholdBytes}B`,
+          `Unexpected file ${file[0]}, contributes ${file[1].size}B to bundle, more than allowed ${thresholdBytes}B`,
         ),
       );
     }
@@ -304,6 +346,7 @@ async function checkBaseRealtimeFiles() {
       calculateAllExportsBundleSize(),
       calculateAndCheckExportSizes(),
       calculateAndCheckFunctionSizes(),
+      calculatePushPluginSize(),
     ])
   ).reduce((accum, current) => ({
     tableRows: [...accum.tableRows, ...current.tableRows],
@@ -311,6 +354,7 @@ async function checkBaseRealtimeFiles() {
   }));
 
   output.errors.push(...(await checkBaseRealtimeFiles()));
+  output.errors.push(...(await checkPushPluginFiles()));
 
   const table = new Table({
     style: { head: ['green'] },

--- a/src/common/lib/client/modularplugins.ts
+++ b/src/common/lib/client/modularplugins.ts
@@ -10,6 +10,7 @@ import {
   fromValuesArray as presenceMessagesFromValuesArray,
 } from '../types/presencemessage';
 import { TransportCtor } from '../transport/transport';
+import * as PushPlugin from 'plugins/push';
 
 export interface PresenceMessagePlugin {
   presenceMessageFromValues: typeof presenceMessageFromValues;
@@ -30,6 +31,7 @@ export interface ModularPlugins {
   XHRRequest?: typeof XHRRequest;
   FetchRequest?: typeof fetchRequest;
   MessageInteractions?: typeof FilteredSubscriptions;
+  Push?: typeof PushPlugin;
 }
 
 export const allCommonModularPlugins: ModularPlugins = { Rest };

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -16,6 +16,7 @@ import BaseClient from './baseclient';
 import { useTokenAuth } from './auth';
 import { RestChannelMixin } from './restchannelmixin';
 import { RestPresenceMixin } from './restpresencemixin';
+import DeviceDetails from '../types/devicedetails';
 
 type BatchResult<T> = API.BatchResult<T>;
 
@@ -40,6 +41,10 @@ export class Rest {
 
   readonly channelMixin = RestChannelMixin;
   readonly presenceMixin = RestPresenceMixin;
+
+  // exposed for plugins but shouldn't be bundled with minimal realtime
+  Resource = Resource;
+  DeviceDetails = DeviceDetails;
 
   constructor(client: BaseClient) {
     this.client = client;

--- a/src/common/lib/types/devicedetails.ts
+++ b/src/common/lib/types/devicedetails.ts
@@ -1,8 +1,9 @@
 import { MsgPack } from 'common/types/msgpack';
+import type { LocalDevice } from 'plugins/push/pushactivation';
 import * as Utils from '../util/utils';
 import ErrorInfo, { IConvertibleToErrorInfo } from './errorinfo';
 
-enum DeviceFormFactor {
+export enum DeviceFormFactor {
   Phone = 'phone',
   Tablet = 'tablet',
   Desktop = 'desktop',
@@ -13,7 +14,7 @@ enum DeviceFormFactor {
   Other = 'other',
 }
 
-enum DevicePlatform {
+export enum DevicePlatform {
   Android = 'android',
   IOS = 'ios',
   Browser = 'browser',
@@ -21,9 +22,24 @@ enum DevicePlatform {
 
 type DevicePushState = 'ACTIVE' | 'FAILING' | 'FAILED';
 
-type DevicePushDetails = {
+interface WebPushRecipient {
+  transportType: 'web';
+  targetUrl: string;
+  encryptionKey: string;
+}
+
+interface PushChannelRecipient {
+  transportType: 'ablyChannel';
+  channel: string;
+  ablyKey: string;
+  ablyUrl: string;
+}
+
+type PushRecipient = WebPushRecipient | PushChannelRecipient;
+
+export type DevicePushDetails = {
   error?: ErrorInfo;
-  recipient?: string;
+  recipient?: PushRecipient;
   state?: DevicePushState;
   metadata?: string;
 };
@@ -94,6 +110,10 @@ class DeviceDetails {
   static fromValues(values: Record<string, unknown>): DeviceDetails {
     values.error = values.error && ErrorInfo.fromValues(values.error as IConvertibleToErrorInfo);
     return Object.assign(new DeviceDetails(), values);
+  }
+
+  static fromLocalDevice(device: LocalDevice): DeviceDetails {
+    return Object.assign(new DeviceDetails(), device);
   }
 
   static fromValuesArray(values: Array<Record<string, unknown>>): DeviceDetails[] {

--- a/src/common/lib/types/devicedetails.ts
+++ b/src/common/lib/types/devicedetails.ts
@@ -22,10 +22,15 @@ export enum DevicePlatform {
 
 type DevicePushState = 'ACTIVE' | 'FAILING' | 'FAILED';
 
+interface WebPushEncryptionKey {
+  p256dh: string;
+  auth: string;
+}
+
 interface WebPushRecipient {
   transportType: 'web';
   targetUrl: string;
-  encryptionKey: string;
+  encryptionKey: WebPushEncryptionKey;
 }
 
 interface PushChannelRecipient {

--- a/src/common/lib/types/devicedetails.ts
+++ b/src/common/lib/types/devicedetails.ts
@@ -31,6 +31,7 @@ interface WebPushRecipient {
   transportType: 'web';
   targetUrl: string;
   encryptionKey: WebPushEncryptionKey;
+  publicVapidKey: string;
 }
 
 interface PushChannelRecipient {

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -344,10 +344,11 @@ const contentTypes = {
   xml: 'application/xml',
   html: 'text/html',
   msgpack: 'application/x-msgpack',
+  text: 'text/plain',
 };
 
 export interface HeadersOptions {
-  format?: Utils.Format;
+  format?: Utils.Format | 'xml' | 'html' | 'text';
   protocolVersion?: number;
 }
 

--- a/src/common/types/ClientOptions.ts
+++ b/src/common/types/ClientOptions.ts
@@ -1,13 +1,14 @@
 import { Modify } from './utils';
 import * as API from '../../../ably';
 import { ModularPlugins } from 'common/lib/client/modularplugins';
+import { StandardPlugins } from 'plugins';
 
 export type RestAgentOptions = {
   keepAlive: boolean;
   maxSockets: number;
 };
 
-export default interface ClientOptions extends API.ClientOptions<API.CorePlugins & ModularPlugins> {
+export default interface ClientOptions extends API.ClientOptions<API.CorePlugins & ModularPlugins & StandardPlugins> {
   restAgentOptions?: RestAgentOptions;
   pushFullWait?: boolean;
   agents?: Record<string, string | undefined>;

--- a/src/common/types/IPlatformConfig.d.ts
+++ b/src/common/types/IPlatformConfig.d.ts
@@ -1,3 +1,5 @@
+import { DeviceFormFactor, DevicePlatform } from 'common/lib/types/devicedetails';
+
 /**
  * Interface for common config properties shared between all platforms and that are relevant for all platforms.
  *
@@ -15,6 +17,7 @@ export interface ICommonPlatformConfig {
   inspect: (value: unknown) => string;
   stringByteSize: Buffer.byteLength;
   getRandomArrayBuffer: (byteLength: number) => Promise<ArrayBuffer>;
+  push?: IPlatformPushConfig;
 }
 
 /**
@@ -35,6 +38,19 @@ export interface ISpecificPlatformConfig {
   TextEncoder?: typeof TextEncoder;
   TextDecoder?: typeof TextDecoder;
   isWebworker?: boolean;
+}
+
+export interface IPlatformPushStorage {
+  get(name: string): string;
+  set(name: string, value: string);
+  remove(name: string);
+}
+
+export interface IPlatformPushConfig {
+  platform: DevicePlatform;
+  formFactor: DeviceFormFactor;
+  storage: IPlatformPushStorage;
+  getPushDeviceDetails?(machine: any);
 }
 
 export type IPlatformConfig = ICommonPlatformConfig & ISpecificPlatformConfig;

--- a/src/platform/web/config.ts
+++ b/src/platform/web/config.ts
@@ -1,5 +1,7 @@
 import { IPlatformConfig } from '../../common/types/IPlatformConfig';
 import * as Utils from 'common/lib/util/utils';
+import { DeviceFormFactor, DevicePlatform } from 'common/lib/types/devicedetails';
+import webstorage from './lib/util/webstorage';
 
 // Workaround for salesforce lightning locker compat
 const globalObject = Utils.getGlobalObject();
@@ -79,6 +81,11 @@ const Config: IPlatformConfig = {
     return byteArray.buffer;
   },
   isWebworker: isWebWorkerContext(),
+  push: {
+    platform: DevicePlatform.Browser,
+    formFactor: DeviceFormFactor.Desktop,
+    storage: webstorage,
+  },
 };
 
 export default Config;

--- a/src/plugins/index.d.ts
+++ b/src/plugins/index.d.ts
@@ -1,0 +1,5 @@
+import Push from './push';
+
+export interface StandardPlugins {
+  Push?: typeof Push;
+}

--- a/src/plugins/push/getW3CDeviceDetails.ts
+++ b/src/plugins/push/getW3CDeviceDetails.ts
@@ -73,6 +73,7 @@ export async function getW3CPushDeviceDetails(machine: ActivationStateMachine) {
     device.push.recipient = {
       transportType: 'web',
       targetUrl: btoa(endpoint),
+      publicVapidKey: appServerKey,
       encryptionKey: {
         p256dh: toBase64Url(p256dh),
         auth: toBase64Url(auth),

--- a/src/plugins/push/getW3CDeviceDetails.ts
+++ b/src/plugins/push/getW3CDeviceDetails.ts
@@ -1,0 +1,89 @@
+import { ActivationStateMachine } from 'plugins/push/pushactivation';
+
+function toBase64Url(arrayBuffer: ArrayBuffer) {
+  const buffer = new Uint8Array(arrayBuffer.slice(0, arrayBuffer.byteLength));
+  return btoa(String.fromCharCode.apply(null, Array.from(buffer)));
+}
+
+function urlBase64ToBase64(base64String: string) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  return base64;
+}
+
+function base64ToUint8Array(base64String: string) {
+  const rawData = window.atob(base64String);
+  const rawDataChars = [];
+  for (let i = 0; i < rawData.length; i++) {
+    rawDataChars.push(rawData[i].charCodeAt(0));
+  }
+  return Uint8Array.from(rawDataChars);
+}
+
+export async function getW3CPushDeviceDetails(machine: ActivationStateMachine) {
+  const GettingPushDeviceDetailsFailed = machine.GettingPushDeviceDetailsFailed;
+  const GotPushDeviceDetails = machine.GotPushDeviceDetails;
+  const { ErrorInfo, Defaults } = machine.client;
+
+  const permission = await Notification.requestPermission();
+
+  if (permission !== 'granted') {
+    machine.handleEvent(
+      new GettingPushDeviceDetailsFailed(new ErrorInfo('User denied permission to send notifications', 400, 40000)),
+    );
+    return;
+  }
+
+  const swUrl = machine.client.options.pushServiceWorkerUrl;
+  if (!swUrl) {
+    machine.handleEvent(
+      new GettingPushDeviceDetailsFailed(new ErrorInfo('Missing ClientOptions.pushServiceWorkerUrl', 400, 40000)),
+    );
+    return;
+  }
+
+  try {
+    const worker = await navigator.serviceWorker.register(swUrl);
+
+    machine._pushManager = worker.pushManager;
+
+    const headers = Defaults.defaultGetHeaders(machine.client.options, { format: 'text' });
+    const appServerKey = (
+      await machine.client.rest.Resource.get(machine.client, '/push/publicVapidKey', headers, {}, null, true)
+    ).body as string;
+
+    if (!worker.active) {
+      await navigator.serviceWorker.ready;
+    }
+
+    const subscription = await worker.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: base64ToUint8Array(urlBase64ToBase64(appServerKey)),
+    });
+
+    const endpoint = subscription.endpoint;
+
+    const [p256dh, auth] = [subscription.getKey('p256dh'), subscription.getKey('auth')];
+
+    if (!p256dh || !auth) {
+      throw new ErrorInfo('Public key not found', 50000, 500);
+    }
+
+    const device = machine.client.device;
+    device.push.recipient = {
+      transportType: 'web',
+      targetUrl: btoa(endpoint),
+      encryptionKey: {
+        p256dh: toBase64Url(p256dh),
+        auth: toBase64Url(auth),
+      },
+    };
+    device.persist();
+
+    machine.handleEvent(new GotPushDeviceDetails());
+  } catch (err) {
+    machine.handleEvent(
+      new GettingPushDeviceDetailsFailed(new ErrorInfo('Failed to register service worker', 50000, 500, err as Error)),
+    );
+  }
+}

--- a/src/plugins/push/index.ts
+++ b/src/plugins/push/index.ts
@@ -1,4 +1,5 @@
 import PushChannel from './pushchannel';
+import { getW3CPushDeviceDetails } from './getW3CDeviceDetails';
 import { ActivationStateMachine, CalledActivate, CalledDeactivate, localDeviceFactory } from './pushactivation';
 
 export {
@@ -7,6 +8,7 @@ export {
   CalledActivate,
   CalledDeactivate,
   PushChannel,
+  getW3CPushDeviceDetails,
 };
 
 export default {
@@ -15,4 +17,5 @@ export default {
   CalledActivate,
   CalledDeactivate,
   PushChannel,
+  getW3CPushDeviceDetails,
 };

--- a/src/plugins/push/index.ts
+++ b/src/plugins/push/index.ts
@@ -1,0 +1,18 @@
+import PushChannel from './pushchannel';
+import { ActivationStateMachine, CalledActivate, CalledDeactivate, localDeviceFactory } from './pushactivation';
+
+export {
+  ActivationStateMachine,
+  localDeviceFactory,
+  CalledActivate,
+  CalledDeactivate,
+  PushChannel,
+};
+
+export default {
+  ActivationStateMachine,
+  localDeviceFactory,
+  CalledActivate,
+  CalledDeactivate,
+  PushChannel,
+};

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -1,0 +1,687 @@
+import * as API from '../../../ably';
+import { IPlatformPushConfig } from 'common/types/IPlatformConfig';
+import { ulid } from 'ulid';
+import type { ErrCallback, StandardCallback } from 'common/types/utils';
+import type ErrorInfo from 'common/lib/types/errorinfo';
+import DeviceDetails, { DevicePlatform, DevicePushDetails } from 'common/lib/types/devicedetails';
+import { getW3CPushDeviceDetails } from './getW3CDeviceDetails';
+import type BaseClient from 'common/lib/client/baseclient';
+
+const persistKeys = {
+  deviceId: 'ably.push.deviceId',
+  deviceSecret: 'ably.push.deviceSecret',
+  deviceIdentityToken: 'ably.push.deviceIdentityToken',
+  pushRecipient: 'ably.push.pushRecipient',
+  activationState: 'ably.push.activationState',
+};
+
+type DeviceRegistration = Required<{
+  [K in keyof DeviceDetails]: K extends 'deviceIdentityToken' ? API.TokenDetails : DeviceDetails[K];
+}>;
+
+export type RegisterCallback = (device: DeviceDetails, callback: StandardCallback<DeviceRegistration>) => void;
+export type DeregisterCallback = (device: DeviceDetails, callback: StandardCallback<string>) => void;
+
+export interface LocalDeviceAuthDetails {
+  headers: Record<string, string>;
+  params: Record<string, unknown>;
+}
+
+export type LocalDeviceFactory = ReturnType<typeof localDeviceFactory>;
+export type LocalDevice = ReturnType<LocalDeviceFactory['load']>;
+
+/**
+ * LocalDevice extends DeviceDetails, but DeviceDetails is part of core ably-js and LocalDevice is part of the Push plugin
+ * In order to avoid bundling the DeviceDetails class in both core ably-js and the plugin, the LocalDevice is exported as
+ * a factory, and the DeviceDetails constructor is used to create the class declaration for LocalDevice when the plugin is
+ * loaded.
+ */
+export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
+  return class LocalDevice extends deviceDetails {
+    rest: BaseClient;
+    push: DevicePushDetails;
+
+    private constructor(rest: BaseClient) {
+      super();
+      this.push = {};
+      this.rest = rest;
+    }
+
+    static load(rest: BaseClient) {
+      const device = new LocalDevice(rest);
+      device.loadPersisted();
+      return device;
+    }
+
+    loadPersisted() {
+      const Platform = this.rest.Platform;
+      if (!Platform.Config.push) {
+        throw new this.rest.ErrorInfo('Push activation is not available on this platform', 40000, 400);
+      }
+      this.platform = Platform.Config.push.platform;
+      this.clientId = this.rest.auth.clientId ?? undefined;
+      this.formFactor = Platform.Config.push.formFactor;
+      this.id = Platform.Config.push.storage.get(persistKeys.deviceId);
+
+      if (this.id) {
+        this.deviceSecret = Platform.Config.push.storage.get(persistKeys.deviceSecret) || undefined;
+        this.deviceIdentityToken = JSON.parse(
+          Platform.Config.push.storage.get(persistKeys.deviceIdentityToken) || 'null',
+        );
+        this.push.recipient = JSON.parse(Platform.Config.push.storage.get(persistKeys.pushRecipient) || 'null');
+      } else {
+        this.resetId();
+      }
+    }
+
+    persist() {
+      const config = this.rest.Platform.Config;
+      if (!config.push) {
+        throw new this.rest.ErrorInfo('Push activation is not available on this platform', 40000, 400);
+      }
+      if (this.id) {
+        config.push.storage.set(persistKeys.deviceId, this.id);
+      }
+      if (this.deviceSecret) {
+        config.push.storage.set(persistKeys.deviceSecret, this.deviceSecret);
+      }
+      if (this.deviceIdentityToken) {
+        config.push.storage.set(persistKeys.deviceIdentityToken, JSON.stringify(this.deviceIdentityToken));
+      }
+      if (this.push.recipient) {
+        config.push.storage.set(persistKeys.pushRecipient, JSON.stringify(this.push.recipient));
+      }
+    }
+
+    resetId() {
+      this.id = ulid();
+      this.deviceSecret = ulid();
+      this.persist();
+    }
+
+    getAuthDetails(
+      rest: BaseClient,
+      headers: Record<string, string>,
+      params: Record<string, unknown>,
+    ): LocalDeviceAuthDetails {
+      if (!this.deviceIdentityToken) {
+        throw new this.rest.ErrorInfo('Unable to update device registration; no deviceIdentityToken', 50000, 500);
+      }
+      if (this.rest.http.supportsAuthHeaders) {
+        return {
+          headers: rest.Utils.mixin(
+            { authorization: 'Bearer ' + rest.Utils.toBase64(this.deviceIdentityToken) },
+            headers,
+          ) as Record<string, string>,
+          params,
+        };
+      } else {
+        return { headers, params: rest.Utils.mixin({ access_token: this.deviceIdentityToken }, params) };
+      }
+    }
+  };
+}
+
+export class ActivationStateMachine {
+  client: BaseClient;
+  current: ActivationState;
+  pendingEvents: ActivationEvent[];
+  handling: boolean;
+  deactivatedCallback?: ErrCallback;
+  activatedCallback?: ErrCallback;
+  _pushConfig?: IPlatformPushConfig;
+  registerCallback?: RegisterCallback;
+  deregisterCallback?: DeregisterCallback;
+  updateFailedCallback?: ErrCallback;
+
+  // Used for testing
+  pushManager?: PushManager;
+
+  // exported for testing
+  GettingPushDeviceDetailsFailed = GettingPushDeviceDetailsFailed;
+  GotPushDeviceDetails = GotPushDeviceDetails;
+
+  constructor(rest: BaseClient) {
+    this.client = rest;
+    this._pushConfig = rest.Platform.Config.push;
+    this.current = new ActivationStates[
+      (this.pushConfig.storage.get(persistKeys.activationState) as ActivationStateName) || 'NotActivated'
+    ](null);
+    this.pendingEvents = [];
+    this.handling = false;
+  }
+
+  get pushConfig() {
+    if (!this._pushConfig) {
+      throw new this.client.ErrorInfo('This platform is not supported as a target of push notifications', 40000, 400);
+    }
+    return this._pushConfig;
+  }
+
+  persist() {
+    if (isPersistentState(this.current)) {
+      this.pushConfig.storage.set(persistKeys.activationState, this.current.name);
+    }
+  }
+
+  callUpdateRegistrationFailedCallback(reason: ErrorInfo) {
+    if (this.updateFailedCallback) {
+      this.updateFailedCallback(reason);
+    } else {
+      this.client.Logger.logAction(
+        this.client.logger,
+        this.client.Logger.LOG_ERROR,
+        'UpdateRegistrationFailed',
+        'Failed updating device push registration: ' + this.client.Utils.inspectError(reason),
+      );
+    }
+  }
+
+  callCustomRegisterer(device: LocalDevice, isNew: boolean) {
+    this.registerCallback?.(device, (error: ErrorInfo, deviceRegistration?: DeviceRegistration) => {
+      if (error) {
+        if (isNew) {
+          this.handleEvent(new GettingDeviceRegistrationFailed(error));
+        } else {
+          this.handleEvent(new SyncRegistrationFailed(error));
+        }
+        return;
+      }
+
+      if (!deviceRegistration) {
+        this.handleEvent(
+          new GettingDeviceRegistrationFailed(
+            new this.client.ErrorInfo('registerCallback did not return deviceRegistration', 40000, 400),
+          ),
+        );
+      }
+
+      if (isNew) {
+        this.handleEvent(new GotDeviceRegistration(deviceRegistration as any));
+      } else {
+        this.handleEvent(new RegistrationSynced());
+      }
+    });
+  }
+
+  callCustomDeregisterer(device: LocalDevice) {
+    this.deregisterCallback?.(device, (err: ErrorInfo) => {
+      if (err) {
+        this.handleEvent(new DeregistrationFailed(err));
+        return;
+      }
+      this.handleEvent(new Deregistered());
+    });
+  }
+
+  async updateRegistration() {
+    const localDevice = this.client.device as LocalDevice;
+    if (this.registerCallback) {
+      this.callCustomRegisterer(localDevice, false);
+    } else {
+      const client = this.client;
+      const format = client.options.useBinaryProtocol
+          ? this.client.Utils.Format.msgpack
+          : this.client.Utils.Format.json,
+        body = client.rest.DeviceDetails.fromLocalDevice(localDevice),
+        headers = this.client.Defaults.defaultPostHeaders(this.client.options, { format }),
+        params = {};
+
+      if (client.options.headers) {
+        this.client.Utils.mixin(headers, client.options.headers);
+      }
+
+      if (client.options.pushFullWait) {
+        this.client.Utils.mixin(params, { fullWait: 'true' });
+      }
+
+      const requestBody = this.client.Utils.encodeBody(body, client._MsgPack, format);
+      const authDetails = localDevice.getAuthDetails(client, headers, params);
+      try {
+        const response = await this.client.rest.Resource.patch(
+          client,
+          '/push/deviceRegistrations',
+          requestBody,
+          authDetails.headers,
+          authDetails.params,
+          format,
+          true,
+        );
+        this.handleEvent(new GotDeviceRegistration(response.body as DeviceRegistration));
+      } catch (err) {
+        this.handleEvent(new GettingDeviceRegistrationFailed(err as ErrorInfo));
+      }
+    }
+  }
+
+  async deregister() {
+    const device = this.client.device as LocalDevice;
+    if (this.deregisterCallback) {
+      this.callCustomDeregisterer(device);
+    } else {
+      const rest = this.client;
+      const format = rest.options.useBinaryProtocol ? this.client.Utils.Format.msgpack : this.client.Utils.Format.json,
+        headers = this.client.Defaults.defaultPostHeaders(rest.options, { format }),
+        params = { deviceId: device.id };
+
+      if (rest.options.headers) this.client.Utils.mixin(headers, rest.options.headers);
+
+      if (rest.options.pushFullWait) this.client.Utils.mixin(params, { fullWait: 'true' });
+
+      try {
+        await this.client.rest.Resource.delete(rest, '/push/deviceRegistrations', headers, params, format, true);
+        this.handleEvent(new Deregistered());
+      } catch (err) {
+        this.handleEvent(new DeregistrationFailed(err as ErrorInfo));
+      }
+    }
+  }
+
+  callActivatedCallback(err: ErrorInfo | null) {
+    this.activatedCallback?.(err);
+    delete this.activatedCallback;
+  }
+
+  callDeactivatedCallback(err: ErrorInfo | null) {
+    this.deactivatedCallback?.(err);
+    delete this.deactivatedCallback;
+  }
+
+  handleEvent(event: ActivationEvent) {
+    if (this.handling) {
+      this.client.Platform.Config.nextTick(() => {
+        this.handleEvent(event);
+      });
+      return;
+    }
+
+    this.handling = true;
+    this.client.Logger.logAction(
+      this.client.logger,
+      this.client.Logger.LOG_MAJOR,
+      'Push.ActivationStateMachine.handleEvent()',
+      'handling event ' + event.name + ' from ' + this.current.name,
+    );
+
+    let maybeNext = this.current.processEvent(this, event);
+    if (!maybeNext) {
+      this.client.Logger.logAction(
+        this.client.logger,
+        this.client.Logger.LOG_MAJOR,
+        'Push.ActivationStateMachine.handleEvent()',
+        'enqueing event: ' + event.name,
+      );
+      this.pendingEvents.push(event);
+      this.handling = false;
+      return;
+    }
+
+    this.client.Logger.logAction(
+      this.client.logger,
+      this.client.Logger.LOG_MAJOR,
+      'Push.ActivationStateMachine.handleEvent()',
+      'transition: ' + this.current.name + ' -(' + event.name + ')-> ' + maybeNext.name,
+    );
+    this.current = maybeNext;
+
+    while (this.pendingEvents.length > 0) {
+      const pending = this.pendingEvents[0];
+
+      this.client.Logger.logAction(
+        this.client.logger,
+        this.client.Logger.LOG_MAJOR,
+        'Push.ActivationStateMachine.handleEvent()',
+        'attempting to consume pending event: ' + pending.name,
+      );
+
+      maybeNext = this.current.processEvent(this, pending);
+      if (!maybeNext) {
+        break;
+      }
+      this.pendingEvents.splice(0, 1);
+
+      this.client.Logger.logAction(
+        this.client.logger,
+        this.client.Logger.LOG_MAJOR,
+        'Push.ActivationStateMachine.handleEvent()',
+        'transition: ' + this.current.name + ' -(' + pending.name + ')-> ' + maybeNext.name,
+      );
+      this.current = maybeNext;
+    }
+
+    this.persist();
+    this.handling = false;
+  }
+}
+
+// Events
+export class CalledActivate {
+  name = 'CalledActivate';
+
+  constructor(machine: ActivationStateMachine, registerCallback?: RegisterCallback) {
+    if (registerCallback) {
+      machine.registerCallback = registerCallback;
+    }
+    machine.persist();
+  }
+}
+
+export class CalledDeactivate {
+  name = 'CalledDeactivate';
+
+  constructor(machine: ActivationStateMachine, deregisterCallback?: DeregisterCallback) {
+    machine.deregisterCallback = deregisterCallback;
+    machine.persist();
+  }
+}
+
+export class GotPushDeviceDetails {
+  name = 'GotPushDeviceDetails';
+}
+
+export class GettingPushDeviceDetailsFailed {
+  name = 'GettingPushDeviceDetailsFailed';
+  reason: ErrorInfo;
+
+  constructor(reason: ErrorInfo) {
+    this.reason = reason;
+  }
+}
+
+class GotDeviceRegistration {
+  name = 'GotDeviceRegistration';
+  tokenDetails: API.TokenDetails;
+
+  constructor(deviceRegistration: DeviceRegistration) {
+    this.tokenDetails = deviceRegistration.deviceIdentityToken;
+  }
+}
+
+class GettingDeviceRegistrationFailed {
+  name = 'GettingDeviceRegistrationFailed';
+  reason: ErrorInfo;
+  constructor(reason: ErrorInfo) {
+    this.reason = reason;
+  }
+}
+
+class RegistrationSynced {
+  name = 'RegistrationSynced';
+}
+
+class SyncRegistrationFailed {
+  name = 'SyncRegistrationFailed';
+  reason: ErrorInfo;
+
+  constructor(reason: ErrorInfo) {
+    this.reason = reason;
+  }
+}
+
+class Deregistered {
+  name = 'Deregistered';
+}
+
+class DeregistrationFailed {
+  name = 'DeregistrationFailed';
+  reason: ErrorInfo;
+  constructor(reason: ErrorInfo) {
+    this.reason = reason;
+  }
+}
+
+type ActivationEvent =
+  | CalledActivate
+  | CalledDeactivate
+  | GotPushDeviceDetails
+  | GettingPushDeviceDetailsFailed
+  | GotDeviceRegistration
+  | GettingDeviceRegistrationFailed
+  | RegistrationSynced
+  | SyncRegistrationFailed
+  | Deregistered
+  | DeregistrationFailed;
+
+// States
+abstract class ActivationState {
+  name: ActivationStateName;
+
+  constructor(name: ActivationStateName) {
+    this.name = name;
+  }
+
+  abstract processEvent(machine: ActivationStateMachine, event: ActivationEvent): ActivationState | null;
+}
+
+class NotActivated extends ActivationState {
+  constructor() {
+    super('NotActivated');
+  }
+
+  processEvent(machine: ActivationStateMachine, event: ActivationEvent): ActivationState | null {
+    if (event instanceof CalledDeactivate) {
+      machine.callDeactivatedCallback(null);
+      return new NotActivated();
+    } else if (event instanceof CalledActivate) {
+      const device = machine.client.device as LocalDevice;
+
+      if (device.deviceIdentityToken != null) {
+        if (device.clientId && device.clientId !== machine.client.auth.clientId) {
+          machine.handleEvent(
+            new SyncRegistrationFailed(
+              new machine.client.ErrorInfo('clientId not compatible with local device clientId', 61002, 400),
+            ),
+          );
+          return null;
+        }
+        // Already registered.
+        machine.pendingEvents.push(event);
+        return new WaitingForNewPushDeviceDetails();
+      }
+
+      if (device.push.recipient) {
+        machine.pendingEvents.push(new GotPushDeviceDetails());
+      } else {
+        if (machine.pushConfig.getPushDeviceDetails) {
+          machine.pushConfig.getPushDeviceDetails?.(machine);
+        } else if (machine.pushConfig.platform === DevicePlatform.Browser) {
+          getW3CPushDeviceDetails(machine);
+        } else {
+          machine.handleEvent(
+            new GettingPushDeviceDetailsFailed(
+              new machine.client.ErrorInfo('No available implementation to get push device details', 50000, 500),
+            ),
+          );
+        }
+      }
+
+      return new WaitingForPushDeviceDetails();
+    } else if (event instanceof GotPushDeviceDetails) {
+      return new NotActivated();
+    }
+    return null;
+  }
+}
+
+class WaitingForPushDeviceDetails extends ActivationState {
+  constructor() {
+    super('WaitingForPushDeviceDetails');
+  }
+
+  processEvent(machine: ActivationStateMachine, event: ActivationEvent) {
+    if (event instanceof CalledActivate) {
+      return new WaitingForPushDeviceDetails();
+    } else if (event instanceof CalledDeactivate) {
+      machine.callDeactivatedCallback(null);
+      return new NotActivated();
+    } else if (event instanceof GotPushDeviceDetails) {
+      const client = machine.client;
+      const device = client.device as LocalDevice;
+
+      if (machine.registerCallback) {
+        machine.callCustomRegisterer(device, true);
+      } else {
+        const format = client.options.useBinaryProtocol
+            ? machine.client.Utils.Format.msgpack
+            : machine.client.Utils.Format.json,
+          body = client.rest.DeviceDetails.fromLocalDevice(device),
+          headers = machine.client.Defaults.defaultPostHeaders(client.options, { format }),
+          params = {};
+
+        if (client.options.headers) machine.client.Utils.mixin(headers, client.options.headers);
+
+        if (client.options.pushFullWait) machine.client.Utils.mixin(params, { fullWait: 'true' });
+
+        const requestBody = machine.client.Utils.encodeBody(body, client._MsgPack, format);
+
+        machine.client.rest.Resource.post(client, '/push/deviceRegistrations', requestBody, headers, params, null, true)
+          .then((response) => {
+            const deviceDetails = response.unpacked
+              ? response.body
+              : client.rest.DeviceDetails.fromResponseBody(response.body as any, client._MsgPack, format);
+            machine.handleEvent(new GotDeviceRegistration(deviceDetails as DeviceRegistration));
+          })
+          .catch((err) => {
+            machine.handleEvent(new GettingDeviceRegistrationFailed(err as ErrorInfo));
+          });
+      }
+
+      return new WaitingForDeviceRegistration();
+    } else if (event instanceof GettingPushDeviceDetailsFailed) {
+      machine.callActivatedCallback(event.reason);
+      return new NotActivated();
+    }
+    return null;
+  }
+}
+
+class WaitingForDeviceRegistration extends ActivationState {
+  constructor() {
+    super('WaitingForDeviceRegistration');
+  }
+
+  processEvent(machine: ActivationStateMachine, event: ActivationEvent) {
+    if (event instanceof CalledActivate) {
+      return new WaitingForDeviceRegistration();
+    } else if (event instanceof GotDeviceRegistration) {
+      const device = machine.client.device as LocalDevice;
+      device.deviceIdentityToken = event.tokenDetails.token;
+      device.persist();
+      machine.callActivatedCallback(null);
+      return new WaitingForNewPushDeviceDetails();
+    } else if (event instanceof GettingDeviceRegistrationFailed) {
+      machine.callActivatedCallback(event.reason);
+      return new NotActivated();
+    }
+    return null;
+  }
+}
+
+class WaitingForNewPushDeviceDetails extends ActivationState {
+  constructor() {
+    super('WaitingForNewPushDeviceDetails');
+  }
+
+  processEvent(machine: ActivationStateMachine, event: ActivationEvent) {
+    if (event instanceof CalledActivate) {
+      machine.callActivatedCallback(null);
+      return new WaitingForNewPushDeviceDetails();
+    } else if (event instanceof CalledDeactivate) {
+      machine.deregister();
+      return new WaitingForDeregistration(this);
+    } else if (event instanceof GotPushDeviceDetails) {
+      machine.updateRegistration();
+      return new WaitingForRegistrationSync();
+    }
+    return null;
+  }
+}
+
+class WaitingForRegistrationSync extends ActivationState {
+  triggeredByCalledActivate: boolean | null;
+
+  constructor(triggeredByCalledActivate: boolean | null = false) {
+    super('WaitingForRegistrationSync');
+    this.triggeredByCalledActivate = triggeredByCalledActivate;
+  }
+
+  processEvent(machine: ActivationStateMachine, event: ActivationEvent) {
+    if (event instanceof CalledActivate && !this.triggeredByCalledActivate) {
+      machine.callActivatedCallback(null);
+      return new WaitingForRegistrationSync(true);
+    } else if (event instanceof RegistrationSynced) {
+      return new WaitingForNewPushDeviceDetails();
+    } else if (event instanceof SyncRegistrationFailed) {
+      machine.callUpdateRegistrationFailedCallback(event.reason);
+      return new AfterRegistrationSyncFailed();
+    }
+    return null;
+  }
+}
+
+class AfterRegistrationSyncFailed extends ActivationState {
+  constructor() {
+    super('AfterRegistrationSyncFailed');
+  }
+
+  processEvent(machine: ActivationStateMachine, event: ActivationEvent) {
+    if (event instanceof CalledActivate || event instanceof GotPushDeviceDetails) {
+      machine.updateRegistration();
+      return new WaitingForRegistrationSync(event instanceof CalledActivate);
+    } else if (event instanceof CalledDeactivate) {
+      machine.deregister();
+      return new WaitingForDeregistration(this);
+    }
+    return null;
+  }
+}
+
+class WaitingForDeregistration extends ActivationState {
+  previousState: ActivationState | null;
+
+  constructor(previousState: ActivationState | null) {
+    super('WaitingForDeregistration');
+    this.previousState = previousState;
+  }
+
+  processEvent(machine: ActivationStateMachine, event: ActivationEvent): ActivationState | null {
+    if (event instanceof CalledDeactivate) {
+      return new WaitingForDeregistration(this.previousState);
+    } else if (event instanceof Deregistered) {
+      const device = machine.client.device as LocalDevice;
+      delete device.deviceIdentityToken;
+      delete device.push.recipient;
+      device.resetId();
+      device.persist();
+      machine.callDeactivatedCallback(null);
+      return new NotActivated();
+    } else if (event instanceof DeregistrationFailed) {
+      machine.callDeactivatedCallback(event.reason);
+      return this.previousState;
+    }
+    return null;
+  }
+}
+
+type ActivationStateName =
+  | 'NotActivated'
+  | 'WaitingForPushDeviceDetails'
+  | 'WaitingForDeviceRegistration'
+  | 'WaitingForNewPushDeviceDetails'
+  | 'WaitingForRegistrationSync'
+  | 'AfterRegistrationSyncFailed'
+  | 'WaitingForDeregistration';
+
+export const ActivationStates = {
+  NotActivated,
+  WaitingForPushDeviceDetails,
+  WaitingForDeviceRegistration,
+  WaitingForNewPushDeviceDetails,
+  WaitingForRegistrationSync,
+  AfterRegistrationSyncFailed,
+  WaitingForDeregistration,
+};
+
+function isPersistentState(state: ActivationState) {
+  return state.name == 'NotActivated' || state.name == 'WaitingForNewPushDeviceDetails';
+}

--- a/src/plugins/push/pushchannel.ts
+++ b/src/plugins/push/pushchannel.ts
@@ -1,0 +1,119 @@
+import type BaseClient from 'common/lib/client/baseclient';
+import type RealtimeChannel from 'common/lib/client/realtimechannel';
+import type RestChannel from 'common/lib/client/restchannel';
+import type { LocalDevice } from 'plugins/push/pushactivation';
+
+class PushChannel {
+  client: BaseClient;
+  channel: RestChannel | RealtimeChannel;
+
+  constructor(channel: RestChannel | RealtimeChannel) {
+    this.channel = channel;
+    this.client = channel.client;
+  }
+
+  async subscribeDevice() {
+    const client = this.client;
+    const device = client.device as LocalDevice;
+    const format = client.options.useBinaryProtocol ? client.Utils.Format.msgpack : client.Utils.Format.json,
+      body = { deviceId: device.id, channel: this.channel.name },
+      headers = client.Defaults.defaultPostHeaders(client.options, { format });
+
+    if (client.options.headers) client.Utils.mixin(headers, client.options.headers);
+
+    client.Utils.mixin(headers, this._getPushAuthHeaders());
+
+    const requestBody = client.Utils.encodeBody(body, client._MsgPack, format);
+    await client.rest.Resource.post(client, '/push/channelSubscriptions', requestBody, headers, {}, format, true);
+  }
+
+  async unsubscribeDevice() {
+    const client = this.client;
+    const device = client.device as LocalDevice;
+    const format = client.options.useBinaryProtocol ? client.Utils.Format.msgpack : client.Utils.Format.json,
+      headers = client.Defaults.defaultPostHeaders(client.options, { format });
+
+    if (client.options.headers) client.Utils.mixin(headers, client.options.headers);
+
+    client.Utils.mixin(headers, this._getPushAuthHeaders());
+
+    await client.rest.Resource.delete(
+      client,
+      '/push/channelSubscriptions',
+      headers,
+      { deviceId: device.id, channel: this.channel.name },
+      format,
+      true,
+    );
+  }
+
+  async subscribeClient() {
+    const client = this.client;
+    const clientId = this.client.auth.clientId;
+    if (!clientId) {
+      throw new this.client.ErrorInfo('Cannot subscribe from client without client ID', 50000, 500);
+    }
+    const format = client.options.useBinaryProtocol ? client.Utils.Format.msgpack : client.Utils.Format.json,
+      body = { clientId: clientId, channel: this.channel.name },
+      headers = client.Defaults.defaultPostHeaders(client.options, { format });
+
+    if (client.options.headers) client.Utils.mixin(headers, client.options.headers);
+
+    const requestBody = client.Utils.encodeBody(body, client._MsgPack, format);
+    await client.rest.Resource.post(client, '/push/channelSubscriptions', requestBody, headers, {}, format, true);
+  }
+
+  async unsubscribeClient() {
+    const client = this.client;
+
+    const clientId = this.client.auth.clientId;
+    if (!clientId) {
+      throw new this.client.ErrorInfo('Cannot unsubscribe from client without client ID', 50000, 500);
+    }
+    const format = client.options.useBinaryProtocol ? client.Utils.Format.msgpack : client.Utils.Format.json,
+      headers = client.Defaults.defaultPostHeaders(client.options, { format });
+
+    if (client.options.headers) client.Utils.mixin(headers, client.options.headers);
+
+    await client.rest.Resource.delete(
+      client,
+      '/push/channelSubscriptions',
+      headers,
+      { clientId: clientId, channel: this.channel.name },
+      format,
+      true,
+    );
+  }
+
+  async listSubscriptions(params?: Record<string, string>) {
+    this.client.Logger.logAction(
+      this.client.logger,
+      this.client.Logger.LOG_MICRO,
+      'PushChannel.listSubscriptions()',
+      'channel = ' + this.channel.name,
+    );
+
+    return this.client.push.admin.channelSubscriptions.list({
+      ...params,
+      channel: this.channel.name,
+      concatFilters: true,
+    });
+  }
+
+  private _getDeviceIdentityToken() {
+    const device = this.client.device as LocalDevice;
+    const deviceIdentityToken = device.deviceIdentityToken;
+    if (deviceIdentityToken) {
+      return deviceIdentityToken;
+    } else {
+      throw new this.client.ErrorInfo('Cannot subscribe from client without deviceIdentityToken', 50000, 500);
+    }
+  }
+
+  private _getPushAuthHeaders() {
+    const deviceIdentityToken = this._getDeviceIdentityToken();
+    return { 'X-Ably-DeviceToken': deviceIdentityToken };
+  }
+}
+
+export default PushChannel;

--- a/test/browser/push.test.js
+++ b/test/browser/push.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+define(['ably', 'shared_helper', 'chai', 'push'], function (Ably, helper, chai, PushPlugin) {
+  const expect = chai.expect;
+  const whenPromiseSettles = helper.whenPromiseSettles;
+  const swUrl = '/push_sw.js';
+  let rest;
+
+  const persistKeys = {
+    deviceId: 'ably.push.deviceId',
+    deviceSecret: 'ably.push.deviceSecret',
+    deviceIdentityToken: 'ably.push.deviceIdentityToken',
+    pushRecipient: 'ably.push.pushRecipient',
+    activationState: 'ably.push.activationState',
+  };
+
+  const messageChannel = new MessageChannel();
+
+  /**
+   * These tests don't work in CI for various reasons (below) but should work when running locally via `npm run test:webserver`, provided
+   * that you have enabled notification permissions for the origin serving the test ui.
+   *
+   * chromium, firefox - don't support push notifications in incognito
+   * webkit - doesn't have a way to launch programatically with notification permissions granted
+   */
+  if (Notification.permission === 'granted') {
+    describe('browser/push', function () {
+      this.timeout(60 * 1000);
+
+      before(function (done) {
+        helper.setupApp(function () {
+          rest = helper.AblyRest({
+            pushServiceWorkerUrl: swUrl,
+            plugins: { Push: PushPlugin },
+          });
+          done();
+        });
+      });
+
+      beforeEach(async function () {
+        Object.values(persistKeys).forEach((key) => {
+          Ably.Realtime.Platform.Config.push.storage.remove(key);
+        });
+
+        const worker = await navigator.serviceWorker.getRegistration(swUrl);
+
+        if (worker) {
+          await worker.unregister();
+        }
+      });
+
+      afterEach(async function () {
+        await rest.push.deactivate();
+      });
+
+      /*
+       * RSH2a
+       */
+      it('push_activation_succeeds', async function () {
+        await rest.push.activate();
+        expect(rest.device.deviceIdentityToken).to.be.ok;
+      });
+
+      // no spec item
+      it('direct_publish_device_id', async function () {
+        await rest.push.activate();
+
+        const pushRecipient = {
+          deviceId: rest.device.id,
+        };
+
+        const pushPayload = {
+          notification: { title: 'Test message', body: 'Test message body' },
+          data: { foo: 'bar' },
+        };
+
+        const sw = await navigator.serviceWorker.getRegistration(swUrl);
+
+        sw.active.postMessage({ type: 'INIT_PORT' }, [messageChannel.port2]);
+
+        const receivedPushPayload = await new Promise((resolve, reject) => {
+          messageChannel.port1.onmessage = function (event) {
+            resolve(event.data.payload);
+          };
+
+          rest.push.admin.publish(pushRecipient, pushPayload).catch(reject);
+        });
+
+        expect(receivedPushPayload.data).to.deep.equal(pushPayload.data);
+        expect(receivedPushPayload.notification.title).to.equal(pushPayload.notification.title);
+        expect(receivedPushPayload.notification.body).to.equal(pushPayload.notification.body);
+      });
+    });
+  }
+});

--- a/test/common/globals/named_dependencies.js
+++ b/test/common/globals/named_dependencies.js
@@ -7,11 +7,16 @@ define(function () {
       browser: 'node_modules/@ably/vcdiff-decoder/dist/vcdiff-decoder',
       node: 'node_modules/@ably/vcdiff-decoder',
     },
+    push: {
+      browser: 'build/push',
+      node: 'build/push',
+    },
 
     // test modules
     globals: { browser: 'test/common/globals/environment', node: 'test/common/globals/environment' },
     shared_helper: { browser: 'test/common/modules/shared_helper', node: 'test/common/modules/shared_helper' },
     async: { browser: 'node_modules/async/lib/async' },
     chai: { browser: 'node_modules/chai/chai', node: 'node_modules/chai/chai' },
+    ulid: { browser: 'node_modules/ulid/dist/index.umd', node: 'node_modules/ulid/dist/index.umd' },
   });
 });

--- a/test/support/browser_file_list.js
+++ b/test/support/browser_file_list.js
@@ -61,6 +61,7 @@ window.__testFiles__.files = {
   'test/browser/connection.test.js': true,
   'test/browser/simple.test.js': true,
   'test/browser/http.test.js': true,
+  'test/browser/push.test.js': true,
   'test/rest/status.test.js': true,
   'test/rest/batch.test.js': true,
 };

--- a/test/support/push_channel_transport.js
+++ b/test/support/push_channel_transport.js
@@ -1,0 +1,57 @@
+define(['ably'], function (Ably) {
+  var Defaults = Ably.Realtime.Platform.Defaults;
+  var ErrorInfo = Ably.ErrorInfo;
+  return (module.exports = {
+    getPushDeviceDetails: function (machine) {
+      var channel = machine.client.options.pushRecipientChannel;
+      if (!channel) {
+        machine.handleEvent(
+          new machine.GettingPushDeviceDetailsFailed(
+            new ErrorInfo('Missing ClientOptions.pushRecipientChannel', 40000, 400),
+          ),
+        );
+        return;
+      }
+
+      var ablyKey = machine.client.options.pushAblyKey || machine.client.options.key;
+      if (!ablyKey) {
+        machine.handleEvent(
+          new machine.GettingPushDeviceDetailsFailed(new ErrorInfo('Missing options.pushAblyKey', 40000, 400)),
+        );
+        return;
+      }
+
+      var ablyUrl = machine.client.baseUri(Defaults.getHosts(machine.client.options)[0]);
+
+      var device = machine.client.device;
+      device.push.recipient = {
+        transportType: 'ablyChannel',
+        channel: channel,
+        ablyKey: ablyKey,
+        ablyUrl: ablyUrl,
+      };
+      device.persist();
+
+      machine.handleEvent(new machine.GotPushDeviceDetails());
+    },
+    storage: (function () {
+      var values = {};
+      return {
+        set: function (name, value) {
+          values[name] = value;
+        },
+        get: function (name) {
+          return values[name];
+        },
+        remove: function (name) {
+          delete values[name];
+        },
+        clear: function () {
+          values = {};
+        },
+      };
+    })(),
+    platform: 'browser',
+    formFactor: 'desktop',
+  });
+});

--- a/test/support/push_sw.js
+++ b/test/support/push_sw.js
@@ -1,0 +1,12 @@
+let port;
+
+self.addEventListener('push', (event) => {
+  const res = event.data.json();
+  port.postMessage({ payload: res });
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data.type === 'INIT_PORT') {
+    port = event.ports[0];
+  }
+});

--- a/test/support/runPlaywrightTests.js
+++ b/test/support/runPlaywrightTests.js
@@ -12,7 +12,8 @@ const mochaServer = new MochaServer(/* playwrightTest: */ true);
 const runTests = async (browserType) => {
   mochaServer.listen();
   const browser = await browserType.launch();
-  const page = await browser.newPage();
+  const context = await browser.newContext();
+  const page = await context.newPage();
   await page.goto(`http://${host}:${port}`);
 
   console.log(`\nrunning tests in ${browserType.name()}`);

--- a/test/web_server.js
+++ b/test/web_server.js
@@ -1,5 +1,6 @@
 var express = require('express'),
-  cors = require('cors');
+  cors = require('cors'),
+  path = require('path');
 
 /**
  * Runs a simple web server that runs the mocha.html tests
@@ -31,6 +32,11 @@ class MochaServer {
       } else {
         res.redirect('/mocha.html');
       }
+    });
+
+    // service workers have limited scope if not served from the base path
+    app.get('/push_sw.js', (req, res) => {
+      res.sendFile(path.join(__dirname, 'support', 'push_sw.js'));
     });
 
     app.use('/node_modules', express.static(__dirname + '/../node_modules'));


### PR DESCRIPTION
- adds a plugin which enables clients to be activated for receipt of push notifications.
- adds support for w3c push transport to web clients.
- adds push channel transport for testing push activation on all platforms.