### PR TITLE
[ECO-4819] Fix `Unable to enter presence channel while in suspended state` error with `usePresence`

### DIFF
--- a/src/platform/react-hooks/src/hooks/useChannelStateListener.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelStateListener.ts
@@ -7,6 +7,8 @@ type ChannelStateListener = (stateChange: Ably.ChannelStateChange) => any;
 
 export function useChannelStateListener(channelName: string, listener?: ChannelStateListener);
 
+export function useChannelStateListener(options: ChannelNameAndAblyId, listener?: ChannelStateListener);
+
 export function useChannelStateListener(
   options: ChannelNameAndAblyId | string,
   state?: Ably.ChannelState | Ably.ChannelState[],


### PR DESCRIPTION
Similar to the fix in https://github.com/ably/ably-js/pull/1761 with `Connection closed` errors, we should avoid entering presence for specific channel states.

Resolves https://github.com/ably/ably-js/issues/1780