### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.1.0](https://github.com/ably/ably-js/tree/2.1.0) (2024-06-03)
+
+With this release, Ably React Hooks have now moved to the general availability phase and are considered stable. Non-major version changes to the `ably` package won't include breaking changes for React Hooks going forward.
+
+All changes:
+
+- Add support for optional multiple recovery scopes via `ClientOptions.recoveryKeyStorageName` [\#1762](https://github.com/ably/ably-js/pull/1762)
+- Add wildcard `*` and `privileged-headers` values for `TokenParams.capability` field [\#1765](https://github.com/ably/ably-js/pull/1765)
+- Add support for unique `logHandler` per Ably client by removing the global effects of setting `logHandler` and `logLevel` [\#1764](https://github.com/ably/ably-js/pull/1764)
+- Change `updateStatus` function returned by `usePresence` hook to be async [\#1777](https://github.com/ably/ably-js/pull/1777)
+- Fix some of the errors thrown by `ConnectionManager` have misleading stack traces [\#1760](https://github.com/ably/ably-js/pull/1760)
+- Fix `FetchRequest` doesn't properly handle a 204 response [\#1773](https://github.com/ably/ably-js/pull/1773)
+- Fix `Connection closed` errors when using `usePresence` hook [\#1761](https://github.com/ably/ably-js/pull/1761)
+- Fix `Unable to enter presence channel while in suspended state` errors with `usePresence` [\#1781](https://github.com/ably/ably-js/pull/1781)
+- Fix `Can't resolve 'ably'` error for environments that don't support `exports` field in `package.json` yet [\#1782](https://github.com/ably/ably-js/pull/1782)
+
 ## [2.0.4](https://github.com/ably/ably-js/tree/2.0.4) (2024-05-03)
 
 - Fix invalid `accessToken` when using REST API Client in React Native [\#1730](https://github.com/ably/ably-js/issues/1730), [\#1749](https://github.com/ably/ably-js/issues/1749)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This SDK supports the following platforms:
 
 **Node.js:** version 16.x or newer. (1.1.x versions work on Node.js 4.5 or newer, 1.2.x versions work on Node.js 8.17 or newer). We do not currently provide an ESM bundle, please [contact us](https://www.ably.com/contact) if you would would like to use ably-js in a NodeJS ESM project.
 
-**React (release candidate):** We offer a set of React Hooks which make it seamless to use ably-js in your React application. See the [React Hooks documentation](./docs/react.md) for more details.
+**React:** We offer a set of React Hooks which make it seamless to use ably-js in your React application. See the [React Hooks documentation](./docs/react.md) for more details.
 
 **React Native:** We aim to support all platforms supported by React Native. If you find any issues please raise an issue or [contact us](https://www.ably.com/contact).
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -1,8 +1,5 @@
 # ably-js React Hooks
 
-> [!IMPORTANT]
-> The ably-js React Hooks are currently in the release candidate phase, and there may be breaking changes in a future non-major release.
-
 Use Ably in your React application using idiomatic, easy to use, React Hooks!
 
 Using this module you can:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.0.4';
+export const version = '2.1.0';
 
 export function channelOptionsWithAgent(options?: Ably.ChannelOptions) {
   return {


### PR DESCRIPTION
Resolves https://ably.atlassian.net/browse/ECO-4812 (Stable release for reacts hooks)

I think it's better to include documentation changes for removing the release candidate tag for react hooks in this release PR. This way, we avoid a temporary state in the GitHub repo where we claim they are production-ready, but we have not yet released an actual latest https://github.com/ably/ably-js/pull/1777.