### PR TITLE
logger: pass level to logHandlers when logging

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -404,8 +404,9 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
    * Controls the log output of the library. This is a function to handle each line of log output. If you do not set this value, then `console.log` will be used.
    *
    * @param msg - The log message emitted by the library.
+   * @param level - The level of the log. Values are one of: 0 (no logs), 1 (errors only), 2 (errors plus connection and channel state changes), 3 (high-level debug output), and 4 (full debug output).
    */
-  logHandler?: (msg: string) => void;
+  logHandler?: (msg: string, level: number) => void;
 
   /**
    * Enables a non-default Ably port to be specified. For development environments only. The default value is 80.

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -38,7 +38,9 @@ function getHandler(logger: Function): Function {
             msg,
         );
       }
-    : logger;
+    : function (msg: string) {
+        logger(msg);
+      };
 }
 
 const getDefaultLoggers = (): [Function, Function] => {
@@ -117,7 +119,7 @@ class Logger {
 
   private logAction(level: LogLevels, action: string, message?: string) {
     if (this.shouldLog(level)) {
-      (level === LogLevels.Error ? this.logErrorHandler : this.logHandler)('Ably: ' + action + ': ' + message);
+      (level === LogLevels.Error ? this.logErrorHandler : this.logHandler)('Ably: ' + action + ': ' + message, level);
     }
   }
 
@@ -139,7 +141,7 @@ class Logger {
 
   deprecationWarning(message: string) {
     if (this.shouldLog(LogLevels.Error)) {
-      this.logErrorHandler(`Ably: Deprecation warning - ${message}`);
+      this.logErrorHandler(`Ably: Deprecation warning - ${message}`, LogLevels.Error);
     }
   }
 


### PR DESCRIPTION
This allows handlers to make choices depending on the level of the log being raised (e.g. sending the logs to crashlytics when a certain number of error-level logs occur).

Other ecosystems that do already have this have the level before the message, however in this case we'll put the level second in order to ensure backwards compatibility. 