### PR TITLE
[ECO-4776] Re-add `main` and `browser` fields to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "url": "https://github.com/ably/ably-js/issues",
     "email": "support@ably.com"
   },
+  "main": "./build/ably-node.js",
+  "browser": "./build/ably.js",
   "react-native": "./build/ably-reactnative.js",
+  "typings": "./ably.d.ts",
   "exports": {
     ".": {
       "types": "./ably.d.ts",
@@ -24,7 +27,6 @@
       "import": "./react/mjs/index.js"
     }
   },
-  "typings": "./ably.d.ts",
   "files": [
     "build/**",
     "ably.d.ts",


### PR DESCRIPTION
Those fields were removed in https://github.com/ably/ably-js/pull/1498/commits/de5ddfa7d97951697e13ed19d3396aae1aadb742 and replaced with `exports` field we currently use. However, removal of root level entry fields from `package.json` have caused issues with importing `ably` in some setups:
- React Native wasn't able to resolve `ably` at all, due to `exports` field resolution is not enabled by default yet [1] (we fixed this by re-adding root level `react-native` field in https://github.com/ably/ably-js/pull/1713)
- older bundler versions do not support `exports` field, for example, webpack has added support for `exports` only in v5.
- TypeScript added support for resolving `exports` field only in its 4.7 release [2]

This commit re-adds root level entry fields so those setups will still be able to resolve `ably` package.

Resolves #1751

[1] https://reactnative.dev/blog/2023/06/21/package-exports-support
[2] https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing