### PR TITLE
[WIP] Add `unsubscribeAll` methods to unsubscribing all listeners at once

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -1847,9 +1847,14 @@ export declare interface RealtimePresence {
   unsubscribe(listener: messageCallback<PresenceMessage>): void;
   /**
    * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel.
+   *
+   * @deprecated This method overload is deprecated and will be removed in a future version. Use the {@link RealtimePresence.unsubscribeAll | `unsubscribeAll()`} method instead.
    */
   unsubscribe(): void;
-
+  /**
+   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel.
+   */
+  unsubscribeAll(): void;
   /**
    * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Returns an array of {@link PresenceMessage} objects.
    *
@@ -2044,9 +2049,14 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   unsubscribe(listener: messageCallback<InboundMessage>): void;
   /**
    * Deregisters all listeners to messages on this channel. This removes all earlier subscriptions.
+   *
+   * @deprecated This method overload is deprecated and will be removed in a future version. Use the {@link RealtimeChannel.unsubscribeAll | `unsubscribeAll()`} method instead.
    */
   unsubscribe(): void;
-
+  /**
+   * Deregisters all listeners to messages on this channel. This removes all earlier subscriptions.
+   */
+  unsubscribeAll(): void;
   /**
    * A {@link RealtimePresence} object.
    */

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -444,7 +444,18 @@ class RealtimeChannel extends EventEmitter {
       return;
     }
 
+    if (event === undefined && listener === undefined) {
+      this.logger.deprecated(
+        'The ability to call `RealtimeChannel.unsubscribe()` without any valid parameters',
+        'Please use `RealtimeChannel.unsubscribeAll()` method if you want to deregister all listeners to messages on the channel.',
+      );
+    }
+
     this.subscriptions.off(event, listener);
+  }
+
+  unsubscribeAll(): void {
+    this.subscriptions.off();
   }
 
   sync(): void {

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -483,7 +483,19 @@ class RealtimePresence extends EventEmitter {
     const args = RealtimeChannel.processListenerArgs(_args);
     const event = args[0];
     const listener = args[1];
+
+    if (event === undefined && listener === undefined) {
+      this.logger.deprecated(
+        'The ability to call `RealtimePresence.unsubscribe()` without any valid parameters',
+        'Please use `RealtimePresence.unsubscribeAll()` method if you want to deregister all listeners currently receiving presence messages for the channel.',
+      );
+    }
+
     this.subscriptions.off(event, listener);
+  }
+
+  unsubscribeAll(): void {
+    this.subscriptions.off();
   }
 }
 

--- a/test/package/browser/template/src/index-default.ts
+++ b/test/package/browser/template/src/index-default.ts
@@ -25,7 +25,7 @@ globalThis.testAblyPackage = async function () {
   // Check that id and timestamp of a message received from Ably can be assigned to non-optional types
   const { id: string, timestamp: number } = receivedMessage;
 
-  channel.unsubscribe();
+  channel.unsubscribeAll();
 
   // Check that we can use the TypeScript overload that accepts a Message object
   await channel.publish({ name: 'message', data: { foo: 'bar' } });

--- a/test/package/browser/template/src/index-modular.ts
+++ b/test/package/browser/template/src/index-modular.ts
@@ -36,7 +36,7 @@ globalThis.testAblyPackage = async function () {
 
   await checkStandaloneFunction();
 
-  channel.unsubscribe();
+  channel.unsubscribeAll();
 
   // Check that we can use the TypeScript overload that accepts a Message object
   await channel.publish({ name: 'message', data: { foo: 'bar' } });

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1043,7 +1043,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var unsubscribeTest = function () {
           channelByEvent.unsubscribe('event', listenerByEvent);
           channelByListener.unsubscribe(listenerNoEvent);
-          channelAll.unsubscribe();
+          channelAll.unsubscribeAll();
           whenPromiseSettles(channelByEvent.publish('event', 'data'), function (err) {
             try {
               expect(!err, 'Error publishing single event: ' + err).to.be.ok;

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1837,7 +1837,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
           function (cb) {
             channel.presence.subscribe(function (presmsg) {
-              channel.presence.unsubscribe();
+              channel.presence.unsubscribeAll();
               try {
                 expect(presmsg.action).to.equal('leave', 'Check action was leave');
                 expect(presmsg.clientId).to.equal(goneClientId, 'Check goneClient has left');


### PR DESCRIPTION
The change is driven by `unsubscribeAll` used in Chat SDK and related DR https://ably.atlassian.net/wiki/spaces/CHA/pages/3141992466/CHADR-035+Unsubscribing+All+Listeners+at+Once.

Deprecates the ability to call `.unsubscribe()` methods without any valid parameters.

TODO:
test for unsubscribeAll
update spec with unsubscribeAll
add type safety to complain when called `.unsubscribe(undefined)`