### PR TITLE
[ECO-4119] Make `updateStatus` in react-hooks async

### DIFF
--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -7,7 +7,7 @@ import { useStateErrors } from './useStateErrors.js';
 import { useConnectionStateListener } from './useConnectionStateListener.js';
 
 export interface PresenceResult<T> {
-  updateStatus: (messageOrPresenceObject: T) => void;
+  updateStatus: (messageOrPresenceObject: T) => Promise<void>;
   connectionError: Ably.ErrorInfo | null;
   channelError: Ably.ErrorInfo | null;
 }
@@ -71,8 +71,8 @@ export function usePresence<T = any>(
   }, [shouldNotEnterPresence, channel, ably]);
 
   const updateStatus = useCallback(
-    (messageOrPresenceObject: T) => {
-      channel.presence.update(messageOrPresenceObject);
+    async (messageOrPresenceObject: T) => {
+      await channel.presence.update(messageOrPresenceObject);
     },
     [channel],
   );


### PR DESCRIPTION
Resolves #1612

I don't think we need to update README as all examples there can still work without explicitly awaiting the result of the `updateStatus` method. So this change should be all we need.