### PR TITLE
ConnectionManager.ping(): rewrite to fix pings stacking if none ever succeed

### DIFF
--- a/src/common/lib/client/connection.ts
+++ b/src/common/lib/client/connection.ts
@@ -48,9 +48,7 @@ class Connection extends EventEmitter {
 
   async ping(): Promise<number> {
     Logger.logAction(this.logger, Logger.LOG_MINOR, 'Connection.ping()', '');
-    return new Promise((resolve, reject) => {
-      this.connectionManager.ping(null, (err: unknown, result: number) => (err ? reject(err) : resolve(result)));
-    });
+    return this.connectionManager.ping();
   }
 
   close(): void {

--- a/src/common/lib/util/utils.ts
+++ b/src/common/lib/util/utils.ts
@@ -462,3 +462,8 @@ export function createMissingPluginError(pluginName: keyof ModularPlugins): Erro
 export function throwMissingPluginError(pluginName: keyof ModularPlugins): never {
   throw createMissingPluginError(pluginName);
 }
+
+export async function withTimeoutAsync<A>(promise: Promise<A>, timeout = 5000, err = 'Timeout expired'): Promise<A> {
+  const e = new ErrorInfo(err, 50000, 500);
+  return Promise.race([promise, new Promise<A>((_resolve, reject) => setTimeout(() => reject(e), timeout))]);
+}


### PR DESCRIPTION
previously if the transport keeps becoming active but then gets disconnected before the ping succeeds, listeners would just keep stacking up

the whole previous implementation was just way over-complex now we no longer do transport upgrade. rewrote from scratch with a much simpler promise-based one.