### PR TITLE
fix: remove detach hack in `useChannel`

### DIFF
--- a/src/platform/react-hooks/src/hooks/useChannel.ts
+++ b/src/platform/react-hooks/src/hooks/useChannel.ts
@@ -91,14 +91,4 @@ async function handleChannelMount(channel: Ably.RealtimeChannel, ...subscribeArg
 
 async function handleChannelUnmount(channel: Ably.RealtimeChannel, ...subscribeArgs: SubscribeArgs) {
   await (channel.unsubscribe as any)(...subscribeArgs);
-
-  setTimeout(async () => {
-    // React is very mount/unmount happy, so if we just detatch the channel
-    // it's quite likely it will be reattached again by a subsequent handleChannelMount calls.
-    // To solve this, we set a timer, and if all the listeners have been removed, we know that the component
-    // has been removed for good and we can detatch the channel.
-    if (channel.listeners.length === 0) {
-      await channel.detach();
-    }
-  }, 2500);
 }


### PR DESCRIPTION
`channel.listeners.length` is always 1, so `detach` never invokes anyway. We should put `detach` into `ChannelProvider` see https://github.com/ably/ably-js/issues/1795