### PR TITLE
Gather data about private API usage in test suite

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -30,11 +30,15 @@ jobs:
       - env:
           PLAYWRIGHT_BROWSER: ${{ matrix.browser }}
         run: npm run test:playwright
+      - name: Generate private API usage reports
+        run: npm run process-private-api-data private-api-usage/*.json
       - name: Save private API usage data
         uses: actions/upload-artifact@v4
         with:
           name: private-api-usage-${{ matrix.browser }}
-          path: private-api-usage
+          path: |
+            private-api-usage
+            private-api-usage-reports
       - name: Upload test results
         if: always()
         uses: ably/test-observability-action@v1

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -30,6 +30,11 @@ jobs:
       - env:
           PLAYWRIGHT_BROWSER: ${{ matrix.browser }}
         run: npm run test:playwright
+      - name: Save private API usage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: private-api-usage-${{ matrix.browser }}
+          path: private-api-usage
       - name: Upload test results
         if: always()
         uses: ably/test-observability-action@v1

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -28,6 +28,11 @@ jobs:
       - run: npm run test:node
         env:
           CI: true
+      - name: Save private API usage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: private-api-usage-${{ matrix.node-version }}
+          path: private-api-usage
       - name: Upload test results
         if: always()
         uses: ably/test-observability-action@v1

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -28,11 +28,15 @@ jobs:
       - run: npm run test:node
         env:
           CI: true
+      - name: Generate private API usage reports
+        run: npm run process-private-api-data private-api-usage/*.json
       - name: Save private API usage data
         uses: actions/upload-artifact@v4
         with:
           name: private-api-usage-${{ matrix.node-version }}
-          path: private-api-usage
+          path: |
+            private-api-usage
+            private-api-usage-reports
       - name: Upload test results
         if: always()
         uses: ably/test-observability-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ react/
 typedoc/generated/
 junit/
 private-api-usage/
+private-api-usage-reports/
 test/support/mocha_junit_reporter/build/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ build/
 react/
 typedoc/generated/
 junit/
+private-api-usage/
 test/support/mocha_junit_reporter/build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,30 @@ When using the test webserver `npm run test:webserver` the following test variab
 - `tls` - true or false to enable/disable use of TLS respectively
 - `log_level` - Log level for the client libraries, defaults to 2, 4 is `MICRO`
 
+### Adding private API annotations to tests
+
+We have an ongoing project which aims to reuse the ably-js test suite as a unified test suite for all of our client libraries. To enable this work, we want to be able to monitor the test suite’s usage of APIs that are private to ably-js.
+
+When you use a private API in a test, record its usage using the `recordPrivateApi` method on the test’s helper object. For example:
+
+```javascript
+/* Sabotage the reattach attempt, then simulate a server-sent detach */
+helper.recordPrivateApi('replace.channel.sendMessage');
+channel.sendMessage = function () {};
+```
+
+The current list of private API usage identifiers can be found in [`test/common/modules/private_api_recorder.js`](test/common/modules/private_api_recorder.js); add new ones there as necessary.
+
+The following test files do not utilise private API annotations, and you don’t need to add them:
+
+- [`test/realtime/transports.test.js`](test/realtime/transports.test.js)
+- [`test/browser/simple.test.js`](test/browser/simple.test.js)
+- [`test/browser/http.test.js`](test/browser/http.test.js)
+- [`test/browser/connection.test.js`](test/browser/connection.test.js)
+- [`test/browser/modular.test.js`](test/browser/modular.test.js)
+- [`test/browser/push.test.js`](test/browser/push.test.js)
+- [`test/rest/bufferutils.test.js`](test/rest/bufferutils.test.js)
+
 ## React hooks
 
 The react sample application is configured to execute using Vite - which will load a sample web app that acts as a simple test harness for the hooks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "chai": "^4.2.0",
         "cli-table": "^0.3.11",
         "cors": "^2.8.5",
+        "csv": "^6.3.9",
         "dox": "^1.0.0",
         "esbuild": "^0.18.10",
         "esbuild-plugin-umd-wrapper": "ably-forks/esbuild-plugin-umd-wrapper#1.0.7-optional-amd-named-module",
@@ -3153,6 +3154,39 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
+    },
+    "node_modules/csv": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-6.3.9.tgz",
+      "integrity": "sha512-eiN+Qu8NwSLxZYia6WzB8xlX/rAQ/8EgK5A4dIF7Bz96mzcr5dW1jlcNmjG0QWySWKfPdCerH3RQ96ZqqsE8cA==",
+      "dev": true,
+      "dependencies": {
+        "csv-generate": "^4.4.1",
+        "csv-parse": "^5.5.6",
+        "csv-stringify": "^6.5.0",
+        "stream-transform": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 0.1.90"
+      }
+    },
+    "node_modules/csv-generate": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-4.4.1.tgz",
+      "integrity": "sha512-O/einO0v4zPmXaOV+sYqGa02VkST4GP5GLpWBNHEouIU7pF3kpGf3D0kCCvX82ydIY4EKkOK+R8b1BYsRXravg==",
+      "dev": true
+    },
+    "node_modules/csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A==",
+      "dev": true
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.0.tgz",
+      "integrity": "sha512-edlXFVKcUx7r8Vx5zQucsuMg4wb/xT6qyz+Sr1vnLrdXqlLD1+UKyWNyZ9zn6mUW1ewmGxrpVwAcChGF0HQ/2Q==",
       "dev": true
     },
     "node_modules/data-urls": {
@@ -9288,6 +9322,12 @@
         "readable-stream": "^3.5.0"
       }
     },
+    "node_modules/stream-transform": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.3.2.tgz",
+      "integrity": "sha512-v64PUnPy9Qw94NGuaEMo+9RHQe4jTBYf+NkTtqkCgeuiNo8NlL0LtLR7fkKWNVFtp3RhIm5Dlxkgm5uz7TDimQ==",
+      "dev": true
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -13356,6 +13396,36 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
+    },
+    "csv": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-6.3.9.tgz",
+      "integrity": "sha512-eiN+Qu8NwSLxZYia6WzB8xlX/rAQ/8EgK5A4dIF7Bz96mzcr5dW1jlcNmjG0QWySWKfPdCerH3RQ96ZqqsE8cA==",
+      "dev": true,
+      "requires": {
+        "csv-generate": "^4.4.1",
+        "csv-parse": "^5.5.6",
+        "csv-stringify": "^6.5.0",
+        "stream-transform": "^3.3.2"
+      }
+    },
+    "csv-generate": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-4.4.1.tgz",
+      "integrity": "sha512-O/einO0v4zPmXaOV+sYqGa02VkST4GP5GLpWBNHEouIU7pF3kpGf3D0kCCvX82ydIY4EKkOK+R8b1BYsRXravg==",
+      "dev": true
+    },
+    "csv-parse": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.6.tgz",
+      "integrity": "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A==",
+      "dev": true
+    },
+    "csv-stringify": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.0.tgz",
+      "integrity": "sha512-edlXFVKcUx7r8Vx5zQucsuMg4wb/xT6qyz+Sr1vnLrdXqlLD1+UKyWNyZ9zn6mUW1ewmGxrpVwAcChGF0HQ/2Q==",
       "dev": true
     },
     "data-urls": {
@@ -17851,6 +17921,12 @@
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
       }
+    },
+    "stream-transform": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.3.2.tgz",
+      "integrity": "sha512-v64PUnPy9Qw94NGuaEMo+9RHQe4jTBYf+NkTtqkCgeuiNo8NlL0LtLR7fkKWNVFtp3RhIm5Dlxkgm5uz7TDimQ==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "chai": "^4.2.0",
     "cli-table": "^0.3.11",
     "cors": "^2.8.5",
+    "csv": "^6.3.9",
     "dox": "^1.0.0",
     "esbuild": "^0.18.10",
     "esbuild-plugin-umd-wrapper": "ably-forks/esbuild-plugin-umd-wrapper#1.0.7-optional-amd-named-module",
@@ -155,11 +156,12 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "prepare": "npm run build",
-    "format": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modular.d.ts webpack.config.js Gruntfile.js scripts/*.[jt]s docs/**/*.md grunt",
-    "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modular.d.ts webpack.config.js Gruntfile.js scripts/*.[jt]s docs/**/*.md grunt",
+    "format": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modular.d.ts webpack.config.js Gruntfile.js scripts/**/*.[jt]s docs/**/*.md grunt",
+    "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modular.d.ts webpack.config.js Gruntfile.js scripts/**/*.[jt]s docs/**/*.md grunt",
     "sourcemap": "source-map-explorer build/ably.min.js",
     "modulereport": "tsc --noEmit --esModuleInterop scripts/moduleReport.ts && esr scripts/moduleReport.ts",
     "speccoveragereport": "tsc --noEmit --esModuleInterop --target ES2017 --moduleResolution node scripts/specCoverageReport.ts && esr scripts/specCoverageReport.ts",
+    "process-private-api-data": "tsc --noEmit --esModuleInterop --strictNullChecks scripts/processPrivateApiData/run.ts && esr scripts/processPrivateApiData/run.ts",
     "docs": "typedoc"
   }
 }

--- a/scripts/processPrivateApiData/dto.ts
+++ b/scripts/processPrivateApiData/dto.ts
@@ -1,0 +1,53 @@
+export type TestPrivateApiContextDto = {
+  type: 'test';
+  title: string;
+  /**
+   * null means that either the test isn’t parameterised or that this usage is unique to the specific parameter
+   */
+  parameterisedTestTitle: string | null;
+  helperStack: string[];
+  file: string;
+  suite: string[];
+};
+
+export type HookPrivateApiContextDto = {
+  type: 'hook';
+  title: string;
+  helperStack: string[];
+  file: string;
+  suite: string[];
+};
+
+export type RootHookPrivateApiContextDto = {
+  type: 'hook';
+  title: string;
+  helperStack: string[];
+  file: null;
+  suite: null;
+};
+
+export type TestDefinitionPrivateApiContextDto = {
+  type: 'definition';
+  label: string;
+  helperStack: string[];
+  file: string;
+  suite: string[];
+};
+
+export type PrivateApiContextDto =
+  | TestPrivateApiContextDto
+  | HookPrivateApiContextDto
+  | RootHookPrivateApiContextDto
+  | TestDefinitionPrivateApiContextDto;
+
+export type PrivateApiUsageDto = {
+  context: PrivateApiContextDto;
+  privateAPIIdentifier: string;
+};
+
+export type TestStartRecord = {
+  context: TestPrivateApiContextDto;
+  privateAPIIdentifier: null;
+};
+
+export type Record = PrivateApiUsageDto | TestStartRecord;

--- a/scripts/processPrivateApiData/exclusions.ts
+++ b/scripts/processPrivateApiData/exclusions.ts
@@ -1,0 +1,23 @@
+import { PrivateApiUsageDto } from './dto';
+
+type ExclusionRule = {
+  privateAPIIdentifier: string;
+  // i.e. only ignore when called from within this helper
+  helper?: string;
+};
+
+/**
+ * This exclusions mechanism is not currently being used on `main`, but I will use it on a separate unified test suite branch in order to exclude some private API usage that can currently be disregarded in the context of the unified test suite.
+ */
+export function applyingExclusions(usageDtos: PrivateApiUsageDto[]) {
+  const exclusionRules: ExclusionRule[] = [];
+
+  return usageDtos.filter(
+    (usageDto) =>
+      !exclusionRules.some(
+        (exclusionRule) =>
+          exclusionRule.privateAPIIdentifier === usageDto.privateAPIIdentifier &&
+          (!('helper' in exclusionRule) || usageDto.context.helperStack.includes(exclusionRule.helper!)),
+      ),
+  );
+}

--- a/scripts/processPrivateApiData/grouping.ts
+++ b/scripts/processPrivateApiData/grouping.ts
@@ -1,0 +1,76 @@
+import { PrivateApiUsageDto } from './dto';
+
+export type Group<Key, Value> = {
+  key: Key;
+  values: Value[];
+};
+
+export function grouped<Key, Value>(
+  values: Value[],
+  keyForValue: (value: Value) => Key,
+  areKeysEqual: (key1: Key, key2: Key) => boolean,
+) {
+  const result: Group<Key, Value>[] = [];
+
+  for (const value of values) {
+    const key = keyForValue(value);
+
+    let existingGroup = result.find((group) => areKeysEqual(group.key, key));
+
+    if (existingGroup === undefined) {
+      existingGroup = { key, values: [] };
+      result.push(existingGroup);
+    }
+
+    existingGroup.values.push(value);
+  }
+
+  return result;
+}
+
+/**
+ * Makes sure that each private API is only listed once in a given context.
+ */
+function dedupeUsages<Key>(contextGroups: Group<Key, PrivateApiUsageDto>[]) {
+  for (const contextGroup of contextGroups) {
+    const newUsages: typeof contextGroup.values = [];
+
+    for (const usage of contextGroup.values) {
+      const existing = newUsages.find((otherUsage) => otherUsage.privateAPIIdentifier === usage.privateAPIIdentifier);
+      if (existing === undefined) {
+        newUsages.push(usage);
+      }
+    }
+
+    contextGroup.values = newUsages;
+  }
+}
+
+export function groupedAndDeduped<Key>(
+  usages: PrivateApiUsageDto[],
+  keyForUsage: (usage: PrivateApiUsageDto) => Key,
+  areKeysEqual: (key1: Key, key2: Key) => boolean,
+) {
+  const result = grouped(usages, keyForUsage, areKeysEqual);
+  dedupeUsages(result);
+  return result;
+}
+
+/**
+ * Return value is sorted in decreasing order of usage of a given private API identifer
+ */
+export function groupedAndSortedByPrivateAPIIdentifier<Key>(
+  groupedByKey: Group<Key, PrivateApiUsageDto>[],
+): Group<string, Key>[] {
+  const flattened = groupedByKey.flatMap((group) => group.values.map((value) => ({ key: group.key, value })));
+
+  const groupedByPrivateAPIIdentifier = grouped(
+    flattened,
+    (value) => value.value.privateAPIIdentifier,
+    (id1, id2) => id1 === id2,
+  ).map((group) => ({ key: group.key, values: group.values.map((value) => value.key) }));
+
+  groupedByPrivateAPIIdentifier.sort((group1, group2) => group2.values.length - group1.values.length);
+
+  return groupedByPrivateAPIIdentifier;
+}

--- a/scripts/processPrivateApiData/load.ts
+++ b/scripts/processPrivateApiData/load.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs';
+import { applyingExclusions } from './exclusions';
+import { splittingRecords, stripFilePrefix } from './utils';
+import { Record } from './dto';
+
+export function load(jsonFilePath: string) {
+  let records = JSON.parse(readFileSync(jsonFilePath).toString('utf-8')) as Record[];
+
+  stripFilePrefix(records);
+
+  let { usageDtos, testStartRecords } = splittingRecords(records);
+
+  usageDtos = applyingExclusions(usageDtos);
+
+  return { usageDtos, testStartRecords };
+}

--- a/scripts/processPrivateApiData/output.ts
+++ b/scripts/processPrivateApiData/output.ts
@@ -1,0 +1,144 @@
+import { stringify as csvStringify } from 'csv-stringify/sync';
+import { writeFileSync, existsSync, mkdirSync } from 'fs';
+import { PrivateApiUsageDto, TestStartRecord } from './dto';
+import { Group } from './grouping';
+import { RuntimeContext } from './runtimeContext';
+import { StaticContext } from './staticContext';
+import path from 'path';
+
+function suiteAtLevelForCSV(suites: string[] | null, level: number) {
+  return suites?.[level] ?? '';
+}
+
+function suitesColumnsForCSV(suites: string[] | null, maxSuiteLevel: number) {
+  const result: string[] = [];
+  for (let i = 0; i < maxSuiteLevel; i++) {
+    result.push(suiteAtLevelForCSV(suites, i));
+  }
+  return result;
+}
+
+function suitesHeaders(maxSuiteLevel: number) {
+  const result: string[] = [];
+  for (let i = 0; i < maxSuiteLevel; i++) {
+    result.push(`Suite (level ${i + 1})`);
+  }
+  return result;
+}
+
+function commonHeaders(maxSuiteLevel: number) {
+  return ['File', ...suitesHeaders(maxSuiteLevel), 'Description'].filter((val) => val !== null) as string[];
+}
+
+function writeToFile(data: string, name: string) {
+  const outputDirectoryPath = path.join(__dirname, '..', '..', 'private-api-usage-reports');
+
+  if (!existsSync(outputDirectoryPath)) {
+    mkdirSync(outputDirectoryPath);
+  }
+
+  writeFileSync(path.join(outputDirectoryPath, name), data);
+}
+
+function writeCSVData(rows: string[][], name: string) {
+  const data = csvStringify(rows);
+  writeToFile(data, `${name}.csv`);
+}
+
+export function writeRuntimePrivateAPIUsageCSV(contextGroups: Group<RuntimeContext, PrivateApiUsageDto>[]) {
+  const maxSuiteLevel = Math.max(...contextGroups.map((group) => (group.key.suite ?? []).length));
+
+  const columnHeaders = [
+    'Context',
+    ...commonHeaders(maxSuiteLevel),
+    'Via parameterised test helper',
+    'Via misc. helpers',
+    'Private API called',
+  ];
+
+  const csvRows = contextGroups
+    .map((contextGroup) => {
+      const runtimeContext = contextGroup.key;
+
+      const contextColumns = [
+        runtimeContext.type,
+        runtimeContext.file ?? '',
+        ...suitesColumnsForCSV(runtimeContext.suite, maxSuiteLevel),
+        runtimeContext.type === 'definition' ? runtimeContext.label : runtimeContext.title,
+      ];
+
+      return contextGroup.values.map((usage) => [
+        ...contextColumns,
+        (usage.context.type === 'test' ? usage.context.parameterisedTestTitle : null) ?? '',
+        [...usage.context.helperStack].reverse().join(' -> '),
+        usage.privateAPIIdentifier,
+      ]);
+    })
+    .flat();
+
+  writeCSVData([columnHeaders, ...csvRows], 'runtime-private-api-usage');
+}
+
+export function columnsForStaticContext(staticContext: StaticContext, maxSuiteLevel: number) {
+  return [
+    staticContext.type,
+    'file' in staticContext ? staticContext.file : '',
+    ...suitesColumnsForCSV('suite' in staticContext ? staticContext.suite : null, maxSuiteLevel),
+    staticContext.title,
+  ];
+}
+
+export function writeStaticPrivateAPIUsageCSV(contextGroups: Group<StaticContext, PrivateApiUsageDto>[]) {
+  const maxSuiteLevel = Math.max(...contextGroups.map((group) => ('suite' in group.key ? group.key.suite : []).length));
+
+  const columnHeaders = ['Context', ...commonHeaders(maxSuiteLevel), 'Private API called'];
+
+  const csvRows = contextGroups
+    .map((contextGroup) =>
+      contextGroup.values.map((usage) => [
+        ...columnsForStaticContext(contextGroup.key, maxSuiteLevel),
+        usage.privateAPIIdentifier,
+      ]),
+    )
+    .flat();
+
+  writeCSVData([columnHeaders, ...csvRows], 'static-private-api-usage');
+}
+
+export function writeNoPrivateAPIUsageCSV(testStartRecords: TestStartRecord[]) {
+  const maxSuiteLevel = Math.max(...testStartRecords.map((record) => record.context.suite.length));
+
+  const columnHeaders = commonHeaders(maxSuiteLevel);
+
+  const csvRows = testStartRecords.map((record) => {
+    const context = record.context;
+    return [context.file, ...suitesColumnsForCSV(context.suite, maxSuiteLevel), context.title];
+  });
+
+  writeCSVData([columnHeaders, ...csvRows], 'tests-that-do-not-require-private-api');
+}
+
+export function writeByPrivateAPIIdentifierCSV(groups: Group<string, StaticContext>[]) {
+  const maxSuiteLevel = Math.max(
+    ...groups.flatMap((group) => group.values.map((context) => ('suite' in context ? context.suite.length : 0))),
+  );
+
+  const columnHeaders = ['Private API called', 'Context', ...commonHeaders(maxSuiteLevel)];
+
+  const csvRows = groups
+    .map((group) => {
+      const privateAPIIdentifier = group.key;
+
+      return group.values.map((staticContext) => [
+        privateAPIIdentifier,
+        ...columnsForStaticContext(staticContext, maxSuiteLevel),
+      ]);
+    })
+    .flat();
+
+  writeCSVData([columnHeaders, ...csvRows], 'static-private-api-usage-by-private-api');
+}
+
+export function writeSummary(summary: string) {
+  writeToFile(summary, 'summary.txt');
+}

--- a/scripts/processPrivateApiData/run.ts
+++ b/scripts/processPrivateApiData/run.ts
@@ -1,0 +1,59 @@
+import {
+  writeByPrivateAPIIdentifierCSV,
+  writeNoPrivateAPIUsageCSV,
+  writeRuntimePrivateAPIUsageCSV,
+  writeStaticPrivateAPIUsageCSV,
+  writeSummary,
+} from './output';
+import { groupedAndDedupedByRuntimeContext } from './runtimeContext';
+import { groupedAndDedupedByStaticContext } from './staticContext';
+import { load } from './load';
+import { percentageString, sortStaticContextUsages } from './utils';
+import { splitTestsByPrivateAPIUsageRequirement } from './withoutPrivateAPIUsage';
+import { groupedAndSortedByPrivateAPIIdentifier } from './grouping';
+
+if (process.argv.length > 3) {
+  throw new Error('Expected a single argument (path to private API usages JSON file');
+}
+
+const jsonFilePath = process.argv[2];
+
+if (!jsonFilePath) {
+  throw new Error('Path to private API usages JSON file not specified');
+}
+
+const { usageDtos, testStartRecords } = load(jsonFilePath);
+
+const usagesGroupedByRuntimeContext = groupedAndDedupedByRuntimeContext(usageDtos);
+
+const usagesGroupedByStaticContext = groupedAndDedupedByStaticContext(usageDtos);
+sortStaticContextUsages(usagesGroupedByStaticContext);
+
+const {
+  requiringPrivateAPIUsage: testsThatRequirePrivateAPIUsage,
+  notRequiringPrivateAPIUsage: testsThatDoNotRequirePrivateAPIUsage,
+} = splitTestsByPrivateAPIUsageRequirement(testStartRecords, usagesGroupedByRuntimeContext);
+
+const totalNumberOfTests = testStartRecords.length;
+const numberOfTestsThatRequirePrivateApiUsage = testsThatRequirePrivateAPIUsage.length;
+const numberOfTestsThatDoNotRequirePrivateAPIUsage = testsThatDoNotRequirePrivateAPIUsage.length;
+
+const summary = `Total number of tests: ${totalNumberOfTests}
+Number of tests that require private API usage: ${numberOfTestsThatRequirePrivateApiUsage} (${percentageString(
+  numberOfTestsThatRequirePrivateApiUsage,
+  totalNumberOfTests,
+)})
+Number of tests that do not require private API usage: ${numberOfTestsThatDoNotRequirePrivateAPIUsage} (${percentageString(
+  numberOfTestsThatDoNotRequirePrivateAPIUsage,
+  totalNumberOfTests,
+)})
+`;
+console.log(summary);
+
+const byPrivateAPIIdentifier = groupedAndSortedByPrivateAPIIdentifier(usagesGroupedByStaticContext);
+
+writeRuntimePrivateAPIUsageCSV(usagesGroupedByRuntimeContext);
+writeStaticPrivateAPIUsageCSV(usagesGroupedByStaticContext);
+writeNoPrivateAPIUsageCSV(testsThatDoNotRequirePrivateAPIUsage);
+writeByPrivateAPIIdentifierCSV(byPrivateAPIIdentifier);
+writeSummary(summary);

--- a/scripts/processPrivateApiData/runtimeContext.ts
+++ b/scripts/processPrivateApiData/runtimeContext.ts
@@ -1,0 +1,32 @@
+import { PrivateApiContextDto, PrivateApiUsageDto } from './dto';
+import { Group, groupedAndDeduped } from './grouping';
+import { joinComponents } from './utils';
+
+/**
+ * Used for determining whether two contexts are equal.
+ */
+export function runtimeContextIdentifier(context: RuntimeContext) {
+  return joinComponents([
+    { key: 'type', value: context.type },
+    { key: 'file', value: context.file ?? 'null' },
+    { key: 'suite', value: context.suite?.join(',') ?? 'null' },
+    { key: 'title', value: context.type === 'definition' ? context.label : context.title },
+    { key: 'helperStack', value: 'helperStack' in context ? context.helperStack.join(',') : 'null' },
+    {
+      key: 'parameterisedTestTitle',
+      value: ('parameterisedTestTitle' in context ? context.parameterisedTestTitle : null) ?? 'null',
+    },
+  ]);
+}
+
+export type RuntimeContext = PrivateApiContextDto;
+
+export function groupedAndDedupedByRuntimeContext(
+  usages: PrivateApiUsageDto[],
+): Group<RuntimeContext, PrivateApiUsageDto>[] {
+  return groupedAndDeduped(
+    usages,
+    (usage) => usage.context,
+    (context1, context2) => runtimeContextIdentifier(context1) === runtimeContextIdentifier(context2),
+  );
+}

--- a/scripts/processPrivateApiData/staticContext.ts
+++ b/scripts/processPrivateApiData/staticContext.ts
@@ -1,0 +1,117 @@
+import { PrivateApiUsageDto } from './dto';
+import { joinComponents } from './utils';
+import { Group, groupedAndDeduped } from './grouping';
+
+export type MiscHelperStaticContext = {
+  type: 'miscHelper';
+  title: string;
+};
+
+export type TestDefinitionStaticContext = {
+  type: 'testDefinition';
+  title: string;
+  file: string;
+  suite: string[];
+};
+
+export type RootHookStaticContext = {
+  type: 'rootHook';
+  title: string;
+};
+
+export type HookStaticContext = {
+  type: 'hook';
+  title: string;
+  file: string;
+  suite: string[];
+};
+
+export type ParameterisedTestHelperStaticContext = {
+  type: 'parameterisedTestHelper';
+  title: string;
+  file: string;
+  suite: string[];
+};
+
+export type TestStaticContext = {
+  type: 'test';
+  title: string;
+  file: string;
+  suite: string[];
+};
+
+export type StaticContext =
+  | MiscHelperStaticContext
+  | TestDefinitionStaticContext
+  | RootHookStaticContext
+  | HookStaticContext
+  | ParameterisedTestHelperStaticContext
+  | TestStaticContext;
+
+/**
+ * Used for determining whether two contexts are equal.
+ */
+export function staticContextIdentifier(context: StaticContext) {
+  return joinComponents([
+    { key: 'type', value: context.type },
+    { key: 'file', value: 'file' in context ? context.file : 'null' },
+    { key: 'suite', value: 'suite' in context ? context.suite.join(',') : 'null' },
+    { key: 'title', value: context.title },
+  ]);
+}
+
+export function staticContextForUsage(usage: PrivateApiUsageDto): StaticContext {
+  if (usage.context.helperStack.length > 0) {
+    return {
+      type: 'miscHelper',
+      title: usage.context.helperStack[0],
+    };
+  } else if (usage.context.type === 'definition') {
+    return {
+      type: 'testDefinition',
+      file: usage.context.file,
+      suite: usage.context.suite,
+      title: usage.context.label,
+    };
+  } else if (usage.context.type === 'hook') {
+    if (usage.context.file === null) {
+      return {
+        type: 'rootHook',
+        title: usage.context.title,
+      };
+    } else {
+      return {
+        type: 'hook',
+        file: usage.context.file,
+        suite: usage.context.suite,
+        title: usage.context.title,
+      };
+    }
+  } else {
+    if (usage.context.parameterisedTestTitle !== null) {
+      return {
+        type: 'parameterisedTestHelper',
+        file: usage.context.file,
+        suite: usage.context.suite,
+        title: usage.context.parameterisedTestTitle,
+      };
+    } else {
+      return {
+        type: 'test',
+        file: usage.context.file,
+        suite: usage.context.suite,
+        title: usage.context.title,
+      };
+    }
+  }
+}
+
+export function groupedAndDedupedByStaticContext(
+  usages: PrivateApiUsageDto[],
+): Group<StaticContext, PrivateApiUsageDto>[] {
+  return groupedAndDeduped(
+    usages,
+    (usage) => staticContextForUsage(usage),
+    (context1, context2) => staticContextIdentifier(context1) === staticContextIdentifier(context2),
+  );
+}

--- a/scripts/processPrivateApiData/utils.ts
+++ b/scripts/processPrivateApiData/utils.ts
@@ -1,0 +1,45 @@
+import { PrivateApiUsageDto, Record, TestStartRecord } from './dto';
+import { Group } from './grouping';
+import { StaticContext } from './staticContext';
+
+export function stripFilePrefix(records: Record[]) {
+  for (const record of records) {
+    if (record.context.file !== null) {
+      record.context.file = record.context.file.replace('/home/runner/work/ably-js/ably-js/', '');
+    }
+  }
+}
+
+export function splittingRecords(records: Record[]) {
+  return {
+    testStartRecords: records.filter((record) => record.privateAPIIdentifier == null) as TestStartRecord[],
+    usageDtos: records.filter((record) => record.privateAPIIdentifier !== null) as PrivateApiUsageDto[],
+  };
+}
+
+export function percentageString(value: number, total: number) {
+  return `${((100 * value) / total).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`;
+}
+
+/**
+ * Puts the miscHelper usages (i.e. stuff that doesn’t have file info) first.
+ */
+export function sortStaticContextUsages(contextGroups: Group<StaticContext, PrivateApiUsageDto>[]) {
+  const original = [...contextGroups];
+
+  contextGroups.sort((a, b) => {
+    if (a.key.type === 'miscHelper' && b.key.type !== 'miscHelper') {
+      return -1;
+    }
+
+    if (a.key.type !== 'miscHelper' && b.key.type === 'miscHelper') {
+      return 1;
+    }
+
+    return original.indexOf(a) - original.indexOf(b);
+  });
+}
+
+export function joinComponents(components: { key: string; value: string }[]) {
+  return components.map((pair) => `${pair.key}=${pair.value}`).join(';');
+}

--- a/scripts/processPrivateApiData/withoutPrivateAPIUsage.ts
+++ b/scripts/processPrivateApiData/withoutPrivateAPIUsage.ts
@@ -1,0 +1,71 @@
+import { PrivateApiUsageDto, TestStartRecord } from './dto';
+import { Group } from './grouping';
+import { RuntimeContext } from './runtimeContext';
+
+function areStringArraysEqual(arr1: string[], arr2: string[]) {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function mustSuiteHierarchyBeExecutedToRunTest(test: TestStartRecord, suites: string[]) {
+  // i.e. is `suites` a prefix of `test.context.suite`?
+  return areStringArraysEqual(test.context.suite.slice(0, suites.length), suites);
+}
+
+function mustRuntimeContextBeExecutedToRunTest(test: TestStartRecord, runtimeContext: RuntimeContext) {
+  if (runtimeContext.type === 'hook') {
+    if (runtimeContext.file === null) {
+      // root hook; must be executed to run _any_ test
+      return true;
+    }
+    if (
+      runtimeContext.file === test.context.file &&
+      mustSuiteHierarchyBeExecutedToRunTest(test, runtimeContext.suite)
+    ) {
+      // the hook must be executed to run this test
+      return true;
+    }
+  }
+
+  // otherwise, return true if and only if it’s the same test
+  return (
+    runtimeContext.type === 'test' &&
+    runtimeContext.file === test.context.file &&
+    areStringArraysEqual(runtimeContext.suite, test.context.suite) &&
+    test.context.title === runtimeContext.title
+  );
+}
+
+/**
+ * This extracts all of the test start records for the tests that can be run without any private API usage. That is, neither the test itself, nor any of the hooks that the test requires, call a private API. It does not consider whether private APIs are required in order to define the test (that is, contexts of type `testDefinition`).
+ */
+export function splitTestsByPrivateAPIUsageRequirement(
+  testStartRecords: TestStartRecord[],
+  groupedUsages: Group<RuntimeContext, PrivateApiUsageDto>[],
+): { requiringPrivateAPIUsage: TestStartRecord[]; notRequiringPrivateAPIUsage: TestStartRecord[] } {
+  const result: { requiringPrivateAPIUsage: TestStartRecord[]; notRequiringPrivateAPIUsage: TestStartRecord[] } = {
+    requiringPrivateAPIUsage: [],
+    notRequiringPrivateAPIUsage: [],
+  };
+
+  for (const testStartRecord of testStartRecords) {
+    if (
+      groupedUsages.some((contextGroup) => mustRuntimeContextBeExecutedToRunTest(testStartRecord, contextGroup.key))
+    ) {
+      result.requiringPrivateAPIUsage.push(testStartRecord);
+    } else {
+      result.notRequiringPrivateAPIUsage.push(testStartRecord);
+    }
+  }
+
+  return result;
+}

--- a/test/browser/connection.test.js
+++ b/test/browser/connection.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'chai'], function (helper, chai) {
+define(['shared_helper', 'chai'], function (Helper, chai) {
+  const helper = new Helper();
+
   var { expect, assert } = chai;
   var transportPreferenceName = 'ably-transport-preference';
 

--- a/test/browser/connection.test.js
+++ b/test/browser/connection.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'chai'], function (Helper, chai) {
-  const helper = new Helper();
-
   var { expect, assert } = chai;
   var transportPreferenceName = 'ably-transport-preference';
 
@@ -29,6 +27,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       this.timeout(60 * 1000);
 
       before(function (done) {
+        const helper = Helper.forHook(this);
         helper.setupApp(function (err) {
           if (err) {
             done(err);
@@ -43,6 +42,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
       /** @spec RTN20a */
       it('device_going_offline_causes_disconnected_state', function (done) {
+        const helper = this.test.helper;
+
         var realtime = helper.AblyRealtime(),
           connection = realtime.connection,
           offlineEvent = new Event('offline', { bubbles: true });
@@ -86,6 +87,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
       /** @spec RTN20b */
       it('device_going_online_causes_disconnected_connection_to_reconnect_immediately', function (done) {
+        const helper = this.test.helper;
+
         /* Give up trying to connect fairly quickly */
         var realtime = helper.AblyRealtime({ realtimeRequestTimeout: 1000 }),
           connection = realtime.connection,
@@ -132,6 +135,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
       /** @spec RTN20b */
       it('device_going_online_causes_suspended_connection_to_reconnect_immediately', function (done) {
+        const helper = this.test.helper;
+
         /* move to suspended state after 2s of being disconnected */
         var realtime = helper.AblyRealtime({
             disconnectedRetryTimeout: 500,
@@ -178,6 +183,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
       /** @spec RTN20c */
       it('device_going_online_causes_connecting_connection_to_retry_attempt', function (done) {
+        const helper = this.test.helper;
+
         var realtime = helper.AblyRealtime({}),
           connection = realtime.connection,
           onlineEvent = new Event('online', { bubbles: true }),
@@ -217,6 +224,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
        * @specpartial RTN16d
        */
       it('page_refresh_with_recovery', function (done) {
+        const helper = this.test.helper;
+
         var realtimeOpts = {
             recover: function (lastConnectionDetails, cb) {
               cb(true);
@@ -259,6 +268,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
       /** @nospec */
       it('page_refresh_persist_with_denied_recovery', function (done) {
+        const helper = this.test.helper;
+
         var realtimeOpts = {
           recover: function (lastConnectionDetails, cb) {
             cb(false);
@@ -302,10 +313,10 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
       /** @nospec */
       it('page_refresh_with_close_on_unload', function (done) {
-        var realtime = helper.AblyRealtime({ closeOnUnload: true }),
+        var realtime = this.test.helper.AblyRealtime({ closeOnUnload: true }),
           refreshEvent = new Event('beforeunload', { bubbles: true });
 
-        helper.monitorConnection(done, realtime);
+        this.test.helper.monitorConnection(done, realtime);
 
         realtime.connection.once('connected', function () {
           try {
@@ -326,6 +337,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
        * @specpartial RTN16d
        */
       it('page_refresh_with_manual_recovery', function (done) {
+        const helper = this.test.helper;
+
         var realtime = helper.AblyRealtime({ closeOnUnload: false }),
           refreshEvent = new Event('beforeunload', { bubbles: true });
 
@@ -364,12 +377,12 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       });
 
       /** @nospec */
-      it('page_refresh_with_multiple_recovery_scopes', async () => {
+      it('page_refresh_with_multiple_recovery_scopes', async function () {
         const realtimeOpts = { recover: (_, cb) => cb(true) },
           opts1 = Object.assign({ recoveryKeyStorageName: 'recovery-1' }, realtimeOpts),
           opts2 = Object.assign({ recoveryKeyStorageName: 'recovery-2' }, realtimeOpts),
-          realtime1 = helper.AblyRealtime(opts1),
-          realtime2 = helper.AblyRealtime(opts2),
+          realtime1 = this.test.helper.AblyRealtime(opts1),
+          realtime2 = this.test.helper.AblyRealtime(opts2),
           refreshEvent = new Event('beforeunload', { bubbles: true });
 
         await Promise.all([realtime1.connection.once('connected'), realtime2.connection.once('connected')]);
@@ -378,24 +391,26 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
         document.dispatchEvent(refreshEvent);
 
-        helper.simulateDroppedConnection(realtime1);
-        helper.simulateDroppedConnection(realtime2);
+        this.test.helper.simulateDroppedConnection(realtime1);
+        this.test.helper.simulateDroppedConnection(realtime2);
 
         await new Promise((res) => setTimeout(res, 1000));
 
-        const newRealtime1 = helper.AblyRealtime(opts1);
-        const newRealtime2 = helper.AblyRealtime(opts2);
+        const newRealtime1 = this.test.helper.AblyRealtime(opts1);
+        const newRealtime2 = this.test.helper.AblyRealtime(opts2);
         await Promise.all([newRealtime1.connection.once('connected'), newRealtime2.connection.once('connected')]);
         assert.equal(connId1, newRealtime1.connection.id);
         assert.equal(connId2, newRealtime2.connection.id);
 
         await Promise.all(
-          [realtime1, realtime2, newRealtime1, newRealtime2].map((rt) => helper.closeAndFinishAsync(rt)),
+          [realtime1, realtime2, newRealtime1, newRealtime2].map((rt) => this.test.helper.closeAndFinishAsync(rt)),
         );
       });
 
       /** @nospec */
       it('persist_preferred_transport', function (done) {
+        const helper = this.test.helper;
+
         var realtime = helper.AblyRealtime();
 
         realtime.connection.connectionManager.on(function (transport) {
@@ -416,15 +431,15 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
       /** @nospec */
       it('browser_transports', function (done) {
-        var realtime = helper.AblyRealtime();
+        var realtime = this.test.helper.AblyRealtime();
         try {
           expect(realtime.connection.connectionManager.baseTransport).to.equal('xhr_polling');
           expect(realtime.connection.connectionManager.webSocketTransportAvailable).to.be.ok;
         } catch (err) {
-          helper.closeAndFinish(done, realtime, err);
+          this.test.helper.closeAndFinish(done, realtime, err);
           return;
         }
-        helper.closeAndFinish(done, realtime);
+        this.test.helper.closeAndFinish(done, realtime);
       });
     });
   }

--- a/test/browser/http.test.js
+++ b/test/browser/http.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
-  const helper = new Helper();
-
   var rest;
   var expect = chai.expect;
 
@@ -10,6 +8,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
     this.timeout(60 * 1000);
     let initialXhrSupported;
     before(function (done) {
+      const helper = Helper.forHook(this);
       initialXhrSupported = Ably.Rest.Platform.Config.xhrSupported;
       Ably.Rest.Platform.Config.xhrSupported = false;
       helper.setupApp(function () {

--- a/test/browser/http.test.js
+++ b/test/browser/http.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
+define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
+  const helper = new Helper();
+
   var rest;
   var expect = chai.expect;
 
@@ -35,7 +37,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
     /** @nospec */
     it('Should succeed in using fetch to publish a message', function (done) {
       const channel = rest.channels.get('http_test_channel');
-      helper.whenPromiseSettles(channel.publish('test', 'Testing fetch support'), (err) => {
+      Helper.whenPromiseSettles(channel.publish('test', 'Testing fetch support'), (err) => {
         expect(err).to.not.exist;
         done();
       });
@@ -49,7 +51,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
      */
     it('Should pass errors correctly', function (done) {
       const channel = rest.channels.get('');
-      helper.whenPromiseSettles(channel.publish('test', 'Invalid message'), (err) => {
+      Helper.whenPromiseSettles(channel.publish('test', 'Invalid message'), (err) => {
         expect(err).to.exist;
         done();
       });

--- a/test/browser/http.test.js
+++ b/test/browser/http.test.js
@@ -3,7 +3,6 @@
 define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
   var rest;
   var expect = chai.expect;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('rest/http/fetch', function () {
     this.timeout(60 * 1000);
@@ -36,7 +35,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
     /** @nospec */
     it('Should succeed in using fetch to publish a message', function (done) {
       const channel = rest.channels.get('http_test_channel');
-      whenPromiseSettles(channel.publish('test', 'Testing fetch support'), (err) => {
+      helper.whenPromiseSettles(channel.publish('test', 'Testing fetch support'), (err) => {
         expect(err).to.not.exist;
         done();
       });
@@ -50,7 +49,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
      */
     it('Should pass errors correctly', function (done) {
       const channel = rest.channels.get('');
-      whenPromiseSettles(channel.publish('test', 'Invalid message'), (err) => {
+      helper.whenPromiseSettles(channel.publish('test', 'Invalid message'), (err) => {
         expect(err).to.exist;
         done();
       });

--- a/test/browser/modular.test.js
+++ b/test/browser/modular.test.js
@@ -21,9 +21,10 @@ import {
   MessageInteractions,
 } from '../../build/modular/index.mjs';
 
-function registerAblyModularTests(helper) {
+function registerAblyModularTests(Helper) {
   describe('browser/modular', function () {
     this.timeout(10 * 1000);
+    const helper = new Helper();
     const expect = chai.expect;
     const BufferUtils = BaseRest.Platform.BufferUtils;
     const loadTestData = async (dataPath) => {
@@ -638,7 +639,7 @@ function registerAblyModularTests(helper) {
 
             const txClient = new BaseRealtime(
               helper.ablyClientOptions({
-                clientId: helper.randomString(),
+                clientId: Helper.randomString(),
                 plugins: {
                   WebSocketTransport,
                   FetchRequest,
@@ -681,7 +682,7 @@ function registerAblyModularTests(helper) {
           const rxChannel = rxClient.channels.get('channel');
 
           await monitorConnectionThenCloseAndFinish(async () => {
-            const txClientId = helper.randomString();
+            const txClientId = Helper.randomString();
             const txClient = new BaseRealtime(
               helper.ablyClientOptions({
                 clientId: txClientId,
@@ -958,8 +959,8 @@ function registerAblyModularTests(helper) {
 // This function is called by browser_setup.js once `require` is available
 window.registerAblyModularTests = async () => {
   return new Promise((resolve) => {
-    require(['shared_helper'], (helper) => {
-      registerAblyModularTests(helper);
+    require(['shared_helper'], (Helper) => {
+      registerAblyModularTests(Helper);
       resolve();
     });
   });

--- a/test/browser/modular.test.js
+++ b/test/browser/modular.test.js
@@ -26,11 +26,6 @@ function registerAblyModularTests(helper) {
     this.timeout(10 * 1000);
     const expect = chai.expect;
     const BufferUtils = BaseRest.Platform.BufferUtils;
-    const ablyClientOptions = helper.ablyClientOptions;
-    const testResourcesPath = helper.testResourcesPath;
-    const testMessageEquality = helper.testMessageEquality;
-    const randomString = helper.randomString;
-    const getTestApp = helper.getTestApp;
     const loadTestData = async (dataPath) => {
       return new Promise((resolve, reject) => {
         helper.loadTestData(dataPath, (err, testData) => (err ? reject(err) : resolve(testData)));
@@ -91,7 +86,7 @@ function registerAblyModularTests(helper) {
         describe(clientClass.name, () => {
           /** @nospec */
           it('throws an error due to the absence of an HTTP plugin', () => {
-            expect(() => new clientClass(ablyClientOptions())).to.throw(
+            expect(() => new clientClass(helper.ablyClientOptions())).to.throw(
               'No HTTP request plugin provided. Provide at least one of the FetchRequest or XHRRequest plugins.',
             );
           });
@@ -110,7 +105,7 @@ function registerAblyModularTests(helper) {
           description: 'call `auth.createTokenRequest()` with `queryTime` option enabled',
           action: (client) =>
             client.auth.createTokenRequest(undefined, {
-              key: getTestApp().keys[0].keyStr /* if passing authOptions you have to explicitly pass the key */,
+              key: helper.getTestApp().keys[0].keyStr /* if passing authOptions you have to explicitly pass the key */,
               queryTime: true,
             }),
         },
@@ -127,7 +122,7 @@ function registerAblyModularTests(helper) {
         {
           description: 'call `auth.revokeTokens(...)`',
           getAdditionalClientOptions: () => {
-            const testApp = getTestApp();
+            const testApp = helper.getTestApp();
             return { key: testApp.keys[4].keyStr /* this key has revocableTokens enabled */ };
           },
           action: (client) => client.auth.revokeTokens([{ type: 'clientId', value: 'foo' }]),
@@ -152,7 +147,7 @@ function registerAblyModularTests(helper) {
           /** @nospec */
           it(`allows you to ${scenario.description}`, async () => {
             const client = new BaseRest(
-              ablyClientOptions({ ...scenario.getAdditionalClientOptions?.(), plugins: { FetchRequest } }),
+              helper.ablyClientOptions({ ...scenario.getAdditionalClientOptions?.(), plugins: { FetchRequest } }),
             );
 
             let thrownError = null;
@@ -172,7 +167,7 @@ function registerAblyModularTests(helper) {
           /** @nospec */
           it(`allows you to ${scenario.description}`, async () => {
             const client = new BaseRealtime(
-              ablyClientOptions({
+              helper.ablyClientOptions({
                 autoConnect: false,
                 ...scenario.getAdditionalClientOptions?.(),
                 plugins: {
@@ -199,7 +194,7 @@ function registerAblyModularTests(helper) {
       describe('BaseRealtime without Rest', () => {
         /** @nospec */
         it('still allows publishing and subscribing', async () => {
-          const client = new BaseRealtime(ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
+          const client = new BaseRealtime(helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
 
           await monitorConnectionThenCloseAndFinish(async () => {
             const channel = client.channels.get('channel');
@@ -221,7 +216,7 @@ function registerAblyModularTests(helper) {
         /** @nospec */
         it('allows `auth.createTokenRequest()` without `queryTime` option enabled', async () => {
           const client = new BaseRealtime(
-            ablyClientOptions({ autoConnect: false, plugins: { WebSocketTransport, FetchRequest } }),
+            helper.ablyClientOptions({ autoConnect: false, plugins: { WebSocketTransport, FetchRequest } }),
           );
 
           const tokenRequest = await client.auth.createTokenRequest();
@@ -232,7 +227,7 @@ function registerAblyModularTests(helper) {
           /** @nospec */
           it(`throws an error when attempting to ${scenario.description}`, async () => {
             const client = new BaseRealtime(
-              ablyClientOptions({
+              helper.ablyClientOptions({
                 autoConnect: false,
                 ...scenario.getAdditionalClientOptions?.(),
                 plugins: {
@@ -279,7 +274,7 @@ function registerAblyModularTests(helper) {
 
     describe('Message standalone functions', () => {
       async function testDecodesMessageData(functionUnderTest) {
-        const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+        const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
 
         const item = testData.items[1];
         const decoded = await functionUnderTest(item.encoded);
@@ -300,7 +295,7 @@ function registerAblyModularTests(helper) {
 
         /** @nospec */
         it('throws an error when given channel options with a cipher', async () => {
-          const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+          const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
           const key = BufferUtils.base64Decode(testData.key);
           const iv = BufferUtils.base64Decode(testData.iv);
 
@@ -324,7 +319,7 @@ function registerAblyModularTests(helper) {
 
         /** @nospec */
         it('decrypts a message', async () => {
-          const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+          const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
 
           const key = BufferUtils.base64Decode(testData.key);
           const iv = BufferUtils.base64Decode(testData.iv);
@@ -335,13 +330,13 @@ function registerAblyModularTests(helper) {
               decodeEncryptedMessage(item.encrypted, { cipher: { key, iv } }),
             ]);
 
-            testMessageEquality(decodedFromEncoded, decodedFromEncrypted);
+            helper.testMessageEquality(decodedFromEncoded, decodedFromEncrypted);
           }
         });
       });
 
       async function testDecodesMessagesData(functionUnderTest) {
-        const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+        const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
 
         const items = [testData.items[1], testData.items[3]];
         const decoded = await functionUnderTest(items.map((item) => item.encoded));
@@ -363,7 +358,7 @@ function registerAblyModularTests(helper) {
 
         /** @nospec */
         it('throws an error when given channel options with a cipher', async () => {
-          const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+          const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
           const key = BufferUtils.base64Decode(testData.key);
           const iv = BufferUtils.base64Decode(testData.iv);
 
@@ -390,7 +385,7 @@ function registerAblyModularTests(helper) {
 
         /** @nospec */
         it('decrypts messages', async () => {
-          const testData = await loadTestData(testResourcesPath + 'crypto-data-128.json');
+          const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
 
           const key = BufferUtils.base64Decode(testData.key);
           const iv = BufferUtils.base64Decode(testData.iv);
@@ -404,7 +399,7 @@ function registerAblyModularTests(helper) {
           ]);
 
           for (let i = 0; i < decodedFromEncoded.length; i++) {
-            testMessageEquality(decodedFromEncoded[i], decodedFromEncrypted[i]);
+            helper.testMessageEquality(decodedFromEncoded[i], decodedFromEncrypted[i]);
           }
         });
       });
@@ -414,7 +409,7 @@ function registerAblyModularTests(helper) {
       describe('without Crypto', () => {
         async function testThrowsAnErrorWhenGivenChannelOptionsWithACipher(clientClassConfig) {
           const client = new clientClassConfig.clientClass(
-            ablyClientOptions({
+            helper.ablyClientOptions({
               ...clientClassConfig.additionalClientOptions,
               plugins: {
                 ...clientClassConfig.additionalPlugins,
@@ -445,7 +440,7 @@ function registerAblyModularTests(helper) {
 
       describe('with Crypto', () => {
         async function testIsAbleToPublishEncryptedMessages(clientClassConfig) {
-          const clientOptions = ablyClientOptions();
+          const clientOptions = helper.ablyClientOptions();
 
           const key = await generateRandomKey();
 
@@ -483,7 +478,7 @@ function registerAblyModularTests(helper) {
 
                 // Verify that the message was correctly encrypted
                 const rxMessageDecrypted = await decodeEncryptedMessage(rxMessage, encryptionChannelOptions);
-                testMessageEquality(rxMessageDecrypted, txMessage);
+                helper.testMessageEquality(rxMessageDecrypted, txMessage);
               },
               txClient,
             );
@@ -546,7 +541,9 @@ function registerAblyModularTests(helper) {
           describe('BaseRest', () => {
             /** @nospec */
             it('uses JSON', async () => {
-              const client = new BaseRest(ablyClientOptions({ useBinaryProtocol: true, plugins: { FetchRequest } }));
+              const client = new BaseRest(
+                helper.ablyClientOptions({ useBinaryProtocol: true, plugins: { FetchRequest } }),
+              );
               await testRestUsesContentType(client, 'application/json');
             });
           });
@@ -555,7 +552,7 @@ function registerAblyModularTests(helper) {
             /** @nospec */
             it('uses JSON', async () => {
               const client = new BaseRealtime(
-                ablyClientOptions({
+                helper.ablyClientOptions({
                   useBinaryProtocol: true,
                   autoConnect: false,
                   plugins: {
@@ -577,7 +574,7 @@ function registerAblyModularTests(helper) {
             /** @nospec */
             it('uses MessagePack', async () => {
               const client = new BaseRest(
-                ablyClientOptions({
+                helper.ablyClientOptions({
                   useBinaryProtocol: true,
                   plugins: {
                     FetchRequest,
@@ -593,7 +590,7 @@ function registerAblyModularTests(helper) {
             /** @nospec */
             it('uses MessagePack', async () => {
               const client = new BaseRealtime(
-                ablyClientOptions({
+                helper.ablyClientOptions({
                   useBinaryProtocol: true,
                   autoConnect: false,
                   plugins: {
@@ -617,7 +614,7 @@ function registerAblyModularTests(helper) {
       describe('BaseRealtime without RealtimePresence', () => {
         /** @nospec */
         it('throws an error when attempting to access the `presence` property', async () => {
-          const client = new BaseRealtime(ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
+          const client = new BaseRealtime(helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
 
           await monitorConnectionThenCloseAndFinish(async () => {
             const channel = client.channels.get('channel');
@@ -628,7 +625,9 @@ function registerAblyModularTests(helper) {
 
         /** @nospec */
         it('doesn’t break when it receives a PRESENCE ProtocolMessage', async () => {
-          const rxClient = new BaseRealtime(ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
+          const rxClient = new BaseRealtime(
+            helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
+          );
 
           await monitorConnectionThenCloseAndFinish(async () => {
             const rxChannel = rxClient.channels.get('channel');
@@ -638,8 +637,8 @@ function registerAblyModularTests(helper) {
             const receivedMessagePromise = new Promise((resolve) => rxChannel.subscribe(resolve));
 
             const txClient = new BaseRealtime(
-              ablyClientOptions({
-                clientId: randomString(),
+              helper.ablyClientOptions({
+                clientId: helper.randomString(),
                 plugins: {
                   WebSocketTransport,
                   FetchRequest,
@@ -671,7 +670,7 @@ function registerAblyModularTests(helper) {
          */
         it('offers realtime presence functionality', async () => {
           const rxClient = new BaseRealtime(
-            ablyClientOptions({
+            helper.ablyClientOptions({
               plugins: {
                 WebSocketTransport,
                 FetchRequest,
@@ -682,9 +681,9 @@ function registerAblyModularTests(helper) {
           const rxChannel = rxClient.channels.get('channel');
 
           await monitorConnectionThenCloseAndFinish(async () => {
-            const txClientId = randomString();
+            const txClientId = helper.randomString();
             const txClient = new BaseRealtime(
-              ablyClientOptions({
+              helper.ablyClientOptions({
                 clientId: txClientId,
                 plugins: {
                   WebSocketTransport,
@@ -773,7 +772,7 @@ function registerAblyModularTests(helper) {
         describe('without a transport plugin', () => {
           /** @nospec */
           it('throws an error due to absence of a transport plugin', () => {
-            expect(() => new BaseRealtime(ablyClientOptions({ plugins: { FetchRequest } }))).to.throw(
+            expect(() => new BaseRealtime(helper.ablyClientOptions({ plugins: { FetchRequest } }))).to.throw(
               'no requested transports available',
             );
           });
@@ -790,7 +789,7 @@ function registerAblyModularTests(helper) {
              */
             it(`is able to use the ${scenario.transportName} transport`, async () => {
               const realtime = new BaseRealtime(
-                ablyClientOptions({
+                helper.ablyClientOptions({
                   autoConnect: false,
                   transports: [scenario.transportName],
                   plugins: {
@@ -835,7 +834,7 @@ function registerAblyModularTests(helper) {
             }
           };
 
-          const rest = new BaseRest(ablyClientOptions({ plugins: { FetchRequest, XHRRequest: XHRRequestSpy } }));
+          const rest = new BaseRest(helper.ablyClientOptions({ plugins: { FetchRequest, XHRRequest: XHRRequestSpy } }));
           await rest.time();
 
           expect(usedXHR).to.be.true;
@@ -848,7 +847,9 @@ function registerAblyModularTests(helper) {
         describe('without MessageInteractions', () => {
           /** @nospec */
           it('is able to subscribe to and unsubscribe from channel events, as long as a MessageFilter isn’t passed', async () => {
-            const realtime = new BaseRealtime(ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
+            const realtime = new BaseRealtime(
+              helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
+            );
 
             await monitorConnectionThenCloseAndFinish(async () => {
               const channel = realtime.channels.get('channel');
@@ -865,7 +866,9 @@ function registerAblyModularTests(helper) {
 
           /** @nospec */
           it('throws an error when attempting to subscribe to channel events using a MessageFilter', async () => {
-            const realtime = new BaseRealtime(ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
+            const realtime = new BaseRealtime(
+              helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
+            );
 
             await monitorConnectionThenCloseAndFinish(async () => {
               const channel = realtime.channels.get('channel');
@@ -890,7 +893,7 @@ function registerAblyModularTests(helper) {
            */
           it('can take a MessageFilter argument when subscribing to and unsubscribing from channel events', async () => {
             const realtime = new BaseRealtime(
-              ablyClientOptions({
+              helper.ablyClientOptions({
                 plugins: {
                   WebSocketTransport,
                   FetchRequest,

--- a/test/browser/modular.test.js
+++ b/test/browser/modular.test.js
@@ -24,16 +24,15 @@ import {
 function registerAblyModularTests(Helper) {
   describe('browser/modular', function () {
     this.timeout(10 * 1000);
-    const helper = new Helper();
     const expect = chai.expect;
     const BufferUtils = BaseRest.Platform.BufferUtils;
-    const loadTestData = async (dataPath) => {
+    const loadTestData = async (helper, dataPath) => {
       return new Promise((resolve, reject) => {
         helper.loadTestData(dataPath, (err, testData) => (err ? reject(err) : resolve(testData)));
       });
     };
 
-    async function monitorConnectionThenCloseAndFinish(action, realtime, states) {
+    async function monitorConnectionThenCloseAndFinish(helper, action, realtime, states) {
       try {
         await helper.monitorConnectionAsync(action, realtime, states);
       } finally {
@@ -41,7 +40,8 @@ function registerAblyModularTests(Helper) {
       }
     }
 
-    before((done) => {
+    before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(done);
     });
 
@@ -84,10 +84,10 @@ function registerAblyModularTests(Helper) {
 
     describe('without any plugins', () => {
       for (const clientClass of [BaseRest, BaseRealtime]) {
-        describe(clientClass.name, () => {
+        describe(clientClass.name, function () {
           /** @nospec */
-          it('throws an error due to the absence of an HTTP plugin', () => {
-            expect(() => new clientClass(helper.ablyClientOptions())).to.throw(
+          it('throws an error due to the absence of an HTTP plugin', function () {
+            expect(() => new clientClass(this.test.helper.ablyClientOptions())).to.throw(
               'No HTTP request plugin provided. Provide at least one of the FetchRequest or XHRRequest plugins.',
             );
           });
@@ -104,7 +104,7 @@ function registerAblyModularTests(Helper) {
         { description: 'call `time()`', action: (client) => client.time() },
         {
           description: 'call `auth.createTokenRequest()` with `queryTime` option enabled',
-          action: (client) =>
+          action: (client, helper) =>
             client.auth.createTokenRequest(undefined, {
               key: helper.getTestApp().keys[0].keyStr /* if passing authOptions you have to explicitly pass the key */,
               queryTime: true,
@@ -122,7 +122,7 @@ function registerAblyModularTests(Helper) {
         },
         {
           description: 'call `auth.revokeTokens(...)`',
-          getAdditionalClientOptions: () => {
+          getAdditionalClientOptions: (helper) => {
             const testApp = helper.getTestApp();
             return { key: testApp.keys[4].keyStr /* this key has revocableTokens enabled */ };
           },
@@ -146,14 +146,15 @@ function registerAblyModularTests(Helper) {
       describe('BaseRest without explicit Rest', () => {
         for (const scenario of restScenarios) {
           /** @nospec */
-          it(`allows you to ${scenario.description}`, async () => {
+          it(`allows you to ${scenario.description}`, async function () {
+            const helper = this.test.helper;
             const client = new BaseRest(
-              helper.ablyClientOptions({ ...scenario.getAdditionalClientOptions?.(), plugins: { FetchRequest } }),
+              helper.ablyClientOptions({ ...scenario.getAdditionalClientOptions?.(helper), plugins: { FetchRequest } }),
             );
 
             let thrownError = null;
             try {
-              await scenario.action(client);
+              await scenario.action(client, helper);
             } catch (error) {
               thrownError = error;
             }
@@ -166,11 +167,12 @@ function registerAblyModularTests(Helper) {
       describe('BaseRealtime with Rest', () => {
         for (const scenario of restScenarios) {
           /** @nospec */
-          it(`allows you to ${scenario.description}`, async () => {
+          it(`allows you to ${scenario.description}`, async function () {
+            const helper = this.test.helper;
             const client = new BaseRealtime(
               helper.ablyClientOptions({
                 autoConnect: false,
-                ...scenario.getAdditionalClientOptions?.(),
+                ...scenario.getAdditionalClientOptions?.(helper),
                 plugins: {
                   WebSocketTransport,
                   FetchRequest,
@@ -182,7 +184,7 @@ function registerAblyModularTests(Helper) {
 
             let thrownError = null;
             try {
-              await scenario.action(client);
+              await scenario.action(client, helper);
             } catch (error) {
               thrownError = error;
             }
@@ -194,30 +196,37 @@ function registerAblyModularTests(Helper) {
 
       describe('BaseRealtime without Rest', () => {
         /** @nospec */
-        it('still allows publishing and subscribing', async () => {
-          const client = new BaseRealtime(helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
+        it('still allows publishing and subscribing', async function () {
+          const helper = this.test.helper;
+          const client = new BaseRealtime(
+            this.test.helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
+          );
 
-          await monitorConnectionThenCloseAndFinish(async () => {
-            const channel = client.channels.get('channel');
-            await channel.attach();
+          await monitorConnectionThenCloseAndFinish(
+            helper,
+            async () => {
+              const channel = client.channels.get('channel');
+              await channel.attach();
 
-            const recievedMessagePromise = new Promise((resolve) => {
-              channel.subscribe((message) => {
-                resolve(message);
+              const recievedMessagePromise = new Promise((resolve) => {
+                channel.subscribe((message) => {
+                  resolve(message);
+                });
               });
-            });
 
-            await channel.publish({ data: { foo: 'bar' } });
+              await channel.publish({ data: { foo: 'bar' } });
 
-            const receivedMessage = await recievedMessagePromise;
-            expect(receivedMessage.data).to.eql({ foo: 'bar' });
-          }, client);
+              const receivedMessage = await recievedMessagePromise;
+              expect(receivedMessage.data).to.eql({ foo: 'bar' });
+            },
+            client,
+          );
         });
 
         /** @nospec */
-        it('allows `auth.createTokenRequest()` without `queryTime` option enabled', async () => {
+        it('allows `auth.createTokenRequest()` without `queryTime` option enabled', async function () {
           const client = new BaseRealtime(
-            helper.ablyClientOptions({ autoConnect: false, plugins: { WebSocketTransport, FetchRequest } }),
+            this.test.helper.ablyClientOptions({ autoConnect: false, plugins: { WebSocketTransport, FetchRequest } }),
           );
 
           const tokenRequest = await client.auth.createTokenRequest();
@@ -226,11 +235,12 @@ function registerAblyModularTests(Helper) {
 
         for (const scenario of restScenarios) {
           /** @nospec */
-          it(`throws an error when attempting to ${scenario.description}`, async () => {
+          it(`throws an error when attempting to ${scenario.description}`, async function () {
+            const helper = this.test.helper;
             const client = new BaseRealtime(
-              helper.ablyClientOptions({
+              this.test.helper.ablyClientOptions({
                 autoConnect: false,
-                ...scenario.getAdditionalClientOptions?.(),
+                ...scenario.getAdditionalClientOptions?.(helper),
                 plugins: {
                   WebSocketTransport,
                   FetchRequest,
@@ -241,7 +251,7 @@ function registerAblyModularTests(Helper) {
 
             let thrownError = null;
             try {
-              await scenario.action(client);
+              await scenario.action(client, helper);
             } catch (error) {
               thrownError = error;
             }
@@ -274,8 +284,8 @@ function registerAblyModularTests(Helper) {
     });
 
     describe('Message standalone functions', () => {
-      async function testDecodesMessageData(functionUnderTest) {
-        const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
+      async function testDecodesMessageData(helper, functionUnderTest) {
+        const testData = await loadTestData(helper, helper.testResourcesPath + 'crypto-data-128.json');
 
         const item = testData.items[1];
         const decoded = await functionUnderTest(item.encoded);
@@ -290,13 +300,14 @@ function registerAblyModularTests(Helper) {
          *
          * @nospec
          */
-        it('decodes a message’s data', async () => {
-          testDecodesMessageData(decodeMessage);
+        it('decodes a message’s data', async function () {
+          testDecodesMessageData(this.test.helper, decodeMessage);
         });
 
         /** @nospec */
-        it('throws an error when given channel options with a cipher', async () => {
-          const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
+        it('throws an error when given channel options with a cipher', async function () {
+          const helper = this.test.helper;
+          const testData = await loadTestData(helper, helper.testResourcesPath + 'crypto-data-128.json');
           const key = BufferUtils.base64Decode(testData.key);
           const iv = BufferUtils.base64Decode(testData.iv);
 
@@ -314,13 +325,14 @@ function registerAblyModularTests(Helper) {
 
       describe('decodeEncryptedMessage', async () => {
         /** @nospec */
-        it('decodes a message’s data', async () => {
-          testDecodesMessageData(decodeEncryptedMessage);
+        it('decodes a message’s data', async function () {
+          testDecodesMessageData(this.test.helper, decodeEncryptedMessage);
         });
 
         /** @nospec */
-        it('decrypts a message', async () => {
-          const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
+        it('decrypts a message', async function () {
+          const helper = this.test.helper;
+          const testData = await loadTestData(helper, helper.testResourcesPath + 'crypto-data-128.json');
 
           const key = BufferUtils.base64Decode(testData.key);
           const iv = BufferUtils.base64Decode(testData.iv);
@@ -331,13 +343,13 @@ function registerAblyModularTests(Helper) {
               decodeEncryptedMessage(item.encrypted, { cipher: { key, iv } }),
             ]);
 
-            helper.testMessageEquality(decodedFromEncoded, decodedFromEncrypted);
+            this.test.helper.testMessageEquality(decodedFromEncoded, decodedFromEncrypted);
           }
         });
       });
 
-      async function testDecodesMessagesData(functionUnderTest) {
-        const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
+      async function testDecodesMessagesData(helper, functionUnderTest) {
+        const testData = await loadTestData(helper, helper.testResourcesPath + 'crypto-data-128.json');
 
         const items = [testData.items[1], testData.items[3]];
         const decoded = await functionUnderTest(items.map((item) => item.encoded));
@@ -353,13 +365,14 @@ function registerAblyModularTests(Helper) {
          *
          * @nospec
          */
-        it('decodes messages’ data', async () => {
-          testDecodesMessagesData(decodeMessages);
+        it('decodes messages’ data', async function () {
+          testDecodesMessagesData(this.test.helper, decodeMessages);
         });
 
         /** @nospec */
-        it('throws an error when given channel options with a cipher', async () => {
-          const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
+        it('throws an error when given channel options with a cipher', async function () {
+          const helper = this.test.helper;
+          const testData = await loadTestData(helper, helper.testResourcesPath + 'crypto-data-128.json');
           const key = BufferUtils.base64Decode(testData.key);
           const iv = BufferUtils.base64Decode(testData.iv);
 
@@ -380,13 +393,14 @@ function registerAblyModularTests(Helper) {
 
       describe('decodeEncryptedMessages', () => {
         /** @nospec */
-        it('decodes messages’ data', async () => {
-          testDecodesMessagesData(decodeEncryptedMessages);
+        it('decodes messages’ data', async function () {
+          testDecodesMessagesData(this.test.helper, decodeEncryptedMessages);
         });
 
         /** @nospec */
-        it('decrypts messages', async () => {
-          const testData = await loadTestData(helper.testResourcesPath + 'crypto-data-128.json');
+        it('decrypts messages', async function () {
+          const helper = this.test.helper;
+          const testData = await loadTestData(helper, helper.testResourcesPath + 'crypto-data-128.json');
 
           const key = BufferUtils.base64Decode(testData.key);
           const iv = BufferUtils.base64Decode(testData.iv);
@@ -400,7 +414,7 @@ function registerAblyModularTests(Helper) {
           ]);
 
           for (let i = 0; i < decodedFromEncoded.length; i++) {
-            helper.testMessageEquality(decodedFromEncoded[i], decodedFromEncrypted[i]);
+            this.test.helper.testMessageEquality(decodedFromEncoded[i], decodedFromEncrypted[i]);
           }
         });
       });
@@ -408,7 +422,7 @@ function registerAblyModularTests(Helper) {
 
     describe('Crypto', () => {
       describe('without Crypto', () => {
-        async function testThrowsAnErrorWhenGivenChannelOptionsWithACipher(clientClassConfig) {
+        async function testThrowsAnErrorWhenGivenChannelOptionsWithACipher(helper, clientClassConfig) {
           const client = new clientClassConfig.clientClass(
             helper.ablyClientOptions({
               ...clientClassConfig.additionalClientOptions,
@@ -432,15 +446,15 @@ function registerAblyModularTests(Helper) {
         ]) {
           describe(clientClassConfig.clientClass.name, () => {
             /** @nospec */
-            it('throws an error when given channel options with a cipher', async () => {
-              await testThrowsAnErrorWhenGivenChannelOptionsWithACipher(clientClassConfig);
+            it('throws an error when given channel options with a cipher', async function () {
+              await testThrowsAnErrorWhenGivenChannelOptionsWithACipher(this.test.helper, clientClassConfig);
             });
           });
         }
       });
 
       describe('with Crypto', () => {
-        async function testIsAbleToPublishEncryptedMessages(clientClassConfig) {
+        async function testIsAbleToPublishEncryptedMessages(helper, clientClassConfig) {
           const clientOptions = helper.ablyClientOptions();
 
           const key = await generateRandomKey();
@@ -449,41 +463,48 @@ function registerAblyModularTests(Helper) {
 
           const rxClient = new BaseRealtime({ ...clientOptions, plugins: { WebSocketTransport, FetchRequest } });
 
-          await monitorConnectionThenCloseAndFinish(async () => {
-            const rxChannel = rxClient.channels.get('channel');
-            await rxChannel.attach();
+          await monitorConnectionThenCloseAndFinish(
+            helper,
+            async () => {
+              const rxChannel = rxClient.channels.get('channel');
+              await rxChannel.attach();
 
-            const rxMessagePromise = new Promise((resolve, _) => rxChannel.subscribe((message) => resolve(message)));
+              const rxMessagePromise = new Promise((resolve, _) => rxChannel.subscribe((message) => resolve(message)));
 
-            const encryptionChannelOptions = { cipher: { key } };
+              const encryptionChannelOptions = { cipher: { key } };
 
-            const txMessage = { name: 'message', data: 'data' };
-            const txClient = new clientClassConfig.clientClass({
-              ...clientOptions,
-              plugins: {
-                ...clientClassConfig.additionalPlugins,
-                FetchRequest,
-                Crypto,
-              },
-            });
+              const txMessage = { name: 'message', data: 'data' };
+              const txClient = new clientClassConfig.clientClass({
+                ...clientOptions,
+                plugins: {
+                  ...clientClassConfig.additionalPlugins,
+                  FetchRequest,
+                  Crypto,
+                },
+              });
 
-            await (clientClassConfig.isRealtime ? monitorConnectionThenCloseAndFinish : async (op) => await op())(
-              async () => {
-                const txChannel = txClient.channels.get('channel', encryptionChannelOptions);
-                await txChannel.publish(txMessage);
+              await (clientClassConfig.isRealtime
+                ? monitorConnectionThenCloseAndFinish
+                : async (helper, op) => await op())(
+                helper,
+                async () => {
+                  const txChannel = txClient.channels.get('channel', encryptionChannelOptions);
+                  await txChannel.publish(txMessage);
 
-                const rxMessage = await rxMessagePromise;
+                  const rxMessage = await rxMessagePromise;
 
-                // Verify that the message was published with encryption
-                expect(rxMessage.encoding).to.equal('utf-8/cipher+aes-256-cbc');
+                  // Verify that the message was published with encryption
+                  expect(rxMessage.encoding).to.equal('utf-8/cipher+aes-256-cbc');
 
-                // Verify that the message was correctly encrypted
-                const rxMessageDecrypted = await decodeEncryptedMessage(rxMessage, encryptionChannelOptions);
-                helper.testMessageEquality(rxMessageDecrypted, txMessage);
-              },
-              txClient,
-            );
-          }, rxClient);
+                  // Verify that the message was correctly encrypted
+                  const rxMessageDecrypted = await decodeEncryptedMessage(rxMessage, encryptionChannelOptions);
+                  helper.testMessageEquality(rxMessageDecrypted, txMessage);
+                },
+                txClient,
+              );
+            },
+            rxClient,
+          );
         }
 
         for (const clientClassConfig of [
@@ -496,8 +517,8 @@ function registerAblyModularTests(Helper) {
         ]) {
           describe(clientClassConfig.clientClass.name, () => {
             /** @nospec */
-            it('is able to publish encrypted messages', async () => {
-              await testIsAbleToPublishEncryptedMessages(clientClassConfig);
+            it('is able to publish encrypted messages', async function () {
+              await testIsAbleToPublishEncryptedMessages(this.test.helper, clientClassConfig);
             });
           });
         }
@@ -541,9 +562,9 @@ function registerAblyModularTests(Helper) {
         describe('without MsgPack', () => {
           describe('BaseRest', () => {
             /** @nospec */
-            it('uses JSON', async () => {
+            it('uses JSON', async function () {
               const client = new BaseRest(
-                helper.ablyClientOptions({ useBinaryProtocol: true, plugins: { FetchRequest } }),
+                this.test.helper.ablyClientOptions({ useBinaryProtocol: true, plugins: { FetchRequest } }),
               );
               await testRestUsesContentType(client, 'application/json');
             });
@@ -551,7 +572,8 @@ function registerAblyModularTests(Helper) {
 
           describe('BaseRealtime', () => {
             /** @nospec */
-            it('uses JSON', async () => {
+            it('uses JSON', async function () {
+              const helper = this.test.helper;
               const client = new BaseRealtime(
                 helper.ablyClientOptions({
                   useBinaryProtocol: true,
@@ -563,9 +585,13 @@ function registerAblyModularTests(Helper) {
                 }),
               );
 
-              await monitorConnectionThenCloseAndFinish(async () => {
-                await testRealtimeUsesFormat(client, 'json');
-              }, client);
+              await monitorConnectionThenCloseAndFinish(
+                helper,
+                async () => {
+                  await testRealtimeUsesFormat(client, 'json');
+                },
+                client,
+              );
             });
           });
         });
@@ -573,9 +599,9 @@ function registerAblyModularTests(Helper) {
         describe('with MsgPack', () => {
           describe('BaseRest', () => {
             /** @nospec */
-            it('uses MessagePack', async () => {
+            it('uses MessagePack', async function () {
               const client = new BaseRest(
-                helper.ablyClientOptions({
+                this.test.helper.ablyClientOptions({
                   useBinaryProtocol: true,
                   plugins: {
                     FetchRequest,
@@ -589,7 +615,8 @@ function registerAblyModularTests(Helper) {
 
           describe('BaseRealtime', () => {
             /** @nospec */
-            it('uses MessagePack', async () => {
+            it('uses MessagePack', async function () {
+              const helper = this.test.helper;
               const client = new BaseRealtime(
                 helper.ablyClientOptions({
                   useBinaryProtocol: true,
@@ -602,9 +629,13 @@ function registerAblyModularTests(Helper) {
                 }),
               );
 
-              await monitorConnectionThenCloseAndFinish(async () => {
-                await testRealtimeUsesFormat(client, 'msgpack');
-              }, client);
+              await monitorConnectionThenCloseAndFinish(
+                helper,
+                async () => {
+                  await testRealtimeUsesFormat(client, 'msgpack');
+                },
+                client,
+              );
             });
           });
         });
@@ -614,51 +645,65 @@ function registerAblyModularTests(Helper) {
     describe('RealtimePresence', () => {
       describe('BaseRealtime without RealtimePresence', () => {
         /** @nospec */
-        it('throws an error when attempting to access the `presence` property', async () => {
+        it('throws an error when attempting to access the `presence` property', async function () {
+          const helper = this.test.helper;
           const client = new BaseRealtime(helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
 
-          await monitorConnectionThenCloseAndFinish(async () => {
-            const channel = client.channels.get('channel');
+          await monitorConnectionThenCloseAndFinish(
+            helper,
+            async () => {
+              const channel = client.channels.get('channel');
 
-            expect(() => channel.presence).to.throw('RealtimePresence plugin not provided');
-          }, client);
+              expect(() => channel.presence).to.throw('RealtimePresence plugin not provided');
+            },
+            client,
+          );
         });
 
         /** @nospec */
-        it('doesn’t break when it receives a PRESENCE ProtocolMessage', async () => {
+        it('doesn’t break when it receives a PRESENCE ProtocolMessage', async function () {
+          const helper = this.test.helper;
           const rxClient = new BaseRealtime(
             helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
           );
 
-          await monitorConnectionThenCloseAndFinish(async () => {
-            const rxChannel = rxClient.channels.get('channel');
+          await monitorConnectionThenCloseAndFinish(
+            helper,
+            async () => {
+              const rxChannel = rxClient.channels.get('channel');
 
-            await rxChannel.attach();
+              await rxChannel.attach();
 
-            const receivedMessagePromise = new Promise((resolve) => rxChannel.subscribe(resolve));
+              const receivedMessagePromise = new Promise((resolve) => rxChannel.subscribe(resolve));
 
-            const txClient = new BaseRealtime(
-              helper.ablyClientOptions({
-                clientId: Helper.randomString(),
-                plugins: {
-                  WebSocketTransport,
-                  FetchRequest,
-                  RealtimePresence,
+              const txClient = new BaseRealtime(
+                this.test.helper.ablyClientOptions({
+                  clientId: Helper.randomString(),
+                  plugins: {
+                    WebSocketTransport,
+                    FetchRequest,
+                    RealtimePresence,
+                  },
+                }),
+              );
+
+              await monitorConnectionThenCloseAndFinish(
+                helper,
+                async () => {
+                  const txChannel = txClient.channels.get('channel');
+
+                  await txChannel.publish('message', 'body');
+                  await txChannel.presence.enter();
+
+                  // The idea being here that in order for receivedMessagePromise to resolve, rxClient must have first processed the PRESENCE ProtocolMessage that resulted from txChannel.presence.enter()
+
+                  await receivedMessagePromise;
                 },
-              }),
-            );
-
-            await monitorConnectionThenCloseAndFinish(async () => {
-              const txChannel = txClient.channels.get('channel');
-
-              await txChannel.publish('message', 'body');
-              await txChannel.presence.enter();
-
-              // The idea being here that in order for receivedMessagePromise to resolve, rxClient must have first processed the PRESENCE ProtocolMessage that resulted from txChannel.presence.enter()
-
-              await receivedMessagePromise;
-            }, txClient);
-          }, rxClient);
+                txClient,
+              );
+            },
+            rxClient,
+          );
         });
       });
 
@@ -669,7 +714,8 @@ function registerAblyModularTests(Helper) {
          *
          * @nospec
          */
-        it('offers realtime presence functionality', async () => {
+        it('offers realtime presence functionality', async function () {
+          const helper = this.test.helper;
           const rxClient = new BaseRealtime(
             helper.ablyClientOptions({
               plugins: {
@@ -681,33 +727,41 @@ function registerAblyModularTests(Helper) {
           );
           const rxChannel = rxClient.channels.get('channel');
 
-          await monitorConnectionThenCloseAndFinish(async () => {
-            const txClientId = Helper.randomString();
-            const txClient = new BaseRealtime(
-              helper.ablyClientOptions({
-                clientId: txClientId,
-                plugins: {
-                  WebSocketTransport,
-                  FetchRequest,
-                  RealtimePresence,
+          await monitorConnectionThenCloseAndFinish(
+            helper,
+            async () => {
+              const txClientId = Helper.randomString();
+              const txClient = new BaseRealtime(
+                this.test.helper.ablyClientOptions({
+                  clientId: txClientId,
+                  plugins: {
+                    WebSocketTransport,
+                    FetchRequest,
+                    RealtimePresence,
+                  },
+                }),
+              );
+
+              await monitorConnectionThenCloseAndFinish(
+                helper,
+                async () => {
+                  const txChannel = txClient.channels.get('channel');
+
+                  let resolveRxPresenceMessagePromise;
+                  const rxPresenceMessagePromise = new Promise((resolve, reject) => {
+                    resolveRxPresenceMessagePromise = resolve;
+                  });
+                  await rxChannel.presence.subscribe('enter', resolveRxPresenceMessagePromise);
+                  await txChannel.presence.enter();
+
+                  const rxPresenceMessage = await rxPresenceMessagePromise;
+                  expect(rxPresenceMessage.clientId).to.equal(txClientId);
                 },
-              }),
-            );
-
-            await monitorConnectionThenCloseAndFinish(async () => {
-              const txChannel = txClient.channels.get('channel');
-
-              let resolveRxPresenceMessagePromise;
-              const rxPresenceMessagePromise = new Promise((resolve, reject) => {
-                resolveRxPresenceMessagePromise = resolve;
-              });
-              await rxChannel.presence.subscribe('enter', resolveRxPresenceMessagePromise);
-              await txChannel.presence.enter();
-
-              const rxPresenceMessage = await rxPresenceMessagePromise;
-              expect(rxPresenceMessage.clientId).to.equal(txClientId);
-            }, txClient);
-          }, rxClient);
+                txClient,
+              );
+            },
+            rxClient,
+          );
         });
       });
     });
@@ -772,8 +826,8 @@ function registerAblyModularTests(Helper) {
       describe('BaseRealtime', () => {
         describe('without a transport plugin', () => {
           /** @nospec */
-          it('throws an error due to absence of a transport plugin', () => {
-            expect(() => new BaseRealtime(helper.ablyClientOptions({ plugins: { FetchRequest } }))).to.throw(
+          it('throws an error due to absence of a transport plugin', function () {
+            expect(() => new BaseRealtime(this.test.helper.ablyClientOptions({ plugins: { FetchRequest } }))).to.throw(
               'no requested transports available',
             );
           });
@@ -788,7 +842,8 @@ function registerAblyModularTests(Helper) {
              * Tests RTN1 support for modular bundle.
              * @nospec
              */
-            it(`is able to use the ${scenario.transportName} transport`, async () => {
+            it(`is able to use the ${scenario.transportName} transport`, async function () {
+              const helper = this.test.helper;
               const realtime = new BaseRealtime(
                 helper.ablyClientOptions({
                   autoConnect: false,
@@ -800,22 +855,26 @@ function registerAblyModularTests(Helper) {
                 }),
               );
 
-              await monitorConnectionThenCloseAndFinish(async () => {
-                let firstTransportCandidate;
-                const connectionManager = realtime.connection.connectionManager;
-                const originalTryATransport = connectionManager.tryATransport;
-                realtime.connection.connectionManager.tryATransport = (transportParams, candidate, callback) => {
-                  if (!firstTransportCandidate) {
-                    firstTransportCandidate = candidate;
-                  }
-                  originalTryATransport.bind(connectionManager)(transportParams, candidate, callback);
-                };
+              await monitorConnectionThenCloseAndFinish(
+                helper,
+                async () => {
+                  let firstTransportCandidate;
+                  const connectionManager = realtime.connection.connectionManager;
+                  const originalTryATransport = connectionManager.tryATransport;
+                  realtime.connection.connectionManager.tryATransport = (transportParams, candidate, callback) => {
+                    if (!firstTransportCandidate) {
+                      firstTransportCandidate = candidate;
+                    }
+                    originalTryATransport.bind(connectionManager)(transportParams, candidate, callback);
+                  };
 
-                realtime.connect();
+                  realtime.connect();
 
-                await realtime.connection.once('connected');
-                expect(firstTransportCandidate).to.equal(scenario.transportName);
-              }, realtime);
+                  await realtime.connection.once('connected');
+                  expect(firstTransportCandidate).to.equal(scenario.transportName);
+                },
+                realtime,
+              );
             });
           });
         }
@@ -825,7 +884,7 @@ function registerAblyModularTests(Helper) {
     describe('HTTP request implementations', () => {
       describe('with multiple HTTP request implementations', () => {
         /** @nospec */
-        it('prefers XHR', async () => {
+        it('prefers XHR', async function () {
           let usedXHR = false;
 
           const XHRRequestSpy = class XHRRequestSpy extends XHRRequest {
@@ -835,7 +894,9 @@ function registerAblyModularTests(Helper) {
             }
           };
 
-          const rest = new BaseRest(helper.ablyClientOptions({ plugins: { FetchRequest, XHRRequest: XHRRequestSpy } }));
+          const rest = new BaseRest(
+            this.test.helper.ablyClientOptions({ plugins: { FetchRequest, XHRRequest: XHRRequestSpy } }),
+          );
           await rest.time();
 
           expect(usedXHR).to.be.true;
@@ -847,43 +908,53 @@ function registerAblyModularTests(Helper) {
       describe('BaseRealtime', () => {
         describe('without MessageInteractions', () => {
           /** @nospec */
-          it('is able to subscribe to and unsubscribe from channel events, as long as a MessageFilter isn’t passed', async () => {
+          it('is able to subscribe to and unsubscribe from channel events, as long as a MessageFilter isn’t passed', async function () {
+            const helper = this.test.helper;
             const realtime = new BaseRealtime(
               helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
             );
 
-            await monitorConnectionThenCloseAndFinish(async () => {
-              const channel = realtime.channels.get('channel');
-              await channel.attach();
+            await monitorConnectionThenCloseAndFinish(
+              helper,
+              async () => {
+                const channel = realtime.channels.get('channel');
+                await channel.attach();
 
-              const subscribeReceivedMessagePromise = new Promise((resolve) => channel.subscribe(resolve));
+                const subscribeReceivedMessagePromise = new Promise((resolve) => channel.subscribe(resolve));
 
-              await channel.publish('message', 'body');
+                await channel.publish('message', 'body');
 
-              const subscribeReceivedMessage = await subscribeReceivedMessagePromise;
-              expect(subscribeReceivedMessage.data).to.equal('body');
-            }, realtime);
+                const subscribeReceivedMessage = await subscribeReceivedMessagePromise;
+                expect(subscribeReceivedMessage.data).to.equal('body');
+              },
+              realtime,
+            );
           });
 
           /** @nospec */
-          it('throws an error when attempting to subscribe to channel events using a MessageFilter', async () => {
+          it('throws an error when attempting to subscribe to channel events using a MessageFilter', async function () {
+            const helper = this.test.helper;
             const realtime = new BaseRealtime(
               helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
             );
 
-            await monitorConnectionThenCloseAndFinish(async () => {
-              const channel = realtime.channels.get('channel');
+            await monitorConnectionThenCloseAndFinish(
+              helper,
+              async () => {
+                const channel = realtime.channels.get('channel');
 
-              let thrownError = null;
-              try {
-                await channel.subscribe({ clientId: 'someClientId' }, () => {});
-              } catch (error) {
-                thrownError = error;
-              }
+                let thrownError = null;
+                try {
+                  await channel.subscribe({ clientId: 'someClientId' }, () => {});
+                } catch (error) {
+                  thrownError = error;
+                }
 
-              expect(thrownError).not.to.be.null;
-              expect(thrownError.message).to.equal('MessageInteractions plugin not provided');
-            }, realtime);
+                expect(thrownError).not.to.be.null;
+                expect(thrownError.message).to.equal('MessageInteractions plugin not provided');
+              },
+              realtime,
+            );
           });
         });
 
@@ -892,7 +963,8 @@ function registerAblyModularTests(Helper) {
            * Tests RTL22d, MFI2e but for a MessageInteractions plugin with modular BaseRealtime.
            * @nospec
            */
-          it('can take a MessageFilter argument when subscribing to and unsubscribing from channel events', async () => {
+          it('can take a MessageFilter argument when subscribing to and unsubscribing from channel events', async function () {
+            const helper = this.test.helper;
             const realtime = new BaseRealtime(
               helper.ablyClientOptions({
                 plugins: {
@@ -903,52 +975,56 @@ function registerAblyModularTests(Helper) {
               }),
             );
 
-            await monitorConnectionThenCloseAndFinish(async () => {
-              const channel = realtime.channels.get('channel');
+            await monitorConnectionThenCloseAndFinish(
+              helper,
+              async () => {
+                const channel = realtime.channels.get('channel');
 
-              await channel.attach();
+                await channel.attach();
 
-              // Test `subscribe` with a filter: send two messages with different clientIds, and check that unfiltered subscription receives both messages but clientId-filtered subscription only receives the matching one.
-              const messageFilter = { clientId: 'someClientId' }; // note that `unsubscribe` compares filter by reference, I found that a bit surprising
+                // Test `subscribe` with a filter: send two messages with different clientIds, and check that unfiltered subscription receives both messages but clientId-filtered subscription only receives the matching one.
+                const messageFilter = { clientId: 'someClientId' }; // note that `unsubscribe` compares filter by reference, I found that a bit surprising
 
-              const filteredSubscriptionReceivedMessages = [];
-              channel.subscribe(messageFilter, (message) => {
-                filteredSubscriptionReceivedMessages.push(message);
-              });
+                const filteredSubscriptionReceivedMessages = [];
+                channel.subscribe(messageFilter, (message) => {
+                  filteredSubscriptionReceivedMessages.push(message);
+                });
 
-              const unfilteredSubscriptionReceivedFirstTwoMessagesPromise = new Promise((resolve) => {
-                const receivedMessages = [];
-                channel.subscribe(function listener(message) {
-                  receivedMessages.push(message);
-                  if (receivedMessages.length === 2) {
+                const unfilteredSubscriptionReceivedFirstTwoMessagesPromise = new Promise((resolve) => {
+                  const receivedMessages = [];
+                  channel.subscribe(function listener(message) {
+                    receivedMessages.push(message);
+                    if (receivedMessages.length === 2) {
+                      channel.unsubscribe(listener);
+                      resolve();
+                    }
+                  });
+                });
+
+                await channel.publish(await decodeMessage({ clientId: 'someClientId' }));
+                await channel.publish(await decodeMessage({ clientId: 'someOtherClientId' }));
+                await unfilteredSubscriptionReceivedFirstTwoMessagesPromise;
+
+                expect(filteredSubscriptionReceivedMessages.length).to.equal(1);
+                expect(filteredSubscriptionReceivedMessages[0].clientId).to.equal('someClientId');
+
+                // Test `unsubscribe` with a filter: call `unsubscribe` with the clientId filter, publish a message matching the filter, check that only the unfiltered listener recieves it
+                channel.unsubscribe(messageFilter);
+
+                const unfilteredSubscriptionReceivedNextMessagePromise = new Promise((resolve) => {
+                  channel.subscribe(function listener() {
                     channel.unsubscribe(listener);
                     resolve();
-                  }
+                  });
                 });
-              });
 
-              await channel.publish(await decodeMessage({ clientId: 'someClientId' }));
-              await channel.publish(await decodeMessage({ clientId: 'someOtherClientId' }));
-              await unfilteredSubscriptionReceivedFirstTwoMessagesPromise;
+                await channel.publish(await decodeMessage({ clientId: 'someClientId' }));
+                await unfilteredSubscriptionReceivedNextMessagePromise;
 
-              expect(filteredSubscriptionReceivedMessages.length).to.equal(1);
-              expect(filteredSubscriptionReceivedMessages[0].clientId).to.equal('someClientId');
-
-              // Test `unsubscribe` with a filter: call `unsubscribe` with the clientId filter, publish a message matching the filter, check that only the unfiltered listener recieves it
-              channel.unsubscribe(messageFilter);
-
-              const unfilteredSubscriptionReceivedNextMessagePromise = new Promise((resolve) => {
-                channel.subscribe(function listener() {
-                  channel.unsubscribe(listener);
-                  resolve();
-                });
-              });
-
-              await channel.publish(await decodeMessage({ clientId: 'someClientId' }));
-              await unfilteredSubscriptionReceivedNextMessagePromise;
-
-              expect(filteredSubscriptionReceivedMessages.length).to./* (still) */ equal(1);
-            }, realtime);
+                expect(filteredSubscriptionReceivedMessages.length).to./* (still) */ equal(1);
+              },
+              realtime,
+            );
           });
         });
       });

--- a/test/browser/push.test.js
+++ b/test/browser/push.test.js
@@ -2,7 +2,6 @@
 
 define(['ably', 'shared_helper', 'chai', 'push'], function (Ably, helper, chai, PushPlugin) {
   const expect = chai.expect;
-  const whenPromiseSettles = helper.whenPromiseSettles;
   const swUrl = '/push_sw.js';
   let rest;
 

--- a/test/browser/push.test.js
+++ b/test/browser/push.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai', 'push'], function (Ably, helper, chai, PushPlugin) {
+define(['ably', 'shared_helper', 'chai', 'push'], function (Ably, Helper, chai, PushPlugin) {
+  const helper = new Helper();
+
   const expect = chai.expect;
   const swUrl = '/push_sw.js';
   let rest;

--- a/test/browser/push.test.js
+++ b/test/browser/push.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'chai', 'push'], function (Ably, Helper, chai, PushPlugin) {
-  const helper = new Helper();
-
   const expect = chai.expect;
   const swUrl = '/push_sw.js';
   let rest;
@@ -29,6 +27,7 @@ define(['ably', 'shared_helper', 'chai', 'push'], function (Ably, Helper, chai, 
       this.timeout(60 * 1000);
 
       before(function (done) {
+        const helper = Helper.forHook(this);
         helper.setupApp(function () {
           rest = helper.AblyRest({
             pushServiceWorkerUrl: swUrl,

--- a/test/browser/simple.test.js
+++ b/test/browser/simple.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
+define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
 
   describe('browser/simple', function () {
@@ -71,7 +73,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         ably.connection.on('connected', function () {
           connectionTimeout.stop();
           heartbeatTimeout = failWithin(25, done, ably, 'wait for heartbeat');
-          helper.whenPromiseSettles(ably.connection.ping(), function (err) {
+          Helper.whenPromiseSettles(ably.connection.ping(), function (err) {
             heartbeatTimeout.stop();
             done(err);
             ably.close();
@@ -115,7 +117,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         receiveMessagesTimeout = failWithin(15, done, ably, 'wait for published messages to be received');
 
         timer = setInterval(function () {
-          helper.whenPromiseSettles(channel.publish('event0', 'Hello world at: ' + new Date()), function (err) {
+          Helper.whenPromiseSettles(channel.publish('event0', 'Hello world at: ' + new Date()), function (err) {
             sentCbCount++;
             checkFinish();
           });

--- a/test/browser/simple.test.js
+++ b/test/browser/simple.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
 
   describe('browser/simple', function () {
     this.timeout(60 * 1000);
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -21,7 +20,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       return transport in Ably.Realtime.ConnectionManager.supportedTransports(Ably.Realtime._transports);
     }
 
-    function realtimeConnection(transports) {
+    function realtimeConnection(helper, transports) {
       var options = {};
       if (transports) options.transports = transports;
       return helper.AblyRealtime(options);
@@ -40,9 +39,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       };
     }
 
-    function connectionWithTransport(done, transport) {
+    function connectionWithTransport(done, helper, transport) {
       try {
-        var ably = realtimeConnection(transport && [transport]),
+        var ably = realtimeConnection(helper, transport && [transport]),
           connectionTimeout = failWithin(10, done, ably, 'connect');
         ably.connection.on('connected', function () {
           connectionTimeout.stop();
@@ -64,9 +63,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       }
     }
 
-    function heartbeatWithTransport(done, transport) {
+    function heartbeatWithTransport(done, helper, transport) {
       try {
-        var ably = realtimeConnection(transport && [transport]),
+        var ably = realtimeConnection(helper, transport && [transport]),
           connectionTimeout = failWithin(10, done, ably, 'connect'),
           heartbeatTimeout;
 
@@ -95,7 +94,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       }
     }
 
-    function publishWithTransport(done, transport) {
+    function publishWithTransport(done, helper, transport) {
       var count = 5;
       var sentCount = 0,
         receivedCount = 0,
@@ -108,7 +107,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
           ably.close();
         }
       };
-      var ably = realtimeConnection(transport && [transport]),
+      var ably = realtimeConnection(helper, transport && [transport]),
         connectionTimeout = failWithin(5, done, ably, 'connect'),
         receiveMessagesTimeout;
 
@@ -140,8 +139,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      */
     it('simpleInitBase0', function (done) {
       try {
-        var timeout,
-          ably = realtimeConnection();
+        var helper = this.test.helper,
+          timeout,
+          ably = realtimeConnection(helper);
 
         ably.connection.on('connected', function () {
           clearTimeout(timeout);
@@ -173,7 +173,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @nospec
        */
       it('wsbase0', function (done) {
-        connectionWithTransport(done, wsTransport);
+        connectionWithTransport(done, this.test.helper, wsTransport);
       });
 
       /**
@@ -183,7 +183,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @nospec
        */
       it('wspublish0', function (done) {
-        publishWithTransport(done, wsTransport);
+        publishWithTransport(done, this.test.helper, wsTransport);
       });
 
       /**
@@ -193,7 +193,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @nospec
        */
       it('wsheartbeat0', function (done) {
-        heartbeatWithTransport(done, wsTransport);
+        heartbeatWithTransport(done, this.test.helper, wsTransport);
       });
     }
 
@@ -205,7 +205,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @nospec
        */
       it('xhrpollingbase0', function (done) {
-        connectionWithTransport(done, xhrPollingTransport);
+        connectionWithTransport(done, this.test.helper, xhrPollingTransport);
       });
 
       /**
@@ -215,7 +215,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @nospec
        */
       it('xhrpollingpublish0', function (done) {
-        publishWithTransport(done, xhrPollingTransport);
+        publishWithTransport(done, this.test.helper, xhrPollingTransport);
       });
 
       /**
@@ -225,7 +225,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @nospec
        */
       it('xhrpollingheartbeat0', function (done) {
-        heartbeatWithTransport(done, xhrPollingTransport);
+        heartbeatWithTransport(done, this.test.helper, xhrPollingTransport);
       });
     }
 
@@ -235,7 +235,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @nospec
      */
     it('auto_transport_base0', function (done) {
-      connectionWithTransport(done);
+      connectionWithTransport(done, this.test.helper);
     });
 
     /**
@@ -245,7 +245,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @nospec
      */
     it('auto_transport_publish0', function (done) {
-      publishWithTransport(done);
+      publishWithTransport(done, this.test.helper);
     });
 
     /**
@@ -255,7 +255,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @nospec
      */
     it('auto_transport_heartbeat0', function (done) {
-      heartbeatWithTransport(done);
+      heartbeatWithTransport(done, this.test.helper);
     });
   });
 });

--- a/test/browser/simple.test.js
+++ b/test/browser/simple.test.js
@@ -2,7 +2,6 @@
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
   var expect = chai.expect;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('browser/simple', function () {
     this.timeout(60 * 1000);
@@ -72,7 +71,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         ably.connection.on('connected', function () {
           connectionTimeout.stop();
           heartbeatTimeout = failWithin(25, done, ably, 'wait for heartbeat');
-          whenPromiseSettles(ably.connection.ping(), function (err) {
+          helper.whenPromiseSettles(ably.connection.ping(), function (err) {
             heartbeatTimeout.stop();
             done(err);
             ably.close();
@@ -116,7 +115,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         receiveMessagesTimeout = failWithin(15, done, ably, 'wait for published messages to be received');
 
         timer = setInterval(function () {
-          whenPromiseSettles(channel.publish('event0', 'Hello world at: ' + new Date()), function (err) {
+          helper.whenPromiseSettles(channel.publish('event0', 'Hello world at: ' + new Date()), function (err) {
             sentCbCount++;
             checkFinish();
           });

--- a/test/common/globals/named_dependencies.js
+++ b/test/common/globals/named_dependencies.js
@@ -18,5 +18,9 @@ define(function () {
     async: { browser: 'node_modules/async/lib/async' },
     chai: { browser: 'node_modules/chai/chai', node: 'node_modules/chai/chai' },
     ulid: { browser: 'node_modules/ulid/dist/index.umd', node: 'node_modules/ulid/dist/index.umd' },
+    private_api_recorder: {
+      browser: 'test/common/modules/private_api_recorder',
+      node: 'test/common/modules/private_api_recorder',
+    },
   });
 });

--- a/test/common/modules/client_module.js
+++ b/test/common/modules/client_module.js
@@ -5,8 +5,11 @@
 define(['ably', 'globals', 'test/common/modules/testapp_module'], function (Ably, ablyGlobals, testAppHelper) {
   var utils = Ably.Realtime.Utils;
 
-  function ablyClientOptions(options) {
+  function ablyClientOptions(helper, options) {
+    helper = helper.addingHelperFunction('ablyClientOptions');
+    helper.recordPrivateApi('call.Utils.copy');
     var clientOptions = utils.copy(ablyGlobals);
+    helper.recordPrivateApi('call.Utils.mixin');
     utils.mixin(clientOptions, options);
     var authMethods = ['authUrl', 'authCallback', 'token', 'tokenDetails', 'key'];
 
@@ -22,12 +25,14 @@ define(['ably', 'globals', 'test/common/modules/testapp_module'], function (Ably
     return clientOptions;
   }
 
-  function ablyRest(options) {
-    return new Ably.Rest(ablyClientOptions(options));
+  function ablyRest(helper, options) {
+    helper = helper.addingHelperFunction('ablyRest');
+    return new Ably.Rest(ablyClientOptions(helper, options));
   }
 
-  function ablyRealtime(options) {
-    return new Ably.Realtime(ablyClientOptions(options));
+  function ablyRealtime(helper, options) {
+    helper = helper.addingHelperFunction('ablyRealtime');
+    return new Ably.Realtime(ablyClientOptions(helper, options));
   }
 
   return (module.exports = {

--- a/test/common/modules/private_api_recorder.js
+++ b/test/common/modules/private_api_recorder.js
@@ -1,0 +1,195 @@
+'use strict';
+
+define(['test/support/output_directory_paths'], function (outputDirectoryPaths) {
+  const privateAPIIdentifiers = [
+    'call.BufferUtils.areBuffersEqual',
+    'call.BufferUtils.base64Decode',
+    'call.BufferUtils.base64Encode',
+    'call.BufferUtils.hexEncode',
+    'call.BufferUtils.isBuffer',
+    'call.BufferUtils.toArrayBuffer',
+    'call.BufferUtils.utf8Encode',
+    'call.ConnectionManager.supportedTransports',
+    'call.Defaults.getHost',
+    'call.Defaults.getHost',
+    'call.Defaults.getHosts',
+    'call.Defaults.getPort',
+    'call.Defaults.normaliseOptions',
+    'call.EventEmitter.emit',
+    'call.Message.decode',
+    'call.Message.encode',
+    'call.Platform.Config.push.storage.clear',
+    'call.Platform.nextTick',
+    'call.PresenceMessage.fromValues',
+    'call.ProtocolMessage.setFlag',
+    'call.Utils.copy',
+    'call.Utils.getRetryTime',
+    'call.Utils.inspectError',
+    'call.Utils.keysArray',
+    'call.Utils.mixin',
+    'call.Utils.toQueryString',
+    'call.auth.getAuthHeaders',
+    'call.channel.checkPendingState',
+    'call.channel.processMessage',
+    'call.channel.requestState',
+    'call.channel.sendPresence',
+    'call.channel.sync',
+    'call.connectionManager.activeProtocol.getTransport',
+    'call.connectionManager.disconnectAllTransports',
+    'call.connectionManager.notifyState',
+    'call.connectionManager.onChannelMessage',
+    'call.connectionManager.requestState',
+    'call.connectionManager.send',
+    'call.filteredSubscriptions.has',
+    'call.http._getHosts',
+    'call.http.checkConnectivity',
+    'call.http.doUri',
+    'call.msgpack.decode',
+    'call.msgpack.encode',
+    'call.presence._myMembers.put',
+    'call.presence.waitSync',
+    'call.protocolMessageFromDeserialized',
+    'call.realtime.baseUri',
+    'call.rest.baseUri',
+    'call.rest.http.do',
+    'call.restChannel._publish',
+    'call.transport.onProtocolMessage',
+    'call.transport.send',
+    'delete.auth.authOptions.requestHeaders',
+    'deserialize.recoveryKey',
+    'listen.channel._allChannelChanges.attached',
+    'listen.channel._allChannelChanges.update',
+    'listen.connectionManager.connectiondetails',
+    'listen.connectionManager.transport.active',
+    'listen.connectionManager.transport.pending',
+    'listen.transport.disposed',
+    'new.Crypto.CipherParams', // This is in a bit of a grey area re whether it’s private API. The CipherParams class is indeed part of the public API in the spec, but it’s not clear whether you’re meant to construct one directly, and furthermore the spec doesn’t describe it as being exposed as a property on Crypto.
+    'pass.clientOption.connectivityCheckUrl', // actually ably-js public API (i.e. it’s in the TypeScript typings) but no other SDK has it and it doesn’t enable ably-js-specific functionality
+    'pass.clientOption.disableConnectivityCheck', // actually ably-js public API (i.e. it’s in the TypeScript typings) but no other SDK has it and it doesn’t enable ably-js-specific functionality
+    'pass.clientOption.pushRecipientChannel',
+    'pass.clientOption.webSocketConnectTimeout',
+    'read.Defaults.version',
+    'read.EventEmitter.events',
+    'read.Platform.Config.push',
+    'read.Realtime._transports',
+    'read.auth.authOptions.authUrl',
+    'read.auth.key',
+    'read.auth.method',
+    'read.auth.tokenParams.version',
+    'read.channel.channelOptions',
+    'read.channel.channelOptions.cipher',
+    'read.connectionManager.activeProtocol',
+    'read.connectionManager.activeProtocol.transport',
+    'read.connectionManager.baseTransport',
+    'read.connectionManager.connectionId',
+    'read.connectionManager.connectionId',
+    'read.connectionManager.connectionStateTtl',
+    'read.connectionManager.httpHosts',
+    'read.connectionManager.msgSerial',
+    'read.connectionManager.options',
+    'read.connectionManager.options.timeouts.httpMaxRetryDuration',
+    'read.connectionManager.options.timeouts.httpRequestTimeout',
+    'read.connectionManager.pendingTransport',
+    'read.connectionManager.queuedMessages.messages',
+    'read.connectionManager.states.disconnected.retryDelay',
+    'read.connectionManager.states.suspended.retryDelay',
+    'read.connectionManager.webSocketTransportAvailable',
+    'read.realtime.options',
+    'read.realtime.options.key',
+    'read.realtime.options.maxMessageSize',
+    'read.realtime.options.token',
+    'read.rest._currentFallback',
+    'read.rest._currentFallback.host',
+    'read.rest._currentFallback.validUntil',
+    'read.rest.options.key',
+    'read.rest.options.realtimeHost',
+    'read.rest.options.token',
+    'read.rest.serverTimeOffset',
+    'read.transport.params.mode',
+    'read.transport.recvRequest.recvUri',
+    'read.transport.uri',
+    'replace.channel.attachImpl',
+    'replace.channel.processMessage',
+    'replace.channel.sendMessage',
+    'replace.channel.sendPresence',
+    'replace.connectionManager.onChannelMessage',
+    'replace.connectionManager.send',
+    'replace.connectionManager.tryATransport',
+    'replace.http.doUri',
+    'replace.rest.http.do',
+    'replace.rest.time',
+    'replace.restChannel._publish',
+    'replace.transport.onProtocolMessage',
+    'replace.transport.send',
+    'serialize.recoveryKey',
+    'write.Defaults.ENVIRONMENT',
+    'write.Platform.Config.push', // This implies using a mock implementation of the internal IPlatformPushConfig interface. Our mock (in push_channel_transport.js) then interacts with internal objects and private APIs of public objects to implement this interface; I haven’t added annotations for that private API usage, since there wasn’t an easy way to pass test context information into the mock. I think that for now we can just say that if we wanted to get rid of this private API usage, then we’d need to remove this mock entirely.
+    'write.auth.authOptions.requestHeaders',
+    'write.auth.key',
+    'write.auth.tokenDetails.token',
+    'write.channel._lastPayload',
+    'write.channel.state',
+    'write.connectionManager.connectionDetails.maxMessageSize',
+    'write.connectionManager.connectionId',
+    'write.connectionManager.connectionKey',
+    'write.connectionManager.lastActivity',
+    'write.connectionManager.msgSerial',
+    'write.realtime.options.timeouts.realtimeRequestTimeout',
+    'write.rest._currentFallback.validUntil',
+  ];
+
+  class PrivateApiRecorder {
+    privateAPIUsages = [];
+
+    /**
+     * Creates a recording context for the current Mocha test case.
+     *
+     * @param context A description of the context for which the calls will be recorded.
+     */
+    createContext(context) {
+      if (!context) {
+        throw new Error('No description passed to createContext');
+      }
+
+      const loggingDescription = JSON.stringify(context);
+
+      return {
+        record: (privateAPIIdentifier) => {
+          if (privateAPIIdentifiers.indexOf(privateAPIIdentifier) == -1) {
+            throw new Error(`(${loggingDescription}) Recorded unknown private API: ${privateAPIIdentifier}`);
+          }
+          this.privateAPIUsages.push({ context, privateAPIIdentifier });
+        },
+        recordTestStart: () => {
+          this.privateAPIUsages.push({ context, privateAPIIdentifier: null });
+        },
+      };
+    }
+
+    dump() {
+      if (isBrowser) {
+        window.dispatchEvent(new CustomEvent('privateApiUsageData', { detail: this.privateAPIUsages }));
+      } else {
+        try {
+          const fs = require('fs');
+          const path = require('path');
+
+          if (!fs.existsSync(outputDirectoryPaths.privateApiUsage)) {
+            fs.mkdirSync(outputDirectoryPaths.privateApiUsage);
+          }
+          const filename = `node-${process.version.split('.')[0]}.json`;
+          fs.writeFileSync(
+            path.join(outputDirectoryPaths.privateApiUsage, filename),
+            JSON.stringify(this.privateAPIUsages),
+            { encoding: 'utf-8' },
+          );
+        } catch (err) {
+          console.log('Failed to write private API usage data: ', err);
+          throw err;
+        }
+      }
+    }
+  }
+
+  return (module.exports = new PrivateApiRecorder());
+});

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -10,7 +10,8 @@ define([
   'globals',
   'async',
   'chai',
-], function (testAppModule, clientModule, testAppManager, globals, async, chai) {
+  'private_api_recorder',
+], function (testAppModule, clientModule, testAppManager, globals, async, chai, privateApiRecorder) {
   var utils = clientModule.Ably.Realtime.Utils;
   var platform = clientModule.Ably.Realtime.Platform;
   var BufferUtils = platform.BufferUtils;
@@ -20,14 +21,9 @@ define([
   var unroutableAddress = 'http://' + unroutableHost + '/';
 
   class SharedHelper {
-    setupApp = testAppModule.setup;
-    tearDownApp = testAppModule.tearDown;
-    createStats = testAppModule.createStatsFixtureData;
     getTestApp = testAppModule.getTestApp;
 
     Ably = clientModule.Ably;
-    AblyRest = clientModule.AblyRest;
-    ablyClientOptions = clientModule.ablyClientOptions;
     Utils = utils;
 
     loadTestData = testAppManager.loadJsonData;
@@ -42,30 +38,123 @@ define([
         throw new Error('SharedHelper created without context');
       }
       this.context = context;
+      this.privateApiContext = privateApiRecorder.createContext(context);
+    }
+
+    addingHelperFunction(helperFunctionName) {
+      return new SharedHelper({ ...this.context, helperStack: [helperFunctionName, ...this.context.helperStack] });
+    }
+
+    withParameterisedTestTitle(title) {
+      return new SharedHelper({ ...this.context, parameterisedTestTitle: title });
+    }
+
+    static createContext(data) {
+      return {
+        ...data,
+        helperStack: [],
+      };
+    }
+
+    static extractSuiteHierarchy(suite) {
+      const hierarchy = [];
+      while (suite.title) {
+        hierarchy.unshift(suite.title);
+        suite = suite.parent;
+      }
+      return hierarchy;
     }
 
     static forTest(thisInBeforeEach) {
-      return new this(thisInBeforeEach.currentTest.fullTitle());
+      const context = {
+        type: 'test',
+        file: thisInBeforeEach.currentTest.file,
+        suite: this.extractSuiteHierarchy(thisInBeforeEach.currentTest.parent),
+        title: thisInBeforeEach.currentTest.title,
+        parameterisedTestTitle: null,
+      };
+
+      return new this(this.createContext(context));
     }
 
     static forHook(thisInHook) {
-      return new this(thisInHook.test.fullTitle());
+      /**
+       * Based on what I’ve observed (haven’t found good documentation about it), the value of `this` in a hook varies:
+       *
+       * - `before` hook in a test file: Context, with properties:
+       *    - test: Hook
+       *
+       * - `beforeEach` hook in a test file: Suite, which has a `ctx`: Context property with properties:
+       *   - test: Hook
+       *
+       * - global `after` hook: Context, with properties:
+       *   - test: Hook
+       *
+       *  For the test file hooks, the Hook has a `file` property, but for some reason the root hook doesn’t (i.e. doesn’t indicate which file the hook lives in)
+       */
+      const mochaContext = 'ctx' in thisInHook ? thisInHook.ctx : thisInHook;
+      const mochaHook = mochaContext.test;
+
+      const context = {
+        type: 'hook',
+        title: mochaHook.originalTitle,
+      };
+
+      if (!mochaHook.parent.root) {
+        // For some reason the root hook doesn’t contain file information
+        context.file = mochaHook.file;
+        context.suite = this.extractSuiteHierarchy(mochaHook.parent);
+      } else {
+        context.file = null;
+        context.suite = null;
+      }
+
+      return new this(this.createContext(context));
     }
 
     static forTestDefinition(thisInDescribe, label) {
       if (!label) {
         throw new Error('SharedHelper.forTestDefinition called without label');
       }
-      return new this(`${thisInDescribe.title} (defining ${label})`);
+
+      const context = {
+        type: 'definition',
+        file: thisInDescribe.file,
+        suite: this.extractSuiteHierarchy(thisInDescribe),
+        label,
+      };
+
+      return new this(this.createContext(context));
+    }
+
+    recordTestStart() {
+      this.privateApiContext.recordTestStart();
+    }
+
+    recordPrivateApi(identifier) {
+      this.privateApiContext.record(identifier);
     }
 
     get availableTransports() {
+      const helper = this.addingHelperFunction('availableTransports');
+      return helper._availableTransports;
+    }
+
+    get _availableTransports() {
+      this.recordPrivateApi('call.Utils.keysArray');
+      this.recordPrivateApi('call.ConnectionManager.supportedTransports');
+      this.recordPrivateApi('read.Realtime._transports');
       return utils.keysArray(
         clientModule.Ably.Realtime.ConnectionManager.supportedTransports(clientModule.Ably.Realtime._transports),
       );
     }
 
     get bestTransport() {
+      const helper = this.addingHelperFunction('bestTransport');
+      return helper._bestTransport;
+    }
+
+    get _bestTransport() {
       return this.availableTransports[0];
     }
 
@@ -99,6 +188,11 @@ define([
     }
 
     closeAndFinish(done, realtime, err) {
+      const helper = this.addingHelperFunction('closeAndFinish');
+      helper._closeAndFinish(done, realtime, err);
+    }
+
+    _closeAndFinish(done, realtime, err) {
       if (typeof realtime === 'undefined') {
         // Likely called in a catch block for an exception
         // that occured before realtime was initialized
@@ -118,6 +212,11 @@ define([
     }
 
     async closeAndFinishAsync(realtime, err) {
+      const helper = this.addingHelperFunction('closeAndFinishAsync');
+      return helper._closeAndFinishAsync(realtime, err);
+    }
+
+    async _closeAndFinishAsync(realtime, err) {
       return new Promise((resolve, reject) => {
         this.closeAndFinish((err) => (err ? reject(err) : resolve()), realtime, err);
       });
@@ -137,18 +236,34 @@ define([
     }
 
     simulateDroppedConnection(realtime) {
+      const helper = this.addingHelperFunction('simulateDroppedConnection');
+      helper._simulateDroppedConnection(realtime);
+    }
+
+    _simulateDroppedConnection(realtime) {
+      const self = this;
       // Go into the 'disconnected' state before actually disconnecting the transports
       // to avoid the instantaneous reconnect attempt that would be triggered in
       // notifyState by the active transport getting disconnected from a connected state
       realtime.connection.once('disconnected', function () {
+        self.recordPrivateApi('call.connectionManager.disconnectAllTransports');
         realtime.connection.connectionManager.disconnectAllTransports();
       });
+      this.recordPrivateApi('call.connectionManager.requestState');
       realtime.connection.connectionManager.requestState({ state: 'disconnected' });
     }
 
     becomeSuspended(realtime, cb) {
+      const helper = this.addingHelperFunction('becomeSuspended');
+      helper._becomeSuspended(realtime, cb);
+    }
+
+    _becomeSuspended(realtime, cb) {
+      this.recordPrivateApi('call.connectionManager.disconnectAllTransports');
       realtime.connection.connectionManager.disconnectAllTransports();
+      const self = this;
       realtime.connection.once('disconnected', function () {
+        self.recordPrivateApi('call.connectionManager.notifyState');
         realtime.connection.connectionManager.notifyState({ state: 'suspended' });
       });
       if (cb)
@@ -158,25 +273,40 @@ define([
     }
 
     callbackOnClose(realtime, callback) {
+      const helper = this.addingHelperFunction('callbackOnClose');
+      helper._callbackOnClose(realtime, callback);
+    }
+
+    _callbackOnClose(realtime, callback) {
+      this.recordPrivateApi('read.connectionManager.activeProtocol');
       if (!realtime.connection.connectionManager.activeProtocol) {
+        this.recordPrivateApi('call.Platform.nextTick');
         platform.Config.nextTick(function () {
           realtime.close();
           callback();
         });
         return;
       }
+      this.recordPrivateApi('read.connectionManager.activeProtocol.transport');
+      this.recordPrivateApi('listen.transport.disposed');
       realtime.connection.connectionManager.activeProtocol.transport.on('disposed', function () {
         callback();
       });
       /* wait a tick before closing in order to avoid the final close
        * happening synchronously in a publish/attach callback, which
        * complicates channelattach_publish_invalid etc. */
+      this.recordPrivateApi('call.Platform.nextTick');
       platform.Config.nextTick(function () {
         realtime.close();
       });
     }
 
     closeAndFinishSeveral(done, realtimeArray, e) {
+      const helper = this.addingHelperFunction('closeAndFinishSeveral');
+      helper._closeAndFinishSeveral(done, realtimeArray, e);
+    }
+
+    _closeAndFinishSeveral(done, realtimeArray, e) {
       async.map(
         realtimeArray,
         (realtime, mapCb) => {
@@ -201,34 +331,46 @@ define([
 
     /* testFn is assumed to be a function of realtimeOptions that returns a mocha test */
     static testOnAllTransports(thisInDescribe, name, testFn, skip) {
-      const helper = this.forTestDefinition(thisInDescribe, name);
+      const helper = this.forTestDefinition(thisInDescribe, name).addingHelperFunction('testOnAllTransports');
       var itFn = skip ? it.skip : it;
+
+      function createTest(options) {
+        return function (done) {
+          this.test.helper = this.test.helper.withParameterisedTestTitle(name);
+          return testFn(options).apply(this, [done]);
+        };
+      }
+
       let transports = helper.availableTransports;
       transports.forEach(function (transport) {
         itFn(
           name + '_with_' + transport + '_binary_transport',
-          testFn({ transports: [transport], useBinaryProtocol: true }),
+          createTest({ transports: [transport], useBinaryProtocol: true }),
         );
         itFn(
           name + '_with_' + transport + '_text_transport',
-          testFn({ transports: [transport], useBinaryProtocol: false }),
+          createTest({ transports: [transport], useBinaryProtocol: false }),
         );
       });
       /* Plus one for no transport specified (ie use websocket/base mechanism if
        * present).  (we explicitly specify all transports since node only does
        * websocket+nodecomet if comet is explicitly requested)
        * */
-      itFn(name + '_with_binary_transport', testFn({ transports, useBinaryProtocol: true }));
-      itFn(name + '_with_text_transport', testFn({ transports, useBinaryProtocol: false }));
+      itFn(name + '_with_binary_transport', createTest({ transports, useBinaryProtocol: true }));
+      itFn(name + '_with_text_transport', createTest({ transports, useBinaryProtocol: false }));
     }
 
     static restTestOnJsonMsgpack(name, testFn, skip) {
       var itFn = skip ? it.skip : it;
       itFn(name + ' with binary protocol', async function () {
-        await testFn(new clientModule.AblyRest({ useBinaryProtocol: true }), name + '_binary', this.test.helper);
+        const helper = this.test.helper.withParameterisedTestTitle(name);
+
+        await testFn(new clientModule.AblyRest(helper, { useBinaryProtocol: true }), name + '_binary', helper);
       });
       itFn(name + ' with text protocol', async function () {
-        await testFn(new clientModule.AblyRest({ useBinaryProtocol: false }), name + '_text', this.test.helper);
+        const helper = this.test.helper.withParameterisedTestTitle(name);
+
+        await testFn(new clientModule.AblyRest(helper, { useBinaryProtocol: false }), name + '_text', helper);
       });
     }
 
@@ -251,6 +393,11 @@ define([
     }
 
     testMessageEquality(one, two) {
+      const helper = this.addingHelperFunction('testMessageEquality');
+      return helper._testMessageEquality(one, two);
+    }
+
+    _testMessageEquality(one, two) {
       // treat `null` same as `undefined` (using ==, rather than ===)
       expect(one.encoding == two.encoding, "Encoding mismatch ('" + one.encoding + "' != '" + two.encoding + "').").to
         .be.ok;
@@ -260,7 +407,9 @@ define([
         return;
       }
 
+      this.recordPrivateApi('call.BufferUtils.isBuffer');
       if (BufferUtils.isBuffer(one.data) && BufferUtils.isBuffer(two.data)) {
+        this.recordPrivateApi('call.BufferUtils.areBuffersEqual');
         expect(BufferUtils.areBuffersEqual(one.data, two.data), 'Buffer data contents mismatch.').to.equal(true);
         return;
       }
@@ -274,10 +423,18 @@ define([
       expect(json1 === json2, 'JSON data contents mismatch.').to.be.ok;
     }
 
+    ablyClientOptions(options) {
+      return clientModule.ablyClientOptions(this, options);
+    }
+
+    AblyRest(options) {
+      return clientModule.AblyRest(this, options);
+    }
+
     static activeClients = [];
 
     AblyRealtime(options) {
-      const client = clientModule.AblyRealtime(options);
+      const client = clientModule.AblyRealtime(this, options);
       SharedHelper.activeClients.push(client);
       return client;
     }
@@ -304,6 +461,22 @@ define([
           console.log();
         }
       }
+    }
+
+    createStats(app, statsData, callback) {
+      testAppModule.createStatsFixtureData(this, app, statsData, callback);
+    }
+
+    setupApp(forceSetup, done) {
+      return testAppModule.setup(this, forceSetup, done);
+    }
+
+    tearDownApp(app, callback) {
+      testAppModule.tearDown(this, app, callback);
+    }
+
+    dumpPrivateApiUsage() {
+      privateApiRecorder.dump();
     }
   }
 

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -43,6 +43,28 @@ define([
     unroutableAddress = unroutableAddress;
     flushTestLogs = globals.flushLogs;
 
+    constructor(context) {
+      if (!context) {
+        throw new Error('SharedHelper created without context');
+      }
+      this.context = context;
+    }
+
+    static forTest(thisInBeforeEach) {
+      return new this(thisInBeforeEach.currentTest.fullTitle());
+    }
+
+    static forHook(thisInHook) {
+      return new this(thisInHook.test.fullTitle());
+    }
+
+    static forTestDefinition(thisInDescribe, label) {
+      if (!label) {
+        throw new Error('SharedHelper.forTestDefinition called without label');
+      }
+      return new this(`${thisInDescribe.title} (defining ${label})`);
+    }
+
     displayError(err) {
       if (typeof err == 'string' || err == null) return err;
 
@@ -198,10 +220,10 @@ define([
     static restTestOnJsonMsgpack(name, testFn, skip) {
       var itFn = skip ? it.skip : it;
       itFn(name + ' with binary protocol', async function () {
-        await testFn(new clientModule.AblyRest({ useBinaryProtocol: true }), name + '_binary');
+        await testFn(new clientModule.AblyRest({ useBinaryProtocol: true }), name + '_binary', this.test.helper);
       });
       itFn(name + ' with text protocol', async function () {
-        await testFn(new clientModule.AblyRest({ useBinaryProtocol: false }), name + '_text');
+        await testFn(new clientModule.AblyRest({ useBinaryProtocol: false }), name + '_text', this.test.helper);
       });
     }
 

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -16,12 +16,12 @@ define([
   var BufferUtils = platform.BufferUtils;
   var expect = chai.expect;
   var availableTransports = utils.keysArray(
-      clientModule.Ably.Realtime.ConnectionManager.supportedTransports(clientModule.Ably.Realtime._transports),
-    ),
-    bestTransport = availableTransports[0],
-    /* IANA reserved; requests to it will hang forever */
-    unroutableHost = '10.255.255.1',
-    unroutableAddress = 'http://' + unroutableHost + '/';
+    clientModule.Ably.Realtime.ConnectionManager.supportedTransports(clientModule.Ably.Realtime._transports),
+  );
+  var bestTransport = availableTransports[0];
+  /* IANA reserved; requests to it will hang forever */
+  var unroutableHost = '10.255.255.1';
+  var unroutableAddress = 'http://' + unroutableHost + '/';
 
   function displayError(err) {
     if (typeof err == 'string' || err == null) return err;

--- a/test/common/modules/testapp_manager.js
+++ b/test/common/modules/testapp_manager.js
@@ -31,9 +31,12 @@ define(['globals', 'ably'], function (ablyGlobals, ably) {
     }
   }
 
-  function toBase64(str) {
+  function toBase64(helper, str) {
+    helper = helper.addingHelperFunction('toBase64');
     var bufferUtils = ably.Realtime.Platform.BufferUtils;
+    helper.recordPrivateApi('call.BufferUtils.utf8Encode');
     var buffer = bufferUtils.utf8Encode(str);
+    helper.recordPrivateApi('call.BufferUtils.base64Encode');
     return bufferUtils.base64Encode(buffer);
   }
 
@@ -164,11 +167,12 @@ define(['globals', 'ably'], function (ablyGlobals, ably) {
     });
   }
 
-  function createStatsFixtureData(app, statsData, callback) {
+  function createStatsFixtureData(helper, app, statsData, callback) {
+    helper = helper.addingHelperFunction('createStatsFixtureData');
     var postData = JSON.stringify(statsData);
 
     var authKey = app.keys[0].keyStr;
-    var authHeader = toBase64(authKey);
+    var authHeader = toBase64(helper, authKey);
 
     var postOptions = {
       host: restHost,
@@ -195,9 +199,10 @@ define(['globals', 'ably'], function (ablyGlobals, ably) {
     });
   }
 
-  function deleteApp(app, callback) {
+  function deleteApp(helper, app, callback) {
+    helper = helper.addingHelperFunction('deleteApp');
     var authKey = app.keys[0].keyStr,
-      authHeader = toBase64(authKey);
+      authHeader = toBase64(helper, authKey);
 
     var delOptions = {
       host: restHost,

--- a/test/common/modules/testapp_module.js
+++ b/test/common/modules/testapp_module.js
@@ -20,7 +20,7 @@ define(['test/common/modules/testapp_manager', 'globals'], function (testAppMana
 		 then no need to recreate a test app, unless forceSetup is true.
 		 If forceSetup is true and existing app exists, then the app will be torn down (deleted)
 		 first */
-  function setup(forceSetup, done) {
+  function setup(helper, forceSetup, done) {
     if (typeof forceSetup === 'function') {
       done = forceSetup;
       forceSetup = false;
@@ -48,7 +48,7 @@ define(['test/common/modules/testapp_manager', 'globals'], function (testAppMana
     };
 
     if (configuredTestApp() && forceSetup) {
-      tearDown(function (err) {
+      tearDown(helper, function (err) {
         if (err) {
           done(err);
         } else {
@@ -63,13 +63,13 @@ define(['test/common/modules/testapp_manager', 'globals'], function (testAppMana
   /* tearDown is typically called by an afterAll test suite block.
 		 If tearDown is called more than once i.e. across multiple suites,
 		 and other test suites are still to run, then we must not yet delete the test app */
-  function tearDown(done) {
+  function tearDown(helper, done) {
     if (!configuredTestApp()) {
       done();
       return;
     }
 
-    testAppManager.tearDown(configuredTestApp(), function (err) {
+    testAppManager.tearDown(helper, configuredTestApp(), function (err) {
       if (err) {
         done(new Error('Could not tear down Test App: ' + JSON.stringify(err)));
       } else {

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -768,7 +768,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA4b1
      * @specpartial RSA4b - token expired
      */
-    Helper.testOnAllTransports('auth_token_expires', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'auth_token_expires', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           clientRealtime,
@@ -871,7 +871,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTN15a - attempt to reconnect and restore the connection state on token expire
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
-    Helper.testOnAllTransports('auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -919,7 +919,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTN15a - attempt to reconnect and restore the connection state on token expire
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
-    Helper.testOnAllTransports('auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -965,7 +965,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA4a
      * @spec RSA4a2
      */
-    Helper.testOnAllTransports('auth_token_string_expiry_with_token', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'auth_token_string_expiry_with_token', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -1012,7 +1012,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA4a
      * @spec RSA4a2
      */
-    Helper.testOnAllTransports('auth_expired_token_string', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'auth_expired_token_string', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -1061,7 +1061,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTC8
      * @specskip
      */
-    Helper.testOnAllTransports.skip('reauth_authCallback', function (realtimeOpts) {
+    Helper.testOnAllTransports.skip(this, 'reauth_authCallback', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -1564,7 +1564,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /** @nospec */
-    Helper.testOnAllTransports('authorize_immediately_after_init', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'authorize_immediately_after_init', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var realtime = helper.AblyRealtime({

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -6,23 +6,16 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
   var exports = {};
   var expect = chai.expect;
   var _exports = {};
-  var utils = helper.Utils;
-  var displayError = helper.displayError;
-  var closeAndFinish = helper.closeAndFinish;
-  var monitorConnection = helper.monitorConnection;
-  var testOnAllTransports = helper.testOnAllTransports;
-  var mixin = helper.Utils.mixin;
   var http = new Ably.Realtime._Http();
   var jwtTestChannelName = 'JWT_test' + String(Math.floor(Math.random() * 10000) + 1);
   var echoServer = 'https://echo.ably.io';
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   /*
    * Helper function to fetch JWT tokens from the echo server
    */
   function getJWT(params, callback) {
     var authUrl = echoServer + '/createJWT';
-    whenPromiseSettles(http.doUri('get', authUrl, null, null, params), function (err, result) {
+    helper.whenPromiseSettles(http.doUri('get', authUrl, null, null, params), function (err, result) {
       if (result.error) {
         callback(result.error, null);
       }
@@ -41,15 +34,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         }
 
         var rest = helper.AblyRest({ queryTime: true });
-        whenPromiseSettles(rest.time(), function (err, time) {
+        helper.whenPromiseSettles(rest.time(), function (err, time) {
           if (err) {
             done(err);
             return;
           } else {
             currentTime = time;
-            whenPromiseSettles(rest.auth.requestToken({}), function (err, tokenDetails) {
+            helper.whenPromiseSettles(rest.auth.requestToken({}), function (err, tokenDetails) {
               try {
-                expect(!err, err && displayError(err)).to.be.ok;
+                expect(!err, err && helper.displayError(err)).to.be.ok;
                 done();
               } catch (err) {
                 done(err);
@@ -67,9 +60,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      */
     it('authbase0', function (done) {
       var realtime = helper.AblyRealtime({ queryTime: true });
-      whenPromiseSettles(realtime.auth.requestToken(), function (err, tokenDetails) {
+      helper.whenPromiseSettles(realtime.auth.requestToken(), function (err, tokenDetails) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
         try {
@@ -78,9 +71,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           expect(tokenDetails.expires && tokenDetails.expires > tokenDetails.issued, 'Verify token expires').to.be.ok;
           expect(tokenDetails.expires).to.equal(60 * 60 * 1000 + tokenDetails.issued, 'Verify default expiry period');
           expect(JSON.parse(tokenDetails.capability)).to.deep.equal({ '*': ['*'] }, 'Verify token capability');
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
     });
@@ -94,9 +87,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('auth_useAuthUrl_json', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
+      helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
 
@@ -105,11 +98,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime = helper.AblyRealtime({ authUrl: authPath });
 
         realtime.connection.on('connected', function () {
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
           return;
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       });
     });
 
@@ -124,9 +117,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('auth_useAuthUrl_post_json', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
+      helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
 
@@ -135,11 +128,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime = helper.AblyRealtime({ authUrl: authUrl, authMethod: 'POST', authParams: tokenDetails });
 
         realtime.connection.on('connected', function () {
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
           return;
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       });
     });
 
@@ -153,9 +146,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('auth_useAuthUrl_plainText', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
+      helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
 
@@ -164,11 +157,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime = helper.AblyRealtime({ authUrl: authPath });
 
         realtime.connection.on('connected', function () {
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
           return;
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       });
     });
 
@@ -183,9 +176,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime,
         rest = helper.AblyRest();
       var authCallback = function (tokenParams, callback) {
-        whenPromiseSettles(rest.auth.createTokenRequest(tokenParams, null), function (err, tokenRequest) {
+        helper.whenPromiseSettles(rest.auth.createTokenRequest(tokenParams, null), function (err, tokenRequest) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           try {
@@ -202,13 +195,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       realtime.connection.on('connected', function () {
         try {
           expect(realtime.auth.method).to.equal('token');
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
 
-      monitorConnection(done, realtime);
+      helper.monitorConnection(done, realtime);
     });
 
     /**
@@ -225,9 +218,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         rest = helper.AblyRest();
       var clientId = 'test clientid';
       var authCallback = function (tokenParams, callback) {
-        whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+        helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           try {
@@ -245,13 +238,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       realtime.connection.on('connected', function () {
         try {
           expect(realtime.auth.method).to.equal('token');
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
 
-      monitorConnection(done, realtime);
+      helper.monitorConnection(done, realtime);
     });
 
     /**
@@ -266,9 +259,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime,
         rest = helper.AblyRest();
       var authCallback = function (tokenParams, callback) {
-        whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+        helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           try {
@@ -285,13 +278,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       realtime.connection.on('connected', function () {
         try {
           expect(realtime.auth.method).to.equal('token');
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
 
-      monitorConnection(done, realtime);
+      helper.monitorConnection(done, realtime);
     });
 
     /**
@@ -305,9 +298,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('auth_useAuthUrl_mixed_authParams_qsParams', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.createTokenRequest(null, null), function (err, tokenRequest) {
+      helper.whenPromiseSettles(rest.auth.createTokenRequest(null, null), function (err, tokenRequest) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
 
@@ -323,12 +316,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           keyName: tokenRequest.keyName,
           mac: tokenRequest.mac,
         };
-        var authPath = echoServer + '/qs_to_body' + utils.toQueryString(lowerPrecedenceTokenRequestParts);
+        var authPath = echoServer + '/qs_to_body' + helper.Utils.toQueryString(lowerPrecedenceTokenRequestParts);
 
         realtime = helper.AblyRealtime({ authUrl: authPath, authParams: higherPrecedenceTokenRequestParts });
 
         realtime.connection.on('connected', function () {
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
           return;
         });
       });
@@ -344,7 +337,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var rest = helper.AblyRest(),
         testClientId = 'testClientId';
       var authCallback = function (tokenParams, callback) {
-        whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+        helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
           if (err) {
             done(err);
             return;
@@ -384,7 +377,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var clientRealtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
         if (err) {
           done(err);
           return;
@@ -412,7 +405,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
+      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
         if (err) {
           done(err);
           return;
@@ -428,7 +421,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           }
           return;
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       });
     });
 
@@ -442,7 +435,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
+      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
         if (err) {
           done(err);
           return;
@@ -458,7 +451,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           }
           return;
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       });
     });
 
@@ -472,7 +465,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var clientRealtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
         if (err) {
           done(err);
           return;
@@ -481,13 +474,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           try {
             expect(clientRealtime.auth.clientId).to.equal(testClientId);
-            closeAndFinish(done, clientRealtime);
+            helper.closeAndFinish(done, clientRealtime);
           } catch (err) {
-            closeAndFinish(done, clientRealtime, err);
+            helper.closeAndFinish(done, clientRealtime, err);
           }
           return;
         });
-        monitorConnection(done, clientRealtime);
+        helper.monitorConnection(done, clientRealtime);
       });
     });
 
@@ -515,9 +508,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             try {
               expect(stateChange.reason.code).to.equal(80019, 'Check correct error code');
               realtime.connection.off();
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           }
         });
@@ -718,9 +711,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('authUrl_403_previously_active', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
+      helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
 
@@ -730,7 +723,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         realtime.connection.on('connected', function () {
           /* replace the authUrl and reauth */
-          whenPromiseSettles(
+          helper.whenPromiseSettles(
             realtime.auth.authorize(null, { authUrl: echoServer + '/respondwith?status=403' }),
             function (err, tokenDetails) {
               try {
@@ -742,9 +735,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   'Check correct cause error code',
                 );
                 expect(realtime.connection.errorReason.code).to.equal(80019, 'Check correct connection error code');
-                closeAndFinish(done, realtime);
+                helper.closeAndFinish(done, realtime);
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
               }
             },
           );
@@ -759,20 +752,22 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RSA4b1
      * @specpartial RSA4b - token expired
      */
-    testOnAllTransports('auth_token_expires', function (realtimeOpts) {
+    helper.testOnAllTransports('auth_token_expires', function (realtimeOpts) {
       return function (done) {
         var clientRealtime,
           rest = helper.AblyRest();
 
-        whenPromiseSettles(rest.auth.requestToken({ ttl: 5000 }, null), function (err, tokenDetails) {
+        helper.whenPromiseSettles(rest.auth.requestToken({ ttl: 5000 }, null), function (err, tokenDetails) {
           if (err) {
             done(err);
             return;
           }
-          clientRealtime = helper.AblyRealtime(mixin(realtimeOpts, { tokenDetails: tokenDetails, queryTime: true }));
+          clientRealtime = helper.AblyRealtime(
+            helper.Utils.mixin(realtimeOpts, { tokenDetails: tokenDetails, queryTime: true }),
+          );
 
           clientRealtime.connection.on('failed', function () {
-            closeAndFinish(done, clientRealtime, new Error('Failed to connect before token expired'));
+            helper.closeAndFinish(done, clientRealtime, new Error('Failed to connect before token expired'));
           });
           clientRealtime.connection.once('connected', function () {
             clientRealtime.connection.off('failed');
@@ -780,9 +775,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               try {
                 expect(stateChange.reason.statusCode).to.equal(401, 'Verify correct disconnect statusCode');
                 expect(stateChange.reason.code).to.equal(40142, 'Verify correct disconnect code');
-                closeAndFinish(done, clientRealtime);
+                helper.closeAndFinish(done, clientRealtime);
               } catch (err) {
-                closeAndFinish(done, clientRealtime, err);
+                helper.closeAndFinish(done, clientRealtime, err);
               }
             });
           });
@@ -822,7 +817,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var asyncFns = [];
       for (var i = 0; i < 10; i++) {
         asyncFns.push(function (callback) {
-          whenPromiseSettles(rest.auth.createTokenRequest({}, null), function (err, tokenDetails) {
+          helper.whenPromiseSettles(rest.auth.createTokenRequest({}, null), function (err, tokenDetails) {
             if (err) {
               return callback(err);
             }
@@ -858,24 +853,26 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RTN15a - attempt to reconnect and restore the connection state on token expire
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
-    testOnAllTransports('auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
+    helper.testOnAllTransports('auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
         var authCallback = function (tokenParams, callback) {
           tokenParams.ttl = 5000;
-          whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+          helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
             callback(null, tokenDetails);
           });
         };
 
-        realtime = helper.AblyRealtime(mixin(realtimeOpts, { authCallback: authCallback, clientId: clientId }));
-        monitorConnection(done, realtime);
+        realtime = helper.AblyRealtime(
+          helper.Utils.mixin(realtimeOpts, { authCallback: authCallback, clientId: clientId }),
+        );
+        helper.monitorConnection(done, realtime);
         realtime.connection.once('connected', function () {
           realtime.connection.once('disconnected', function (stateChange) {
             try {
@@ -891,7 +888,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       };
     });
 
@@ -903,24 +900,26 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RTN15a - attempt to reconnect and restore the connection state on token expire
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
-    testOnAllTransports('auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
+    helper.testOnAllTransports('auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
         var authCallback = function (tokenParams, callback) {
           tokenParams.ttl = 5000;
-          whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+          helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
             callback(null, tokenDetails.token);
           });
         };
 
-        realtime = helper.AblyRealtime(mixin(realtimeOpts, { authCallback: authCallback, clientId: clientId }));
-        monitorConnection(done, realtime);
+        realtime = helper.AblyRealtime(
+          helper.Utils.mixin(realtimeOpts, { authCallback: authCallback, clientId: clientId }),
+        );
+        helper.monitorConnection(done, realtime);
         realtime.connection.once('connected', function () {
           realtime.connection.once('disconnected', function (stateChange) {
             try {
@@ -936,7 +935,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       };
     });
 
@@ -946,19 +945,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RSA4a
      * @spec RSA4a2
      */
-    testOnAllTransports('auth_token_string_expiry_with_token', function (realtimeOpts) {
+    helper.testOnAllTransports('auth_token_string_expiry_with_token', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
-        whenPromiseSettles(
+        helper.whenPromiseSettles(
           rest.auth.requestToken({ ttl: 5000, clientId: clientId }, null),
           function (err, tokenDetails) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
-            realtime = helper.AblyRealtime(mixin(realtimeOpts, { token: tokenDetails.token, clientId: clientId }));
+            realtime = helper.AblyRealtime(
+              helper.Utils.mixin(realtimeOpts, { token: tokenDetails.token, clientId: clientId }),
+            );
             realtime.connection.once('connected', function () {
               realtime.connection.once('disconnected', function (stateChange) {
                 try {
@@ -990,39 +991,44 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RSA4a
      * @spec RSA4a2
      */
-    testOnAllTransports('auth_expired_token_string', function (realtimeOpts) {
+    helper.testOnAllTransports('auth_expired_token_string', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
-        whenPromiseSettles(rest.auth.requestToken({ ttl: 1, clientId: clientId }, null), function (err, tokenDetails) {
-          if (err) {
-            closeAndFinish(done, realtime, err);
-            return;
-          }
-          setTimeout(function () {
-            realtime = helper.AblyRealtime(mixin(realtimeOpts, { token: tokenDetails.token, clientId: clientId }));
-            realtime.connection.once('failed', function (stateChange) {
-              try {
-                expect(stateChange.reason.code).to.equal(40171, 'Verify correct failure code');
-                realtime.close();
-                done();
-              } catch (err) {
-                done(err);
-              }
-            });
-            /* Note: ws transport indicates viability when websocket is
-             * established, before realtime sends error response. So token error
-             * goes through the same path as a connected transport, so goes to
-             * disconnected first */
-            ['connected', 'suspended'].forEach(function (state) {
-              realtime.connection.on(state, function () {
-                done(new Error('State changed to ' + state + ', should have gone to failed'));
-                realtime.close();
+        helper.whenPromiseSettles(
+          rest.auth.requestToken({ ttl: 1, clientId: clientId }, null),
+          function (err, tokenDetails) {
+            if (err) {
+              helper.closeAndFinish(done, realtime, err);
+              return;
+            }
+            setTimeout(function () {
+              realtime = helper.AblyRealtime(
+                helper.Utils.mixin(realtimeOpts, { token: tokenDetails.token, clientId: clientId }),
+              );
+              realtime.connection.once('failed', function (stateChange) {
+                try {
+                  expect(stateChange.reason.code).to.equal(40171, 'Verify correct failure code');
+                  realtime.close();
+                  done();
+                } catch (err) {
+                  done(err);
+                }
               });
-            });
-          }, 100);
-        });
+              /* Note: ws transport indicates viability when websocket is
+               * established, before realtime sends error response. So token error
+               * goes through the same path as a connected transport, so goes to
+               * disconnected first */
+              ['connected', 'suspended'].forEach(function (state) {
+                realtime.connection.on(state, function () {
+                  done(new Error('State changed to ' + state + ', should have gone to failed'));
+                  realtime.close();
+                });
+              });
+            }, 100);
+          },
+        );
       };
     });
 
@@ -1033,7 +1039,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTC8
      * @specskip
      */
-    testOnAllTransports.skip('reauth_authCallback', function (realtimeOpts) {
+    helper.testOnAllTransports.skip('reauth_authCallback', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
@@ -1042,19 +1048,19 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           tokenParams.clientId = '*';
           tokenParams.capability = firstTime ? { wrong: ['*'] } : { right: ['*'] };
           firstTime = false;
-          whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+          helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
             callback(null, tokenDetails);
           });
         };
 
-        realtime = helper.AblyRealtime(mixin(realtimeOpts, { authCallback: authCallback }));
+        realtime = helper.AblyRealtime(helper.Utils.mixin(realtimeOpts, { authCallback: authCallback }));
         realtime.connection.once('connected', function () {
           var channel = realtime.channels.get('right');
-          whenPromiseSettles(channel.attach(), function (err) {
+          helper.whenPromiseSettles(channel.attach(), function (err) {
             try {
               expect(err, 'Check using first token, without channel attach capability').to.be.ok;
               expect(err.code).to.equal(40160, 'Check expected error code');
@@ -1064,25 +1070,25 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             }
 
             /* soon after connected, reauth */
-            whenPromiseSettles(realtime.auth.authorize(null, null), function (err) {
+            helper.whenPromiseSettles(realtime.auth.authorize(null, null), function (err) {
               try {
-                expect(!err, err && displayError(err)).to.be.ok;
+                expect(!err, err && helper.displayError(err)).to.be.ok;
               } catch (err) {
                 done(err);
                 return;
               }
-              whenPromiseSettles(channel.attach(), function (err) {
+              helper.whenPromiseSettles(channel.attach(), function (err) {
                 try {
                   expect(!err, 'Check using second token, with channel attach capability').to.be.ok;
-                  closeAndFinish(done, realtime);
+                  helper.closeAndFinish(done, realtime);
                 } catch (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                 }
               });
             });
           });
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       };
     });
 
@@ -1109,9 +1115,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           'Check authorize completely replaces stored authOptions with passed in ones',
         );
 
-        closeAndFinish(done, realtime);
+        helper.closeAndFinish(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -1124,9 +1130,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var rest = helper.AblyRest(),
         authCallback = function (tokenParams, callback) {
           // Request a token (should happen twice)
-          whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+          helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
             callback(null, tokenDetails);
@@ -1142,9 +1148,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           if (message.action === 17) {
             try {
               expect(message.auth.accessToken, 'Check AUTH message structure is as expected').to.be.ok;
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           } else {
             originalSend.call(this, message);
@@ -1166,7 +1172,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var currentKey = helper.getTestApp().keys[0];
       var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
       var clientId = 'testJWTClientId';
-      var params = mixin(keys, { clientId: clientId });
+      var params = helper.Utils.mixin(keys, { clientId: clientId });
       var authCallback = function (tokenParams, callback) {
         getJWT(params, callback);
       };
@@ -1204,7 +1210,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var currentKey = helper.getTestApp().keys[0];
       var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret, returnType: 'jwt' };
       var clientId = 'testJWTClientId';
-      var params = mixin(keys, { clientId: clientId });
+      var params = helper.Utils.mixin(keys, { clientId: clientId });
       var authCallback = function (tokenParams, callback) {
         getJWT(params, callback);
       };
@@ -1245,7 +1251,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime = helper.AblyRealtime({ authCallback: authCallback });
       realtime.connection.once('connected', function () {
         var channel = realtime.channels.get(jwtTestChannelName);
-        whenPromiseSettles(channel.publish('greeting', 'Hello World!'), function (err) {
+        helper.whenPromiseSettles(channel.publish('greeting', 'Hello World!'), function (err) {
           try {
             expect(err.code).to.equal(40160, 'Verify publish denied code');
             expect(err.statusCode).to.equal(401, 'Verify publish denied status code');
@@ -1378,7 +1384,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('reauth_consistently_expired_token', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken({ ttl: 1 }), function (err, token) {
+      helper.whenPromiseSettles(rest.auth.requestToken({ ttl: 1 }), function (err, token) {
         if (err) {
           done(err);
           return;
@@ -1398,9 +1404,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             try {
               expect(authCallbackCallCount).to.equal(2);
               expect(realtime.connection.state).to.equal('disconnected');
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           }, 3000);
         }, 100);
@@ -1411,7 +1417,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('expired_token_no_autoremove_when_dont_have_servertime', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
+      helper.whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
         if (err) {
           done(err);
           return;
@@ -1427,9 +1433,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime.connection.on('connected', function () {
           try {
             expect(authCallbackCallCount).to.equal(1, 'Check we did not autoremove an expired token ourselves');
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
         });
       });
@@ -1439,7 +1445,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('expired_token_autoremove_when_have_servertime', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
+      helper.whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
         if (err) {
           done(err);
           return;
@@ -1453,7 +1459,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         };
         realtime = helper.AblyRealtime({ authCallback: authCallback, autoConnect: false });
         /* Set the server time offset */
-        whenPromiseSettles(realtime.time(), function () {
+        helper.whenPromiseSettles(realtime.time(), function () {
           realtime.connect();
           realtime.connection.on('connected', function () {
             try {
@@ -1461,9 +1467,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 2,
                 'Check we did autoremove the expired token ourselves, so authCallback is called a second time',
               );
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
         });
@@ -1481,37 +1487,40 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         defaultTokenParams: { capability: { wrong: ['*'] } },
       });
       realtime.connection.once('connected', function () {
-        whenPromiseSettles(realtime.auth.authorize({ capability: { stillWrong: ['*'] } }), function (err) {
+        helper.whenPromiseSettles(realtime.auth.authorize({ capability: { stillWrong: ['*'] } }), function (err) {
           try {
             expect(!err, 'Check first authorize cb was called').to.be.ok;
           } catch (err) {
             done(err);
           }
         });
-        whenPromiseSettles(realtime.auth.authorize({ capability: { alsoNope: ['*'] } }), function (err) {
+        helper.whenPromiseSettles(realtime.auth.authorize({ capability: { alsoNope: ['*'] } }), function (err) {
           try {
             expect(!err, 'Check second authorize cb was called').to.be.ok;
           } catch (err) {
             done(err);
           }
         });
-        whenPromiseSettles(realtime.auth.authorize({ capability: { wtfAreYouThinking: ['*'] } }), function (err) {
-          try {
-            expect(!err, 'Check third authorize one cb was called').to.be.ok;
-          } catch (err) {
-            done(err);
-          }
-        });
-        whenPromiseSettles(realtime.auth.authorize({ capability: { right: ['*'] } }), function (err) {
-          if (err) {
-            closeAndFinish(done, realtime, err);
-          }
-          whenPromiseSettles(realtime.channels.get('right').attach(), function (err) {
+        helper.whenPromiseSettles(
+          realtime.auth.authorize({ capability: { wtfAreYouThinking: ['*'] } }),
+          function (err) {
             try {
-              expect(!err, (err && displayError(err)) || 'Successfully attached').to.be.ok;
-              closeAndFinish(done, realtime);
+              expect(!err, 'Check third authorize one cb was called').to.be.ok;
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              done(err);
+            }
+          },
+        );
+        helper.whenPromiseSettles(realtime.auth.authorize({ capability: { right: ['*'] } }), function (err) {
+          if (err) {
+            helper.closeAndFinish(done, realtime, err);
+          }
+          helper.whenPromiseSettles(realtime.channels.get('right').attach(), function (err) {
+            try {
+              expect(!err, (err && helper.displayError(err)) || 'Successfully attached').to.be.ok;
+              helper.closeAndFinish(done, realtime);
+            } catch (err) {
+              helper.closeAndFinish(done, realtime, err);
             }
           });
         });
@@ -1519,7 +1528,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     });
 
     /** @nospec */
-    testOnAllTransports('authorize_immediately_after_init', function (realtimeOpts) {
+    helper.testOnAllTransports('authorize_immediately_after_init', function (realtimeOpts) {
       return function (done) {
         var realtime = helper.AblyRealtime({
           useTokenAuth: true,
@@ -1527,15 +1536,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         });
         realtime.auth.authorize({ capability: { right: ['*'] } });
         realtime.connection.once('disconnected', function () {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         });
         realtime.connection.once('connected', function () {
-          whenPromiseSettles(realtime.channels.get('right').attach(), function (err) {
+          helper.whenPromiseSettles(realtime.channels.get('right').attach(), function (err) {
             try {
-              expect(!err, (err && displayError(err)) || 'Successfully attached').to.be.ok;
-              closeAndFinish(done, realtime);
+              expect(!err, (err && helper.displayError(err)) || 'Successfully attached').to.be.ok;
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
         });

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var currentTime;
   var exampleTokenDetails;
   var exports = {};
@@ -29,6 +27,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -61,7 +60,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA8a
      */
     it('authbase0', function (done) {
-      var realtime = helper.AblyRealtime({ queryTime: true });
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ queryTime: true });
       Helper.whenPromiseSettles(realtime.auth.requestToken(), function (err, tokenDetails) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
@@ -87,7 +87,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSA8c - expect JSON TokenDetails
      */
     it('auth_useAuthUrl_json', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
@@ -117,7 +118,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSA8c - expect JSON TokenDetails from a POST request
      */
     it('auth_useAuthUrl_post_json', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
@@ -146,7 +148,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSA8g - test authURL returned ably token string
      */
     it('auth_useAuthUrl_plainText', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
@@ -175,7 +178,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial TO3j5 - can pass authCallback property
      */
     it('auth_useAuthCallback_tokenRequestResponse', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       var authCallback = function (tokenParams, callback) {
         Helper.whenPromiseSettles(rest.auth.createTokenRequest(tokenParams, null), function (err, tokenRequest) {
@@ -216,7 +220,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial TO3j5 - can pass authCallback property
      */
     it('auth_useAuthCallback_tokenDetailsResponse', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       var clientId = 'test clientid';
       var authCallback = function (tokenParams, callback) {
@@ -258,7 +263,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSA8g - authCallback returned ably token string
      */
     it('auth_useAuthCallback_tokenStringResponse', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       var authCallback = function (tokenParams, callback) {
         Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
@@ -298,7 +304,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA8c1c
      */
     it('auth_useAuthUrl_mixed_authParams_qsParams', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.createTokenRequest(null, null), function (err, tokenRequest) {
         if (err) {
@@ -336,7 +343,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA7b2
      */
     it('auth_clientid_inheritance', function (done) {
-      var rest = helper.AblyRest(),
+      var helper = this.test.helper,
+        rest = helper.AblyRest(),
         testClientId = 'testClientId';
       var authCallback = function (tokenParams, callback) {
         Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
@@ -376,7 +384,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA15c
      */
     it('auth_clientid_inheritance2', function (done) {
-      var clientRealtime,
+      var helper = this.test.helper,
+        clientRealtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
@@ -404,7 +413,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA15b
      */
     it('auth_clientid_inheritance3', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
@@ -434,7 +444,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA15b
      */
     it('auth_clientid_inheritance4', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
@@ -464,7 +475,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA7b3
      */
     it('auth_clientid_inheritance5', function (done) {
-      var clientRealtime,
+      var helper = this.test.helper,
+        clientRealtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
@@ -490,9 +502,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * RSA4c, RSA4e
      * Try to connect with an authCallback that fails in various ways (calling back with an error, calling back with nothing, timing out, etc) should go to disconnected, not failed, and wrapped in a 80019 error code
      */
-    function authCallback_failures(realtimeOptions, expectFailure) {
+    function authCallback_failures(createRealtimeOptions, expectFailure) {
       return function (done) {
-        var realtime = helper.AblyRealtime(realtimeOptions);
+        const helper = this.test.helper;
+        var realtime = helper.AblyRealtime(createRealtimeOptions(helper));
         realtime.connection.on(function (stateChange) {
           if (stateChange.previous !== 'initialized') {
             try {
@@ -526,11 +539,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authCallback_error',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authCallback: function (tokenParams, callback) {
           callback(new Error('An error from client code that the authCallback might return'));
         },
-      }),
+      })),
     );
 
     /**
@@ -540,12 +553,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authCallback_timeout',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authCallback: function () {
           /* (^._.^)ﾉ */
         },
         realtimeRequestTimeout: 100,
-      }),
+      })),
     );
 
     /**
@@ -555,11 +568,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authCallback_nothing',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authCallback: function (tokenParams, callback) {
           callback();
         },
-      }),
+      })),
     );
 
     /**
@@ -570,11 +583,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authCallback_malformed',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authCallback: function (tokenParams, callback) {
           callback(null, { horse: 'ebooks' });
         },
-      }),
+      })),
     );
 
     /**
@@ -585,7 +598,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authCallback_too_long_string',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authCallback: function (tokenParams, callback) {
           var token = '';
           for (var i = 0; i < Math.pow(2, 17) + 1; i++) {
@@ -593,7 +606,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           }
           callback(null, token);
         },
-      }),
+      })),
     );
 
     /**
@@ -603,11 +616,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authCallback_empty_string',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authCallback: function (tokenParams, callback) {
           callback(null, '');
         },
-      }),
+      })),
     );
 
     /**
@@ -617,10 +630,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authUrl_timeout',
-      authCallback_failures({
+      authCallback_failures((helper) => ({
         authUrl: helper.unroutableAddress,
         realtimeRequestTimeout: 100,
-      }),
+      })),
     );
 
     /**
@@ -630,9 +643,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authUrl_404',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authUrl: 'http://example.com/404',
-      }),
+      })),
     );
 
     /**
@@ -643,9 +656,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authUrl_wrong_content_type',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authUrl: 'http://example.com/',
-      }),
+      })),
     );
 
     /**
@@ -655,9 +668,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authUrl_401',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authUrl: echoServer + '/respondwith?status=401',
-      }),
+      })),
     );
 
     /**
@@ -667,10 +680,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it(
       'authUrl_double_encoded',
-      authCallback_failures({
+      authCallback_failures(() => ({
         authUrl:
           echoServer + '/?type=json&body=' + encodeURIComponent(JSON.stringify(JSON.stringify({ keyName: 'foo.bar' }))),
-      }),
+      })),
     );
 
     /**
@@ -681,9 +694,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     it(
       'authUrl_403',
       authCallback_failures(
-        {
+        () => ({
           authUrl: echoServer + '/respondwith?status=403',
-        },
+        }),
         true,
       ),
     ); /* expectFailed: */
@@ -696,12 +709,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     it(
       'authUrl_403_custom_error',
       authCallback_failures(
-        {
+        () => ({
           authUrl:
             echoServer +
             '/?status=403&type=json&body=' +
             encodeURIComponent(JSON.stringify({ error: { some_custom: 'error' } })),
-        },
+        }),
         true,
       ),
     );
@@ -711,7 +724,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSA4d1 - explicit authorize() call
      */
     it('authUrl_403_previously_active', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
@@ -756,7 +770,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('auth_token_expires', function (realtimeOpts) {
       return function (done) {
-        var clientRealtime,
+        var helper = this.test.helper,
+          clientRealtime,
           rest = helper.AblyRest();
 
         Helper.whenPromiseSettles(rest.auth.requestToken({ ttl: 5000 }, null), function (err, tokenDetails) {
@@ -796,7 +811,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec TO3j10
      */
     it('auth_query_time_once', function (done) {
-      var rest = helper.AblyRest({ queryTime: true }),
+      var helper = this.test.helper,
+        rest = helper.AblyRest({ queryTime: true }),
         timeRequestCount = 0,
         originalTime = rest.time;
 
@@ -857,7 +873,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
-        var realtime,
+        var helper = this.test.helper,
+          realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
         var authCallback = function (tokenParams, callback) {
@@ -904,7 +921,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
-        var realtime,
+        var helper = this.test.helper,
+          realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
         var authCallback = function (tokenParams, callback) {
@@ -949,7 +967,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('auth_token_string_expiry_with_token', function (realtimeOpts) {
       return function (done) {
-        var realtime,
+        var helper = this.test.helper,
+          realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
         Helper.whenPromiseSettles(
@@ -995,7 +1014,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('auth_expired_token_string', function (realtimeOpts) {
       return function (done) {
-        var realtime,
+        var helper = this.test.helper,
+          realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
         Helper.whenPromiseSettles(
@@ -1043,7 +1063,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports.skip('reauth_authCallback', function (realtimeOpts) {
       return function (done) {
-        var realtime,
+        var helper = this.test.helper,
+          realtime,
           rest = helper.AblyRest();
         var firstTime = true;
         var authCallback = function (tokenParams, callback) {
@@ -1096,12 +1117,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RSA10j */
     it('authorize_updates_stored_details', function (done) {
-      var realtime = helper.AblyRealtime({
-        autoConnect: false,
-        defaultTokenParams: { version: 1 },
-        token: '1',
-        authUrl: '1',
-      });
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({
+          autoConnect: false,
+          defaultTokenParams: { version: 1 },
+          token: '1',
+          authUrl: '1',
+        });
 
       try {
         expect(realtime.auth.tokenParams.version).to.equal(1, 'Check initial defaultTokenParams stored');
@@ -1129,7 +1151,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTN22
      */
     it('mocked_reauth', function (done) {
-      var rest = helper.AblyRest(),
+      var helper = this.test.helper,
+        rest = helper.AblyRest(),
         authCallback = function (tokenParams, callback) {
           // Request a token (should happen twice)
           Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
@@ -1171,6 +1194,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSA8g - authCallback returned JWT token string
      */
     it('auth_jwt_with_clientid', function (done) {
+      const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[0];
       var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
       var clientId = 'testJWTClientId';
@@ -1209,6 +1233,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSA8g - authCallback returned JWT token string
      */
     it('auth_jwt_with_clientid_application_jwt', function (done) {
+      const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[0];
       var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret, returnType: 'jwt' };
       var clientId = 'testJWTClientId';
@@ -1244,6 +1269,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('auth_jwt_with_subscribe_only_capability', function (done) {
+      const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[3]; // get subscribe-only keys { "*":["subscribe"] }
       var params = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
       var authCallback = function (tokenParams, callback) {
@@ -1273,6 +1299,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('auth_jwt_with_publish_capability', function (done) {
+      const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[0];
       var params = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
       var authCallback = function (tokenParams, callback) {
@@ -1304,6 +1331,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA4b
      */
     it('auth_jwt_with_token_that_expires', function (done) {
+      const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[0];
       var params = { keyName: currentKey.keyName, keySecret: currentKey.keySecret, expiresIn: 5 };
       var authCallback = function (tokenParams, callback) {
@@ -1332,6 +1360,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
     it('auth_jwt_with_token_that_renews', function (done) {
+      const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[0];
       // Sandbox sends an auth protocol message 30 seconds before a token expires.
       // We create a token that lasts 35 so there's room to receive the update event message.
@@ -1362,6 +1391,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec TN3
      */
     it('init_client_with_simple_jwt_token', function (done) {
+      const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[0];
       var params = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
       getJWT(params, function (err, token) {
@@ -1384,7 +1414,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTN14b */
     it('reauth_consistently_expired_token', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken({ ttl: 1 }), function (err, token) {
         if (err) {
@@ -1417,7 +1448,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @specpartial RSA4b1 - only autoremove expired tokens if have a server time offset set */
     it('expired_token_no_autoremove_when_dont_have_servertime', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
         if (err) {
@@ -1445,7 +1477,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @specpartial RSA4b1 - second case */
     it('expired_token_autoremove_when_have_servertime', function (done) {
-      var realtime,
+      var helper = this.test.helper,
+        realtime,
         rest = helper.AblyRest();
       Helper.whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
         if (err) {
@@ -1484,6 +1517,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('multiple_concurrent_authorize', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime({
         useTokenAuth: true,
         defaultTokenParams: { capability: { wrong: ['*'] } },
@@ -1532,6 +1566,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     /** @nospec */
     Helper.testOnAllTransports('authorize_immediately_after_init', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var realtime = helper.AblyRealtime({
           useTokenAuth: true,
           defaultTokenParams: { capability: { wrong: ['*'] } },

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var currentTime;
   var exampleTokenDetails;
   var exports = {};
@@ -15,7 +17,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
    */
   function getJWT(params, callback) {
     var authUrl = echoServer + '/createJWT';
-    helper.whenPromiseSettles(http.doUri('get', authUrl, null, null, params), function (err, result) {
+    Helper.whenPromiseSettles(http.doUri('get', authUrl, null, null, params), function (err, result) {
       if (result.error) {
         callback(result.error, null);
       }
@@ -34,13 +36,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         }
 
         var rest = helper.AblyRest({ queryTime: true });
-        helper.whenPromiseSettles(rest.time(), function (err, time) {
+        Helper.whenPromiseSettles(rest.time(), function (err, time) {
           if (err) {
             done(err);
             return;
           } else {
             currentTime = time;
-            helper.whenPromiseSettles(rest.auth.requestToken({}), function (err, tokenDetails) {
+            Helper.whenPromiseSettles(rest.auth.requestToken({}), function (err, tokenDetails) {
               try {
                 expect(!err, err && helper.displayError(err)).to.be.ok;
                 done();
@@ -60,7 +62,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      */
     it('authbase0', function (done) {
       var realtime = helper.AblyRealtime({ queryTime: true });
-      helper.whenPromiseSettles(realtime.auth.requestToken(), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(realtime.auth.requestToken(), function (err, tokenDetails) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -87,7 +89,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('auth_useAuthUrl_json', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -117,7 +119,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('auth_useAuthUrl_post_json', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -146,7 +148,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('auth_useAuthUrl_plainText', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -176,7 +178,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime,
         rest = helper.AblyRest();
       var authCallback = function (tokenParams, callback) {
-        helper.whenPromiseSettles(rest.auth.createTokenRequest(tokenParams, null), function (err, tokenRequest) {
+        Helper.whenPromiseSettles(rest.auth.createTokenRequest(tokenParams, null), function (err, tokenRequest) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -218,7 +220,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         rest = helper.AblyRest();
       var clientId = 'test clientid';
       var authCallback = function (tokenParams, callback) {
-        helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+        Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -259,7 +261,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime,
         rest = helper.AblyRest();
       var authCallback = function (tokenParams, callback) {
-        helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+        Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -298,7 +300,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('auth_useAuthUrl_mixed_authParams_qsParams', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.createTokenRequest(null, null), function (err, tokenRequest) {
+      Helper.whenPromiseSettles(rest.auth.createTokenRequest(null, null), function (err, tokenRequest) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -337,7 +339,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var rest = helper.AblyRest(),
         testClientId = 'testClientId';
       var authCallback = function (tokenParams, callback) {
-        helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+        Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
           if (err) {
             done(err);
             return;
@@ -377,7 +379,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var clientRealtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
         if (err) {
           done(err);
           return;
@@ -405,7 +407,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
         if (err) {
           done(err);
           return;
@@ -435,7 +437,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: '*' }), function (err, tokenDetails) {
         if (err) {
           done(err);
           return;
@@ -465,7 +467,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var clientRealtime,
         testClientId = 'test client id';
       var rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
         if (err) {
           done(err);
           return;
@@ -711,7 +713,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('authUrl_403_previously_active', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
+      Helper.whenPromiseSettles(rest.auth.requestToken(null, null), function (err, tokenDetails) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -723,7 +725,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         realtime.connection.on('connected', function () {
           /* replace the authUrl and reauth */
-          helper.whenPromiseSettles(
+          Helper.whenPromiseSettles(
             realtime.auth.authorize(null, { authUrl: echoServer + '/respondwith?status=403' }),
             function (err, tokenDetails) {
               try {
@@ -752,12 +754,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RSA4b1
      * @specpartial RSA4b - token expired
      */
-    helper.testOnAllTransports('auth_token_expires', function (realtimeOpts) {
+    Helper.testOnAllTransports('auth_token_expires', function (realtimeOpts) {
       return function (done) {
         var clientRealtime,
           rest = helper.AblyRest();
 
-        helper.whenPromiseSettles(rest.auth.requestToken({ ttl: 5000 }, null), function (err, tokenDetails) {
+        Helper.whenPromiseSettles(rest.auth.requestToken({ ttl: 5000 }, null), function (err, tokenDetails) {
           if (err) {
             done(err);
             return;
@@ -817,7 +819,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var asyncFns = [];
       for (var i = 0; i < 10; i++) {
         asyncFns.push(function (callback) {
-          helper.whenPromiseSettles(rest.auth.createTokenRequest({}, null), function (err, tokenDetails) {
+          Helper.whenPromiseSettles(rest.auth.createTokenRequest({}, null), function (err, tokenDetails) {
             if (err) {
               return callback(err);
             }
@@ -853,14 +855,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RTN15a - attempt to reconnect and restore the connection state on token expire
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
-    helper.testOnAllTransports('auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
+    Helper.testOnAllTransports('auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
         var authCallback = function (tokenParams, callback) {
           tokenParams.ttl = 5000;
-          helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+          Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -900,14 +902,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RTN15a - attempt to reconnect and restore the connection state on token expire
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
-    helper.testOnAllTransports('auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
+    Helper.testOnAllTransports('auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
         var authCallback = function (tokenParams, callback) {
           tokenParams.ttl = 5000;
-          helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+          Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -945,12 +947,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RSA4a
      * @spec RSA4a2
      */
-    helper.testOnAllTransports('auth_token_string_expiry_with_token', function (realtimeOpts) {
+    Helper.testOnAllTransports('auth_token_string_expiry_with_token', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           rest.auth.requestToken({ ttl: 5000, clientId: clientId }, null),
           function (err, tokenDetails) {
             if (err) {
@@ -991,12 +993,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RSA4a
      * @spec RSA4a2
      */
-    helper.testOnAllTransports('auth_expired_token_string', function (realtimeOpts) {
+    Helper.testOnAllTransports('auth_expired_token_string', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
         var clientId = 'test clientid';
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           rest.auth.requestToken({ ttl: 1, clientId: clientId }, null),
           function (err, tokenDetails) {
             if (err) {
@@ -1039,7 +1041,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTC8
      * @specskip
      */
-    helper.testOnAllTransports.skip('reauth_authCallback', function (realtimeOpts) {
+    Helper.testOnAllTransports.skip('reauth_authCallback', function (realtimeOpts) {
       return function (done) {
         var realtime,
           rest = helper.AblyRest();
@@ -1048,7 +1050,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           tokenParams.clientId = '*';
           tokenParams.capability = firstTime ? { wrong: ['*'] } : { right: ['*'] };
           firstTime = false;
-          helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+          Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -1060,7 +1062,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime = helper.AblyRealtime(helper.Utils.mixin(realtimeOpts, { authCallback: authCallback }));
         realtime.connection.once('connected', function () {
           var channel = realtime.channels.get('right');
-          helper.whenPromiseSettles(channel.attach(), function (err) {
+          Helper.whenPromiseSettles(channel.attach(), function (err) {
             try {
               expect(err, 'Check using first token, without channel attach capability').to.be.ok;
               expect(err.code).to.equal(40160, 'Check expected error code');
@@ -1070,14 +1072,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             }
 
             /* soon after connected, reauth */
-            helper.whenPromiseSettles(realtime.auth.authorize(null, null), function (err) {
+            Helper.whenPromiseSettles(realtime.auth.authorize(null, null), function (err) {
               try {
                 expect(!err, err && helper.displayError(err)).to.be.ok;
               } catch (err) {
                 done(err);
                 return;
               }
-              helper.whenPromiseSettles(channel.attach(), function (err) {
+              Helper.whenPromiseSettles(channel.attach(), function (err) {
                 try {
                   expect(!err, 'Check using second token, with channel attach capability').to.be.ok;
                   helper.closeAndFinish(done, realtime);
@@ -1130,7 +1132,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var rest = helper.AblyRest(),
         authCallback = function (tokenParams, callback) {
           // Request a token (should happen twice)
-          helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
+          Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, tokenDetails) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -1251,7 +1253,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime = helper.AblyRealtime({ authCallback: authCallback });
       realtime.connection.once('connected', function () {
         var channel = realtime.channels.get(jwtTestChannelName);
-        helper.whenPromiseSettles(channel.publish('greeting', 'Hello World!'), function (err) {
+        Helper.whenPromiseSettles(channel.publish('greeting', 'Hello World!'), function (err) {
           try {
             expect(err.code).to.equal(40160, 'Verify publish denied code');
             expect(err.statusCode).to.equal(401, 'Verify publish denied status code');
@@ -1384,7 +1386,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('reauth_consistently_expired_token', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken({ ttl: 1 }), function (err, token) {
+      Helper.whenPromiseSettles(rest.auth.requestToken({ ttl: 1 }), function (err, token) {
         if (err) {
           done(err);
           return;
@@ -1417,7 +1419,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('expired_token_no_autoremove_when_dont_have_servertime', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
+      Helper.whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
         if (err) {
           done(err);
           return;
@@ -1445,7 +1447,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('expired_token_autoremove_when_have_servertime', function (done) {
       var realtime,
         rest = helper.AblyRest();
-      helper.whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
+      Helper.whenPromiseSettles(rest.auth.requestToken(), function (err, token) {
         if (err) {
           done(err);
           return;
@@ -1459,7 +1461,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         };
         realtime = helper.AblyRealtime({ authCallback: authCallback, autoConnect: false });
         /* Set the server time offset */
-        helper.whenPromiseSettles(realtime.time(), function () {
+        Helper.whenPromiseSettles(realtime.time(), function () {
           realtime.connect();
           realtime.connection.on('connected', function () {
             try {
@@ -1487,21 +1489,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         defaultTokenParams: { capability: { wrong: ['*'] } },
       });
       realtime.connection.once('connected', function () {
-        helper.whenPromiseSettles(realtime.auth.authorize({ capability: { stillWrong: ['*'] } }), function (err) {
+        Helper.whenPromiseSettles(realtime.auth.authorize({ capability: { stillWrong: ['*'] } }), function (err) {
           try {
             expect(!err, 'Check first authorize cb was called').to.be.ok;
           } catch (err) {
             done(err);
           }
         });
-        helper.whenPromiseSettles(realtime.auth.authorize({ capability: { alsoNope: ['*'] } }), function (err) {
+        Helper.whenPromiseSettles(realtime.auth.authorize({ capability: { alsoNope: ['*'] } }), function (err) {
           try {
             expect(!err, 'Check second authorize cb was called').to.be.ok;
           } catch (err) {
             done(err);
           }
         });
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           realtime.auth.authorize({ capability: { wtfAreYouThinking: ['*'] } }),
           function (err) {
             try {
@@ -1511,11 +1513,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             }
           },
         );
-        helper.whenPromiseSettles(realtime.auth.authorize({ capability: { right: ['*'] } }), function (err) {
+        Helper.whenPromiseSettles(realtime.auth.authorize({ capability: { right: ['*'] } }), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
           }
-          helper.whenPromiseSettles(realtime.channels.get('right').attach(), function (err) {
+          Helper.whenPromiseSettles(realtime.channels.get('right').attach(), function (err) {
             try {
               expect(!err, (err && helper.displayError(err)) || 'Successfully attached').to.be.ok;
               helper.closeAndFinish(done, realtime);
@@ -1528,7 +1530,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     });
 
     /** @nospec */
-    helper.testOnAllTransports('authorize_immediately_after_init', function (realtimeOpts) {
+    Helper.testOnAllTransports('authorize_immediately_after_init', function (realtimeOpts) {
       return function (done) {
         var realtime = helper.AblyRealtime({
           useTokenAuth: true,
@@ -1539,7 +1541,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           helper.closeAndFinish(done, realtime, err);
         });
         realtime.connection.once('connected', function () {
-          helper.whenPromiseSettles(realtime.channels.get('right').attach(), function (err) {
+          Helper.whenPromiseSettles(realtime.channels.get('right').attach(), function (err) {
             try {
               expect(!err, (err && helper.displayError(err)) || 'Successfully attached').to.be.ok;
               helper.closeAndFinish(done, realtime);

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -170,7 +170,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTS3c
      * @spec RTL16
      */
-    Helper.testOnAllTransports('channelinit0', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'channelinit0', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -207,7 +207,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL4
      */
-    Helper.testOnAllTransports('channelattach0', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'channelattach0', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -234,7 +234,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL4
      */
-    Helper.testOnAllTransports('channelattach2', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'channelattach2', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -262,6 +262,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL5
      */
     Helper.testOnAllTransports(
+      this,
       'channelattach3',
       function (realtimeOpts) {
         return function (done) {
@@ -301,7 +302,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL4d
      */
-    Helper.testOnAllTransports('channelattachempty', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'channelattachempty', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -336,7 +337,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL4d
      */
-    Helper.testOnAllTransports('channelattachinvalid', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'channelattachinvalid', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -377,7 +378,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL6
      */
-    Helper.testOnAllTransports('publish_no_attach', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'publish_no_attach', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -407,7 +408,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @specpartial RTL6b - callback which is called with an error
      */
-    Helper.testOnAllTransports('channelattach_publish_invalid', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'channelattach_publish_invalid', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -441,7 +442,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @nospec
      */
-    Helper.testOnAllTransports('channelattach_invalid_twice', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'channelattach_invalid_twice', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -536,7 +537,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4k1
      * @spec RTL4m
      */
-    Helper.testOnAllTransports('attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelParamsBasicChannelsGet';
@@ -598,7 +599,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4m
      * @spec RTL16
      */
-    Helper.testOnAllTransports('attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelParamsBasicSetOptions';
@@ -652,7 +653,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL16
      * @spec RTL7c
      */
-    Helper.testOnAllTransports('subscribeAfterSetOptions', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'subscribeAfterSetOptions', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'subscribeAfterSetOptions';
@@ -728,7 +729,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /** @spec RTL16a */
-    Helper.testOnAllTransports('setOptionsCallbackBehaviour', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'setOptionsCallbackBehaviour', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'setOptionsCallbackBehaviour';
@@ -807,7 +808,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * Verify modes is ignored when params.modes is present
      * @nospec
      */
-    Helper.testOnAllTransports('attachWithChannelParamsModesAndChannelModes', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'attachWithChannelParamsModesAndChannelModes', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelParamsModesAndChannelModes';
@@ -869,7 +870,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4l
      * @spec RTL4m
      */
-    Helper.testOnAllTransports('attachWithChannelModes', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'attachWithChannelModes', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelModes';
@@ -928,7 +929,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4l
      * @spec RTL4m
      */
-    Helper.testOnAllTransports('attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelParamsDeltaAndModes';

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var exports = {};
   var _exports = {};
   var expect = chai.expect;
@@ -154,6 +152,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -173,6 +172,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('channelinit0', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.on('connected', function () {
@@ -209,6 +209,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('channelattach0', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.on('connected', function () {
@@ -235,6 +236,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('channelattach2', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           var channel2 = realtime.channels.get('channelattach2');
@@ -263,6 +265,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       'channelattach3',
       function (realtimeOpts) {
         return function (done) {
+          const helper = this.test.helper;
           try {
             var realtime = helper.AblyRealtime(realtimeOpts);
             realtime.connection.on('connected', function () {
@@ -300,6 +303,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('channelattachempty', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
@@ -334,6 +338,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('channelattachinvalid', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
@@ -374,6 +379,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('publish_no_attach', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
@@ -403,6 +409,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('channelattach_publish_invalid', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
@@ -436,6 +443,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('channelattach_invalid_twice', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
@@ -475,6 +483,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('channelattachWhenState', function (done) {
+      const helper = this.test.helper;
       try {
         var realtime = helper.AblyRealtime(),
           channel = realtime.channels.get('channelattachWhenState');
@@ -496,6 +505,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL25b
      */
     it('channelattachOnceOrIfBefore', function (done) {
+      const helper = this.test.helper;
       try {
         var realtime = helper.AblyRealtime(),
           channel = realtime.channels.get('channelattachOnceOrIf'),
@@ -528,6 +538,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var testName = 'attachWithChannelParamsBasicChannelsGet';
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -589,6 +600,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var testName = 'attachWithChannelParamsBasicSetOptions';
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -642,6 +654,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('subscribeAfterSetOptions', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var testName = 'subscribeAfterSetOptions';
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -672,6 +685,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTS3c1 */
     it('channelGetShouldThrowWhenWouldCauseReattach', function (done) {
+      const helper = this.test.helper;
       var testName = 'channelGetShouldThrowWhenWouldCauseReattach';
       try {
         var realtime = helper.AblyRealtime();
@@ -716,6 +730,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     /** @spec RTL16a */
     Helper.testOnAllTransports('setOptionsCallbackBehaviour', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var testName = 'setOptionsCallbackBehaviour';
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -794,6 +809,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('attachWithChannelParamsModesAndChannelModes', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var testName = 'attachWithChannelParamsModesAndChannelModes';
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -855,6 +871,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('attachWithChannelModes', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var testName = 'attachWithChannelModes';
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -913,6 +930,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var testName = 'attachWithChannelParamsDeltaAndModes';
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -968,6 +986,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4k1
      */
     it('attachWithInvalidChannelParams', function (done) {
+      const helper = this.test.helper;
       var testName = 'attachWithInvalidChannelParams';
       var defaultChannelModes = 'presence,publish,subscribe,presence_subscribe';
       try {
@@ -1081,6 +1100,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it('channelsubscribe0', function (done) {
       try {
+        const helper = this.test.helper;
         var realtime = helper.AblyRealtime({ useBinaryProtocol: true });
         realtime.connection.on('connected', function () {
           var channel6 = realtime.channels.get('channelsubscribe0');
@@ -1120,6 +1140,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL8b
      */
     it('channelsubscribe1', function (done) {
+      const helper = this.test.helper;
       var messagesReceived = 0;
 
       try {
@@ -1200,7 +1221,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL13
      */
     it('server_sent_detached', function (done) {
-      var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
         channelName = 'server_sent_detached',
         channel = realtime.channels.get(channelName);
 
@@ -1253,7 +1275,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTL13b - tests transition to the SUSPENDED state with emitted error
      */
     it('server_sent_detached_while_attaching', function (done) {
-      var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
         channelName = 'server_sent_detached_while_attaching',
         channel = realtime.channels.get(channelName);
 
@@ -1295,7 +1318,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTL14 - tests transition to the FAILED state
      */
     it('server_sent_error', function (done) {
-      var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
         channelName = 'server_sent_error',
         channel = realtime.channels.get(channelName);
 
@@ -1334,7 +1358,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL12
      */
     it('server_sent_attached_err', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         channelName = 'server_sent_attached_err',
         channel = realtime.channels.get(channelName);
 
@@ -1380,7 +1405,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec TO3g
      */
     it('publish_no_queueing', function (done) {
-      var realtime = helper.AblyRealtime({ queueMessages: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ queueMessages: false }),
         channel = realtime.channels.get('publish_no_queueing');
 
       /* try a publish while not yet connected */
@@ -1402,7 +1428,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it('channel_attach_timeout', function (done) {
       /* Use a fixed transport as attaches are resent when the transport changes */
-      var realtime = helper.AblyRealtime({
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({
           transports: [helper.bestTransport],
           realtimeRequestTimeout: 2000,
           channelRetryTimeout: 100,
@@ -1453,7 +1480,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     it('suspended_connection', function (done) {
       /* Use a fixed transport as attaches are resent when the transport changes */
       /* Browsers throttle setTimeouts to min 1s in in active tabs; having timeouts less than that screws with the relative timings */
-      var realtime = helper.AblyRealtime({
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({
           transports: [helper.bestTransport],
           channelRetryTimeout: 1010,
           suspendedRetryTimeout: 1100,
@@ -1521,7 +1549,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTL5i */
     it('attached_while_detaching', function (done) {
-      var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
         channelName = 'server_sent_detached',
         channel = realtime.channels.get(channelName);
 
@@ -1563,6 +1592,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTL5j */
     it('detaching from suspended channel transitions channel to detached state', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] });
       var channelName = 'detach_from_suspended';
       var channel = realtime.channels.get(channelName);
@@ -1584,6 +1614,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTL5b */
     it('detaching from failed channel results in error', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] });
       var channelName = 'detach_from_failed';
       var channel = realtime.channels.get(channelName);
@@ -1601,6 +1632,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @nospec */
     it('rewind works on channel after reattaching', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] });
       var channelName = 'rewind_after_detach';
       var channel = realtime.channels.get(channelName);
@@ -1629,6 +1661,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTL4d1 */
     it('attach_returns_state_change', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime();
       var channelName = 'attach_returns_state_chnage';
       var channel = realtime.channels.get(channelName);
@@ -1666,6 +1699,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTL7c */
     it('subscribe_returns_state_change', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime();
       var channelName = 'subscribe_returns_state_chnage';
       var channel = realtime.channels.get(channelName);
@@ -1693,6 +1727,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @specpartial RTL2i - hasBacklog is false with no backlog */
     it('rewind_has_backlog_0', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime();
       var channelName = 'rewind_has_backlog_0';
       var channelOpts = { params: { rewind: '1' } };
@@ -1717,6 +1752,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @specpartial RTL2i - hasBacklog is true with backlog */
     it('rewind_has_backlog_1', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime();
       var rest = helper.AblyRest();
       var channelName = 'rewind_has_backlog_1';
@@ -1749,6 +1785,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTS3c1 - test .get() with same options should not trigger reattachment and exception */
     it('should not throw exception then run RealtimeChannels.get() with same options', function (done) {
+      const helper = this.test.helper;
       const realtime = helper.AblyRealtime();
       const channel = realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
       channel.attach();
@@ -1766,7 +1803,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL25a
      * @spec RTL25b
      */
-    it('whenState', async () => {
+    it('whenState', async function () {
+      const helper = this.test.helper;
       const realtime = helper.AblyRealtime();
 
       await helper.monitorConnectionAsync(async () => {

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -4,21 +4,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
   var exports = {};
   var _exports = {};
   var expect = chai.expect;
-  var displayError = helper.displayError;
-  var closeAndFinish = helper.closeAndFinish;
-  var closeAndFinishAsync = helper.closeAndFinishAsync;
-  var monitorConnection = helper.monitorConnection;
-  var monitorConnectionAsync = helper.monitorConnectionAsync;
   var createPM = Ably.protocolMessageFromDeserialized;
-  var testOnAllTransports = helper.testOnAllTransports;
-  var whenPromiseSettles = helper.whenPromiseSettles;
-  var randomString = helper.randomString;
 
   function checkCanSubscribe(channel, testChannel) {
     return function (callback) {
       var timeout,
         received = false,
-        eventName = randomString();
+        eventName = helper.randomString();
 
       channel.subscribe(eventName, function (msg) {
         channel.unsubscribe(eventName);
@@ -27,7 +19,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         callback();
       });
 
-      whenPromiseSettles(testChannel.publish(eventName, null), function (err) {
+      helper.whenPromiseSettles(testChannel.publish(eventName, null), function (err) {
         if (received) return;
         if (err) callback(err);
         timeout = setTimeout(function () {
@@ -42,7 +34,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     return function (callback) {
       var timeout,
         received = false,
-        eventName = randomString();
+        eventName = helper.randomString();
 
       channel.subscribe(eventName, function (message) {
         channel.presence.unsubscribe(eventName);
@@ -51,7 +43,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         callback('checkCantSubscribe: unexpectedly received message');
       });
 
-      whenPromiseSettles(testChannel.publish(eventName, null), function (err) {
+      helper.whenPromiseSettles(testChannel.publish(eventName, null), function (err) {
         if (received) return;
         if (err) callback(err);
         timeout = setTimeout(function () {
@@ -64,13 +56,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
   function checkCanPublish(channel) {
     return function (callback) {
-      whenPromiseSettles(channel.publish(null, null), callback);
+      helper.whenPromiseSettles(channel.publish(null, null), callback);
     };
   }
 
   function checkCantPublish(channel) {
     return function (callback) {
-      whenPromiseSettles(channel.publish(null, null), function (err) {
+      helper.whenPromiseSettles(channel.publish(null, null), function (err) {
         if (err && err.code === 40160) {
           callback();
         } else {
@@ -82,8 +74,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
   function checkCanEnterPresence(channel) {
     return function (callback) {
-      var clientId = randomString();
-      whenPromiseSettles(channel.presence.enterClient(clientId, null), function (err) {
+      var clientId = helper.randomString();
+      helper.whenPromiseSettles(channel.presence.enterClient(clientId, null), function (err) {
         channel.presence.leaveClient(clientId);
         callback(err);
       });
@@ -92,7 +84,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
   function checkCantEnterPresence(channel) {
     return function (callback) {
-      whenPromiseSettles(channel.presence.enterClient(randomString(), null), function (err) {
+      helper.whenPromiseSettles(channel.presence.enterClient(helper.randomString(), null), function (err) {
         if (err && err.code === 40160) {
           callback();
         } else {
@@ -106,7 +98,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     return function (callback) {
       var timeout,
         received = false,
-        clientId = randomString();
+        clientId = helper.randomString();
 
       channel.presence.subscribe('enter', function (message) {
         channel.presence.unsubscribe('enter');
@@ -116,7 +108,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         callback();
       });
 
-      whenPromiseSettles(testChannel.presence.enterClient(clientId, null), function (err) {
+      helper.whenPromiseSettles(testChannel.presence.enterClient(clientId, null), function (err) {
         if (received) return;
         if (err) callback(err);
         timeout = setTimeout(function () {
@@ -132,7 +124,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     return function (callback) {
       var timeout,
         received = false,
-        clientId = randomString();
+        clientId = helper.randomString();
 
       channel.presence.subscribe('enter', function (message) {
         channel.presence.unsubscribe('enter');
@@ -142,7 +134,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         callback('checkCantPresenceSubscribe: unexpectedly received message');
       });
 
-      whenPromiseSettles(testChannel.presence.enterClient(clientId, null), function (err) {
+      helper.whenPromiseSettles(testChannel.presence.enterClient(clientId, null), function (err) {
         if (received) return;
         if (err) callback(err);
         timeout = setTimeout(function () {
@@ -177,7 +169,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTS3c
      * @spec RTL16
      */
-    testOnAllTransports('channelinit0', function (realtimeOpts) {
+    helper.testOnAllTransports('channelinit0', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -195,14 +187,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               /* set options with setOptions */
               channel1.setOptions({ fakeOption: true });
               expect(channel1.channelOptions.fakeOption).to.equal(true);
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -213,22 +205,22 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL4
      */
-    testOnAllTransports('channelattach0', function (realtimeOpts) {
+    helper.testOnAllTransports('channelattach0', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.on('connected', function () {
             var channel0 = realtime.channels.get('channelattach0');
-            whenPromiseSettles(channel0.attach(), function (err) {
+            helper.whenPromiseSettles(channel0.attach(), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
               }
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -239,21 +231,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL4
      */
-    testOnAllTransports('channelattach2', function (realtimeOpts) {
+    helper.testOnAllTransports('channelattach2', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           var channel2 = realtime.channels.get('channelattach2');
-          whenPromiseSettles(channel2.attach(), function (err) {
+          helper.whenPromiseSettles(channel2.attach(), function (err) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -265,7 +257,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4
      * @spec RTL5
      */
-    testOnAllTransports(
+    helper.testOnAllTransports(
       'channelattach3',
       function (realtimeOpts) {
         return function (done) {
@@ -273,25 +265,25 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             var realtime = helper.AblyRealtime(realtimeOpts);
             realtime.connection.on('connected', function () {
               var channel0 = realtime.channels.get('channelattach3');
-              whenPromiseSettles(channel0.attach(), function (err) {
+              helper.whenPromiseSettles(channel0.attach(), function (err) {
                 if (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                 }
-                whenPromiseSettles(channel0.detach(), function (err) {
+                helper.whenPromiseSettles(channel0.detach(), function (err) {
                   if (err) {
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   }
                   if (channel0.state == 'detached') {
-                    closeAndFinish(done, realtime);
+                    helper.closeAndFinish(done, realtime);
                   } else {
-                    closeAndFinish(done, realtime, new Error('Detach failed: State is ' + channel0.state));
+                    helper.closeAndFinish(done, realtime, new Error('Detach failed: State is ' + channel0.state));
                   }
                 });
               });
             });
-            monitorConnection(done, realtime);
+            helper.monitorConnection(done, realtime);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
         };
       },
@@ -304,30 +296,30 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL4d
      */
-    testOnAllTransports('channelattachempty', function (realtimeOpts) {
+    helper.testOnAllTransports('channelattachempty', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
             var channel0 = realtime.channels.get('');
-            whenPromiseSettles(channel0.attach(), function (err) {
+            helper.whenPromiseSettles(channel0.attach(), function (err) {
               if (err) {
                 setTimeout(function () {
                   try {
                     expect(realtime.connection.state === 'connected', 'Client should still be connected').to.be.ok;
-                    closeAndFinish(done, realtime);
+                    helper.closeAndFinish(done, realtime);
                   } catch (err) {
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   }
                 }, 1000);
                 return;
               }
-              closeAndFinish(done, realtime, new Error('Unexpected attach success'));
+              helper.closeAndFinish(done, realtime, new Error('Unexpected attach success'));
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -338,37 +330,37 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL4d
      */
-    testOnAllTransports('channelattachinvalid', function (realtimeOpts) {
+    helper.testOnAllTransports('channelattachinvalid', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
             var channel = realtime.channels.get(':hell');
-            whenPromiseSettles(channel.attach(), function (err) {
+            helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
                 try {
                   expect(channel.errorReason.code).to.equal(40010, 'Attach error was set as the channel errorReason');
                   expect(err.code).to.equal(40010, 'Attach error was passed to the attach callback');
                 } catch (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                   return;
                 }
                 setTimeout(function () {
                   try {
                     expect(realtime.connection.state === 'connected', 'Client should still be connected').to.be.ok;
-                    closeAndFinish(done, realtime);
+                    helper.closeAndFinish(done, realtime);
                   } catch (err) {
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   }
                 }, 1000);
                 return;
               }
-              closeAndFinish(done, realtime, 'Unexpected attach success');
+              helper.closeAndFinish(done, realtime, 'Unexpected attach success');
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -378,22 +370,26 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL6
      */
-    testOnAllTransports('publish_no_attach', function (realtimeOpts) {
+    helper.testOnAllTransports('publish_no_attach', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
-            whenPromiseSettles(realtime.channels.get('publish_no_attach').publish(), function (err) {
+            helper.whenPromiseSettles(realtime.channels.get('publish_no_attach').publish(), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, new Error('Unexpected attach failure: ' + helper.displayError(err)));
+                helper.closeAndFinish(
+                  done,
+                  realtime,
+                  new Error('Unexpected attach failure: ' + helper.displayError(err)),
+                );
                 return;
               }
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -403,27 +399,27 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @specpartial RTL6b - callback which is called with an error
      */
-    testOnAllTransports('channelattach_publish_invalid', function (realtimeOpts) {
+    helper.testOnAllTransports('channelattach_publish_invalid', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
-            whenPromiseSettles(realtime.channels.get(':hell').publish(), function (err) {
+            helper.whenPromiseSettles(realtime.channels.get(':hell').publish(), function (err) {
               if (err) {
                 try {
                   expect(err.code).to.equal(40010, 'correct error code');
-                  closeAndFinish(done, realtime);
+                  helper.closeAndFinish(done, realtime);
                 } catch (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                 }
                 return;
               }
-              closeAndFinish(done, realtime, new Error('Unexpected attach success'));
+              helper.closeAndFinish(done, realtime, new Error('Unexpected attach success'));
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -436,36 +432,36 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @nospec
      */
-    testOnAllTransports('channelattach_invalid_twice', function (realtimeOpts) {
+    helper.testOnAllTransports('channelattach_invalid_twice', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
-            whenPromiseSettles(realtime.channels.get(':hell').attach(), function (err) {
+            helper.whenPromiseSettles(realtime.channels.get(':hell').attach(), function (err) {
               if (err) {
                 /* attempt second attach */
-                whenPromiseSettles(realtime.channels.get(':hell').attach(), function (err) {
+                helper.whenPromiseSettles(realtime.channels.get(':hell').attach(), function (err) {
                   if (err) {
                     setTimeout(function () {
                       try {
                         expect(realtime.connection.state === 'connected', 'Client should still be connected').to.be.ok;
-                        closeAndFinish(done, realtime);
+                        helper.closeAndFinish(done, realtime);
                       } catch (err) {
-                        closeAndFinish(done, realtime, err);
+                        helper.closeAndFinish(done, realtime, err);
                       }
                     }, 1000);
                     return;
                   }
-                  closeAndFinish(done, realtime, new Error('Unexpected attach (second attempt) success'));
+                  helper.closeAndFinish(done, realtime, new Error('Unexpected attach (second attempt) success'));
                 });
                 return;
               }
-              closeAndFinish(done, realtime, new Error('Unexpected attach success'));
+              helper.closeAndFinish(done, realtime, new Error('Unexpected attach success'));
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -481,14 +477,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var realtime = helper.AblyRealtime(),
           channel = realtime.channels.get('channelattachWhenState');
 
-        whenPromiseSettles(channel.attach(), function (err) {
-          whenPromiseSettles(channel.whenState('attached'), function () {
-            closeAndFinish(done, realtime, err);
+        helper.whenPromiseSettles(channel.attach(), function (err) {
+          helper.whenPromiseSettles(channel.whenState('attached'), function () {
+            helper.closeAndFinish(done, realtime, err);
           });
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -504,19 +500,19 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           firedImmediately = false;
 
         channel.attach();
-        whenPromiseSettles(channel.whenState('attached'), function () {
+        helper.whenPromiseSettles(channel.whenState('attached'), function () {
           firedImmediately = true;
           try {
             expect(channel.state).to.equal('attached', 'whenState fired when attached');
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
         });
         expect(!firedImmediately, 'whenState should not fire immediately as not attached').to.be.ok;
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -528,7 +524,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4k1
      * @spec RTL4m
      */
-    testOnAllTransports('attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
+    helper.testOnAllTransports('attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelParamsBasicChannelsGet';
         try {
@@ -542,9 +538,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               params: params,
             };
             var channel = realtime.channels.get(testName, channelOptions);
-            whenPromiseSettles(channel.attach(), function (err) {
+            helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
               try {
@@ -552,7 +548,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 expect(channel.params).to.deep.equal(params, 'Check result params');
                 expect(channel.modes).to.deep.equal(['subscribe'], 'Check result modes');
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
 
@@ -568,15 +564,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   ],
                   function (err) {
                     testRealtime.close();
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   },
                 );
               });
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -589,7 +585,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4m
      * @spec RTL16
      */
-    testOnAllTransports('attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
+    helper.testOnAllTransports('attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelParamsBasicSetOptions';
         try {
@@ -604,9 +600,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             };
             var channel = realtime.channels.get(testName);
             channel.setOptions(channelOptions);
-            whenPromiseSettles(channel.attach(), function (err) {
+            helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
               expect(channel.channelOptions).to.deep.equal(channelOptions, 'Check requested channel options');
@@ -625,15 +621,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   ],
                   function (err) {
                     testRealtime.close();
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   },
                 );
               });
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -642,7 +638,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL16
      * @spec RTL7c
      */
-    testOnAllTransports('subscribeAfterSetOptions', function (realtimeOpts) {
+    helper.testOnAllTransports('subscribeAfterSetOptions', function (realtimeOpts) {
       return function (done) {
         var testName = 'subscribeAfterSetOptions';
         try {
@@ -658,16 +654,16 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             channel.subscribe(function (message) {
               try {
                 expect(message.data).to.equal(testData, 'Check data');
-                closeAndFinish(done, realtime);
+                helper.closeAndFinish(done, realtime);
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
               }
             });
             channel.publish(undefined, testData);
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -685,9 +681,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           var channel = realtime.channels.get(testName, {
             params: params,
           });
-          whenPromiseSettles(channel.attach(), function (err) {
+          helper.whenPromiseSettles(channel.attach(), function (err) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
 
@@ -702,21 +698,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 expect(err.code).to.equal(40000, 'Check error code');
                 expect(err.statusCode).to.equal(400, 'Check error status code');
                 expect(err.message.includes('setOptions'), 'Check error message').to.be.ok;
-                closeAndFinish(done, realtime);
+                helper.closeAndFinish(done, realtime);
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
               }
             }
           });
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
     /** @spec RTL16a */
-    testOnAllTransports('setOptionsCallbackBehaviour', function (realtimeOpts) {
+    helper.testOnAllTransports('setOptionsCallbackBehaviour', function (realtimeOpts) {
       return function (done) {
         var testName = 'setOptionsCallbackBehaviour';
         try {
@@ -732,7 +728,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             async.series(
               [
                 function (cb) {
-                  whenPromiseSettles(channel.attach(), cb);
+                  helper.whenPromiseSettles(channel.attach(), cb);
                 },
                 function (cb) {
                   var channelUpdated = false;
@@ -740,7 +736,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                     channelUpdated = true;
                   });
 
-                  whenPromiseSettles(
+                  helper.whenPromiseSettles(
                     channel.setOptions({
                       params: {
                         modes: 'publish',
@@ -765,7 +761,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                     channelUpdated = true;
                   });
 
-                  whenPromiseSettles(
+                  helper.whenPromiseSettles(
                     channel.setOptions({
                       modes: ['subscribe'],
                     }),
@@ -779,13 +775,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 },
               ],
               function (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
               },
             );
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -794,7 +790,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * Verify modes is ignored when params.modes is present
      * @nospec
      */
-    testOnAllTransports('attachWithChannelParamsModesAndChannelModes', function (realtimeOpts) {
+    helper.testOnAllTransports('attachWithChannelParamsModesAndChannelModes', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelParamsModesAndChannelModes';
         try {
@@ -809,9 +805,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               modes: ['publish', 'presence_subscribe'],
             };
             var channel = realtime.channels.get(testName, channelOptions);
-            whenPromiseSettles(channel.attach(), function (err) {
+            helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
               try {
@@ -819,7 +815,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 expect(channel.params).to.deep.equal(params, 'Check result params');
                 expect(channel.modes).to.deep.equal(paramsModes, 'Check result modes');
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
 
@@ -835,15 +831,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   ],
                   function (err) {
                     testRealtime.close();
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   },
                 );
               });
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -855,7 +851,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4l
      * @spec RTL4m
      */
-    testOnAllTransports('attachWithChannelModes', function (realtimeOpts) {
+    helper.testOnAllTransports('attachWithChannelModes', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelModes';
         try {
@@ -866,16 +862,16 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               modes: modes,
             };
             var channel = realtime.channels.get(testName, channelOptions);
-            whenPromiseSettles(channel.attach(), function (err) {
+            helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
               try {
                 expect(channel.channelOptions).to.deep.equal(channelOptions, 'Check requested channel options');
                 expect(channel.modes).to.deep.equal(modes, 'Check result modes');
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
 
@@ -891,15 +887,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   ],
                   function (err) {
                     testRealtime.close();
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   },
                 );
               });
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -913,7 +909,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4l
      * @spec RTL4m
      */
-    testOnAllTransports('attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
+    helper.testOnAllTransports('attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelParamsDeltaAndModes';
         try {
@@ -925,9 +921,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               params: { delta: 'vcdiff' },
             };
             var channel = realtime.channels.get(testName, channelOptions);
-            whenPromiseSettles(channel.attach(), function (err) {
+            helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
               try {
@@ -935,7 +931,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 expect(channel.params).to.deep.equal({ delta: 'vcdiff' }, 'Check result params');
                 expect(channel.modes).to.deep.equal(modes, 'Check result modes');
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
 
@@ -951,15 +947,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   ],
                   function (err) {
                     testRealtime.close();
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   },
                 );
               });
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       };
     });
@@ -979,7 +975,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           async.series(
             [
               function (cb) {
-                whenPromiseSettles(channel.attach(), function (err) {
+                helper.whenPromiseSettles(channel.attach(), function (err) {
                   cb(err);
                 });
               },
@@ -987,7 +983,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   modes: 'subscribe',
                 };
-                whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.modes).to.deep.equal(
@@ -1001,7 +997,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   modes: [1, 'subscribe'],
                 };
-                whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.modes).to.deep.equal(
@@ -1015,7 +1011,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   params: 'test',
                 };
-                whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.params).to.deep.equal({}, 'Check channel options params');
@@ -1027,7 +1023,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   params: { nonexistent: 'foo' },
                 };
-                whenPromiseSettles(channel.setOptions(channelOptions), function () {
+                helper.whenPromiseSettles(channel.setOptions(channelOptions), function () {
                   expect(channel.params).to.deep.equal({}, 'Check channel params');
                   cb();
                 });
@@ -1036,7 +1032,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   modes: undefined,
                 };
-                whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.params).to.deep.equal({}, 'Check channel options params result');
@@ -1051,7 +1047,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   modes: ['susribe'],
                 };
-                whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.params).to.deep.equal({}, 'Check channel options params result');
@@ -1064,13 +1060,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               },
             ],
             function (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             },
           );
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -1086,9 +1082,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var realtime = helper.AblyRealtime({ useBinaryProtocol: true });
         realtime.connection.on('connected', function () {
           var channel6 = realtime.channels.get('channelsubscribe0');
-          whenPromiseSettles(channel6.attach(), function (err) {
+          helper.whenPromiseSettles(channel6.attach(), function (err) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
             try {
@@ -1096,19 +1092,19 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               setTimeout(function () {
                 try {
                   channel6.unsubscribe('event0', function () {});
-                  closeAndFinish(done, realtime);
+                  helper.closeAndFinish(done, realtime);
                 } catch (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                 }
               }, 1000);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -1132,27 +1128,27 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           channelByEvent.unsubscribe('event', listenerByEvent);
           channelByListener.unsubscribe(listenerNoEvent);
           channelAll.unsubscribe();
-          whenPromiseSettles(channelByEvent.publish('event', 'data'), function (err) {
+          helper.whenPromiseSettles(channelByEvent.publish('event', 'data'), function (err) {
             try {
               expect(!err, 'Error publishing single event: ' + err).to.be.ok;
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
-            whenPromiseSettles(channelByListener.publish(null, 'data'), function (err) {
+            helper.whenPromiseSettles(channelByListener.publish(null, 'data'), function (err) {
               try {
                 expect(!err, 'Error publishing any event: ' + err).to.be.ok;
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
-              whenPromiseSettles(channelAll.publish(null, 'data'), function (err) {
+              helper.whenPromiseSettles(channelAll.publish(null, 'data'), function (err) {
                 try {
                   expect(!err, 'Error publishing any event: ' + err).to.be.ok;
                   expect(messagesReceived).to.equal(3, 'Only three messages should be received by the listeners');
-                  closeAndFinish(done, realtime);
+                  helper.closeAndFinish(done, realtime);
                 } catch (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                 }
               });
             });
@@ -1177,21 +1173,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         realtime.connection.on('connected', function () {
           channelByEvent = realtime.channels.get('channelsubscribe1-event');
-          whenPromiseSettles(channelByEvent.subscribe('event', listenerByEvent), function () {
+          helper.whenPromiseSettles(channelByEvent.subscribe('event', listenerByEvent), function () {
             channelByEvent.publish('event', 'data');
             channelByListener = realtime.channels.get('channelsubscribe1-listener');
-            whenPromiseSettles(channelByListener.subscribe(null, listenerNoEvent), function () {
+            helper.whenPromiseSettles(channelByListener.subscribe(null, listenerNoEvent), function () {
               channelByListener.publish(null, 'data');
               channelAll = realtime.channels.get('channelsubscribe1-all');
-              whenPromiseSettles(channelAll.subscribe(listenerAllEvents), function () {
+              helper.whenPromiseSettles(channelAll.subscribe(listenerAllEvents), function () {
                 channelAll.publish(null, 'data');
               });
             });
           });
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -1214,7 +1210,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            whenPromiseSettles(channel.attach(), cb);
+            helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             /* Sabotage the reattach attempt, then simulate a server-sent detach */
@@ -1243,7 +1239,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
         ],
         function (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         },
       );
     });
@@ -1266,7 +1262,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           try {
             expect(msg.action).to.equal(10, 'check attach action');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           Ably.Realtime.Platform.Config.nextTick(function () {
@@ -1279,13 +1275,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             );
           });
         };
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           try {
             expect(err.code).to.equal(50000, 'check error is propogated to the attach callback');
             expect(channel.state).to.equal('suspended', 'check channel goes into suspended');
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
         });
       });
@@ -1302,18 +1298,18 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channel = realtime.channels.get(channelName);
 
       realtime.connection.once('connected', function () {
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
 
           channel.on('failed', function (stateChange) {
             try {
               expect(stateChange.reason.code).to.equal(50000, 'check error is propogated');
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
           var transport = realtime.connection.connectionManager.activeProtocol.getTransport();
@@ -1348,7 +1344,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            whenPromiseSettles(channel.attach(), cb);
+            helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             channel.once(function (stateChange) {
@@ -1371,7 +1367,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
         ],
         function (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         },
       );
     });
@@ -1386,12 +1382,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channel = realtime.channels.get('publish_no_queueing');
 
       /* try a publish while not yet connected */
-      whenPromiseSettles(channel.publish('foo', 'bar'), function (err) {
+      helper.whenPromiseSettles(channel.publish('foo', 'bar'), function (err) {
         try {
           expect(err, 'Check publish while disconnected/connecting is rejected').to.be.ok;
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
     });
@@ -1423,7 +1419,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            whenPromiseSettles(channel.attach(), function (err) {
+            helper.whenPromiseSettles(channel.attach(), function (err) {
               expect(err, 'Channel attach timed out as expected').to.be.ok;
               expect(err && err.code).to.equal(90007, 'Attach timeout err passed to attach callback');
               expect(channel.state).to.equal('suspended', 'Check channel state goes to suspended');
@@ -1441,7 +1437,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
         ],
         function (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         },
       );
     });
@@ -1471,7 +1467,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            whenPromiseSettles(channel.attach(), cb);
+            helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             /* Have the connection go into the suspended state, and check that the
@@ -1516,7 +1512,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
         ],
         function (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         },
       );
     });
@@ -1535,7 +1531,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            whenPromiseSettles(channel.attach(), cb);
+            helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             /* Sabotage the detach attempt, detach, then simulate a server-sent attached while
@@ -1558,7 +1554,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
         ],
         function (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         },
       );
     });
@@ -1570,16 +1566,16 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var channel = realtime.channels.get(channelName);
 
       channel.state = 'suspended';
-      whenPromiseSettles(channel.detach(), function () {
+      helper.whenPromiseSettles(channel.detach(), function () {
         try {
           expect(channel.state).to.equal(
             'detached',
             'Check that detach on suspended channel results in detached channel',
           );
 
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
     });
@@ -1592,12 +1588,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       channel.state = 'failed';
 
-      whenPromiseSettles(channel.detach(), function (err) {
+      helper.whenPromiseSettles(channel.detach(), function (err) {
         if (!err) {
-          closeAndFinish(done, realtime, new Error('expected detach to return error response'));
+          helper.closeAndFinish(done, realtime, new Error('expected detach to return error response'));
           return;
         }
-        closeAndFinish(done, realtime);
+        helper.closeAndFinish(done, realtime);
       });
     });
 
@@ -1612,14 +1608,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var subscriber = function (message) {
         expect(message.data).to.equal('message');
         channel.unsubscribe(subscriber);
-        whenPromiseSettles(channel.detach(), function (err) {
+        helper.whenPromiseSettles(channel.detach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           channel.subscribe(function (message) {
             expect(message.data).to.equal('message');
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           });
         });
       };
@@ -1634,9 +1630,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime = helper.AblyRealtime();
       var channelName = 'attach_returns_state_chnage';
       var channel = realtime.channels.get(channelName);
-      whenPromiseSettles(channel.attach(), function (err, stateChange) {
+      helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
 
@@ -1644,24 +1640,24 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           expect(stateChange.current).to.equal('attached');
           expect(stateChange.previous).to.equal('attaching');
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
 
         // for an already-attached channel, null is returned
-        whenPromiseSettles(channel.attach(), function (err, stateChange) {
+        helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
 
           try {
             expect(stateChange).to.equal(null);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       });
     });
@@ -1671,13 +1667,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime = helper.AblyRealtime();
       var channelName = 'subscribe_returns_state_chnage';
       var channel = realtime.channels.get(channelName);
-      whenPromiseSettles(
+      helper.whenPromiseSettles(
         channel.subscribe(
           function () {}, // message listener
         ),
         function (err, stateChange) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
 
@@ -1685,10 +1681,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             expect(stateChange.current).to.equal('attached');
             expect(stateChange.previous).to.equal('attaching');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         },
       );
     });
@@ -1701,19 +1697,19 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var channel = realtime.channels.get(channelName, channelOpts);
 
       // attach with rewind but no channel history - hasBacklog should be false
-      whenPromiseSettles(channel.attach(), function (err, stateChange) {
+      helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
 
         try {
           expect(!stateChange.hasBacklog).to.be.ok;
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
-        closeAndFinish(done, realtime);
+        helper.closeAndFinish(done, realtime);
       });
     });
 
@@ -1727,24 +1723,24 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var restChannel = rest.channels.get(channelName);
 
       // attach with rewind after publishing - hasBacklog should be true
-      whenPromiseSettles(restChannel.publish('foo', 'bar'), function (err) {
+      helper.whenPromiseSettles(restChannel.publish('foo', 'bar'), function (err) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
-        whenPromiseSettles(rtChannel.attach(), function (err, stateChange) {
+        helper.whenPromiseSettles(rtChannel.attach(), function (err, stateChange) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
 
           try {
             expect(stateChange.hasBacklog).to.be.ok;
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       });
     });
@@ -1754,12 +1750,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       const realtime = helper.AblyRealtime();
       const channel = realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
       channel.attach();
-      whenPromiseSettles(channel.whenState('attaching'), function () {
+      helper.whenPromiseSettles(channel.whenState('attaching'), function () {
         try {
           realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
     });
@@ -1771,7 +1767,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('whenState', async () => {
       const realtime = helper.AblyRealtime();
 
-      await monitorConnectionAsync(async () => {
+      await helper.monitorConnectionAsync(async () => {
         const channel = realtime.channels.get('channel');
 
         // RTL25a - when already in given state, returns null
@@ -1787,7 +1783,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         expect(attachedStateChange.current).to.equal('attached');
       }, realtime);
 
-      await closeAndFinishAsync(realtime);
+      await helper.closeAndFinishAsync(realtime);
     });
   });
 });

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var exports = {};
   var _exports = {};
   var expect = chai.expect;
@@ -10,7 +12,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     return function (callback) {
       var timeout,
         received = false,
-        eventName = helper.randomString();
+        eventName = Helper.randomString();
 
       channel.subscribe(eventName, function (msg) {
         channel.unsubscribe(eventName);
@@ -19,7 +21,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         callback();
       });
 
-      helper.whenPromiseSettles(testChannel.publish(eventName, null), function (err) {
+      Helper.whenPromiseSettles(testChannel.publish(eventName, null), function (err) {
         if (received) return;
         if (err) callback(err);
         timeout = setTimeout(function () {
@@ -34,7 +36,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     return function (callback) {
       var timeout,
         received = false,
-        eventName = helper.randomString();
+        eventName = Helper.randomString();
 
       channel.subscribe(eventName, function (message) {
         channel.presence.unsubscribe(eventName);
@@ -43,7 +45,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         callback('checkCantSubscribe: unexpectedly received message');
       });
 
-      helper.whenPromiseSettles(testChannel.publish(eventName, null), function (err) {
+      Helper.whenPromiseSettles(testChannel.publish(eventName, null), function (err) {
         if (received) return;
         if (err) callback(err);
         timeout = setTimeout(function () {
@@ -56,13 +58,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
   function checkCanPublish(channel) {
     return function (callback) {
-      helper.whenPromiseSettles(channel.publish(null, null), callback);
+      Helper.whenPromiseSettles(channel.publish(null, null), callback);
     };
   }
 
   function checkCantPublish(channel) {
     return function (callback) {
-      helper.whenPromiseSettles(channel.publish(null, null), function (err) {
+      Helper.whenPromiseSettles(channel.publish(null, null), function (err) {
         if (err && err.code === 40160) {
           callback();
         } else {
@@ -74,8 +76,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
   function checkCanEnterPresence(channel) {
     return function (callback) {
-      var clientId = helper.randomString();
-      helper.whenPromiseSettles(channel.presence.enterClient(clientId, null), function (err) {
+      var clientId = Helper.randomString();
+      Helper.whenPromiseSettles(channel.presence.enterClient(clientId, null), function (err) {
         channel.presence.leaveClient(clientId);
         callback(err);
       });
@@ -84,7 +86,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
   function checkCantEnterPresence(channel) {
     return function (callback) {
-      helper.whenPromiseSettles(channel.presence.enterClient(helper.randomString(), null), function (err) {
+      Helper.whenPromiseSettles(channel.presence.enterClient(Helper.randomString(), null), function (err) {
         if (err && err.code === 40160) {
           callback();
         } else {
@@ -98,7 +100,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     return function (callback) {
       var timeout,
         received = false,
-        clientId = helper.randomString();
+        clientId = Helper.randomString();
 
       channel.presence.subscribe('enter', function (message) {
         channel.presence.unsubscribe('enter');
@@ -108,7 +110,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         callback();
       });
 
-      helper.whenPromiseSettles(testChannel.presence.enterClient(clientId, null), function (err) {
+      Helper.whenPromiseSettles(testChannel.presence.enterClient(clientId, null), function (err) {
         if (received) return;
         if (err) callback(err);
         timeout = setTimeout(function () {
@@ -124,7 +126,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     return function (callback) {
       var timeout,
         received = false,
-        clientId = helper.randomString();
+        clientId = Helper.randomString();
 
       channel.presence.subscribe('enter', function (message) {
         channel.presence.unsubscribe('enter');
@@ -134,7 +136,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         callback('checkCantPresenceSubscribe: unexpectedly received message');
       });
 
-      helper.whenPromiseSettles(testChannel.presence.enterClient(clientId, null), function (err) {
+      Helper.whenPromiseSettles(testChannel.presence.enterClient(clientId, null), function (err) {
         if (received) return;
         if (err) callback(err);
         timeout = setTimeout(function () {
@@ -169,7 +171,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTS3c
      * @spec RTL16
      */
-    helper.testOnAllTransports('channelinit0', function (realtimeOpts) {
+    Helper.testOnAllTransports('channelinit0', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
@@ -205,13 +207,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL4
      */
-    helper.testOnAllTransports('channelattach0', function (realtimeOpts) {
+    Helper.testOnAllTransports('channelattach0', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.on('connected', function () {
             var channel0 = realtime.channels.get('channelattach0');
-            helper.whenPromiseSettles(channel0.attach(), function (err) {
+            Helper.whenPromiseSettles(channel0.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
               }
@@ -231,12 +233,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL4
      */
-    helper.testOnAllTransports('channelattach2', function (realtimeOpts) {
+    Helper.testOnAllTransports('channelattach2', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           var channel2 = realtime.channels.get('channelattach2');
-          helper.whenPromiseSettles(channel2.attach(), function (err) {
+          Helper.whenPromiseSettles(channel2.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -257,7 +259,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4
      * @spec RTL5
      */
-    helper.testOnAllTransports(
+    Helper.testOnAllTransports(
       'channelattach3',
       function (realtimeOpts) {
         return function (done) {
@@ -265,11 +267,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             var realtime = helper.AblyRealtime(realtimeOpts);
             realtime.connection.on('connected', function () {
               var channel0 = realtime.channels.get('channelattach3');
-              helper.whenPromiseSettles(channel0.attach(), function (err) {
+              Helper.whenPromiseSettles(channel0.attach(), function (err) {
                 if (err) {
                   helper.closeAndFinish(done, realtime, err);
                 }
-                helper.whenPromiseSettles(channel0.detach(), function (err) {
+                Helper.whenPromiseSettles(channel0.detach(), function (err) {
                   if (err) {
                     helper.closeAndFinish(done, realtime, err);
                   }
@@ -296,13 +298,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL4d
      */
-    helper.testOnAllTransports('channelattachempty', function (realtimeOpts) {
+    Helper.testOnAllTransports('channelattachempty', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
             var channel0 = realtime.channels.get('');
-            helper.whenPromiseSettles(channel0.attach(), function (err) {
+            Helper.whenPromiseSettles(channel0.attach(), function (err) {
               if (err) {
                 setTimeout(function () {
                   try {
@@ -330,13 +332,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL4d
      */
-    helper.testOnAllTransports('channelattachinvalid', function (realtimeOpts) {
+    Helper.testOnAllTransports('channelattachinvalid', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
             var channel = realtime.channels.get(':hell');
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
                 try {
                   expect(channel.errorReason.code).to.equal(40010, 'Attach error was set as the channel errorReason');
@@ -370,12 +372,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @spec RTL6
      */
-    helper.testOnAllTransports('publish_no_attach', function (realtimeOpts) {
+    Helper.testOnAllTransports('publish_no_attach', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
-            helper.whenPromiseSettles(realtime.channels.get('publish_no_attach').publish(), function (err) {
+            Helper.whenPromiseSettles(realtime.channels.get('publish_no_attach').publish(), function (err) {
               if (err) {
                 helper.closeAndFinish(
                   done,
@@ -399,12 +401,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @specpartial RTL6b - callback which is called with an error
      */
-    helper.testOnAllTransports('channelattach_publish_invalid', function (realtimeOpts) {
+    Helper.testOnAllTransports('channelattach_publish_invalid', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
-            helper.whenPromiseSettles(realtime.channels.get(':hell').publish(), function (err) {
+            Helper.whenPromiseSettles(realtime.channels.get(':hell').publish(), function (err) {
               if (err) {
                 try {
                   expect(err.code).to.equal(40010, 'correct error code');
@@ -432,15 +434,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      *
      * @nospec
      */
-    helper.testOnAllTransports('channelattach_invalid_twice', function (realtimeOpts) {
+    Helper.testOnAllTransports('channelattach_invalid_twice', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
-            helper.whenPromiseSettles(realtime.channels.get(':hell').attach(), function (err) {
+            Helper.whenPromiseSettles(realtime.channels.get(':hell').attach(), function (err) {
               if (err) {
                 /* attempt second attach */
-                helper.whenPromiseSettles(realtime.channels.get(':hell').attach(), function (err) {
+                Helper.whenPromiseSettles(realtime.channels.get(':hell').attach(), function (err) {
                   if (err) {
                     setTimeout(function () {
                       try {
@@ -477,8 +479,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var realtime = helper.AblyRealtime(),
           channel = realtime.channels.get('channelattachWhenState');
 
-        helper.whenPromiseSettles(channel.attach(), function (err) {
-          helper.whenPromiseSettles(channel.whenState('attached'), function () {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
+          Helper.whenPromiseSettles(channel.whenState('attached'), function () {
             helper.closeAndFinish(done, realtime, err);
           });
         });
@@ -500,7 +502,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           firedImmediately = false;
 
         channel.attach();
-        helper.whenPromiseSettles(channel.whenState('attached'), function () {
+        Helper.whenPromiseSettles(channel.whenState('attached'), function () {
           firedImmediately = true;
           try {
             expect(channel.state).to.equal('attached', 'whenState fired when attached');
@@ -524,7 +526,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4k1
      * @spec RTL4m
      */
-    helper.testOnAllTransports('attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
+    Helper.testOnAllTransports('attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelParamsBasicChannelsGet';
         try {
@@ -538,7 +540,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               params: params,
             };
             var channel = realtime.channels.get(testName, channelOptions);
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;
@@ -585,7 +587,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4m
      * @spec RTL16
      */
-    helper.testOnAllTransports('attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
+    Helper.testOnAllTransports('attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelParamsBasicSetOptions';
         try {
@@ -600,7 +602,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             };
             var channel = realtime.channels.get(testName);
             channel.setOptions(channelOptions);
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;
@@ -638,7 +640,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL16
      * @spec RTL7c
      */
-    helper.testOnAllTransports('subscribeAfterSetOptions', function (realtimeOpts) {
+    Helper.testOnAllTransports('subscribeAfterSetOptions', function (realtimeOpts) {
       return function (done) {
         var testName = 'subscribeAfterSetOptions';
         try {
@@ -681,7 +683,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           var channel = realtime.channels.get(testName, {
             params: params,
           });
-          helper.whenPromiseSettles(channel.attach(), function (err) {
+          Helper.whenPromiseSettles(channel.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -712,7 +714,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     });
 
     /** @spec RTL16a */
-    helper.testOnAllTransports('setOptionsCallbackBehaviour', function (realtimeOpts) {
+    Helper.testOnAllTransports('setOptionsCallbackBehaviour', function (realtimeOpts) {
       return function (done) {
         var testName = 'setOptionsCallbackBehaviour';
         try {
@@ -728,7 +730,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             async.series(
               [
                 function (cb) {
-                  helper.whenPromiseSettles(channel.attach(), cb);
+                  Helper.whenPromiseSettles(channel.attach(), cb);
                 },
                 function (cb) {
                   var channelUpdated = false;
@@ -736,7 +738,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                     channelUpdated = true;
                   });
 
-                  helper.whenPromiseSettles(
+                  Helper.whenPromiseSettles(
                     channel.setOptions({
                       params: {
                         modes: 'publish',
@@ -761,7 +763,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                     channelUpdated = true;
                   });
 
-                  helper.whenPromiseSettles(
+                  Helper.whenPromiseSettles(
                     channel.setOptions({
                       modes: ['subscribe'],
                     }),
@@ -790,7 +792,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * Verify modes is ignored when params.modes is present
      * @nospec
      */
-    helper.testOnAllTransports('attachWithChannelParamsModesAndChannelModes', function (realtimeOpts) {
+    Helper.testOnAllTransports('attachWithChannelParamsModesAndChannelModes', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelParamsModesAndChannelModes';
         try {
@@ -805,7 +807,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               modes: ['publish', 'presence_subscribe'],
             };
             var channel = realtime.channels.get(testName, channelOptions);
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;
@@ -851,7 +853,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4l
      * @spec RTL4m
      */
-    helper.testOnAllTransports('attachWithChannelModes', function (realtimeOpts) {
+    Helper.testOnAllTransports('attachWithChannelModes', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelModes';
         try {
@@ -862,7 +864,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               modes: modes,
             };
             var channel = realtime.channels.get(testName, channelOptions);
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;
@@ -909,7 +911,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL4l
      * @spec RTL4m
      */
-    helper.testOnAllTransports('attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
+    Helper.testOnAllTransports('attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
       return function (done) {
         var testName = 'attachWithChannelParamsDeltaAndModes';
         try {
@@ -921,7 +923,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               params: { delta: 'vcdiff' },
             };
             var channel = realtime.channels.get(testName, channelOptions);
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;
@@ -975,7 +977,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           async.series(
             [
               function (cb) {
-                helper.whenPromiseSettles(channel.attach(), function (err) {
+                Helper.whenPromiseSettles(channel.attach(), function (err) {
                   cb(err);
                 });
               },
@@ -983,7 +985,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   modes: 'subscribe',
                 };
-                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                Helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.modes).to.deep.equal(
@@ -997,7 +999,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   modes: [1, 'subscribe'],
                 };
-                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                Helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.modes).to.deep.equal(
@@ -1011,7 +1013,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   params: 'test',
                 };
-                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                Helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.params).to.deep.equal({}, 'Check channel options params');
@@ -1023,7 +1025,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   params: { nonexistent: 'foo' },
                 };
-                helper.whenPromiseSettles(channel.setOptions(channelOptions), function () {
+                Helper.whenPromiseSettles(channel.setOptions(channelOptions), function () {
                   expect(channel.params).to.deep.equal({}, 'Check channel params');
                   cb();
                 });
@@ -1032,7 +1034,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   modes: undefined,
                 };
-                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                Helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.params).to.deep.equal({}, 'Check channel options params result');
@@ -1047,7 +1049,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 var channelOptions = {
                   modes: ['susribe'],
                 };
-                helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
+                Helper.whenPromiseSettles(channel.setOptions(channelOptions), function (err) {
                   expect(err.code).to.equal(40000, 'Check channelOptions validation error code');
                   expect(err.statusCode).to.equal(400, 'Check channelOptions validation error statusCode');
                   expect(channel.params).to.deep.equal({}, 'Check channel options params result');
@@ -1082,7 +1084,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var realtime = helper.AblyRealtime({ useBinaryProtocol: true });
         realtime.connection.on('connected', function () {
           var channel6 = realtime.channels.get('channelsubscribe0');
-          helper.whenPromiseSettles(channel6.attach(), function (err) {
+          Helper.whenPromiseSettles(channel6.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -1128,21 +1130,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           channelByEvent.unsubscribe('event', listenerByEvent);
           channelByListener.unsubscribe(listenerNoEvent);
           channelAll.unsubscribe();
-          helper.whenPromiseSettles(channelByEvent.publish('event', 'data'), function (err) {
+          Helper.whenPromiseSettles(channelByEvent.publish('event', 'data'), function (err) {
             try {
               expect(!err, 'Error publishing single event: ' + err).to.be.ok;
             } catch (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
             }
-            helper.whenPromiseSettles(channelByListener.publish(null, 'data'), function (err) {
+            Helper.whenPromiseSettles(channelByListener.publish(null, 'data'), function (err) {
               try {
                 expect(!err, 'Error publishing any event: ' + err).to.be.ok;
               } catch (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;
               }
-              helper.whenPromiseSettles(channelAll.publish(null, 'data'), function (err) {
+              Helper.whenPromiseSettles(channelAll.publish(null, 'data'), function (err) {
                 try {
                   expect(!err, 'Error publishing any event: ' + err).to.be.ok;
                   expect(messagesReceived).to.equal(3, 'Only three messages should be received by the listeners');
@@ -1173,13 +1175,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         realtime.connection.on('connected', function () {
           channelByEvent = realtime.channels.get('channelsubscribe1-event');
-          helper.whenPromiseSettles(channelByEvent.subscribe('event', listenerByEvent), function () {
+          Helper.whenPromiseSettles(channelByEvent.subscribe('event', listenerByEvent), function () {
             channelByEvent.publish('event', 'data');
             channelByListener = realtime.channels.get('channelsubscribe1-listener');
-            helper.whenPromiseSettles(channelByListener.subscribe(null, listenerNoEvent), function () {
+            Helper.whenPromiseSettles(channelByListener.subscribe(null, listenerNoEvent), function () {
               channelByListener.publish(null, 'data');
               channelAll = realtime.channels.get('channelsubscribe1-all');
-              helper.whenPromiseSettles(channelAll.subscribe(listenerAllEvents), function () {
+              Helper.whenPromiseSettles(channelAll.subscribe(listenerAllEvents), function () {
                 channelAll.publish(null, 'data');
               });
             });
@@ -1210,7 +1212,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             /* Sabotage the reattach attempt, then simulate a server-sent detach */
@@ -1275,7 +1277,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             );
           });
         };
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           try {
             expect(err.code).to.equal(50000, 'check error is propogated to the attach callback');
             expect(channel.state).to.equal('suspended', 'check channel goes into suspended');
@@ -1298,7 +1300,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channel = realtime.channels.get(channelName);
 
       realtime.connection.once('connected', function () {
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -1344,7 +1346,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             channel.once(function (stateChange) {
@@ -1382,7 +1384,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channel = realtime.channels.get('publish_no_queueing');
 
       /* try a publish while not yet connected */
-      helper.whenPromiseSettles(channel.publish('foo', 'bar'), function (err) {
+      Helper.whenPromiseSettles(channel.publish('foo', 'bar'), function (err) {
         try {
           expect(err, 'Check publish while disconnected/connecting is rejected').to.be.ok;
           helper.closeAndFinish(done, realtime);
@@ -1419,7 +1421,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               expect(err, 'Channel attach timed out as expected').to.be.ok;
               expect(err && err.code).to.equal(90007, 'Attach timeout err passed to attach callback');
               expect(channel.state).to.equal('suspended', 'Check channel state goes to suspended');
@@ -1467,7 +1469,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             /* Have the connection go into the suspended state, and check that the
@@ -1531,7 +1533,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             /* Sabotage the detach attempt, detach, then simulate a server-sent attached while
@@ -1566,7 +1568,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var channel = realtime.channels.get(channelName);
 
       channel.state = 'suspended';
-      helper.whenPromiseSettles(channel.detach(), function () {
+      Helper.whenPromiseSettles(channel.detach(), function () {
         try {
           expect(channel.state).to.equal(
             'detached',
@@ -1588,7 +1590,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       channel.state = 'failed';
 
-      helper.whenPromiseSettles(channel.detach(), function (err) {
+      Helper.whenPromiseSettles(channel.detach(), function (err) {
         if (!err) {
           helper.closeAndFinish(done, realtime, new Error('expected detach to return error response'));
           return;
@@ -1608,7 +1610,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var subscriber = function (message) {
         expect(message.data).to.equal('message');
         channel.unsubscribe(subscriber);
-        helper.whenPromiseSettles(channel.detach(), function (err) {
+        Helper.whenPromiseSettles(channel.detach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -1630,7 +1632,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime = helper.AblyRealtime();
       var channelName = 'attach_returns_state_chnage';
       var channel = realtime.channels.get(channelName);
-      helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
+      Helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -1645,7 +1647,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         }
 
         // for an already-attached channel, null is returned
-        helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
+        Helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -1667,7 +1669,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime = helper.AblyRealtime();
       var channelName = 'subscribe_returns_state_chnage';
       var channel = realtime.channels.get(channelName);
-      helper.whenPromiseSettles(
+      Helper.whenPromiseSettles(
         channel.subscribe(
           function () {}, // message listener
         ),
@@ -1697,7 +1699,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var channel = realtime.channels.get(channelName, channelOpts);
 
       // attach with rewind but no channel history - hasBacklog should be false
-      helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
+      Helper.whenPromiseSettles(channel.attach(), function (err, stateChange) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -1723,12 +1725,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var restChannel = rest.channels.get(channelName);
 
       // attach with rewind after publishing - hasBacklog should be true
-      helper.whenPromiseSettles(restChannel.publish('foo', 'bar'), function (err) {
+      Helper.whenPromiseSettles(restChannel.publish('foo', 'bar'), function (err) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
         }
-        helper.whenPromiseSettles(rtChannel.attach(), function (err, stateChange) {
+        Helper.whenPromiseSettles(rtChannel.attach(), function (err, stateChange) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -1750,7 +1752,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       const realtime = helper.AblyRealtime();
       const channel = realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
       channel.attach();
-      helper.whenPromiseSettles(channel.whenState('attaching'), function () {
+      Helper.whenPromiseSettles(channel.whenState('attaching'), function () {
         try {
           realtime.channels.get('channel-with-options', { modes: ['PRESENCE'] });
           helper.closeAndFinish(done, realtime);

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -2,13 +2,7 @@
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
   var expect = chai.expect;
-  var closeAndFinish = helper.closeAndFinish;
-  var closeAndFinishAsync = helper.closeAndFinishAsync;
   var createPM = Ably.protocolMessageFromDeserialized;
-  var displayError = helper.displayError;
-  var monitorConnection = helper.monitorConnection;
-  var monitorConnectionAsync = helper.monitorConnectionAsync;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('realtime/connection', function () {
     this.timeout(60 * 1000);
@@ -30,14 +24,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime.connection.on('connected', function () {
           try {
             realtime.connection.ping();
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -47,23 +41,23 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       try {
         realtime = helper.AblyRealtime();
         realtime.connection.on('connected', function () {
-          whenPromiseSettles(realtime.connection.ping(), function (err, responseTime) {
+          helper.whenPromiseSettles(realtime.connection.ping(), function (err, responseTime) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
             try {
               expect(typeof responseTime).to.equal('number', 'check that a responseTime returned');
               expect(responseTime > 0, 'check that responseTime was +ve').to.be.ok;
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -81,14 +75,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             expect(recoveryContext.connectionKey).to.equal(realtime.connection.key);
             expect(recoveryContext.msgSerial).to.equal(realtime.connection.connectionManager.msgSerial);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
 
           var channel = realtime.channels.get('connectionattributes');
-          whenPromiseSettles(channel.attach(), function (err) {
+          helper.whenPromiseSettles(channel.attach(), function (err) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
             async.parallel(
@@ -104,30 +98,30 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   });
                 },
                 function (cb) {
-                  whenPromiseSettles(channel.publish('name', 'data'), cb);
+                  helper.whenPromiseSettles(channel.publish('name', 'data'), cb);
                 },
               ],
               function (err) {
                 if (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                   return;
                 }
                 realtime.connection.close();
-                whenPromiseSettles(realtime.connection.whenState('closed'), function () {
+                helper.whenPromiseSettles(realtime.connection.whenState('closed'), function () {
                   try {
                     expect(realtime.connection.recoveryKey).to.equal(null, 'verify recovery key null after close');
-                    closeAndFinish(done, realtime);
+                    helper.closeAndFinish(done, realtime);
                   } catch (err) {
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   }
                 });
               },
             );
           });
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -159,13 +153,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               -1,
               'verify connection using a new connectionkey',
             );
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
         });
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -186,9 +180,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       realtime.connection.once('connected', function () {
         var transport = connectionManager.activeProtocol.transport;
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
 
@@ -215,7 +209,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 transportSendCallback = cb;
 
                 /* Sabotaged publish */
-                whenPromiseSettles(channel.publish('first', null), function (err) {
+                helper.whenPromiseSettles(channel.publish('first', null), function (err) {
                   if (!publishCallback) {
                     done(new Error('publish completed before publishCallback populated'));
                   }
@@ -283,7 +277,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               },
             ],
             function (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             },
           );
         });
@@ -313,10 +307,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             expect(realtime.auth.clientId).to.equal('foo', 'Check clientId set in auth');
             expect(realtime.options.maxMessageSize).to.equal(98765, 'Check maxMessageSize set');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
         connectionManager.activeProtocol.getTransport().onProtocolMessage(
           createPM({
@@ -332,7 +326,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           }),
         );
       });
-      monitorConnection(done, realtime);
+      helper.monitorConnection(done, realtime);
     });
 
     /**
@@ -342,7 +336,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     it('whenState', async () => {
       const realtime = helper.AblyRealtime({ autoConnect: false });
 
-      await monitorConnectionAsync(async () => {
+      await helper.monitorConnectionAsync(async () => {
         // RTN26a - when already in given state, returns null
         const initializedStateChange = await realtime.connection.whenState('initialized');
         expect(initializedStateChange).to.be.null;
@@ -356,7 +350,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         expect(connectedStateChange.current).to.equal('connected');
       }, realtime);
 
-      await closeAndFinishAsync(realtime);
+      await helper.closeAndFinishAsync(realtime);
     });
   });
 });

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var createPM = Ably.protocolMessageFromDeserialized;
 
@@ -41,7 +43,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       try {
         realtime = helper.AblyRealtime();
         realtime.connection.on('connected', function () {
-          helper.whenPromiseSettles(realtime.connection.ping(), function (err, responseTime) {
+          Helper.whenPromiseSettles(realtime.connection.ping(), function (err, responseTime) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -80,7 +82,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           }
 
           var channel = realtime.channels.get('connectionattributes');
-          helper.whenPromiseSettles(channel.attach(), function (err) {
+          Helper.whenPromiseSettles(channel.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -98,7 +100,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   });
                 },
                 function (cb) {
-                  helper.whenPromiseSettles(channel.publish('name', 'data'), cb);
+                  Helper.whenPromiseSettles(channel.publish('name', 'data'), cb);
                 },
               ],
               function (err) {
@@ -107,7 +109,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   return;
                 }
                 realtime.connection.close();
-                helper.whenPromiseSettles(realtime.connection.whenState('closed'), function () {
+                Helper.whenPromiseSettles(realtime.connection.whenState('closed'), function () {
                   try {
                     expect(realtime.connection.recoveryKey).to.equal(null, 'verify recovery key null after close');
                     helper.closeAndFinish(done, realtime);
@@ -180,7 +182,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       realtime.connection.once('connected', function () {
         var transport = connectionManager.activeProtocol.transport;
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -209,7 +211,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 transportSendCallback = cb;
 
                 /* Sabotaged publish */
-                helper.whenPromiseSettles(channel.publish('first', null), function (err) {
+                Helper.whenPromiseSettles(channel.publish('first', null), function (err) {
                   if (!publishCallback) {
                     done(new Error('publish completed before publishCallback populated'));
                   }

--- a/test/realtime/connection.test.js
+++ b/test/realtime/connection.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var createPM = Ably.protocolMessageFromDeserialized;
 
@@ -10,6 +8,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -20,6 +19,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTN13 */
     it('connectionPing', function (done) {
+      const helper = this.test.helper;
       var realtime;
       try {
         realtime = helper.AblyRealtime();
@@ -39,6 +39,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @specpartial RTN13a - callback is called with response time */
     it('connectionPingWithCallback', function (done) {
+      const helper = this.test.helper;
       var realtime;
       try {
         realtime = helper.AblyRealtime();
@@ -68,6 +69,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTN16g - connectionKey, the current msgSerial
      */
     it('connectionAttributes', function (done) {
+      const helper = this.test.helper;
       var realtime;
       try {
         realtime = helper.AblyRealtime();
@@ -129,6 +131,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RTN15c7 */
     it('unrecoverableConnection', function (done) {
+      const helper = this.test.helper;
       var realtime;
       const fakeRecoveryKey = JSON.stringify({
         connectionKey: '_____!ablyjs_test_fake-key____',
@@ -176,7 +179,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTN19a2
      */
     it('connectionQueuing', function (done) {
-      var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
         channel = realtime.channels.get('connectionQueuing'),
         connectionManager = realtime.connection.connectionManager;
 
@@ -295,7 +299,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial TO3l8 - default can be overridden by the maxMessageSize in the connectionDetails
      */
     it('connectionDetails', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         connectionManager = realtime.connection.connectionManager;
       realtime.connection.once('connected', function () {
         connectionManager.once('connectiondetails', function (details) {
@@ -335,7 +340,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTN26a
      * @spec RTN26b
      */
-    it('whenState', async () => {
+    it('whenState', async function () {
+      const helper = this.test.helper;
       const realtime = helper.AblyRealtime({ autoConnect: false });
 
       await helper.monitorConnectionAsync(async () => {

--- a/test/realtime/connectivity.test.js
+++ b/test/realtime/connectivity.test.js
@@ -23,9 +23,14 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      */
     it('http_connectivity_check', function (done) {
       const helper = this.test.helper;
+      helper.recordPrivateApi('call.http.checkConnectivity');
       Helper.whenPromiseSettles(new Ably.Realtime._Http().checkConnectivity(), function (err, res) {
         try {
-          expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
+          expect(
+            res && !err,
+            'Connectivity check completed ' +
+              (err && (helper.recordPrivateApi('call.Utils.inspectError'), helper.Utils.inspectError(err))),
+          ).to.be.ok;
         } catch (err) {
           done(err);
           return;
@@ -34,7 +39,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       });
     });
 
-    function options(connectivityCheckUrl, disableConnectivityCheck) {
+    function options(helper, connectivityCheckUrl, disableConnectivityCheck) {
+      helper.recordPrivateApi('pass.clientOption.connectivityCheckUrl');
+      helper.recordPrivateApi('pass.clientOption.disableConnectivityCheck');
       return {
         connectivityCheckUrl,
         disableConnectivityCheck,
@@ -51,11 +58,16 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       /** @nospec */
       it('succeeds with scheme', function (done) {
         const helper = this.test.helper;
+        helper.recordPrivateApi('call.http.checkConnectivity');
         Helper.whenPromiseSettles(
-          helper.AblyRealtime(options(urlScheme + successUrl)).http.checkConnectivity(),
+          helper.AblyRealtime(options(helper, urlScheme + successUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
-              expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
+              expect(
+                res && !err,
+                'Connectivity check completed ' +
+                  (err && (helper.recordPrivateApi('call.Utils.inspectError'), helper.Utils.inspectError(err))),
+              ).to.be.ok;
             } catch (err) {
               done(err);
               return;
@@ -68,8 +80,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       /** @nospec */
       it('fails with scheme', function (done) {
         const helper = this.test.helper;
+        helper.recordPrivateApi('call.http.checkConnectivity');
         Helper.whenPromiseSettles(
-          helper.AblyRealtime(options(urlScheme + failUrl)).http.checkConnectivity(),
+          helper.AblyRealtime(options(helper, urlScheme + failUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
               expect(!res, 'Connectivity check expected to return false').to.be.ok;
@@ -84,11 +97,16 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       /** @nospec */
       it('succeeds with querystring', function (done) {
         const helper = this.test.helper;
+        helper.recordPrivateApi('call.http.checkConnectivity');
         Helper.whenPromiseSettles(
-          helper.AblyRealtime(options(successUrl)).http.checkConnectivity(),
+          helper.AblyRealtime(options(helper, successUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
-              expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
+              expect(
+                res && !err,
+                'Connectivity check completed ' +
+                  (err && (helper.recordPrivateApi('call.Utils.inspectError'), helper.Utils.inspectError(err))),
+              ).to.be.ok;
               done();
             } catch (err) {
               done(err);
@@ -100,24 +118,32 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       /** @nospec */
       it('fails with querystring', function (done) {
         const helper = this.test.helper;
-        Helper.whenPromiseSettles(helper.AblyRealtime(options(failUrl)).http.checkConnectivity(), function (err, res) {
-          try {
-            expect(!res, 'Connectivity check expected to return false').to.be.ok;
-            done();
-          } catch (err) {
-            done(err);
-          }
-        });
+        helper.recordPrivateApi('call.http.checkConnectivity');
+        Helper.whenPromiseSettles(
+          helper.AblyRealtime(options(helper, failUrl)).http.checkConnectivity(),
+          function (err, res) {
+            try {
+              expect(!res, 'Connectivity check expected to return false').to.be.ok;
+              done();
+            } catch (err) {
+              done(err);
+            }
+          },
+        );
       });
 
       /** @nospec */
       it('succeeds with plain url', function (done) {
         const helper = this.test.helper;
         Helper.whenPromiseSettles(
-          helper.AblyRealtime(options('sandbox-rest.ably.io/time')).http.checkConnectivity(),
+          helper.AblyRealtime(options(helper, 'sandbox-rest.ably.io/time')).http.checkConnectivity(),
           function (err, res) {
             try {
-              expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
+              expect(
+                res && !err,
+                'Connectivity check completed ' +
+                  (err && (helper.recordPrivateApi('call.Utils.inspectError'), helper.Utils.inspectError(err))),
+              ).to.be.ok;
               done();
             } catch (err) {
               done(err);
@@ -129,8 +155,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       /** @nospec */
       it('fails with plain url', function (done) {
         const helper = this.test.helper;
+        helper.recordPrivateApi('call.http.checkConnectivity');
         Helper.whenPromiseSettles(
-          helper.AblyRealtime(options('echo.ably.io')).http.checkConnectivity(),
+          helper.AblyRealtime(options(helper, 'echo.ably.io')).http.checkConnectivity(),
           function (err, res) {
             try {
               expect(!res, 'Connectivity check expected to return false').to.be.ok;
@@ -146,11 +173,16 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
     /** @nospec */
     it('disable_connectivity_check', function (done) {
       const helper = this.test.helper;
+      helper.recordPrivateApi('call.http.checkConnectivity');
       Helper.whenPromiseSettles(
-        helper.AblyRealtime(options('notarealhost', true)).http.checkConnectivity(),
+        helper.AblyRealtime(options(helper, 'notarealhost', true)).http.checkConnectivity(),
         function (err, res) {
           try {
-            expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
+            expect(
+              res && !err,
+              'Connectivity check completed ' +
+                (err && (helper.recordPrivateApi('call.Utils.inspectError'), helper.Utils.inspectError(err))),
+            ).to.be.ok;
             done();
           } catch (err) {
             done(err);

--- a/test/realtime/connectivity.test.js
+++ b/test/realtime/connectivity.test.js
@@ -49,7 +49,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       /** @nospec */
       it('succeeds with scheme', function (done) {
         helper.whenPromiseSettles(
-          new helper.AblyRealtime(options(urlScheme + successUrl)).http.checkConnectivity(),
+          helper.AblyRealtime(options(urlScheme + successUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
               expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
@@ -65,7 +65,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       /** @nospec */
       it('fails with scheme', function (done) {
         helper.whenPromiseSettles(
-          new helper.AblyRealtime(options(urlScheme + failUrl)).http.checkConnectivity(),
+          helper.AblyRealtime(options(urlScheme + failUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
               expect(!res, 'Connectivity check expected to return false').to.be.ok;
@@ -80,7 +80,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       /** @nospec */
       it('succeeds with querystring', function (done) {
         helper.whenPromiseSettles(
-          new helper.AblyRealtime(options(successUrl)).http.checkConnectivity(),
+          helper.AblyRealtime(options(successUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
               expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
@@ -94,23 +94,20 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('fails with querystring', function (done) {
-        helper.whenPromiseSettles(
-          new helper.AblyRealtime(options(failUrl)).http.checkConnectivity(),
-          function (err, res) {
-            try {
-              expect(!res, 'Connectivity check expected to return false').to.be.ok;
-              done();
-            } catch (err) {
-              done(err);
-            }
-          },
-        );
+        helper.whenPromiseSettles(helper.AblyRealtime(options(failUrl)).http.checkConnectivity(), function (err, res) {
+          try {
+            expect(!res, 'Connectivity check expected to return false').to.be.ok;
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
       });
 
       /** @nospec */
       it('succeeds with plain url', function (done) {
         helper.whenPromiseSettles(
-          new helper.AblyRealtime(options('sandbox-rest.ably.io/time')).http.checkConnectivity(),
+          helper.AblyRealtime(options('sandbox-rest.ably.io/time')).http.checkConnectivity(),
           function (err, res) {
             try {
               expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
@@ -125,7 +122,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       /** @nospec */
       it('fails with plain url', function (done) {
         helper.whenPromiseSettles(
-          new helper.AblyRealtime(options('echo.ably.io')).http.checkConnectivity(),
+          helper.AblyRealtime(options('echo.ably.io')).http.checkConnectivity(),
           function (err, res) {
             try {
               expect(!res, 'Connectivity check expected to return false').to.be.ok;
@@ -141,7 +138,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
     /** @nospec */
     it('disable_connectivity_check', function (done) {
       helper.whenPromiseSettles(
-        new helper.AblyRealtime(options('notarealhost', true)).http.checkConnectivity(),
+        helper.AblyRealtime(options('notarealhost', true)).http.checkConnectivity(),
         function (err, res) {
           try {
             expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;

--- a/test/realtime/connectivity.test.js
+++ b/test/realtime/connectivity.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
+define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
 
   describe('realtime/connectivity', function () {
@@ -21,7 +23,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
      * @nospec
      */
     it('http_connectivity_check', function (done) {
-      helper.whenPromiseSettles(new Ably.Realtime._Http().checkConnectivity(), function (err, res) {
+      Helper.whenPromiseSettles(new Ably.Realtime._Http().checkConnectivity(), function (err, res) {
         try {
           expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
         } catch (err) {
@@ -48,7 +50,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('succeeds with scheme', function (done) {
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           helper.AblyRealtime(options(urlScheme + successUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
@@ -64,7 +66,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('fails with scheme', function (done) {
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           helper.AblyRealtime(options(urlScheme + failUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
@@ -79,7 +81,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('succeeds with querystring', function (done) {
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           helper.AblyRealtime(options(successUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
@@ -94,7 +96,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('fails with querystring', function (done) {
-        helper.whenPromiseSettles(helper.AblyRealtime(options(failUrl)).http.checkConnectivity(), function (err, res) {
+        Helper.whenPromiseSettles(helper.AblyRealtime(options(failUrl)).http.checkConnectivity(), function (err, res) {
           try {
             expect(!res, 'Connectivity check expected to return false').to.be.ok;
             done();
@@ -106,7 +108,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('succeeds with plain url', function (done) {
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           helper.AblyRealtime(options('sandbox-rest.ably.io/time')).http.checkConnectivity(),
           function (err, res) {
             try {
@@ -121,7 +123,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('fails with plain url', function (done) {
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           helper.AblyRealtime(options('echo.ably.io')).http.checkConnectivity(),
           function (err, res) {
             try {
@@ -137,7 +139,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
     /** @nospec */
     it('disable_connectivity_check', function (done) {
-      helper.whenPromiseSettles(
+      Helper.whenPromiseSettles(
         helper.AblyRealtime(options('notarealhost', true)).http.checkConnectivity(),
         function (err, res) {
           try {

--- a/test/realtime/connectivity.test.js
+++ b/test/realtime/connectivity.test.js
@@ -1,14 +1,13 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
 
   describe('realtime/connectivity', function () {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -23,6 +22,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @nospec
      */
     it('http_connectivity_check', function (done) {
+      const helper = this.test.helper;
       Helper.whenPromiseSettles(new Ably.Realtime._Http().checkConnectivity(), function (err, res) {
         try {
           expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
@@ -50,6 +50,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
       /** @nospec */
       it('succeeds with scheme', function (done) {
+        const helper = this.test.helper;
         Helper.whenPromiseSettles(
           helper.AblyRealtime(options(urlScheme + successUrl)).http.checkConnectivity(),
           function (err, res) {
@@ -66,6 +67,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
       /** @nospec */
       it('fails with scheme', function (done) {
+        const helper = this.test.helper;
         Helper.whenPromiseSettles(
           helper.AblyRealtime(options(urlScheme + failUrl)).http.checkConnectivity(),
           function (err, res) {
@@ -81,6 +83,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
       /** @nospec */
       it('succeeds with querystring', function (done) {
+        const helper = this.test.helper;
         Helper.whenPromiseSettles(
           helper.AblyRealtime(options(successUrl)).http.checkConnectivity(),
           function (err, res) {
@@ -96,6 +99,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
       /** @nospec */
       it('fails with querystring', function (done) {
+        const helper = this.test.helper;
         Helper.whenPromiseSettles(helper.AblyRealtime(options(failUrl)).http.checkConnectivity(), function (err, res) {
           try {
             expect(!res, 'Connectivity check expected to return false').to.be.ok;
@@ -108,6 +112,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
       /** @nospec */
       it('succeeds with plain url', function (done) {
+        const helper = this.test.helper;
         Helper.whenPromiseSettles(
           helper.AblyRealtime(options('sandbox-rest.ably.io/time')).http.checkConnectivity(),
           function (err, res) {
@@ -123,6 +128,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
       /** @nospec */
       it('fails with plain url', function (done) {
+        const helper = this.test.helper;
         Helper.whenPromiseSettles(
           helper.AblyRealtime(options('echo.ably.io')).http.checkConnectivity(),
           function (err, res) {
@@ -139,6 +145,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
     /** @nospec */
     it('disable_connectivity_check', function (done) {
+      const helper = this.test.helper;
       Helper.whenPromiseSettles(
         helper.AblyRealtime(options('notarealhost', true)).http.checkConnectivity(),
         function (err, res) {

--- a/test/realtime/connectivity.test.js
+++ b/test/realtime/connectivity.test.js
@@ -2,10 +2,6 @@
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
   var expect = chai.expect;
-  var closeAndFinish = helper.closeAndFinish;
-  var monitorConnection = helper.monitorConnection;
-  var utils = helper.Utils;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('realtime/connectivity', function () {
     this.timeout(60 * 1000);
@@ -25,9 +21,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
      * @nospec
      */
     it('http_connectivity_check', function (done) {
-      whenPromiseSettles(new Ably.Realtime._Http().checkConnectivity(), function (err, res) {
+      helper.whenPromiseSettles(new Ably.Realtime._Http().checkConnectivity(), function (err, res) {
         try {
-          expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
+          expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
         } catch (err) {
           done(err);
           return;
@@ -52,11 +48,11 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('succeeds with scheme', function (done) {
-        whenPromiseSettles(
+        helper.whenPromiseSettles(
           new helper.AblyRealtime(options(urlScheme + successUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
-              expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
+              expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
             } catch (err) {
               done(err);
               return;
@@ -68,7 +64,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('fails with scheme', function (done) {
-        whenPromiseSettles(
+        helper.whenPromiseSettles(
           new helper.AblyRealtime(options(urlScheme + failUrl)).http.checkConnectivity(),
           function (err, res) {
             try {
@@ -83,35 +79,41 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('succeeds with querystring', function (done) {
-        whenPromiseSettles(new helper.AblyRealtime(options(successUrl)).http.checkConnectivity(), function (err, res) {
-          try {
-            expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
-            done();
-          } catch (err) {
-            done(err);
-          }
-        });
+        helper.whenPromiseSettles(
+          new helper.AblyRealtime(options(successUrl)).http.checkConnectivity(),
+          function (err, res) {
+            try {
+              expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
+              done();
+            } catch (err) {
+              done(err);
+            }
+          },
+        );
       });
 
       /** @nospec */
       it('fails with querystring', function (done) {
-        whenPromiseSettles(new helper.AblyRealtime(options(failUrl)).http.checkConnectivity(), function (err, res) {
-          try {
-            expect(!res, 'Connectivity check expected to return false').to.be.ok;
-            done();
-          } catch (err) {
-            done(err);
-          }
-        });
+        helper.whenPromiseSettles(
+          new helper.AblyRealtime(options(failUrl)).http.checkConnectivity(),
+          function (err, res) {
+            try {
+              expect(!res, 'Connectivity check expected to return false').to.be.ok;
+              done();
+            } catch (err) {
+              done(err);
+            }
+          },
+        );
       });
 
       /** @nospec */
       it('succeeds with plain url', function (done) {
-        whenPromiseSettles(
+        helper.whenPromiseSettles(
           new helper.AblyRealtime(options('sandbox-rest.ably.io/time')).http.checkConnectivity(),
           function (err, res) {
             try {
-              expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
+              expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
               done();
             } catch (err) {
               done(err);
@@ -122,7 +124,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
       /** @nospec */
       it('fails with plain url', function (done) {
-        whenPromiseSettles(
+        helper.whenPromiseSettles(
           new helper.AblyRealtime(options('echo.ably.io')).http.checkConnectivity(),
           function (err, res) {
             try {
@@ -138,11 +140,11 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
 
     /** @nospec */
     it('disable_connectivity_check', function (done) {
-      whenPromiseSettles(
+      helper.whenPromiseSettles(
         new helper.AblyRealtime(options('notarealhost', true)).http.checkConnectivity(),
         function (err, res) {
           try {
-            expect(res && !err, 'Connectivity check completed ' + (err && utils.inspectError(err))).to.be.ok;
+            expect(res && !err, 'Connectivity check completed ' + (err && helper.Utils.inspectError(err))).to.be.ok;
             done();
           } catch (err) {
             done(err);

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var BufferUtils = Ably.Realtime.Platform.BufferUtils;
   var Crypto = Ably.Realtime.Platform.Crypto;
@@ -19,7 +17,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     );
   }
 
-  function testMessageEquality(done, one, two) {
+  function testMessageEquality(done, helper, one, two) {
     try {
       helper.testMessageEquality(one, two);
     } catch (err) {
@@ -27,7 +25,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     }
   }
 
-  function testEachFixture(done, filename, channelName, testsPerFixture, testPlaintextVariants, fixtureTest) {
+  function testEachFixture(done, helper, filename, channelName, testsPerFixture, testPlaintextVariants, fixtureTest) {
     if (!Crypto) {
       done(new Error('Encryption not supported'));
       return;
@@ -85,6 +83,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -245,8 +244,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5b - aes 128
      */
     it('encrypt_message_128', function (done) {
+      const helper = this.test.helper;
       testEachFixture(
         done,
+        helper,
         'crypto-data-128.json',
         'encrypt_message_128',
         2,
@@ -255,7 +256,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           /* encrypt plaintext message; encode() also to handle data that is not already string or buffer */
           Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
             /* compare */
-            testMessageEquality(done, testMessage, encryptedMessage);
+            testMessageEquality(done, helper, testMessage, encryptedMessage);
           });
         },
       );
@@ -266,8 +267,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5b - aes 256
      */
     it('encrypt_message_256', function (done) {
+      const helper = this.test.helper;
       testEachFixture(
         done,
+        helper,
         'crypto-data-256.json',
         'encrypt_message_256',
         2,
@@ -276,7 +279,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           /* encrypt plaintext message; encode() also to handle data that is not already string or buffer */
           Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
             /* compare */
-            testMessageEquality(done, testMessage, encryptedMessage);
+            testMessageEquality(done, helper, testMessage, encryptedMessage);
           });
         },
       );
@@ -287,8 +290,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5b - aes 128
      */
     it('decrypt_message_128', function (done) {
+      const helper = this.test.helper;
       testEachFixture(
         done,
+        helper,
         'crypto-data-128.json',
         'decrypt_message_128',
         2,
@@ -297,7 +302,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           /* decrypt encrypted message; decode() also to handle data that is not string or buffer */
           await Message.decode(encryptedMessage, channelOpts);
           /* compare */
-          testMessageEquality(done, testMessage, encryptedMessage);
+          testMessageEquality(done, helper, testMessage, encryptedMessage);
         },
       );
     });
@@ -307,8 +312,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5b - aes 256
      */
     it('decrypt_message_256', function (done) {
+      const helper = this.test.helper;
       testEachFixture(
         done,
+        helper,
         'crypto-data-256.json',
         'decrypt_message_256',
         2,
@@ -317,7 +324,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           /* decrypt encrypted message; decode() also to handle data that is not string or buffer */
           await Message.decode(encryptedMessage, channelOpts);
           /* compare */
-          testMessageEquality(done, testMessage, encryptedMessage);
+          testMessageEquality(done, helper, testMessage, encryptedMessage);
         },
       );
     });
@@ -328,6 +335,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         done(new Error('Encryption not supported'));
         return;
       }
+
+      const helper = this.test.helper;
 
       helper.loadTestData(helper.testResourcesPath + 'crypto-data-256.json', async function (err, testData) {
         if (err) {
@@ -341,7 +350,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           var item = testData.items[i];
           var testMessage = await Message.fromEncoded(item.encoded);
           var decryptedMessage = await Message.fromEncoded(item.encrypted, { cipher: { key: key, iv: iv } });
-          testMessageEquality(done, testMessage, decryptedMessage);
+          testMessageEquality(done, helper, testMessage, decryptedMessage);
         }
         done();
       });
@@ -354,8 +363,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
        * @nospec
        */
       it('msgpack_128', function (done) {
+        const helper = this.test.helper;
         testEachFixture(
           done,
+          helper,
           'crypto-data-128.json',
           'msgpack_128',
           2,
@@ -392,8 +403,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
        * @nospec
        */
       it('msgpack_256', function (done) {
+        const helper = this.test.helper;
         testEachFixture(
           done,
+          helper,
           'crypto-data-256.json',
           'msgpack_256',
           2,
@@ -426,7 +439,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
     }
 
-    function single_send(done, realtimeOpts, keyLength) {
+    function single_send(done, helper, realtimeOpts, keyLength) {
       if (!Crypto) {
         done(new Error('Encryption not supported'));
         return;
@@ -473,18 +486,18 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     /** @specpartial RSL5b - test aes 128 */
     Helper.testOnAllTransports('single_send_128', function (realtimeOpts) {
       return function (done) {
-        single_send(done, realtimeOpts, 128);
+        single_send(done, this.test.helper, realtimeOpts, 128);
       };
     });
 
     /** @specpartial RSL5b - test aes 256 */
     Helper.testOnAllTransports('single_send_256', function (realtimeOpts) {
       return function (done) {
-        single_send(done, realtimeOpts, 256);
+        single_send(done, this.test.helper, realtimeOpts, 256);
       };
     });
 
-    function _multiple_send(done, text, iterations, delay) {
+    function _multiple_send(done, helper, text, iterations, delay) {
       if (!Crypto) {
         done(new Error('Encryption not supported'));
         return;
@@ -546,7 +559,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5a - cipher is set via setOptions instead on channel instantiation
      */
     it('multiple_send_binary_2_200', function (done) {
-      _multiple_send(done, false, 2, 200);
+      _multiple_send(done, this.test.helper, false, 2, 200);
     });
 
     /**
@@ -555,7 +568,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5a - cipher is set via setOptions instead on channel instantiation
      */
     it('multiple_send_text_2_200', function (done) {
-      _multiple_send(done, true, 2, 200);
+      _multiple_send(done, this.test.helper, true, 2, 200);
     });
 
     /**
@@ -564,7 +577,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5a - cipher is set via setOptions instead on channel instantiation
      */
     it('multiple_send_binary_20_100', function (done) {
-      _multiple_send(done, false, 20, 100);
+      _multiple_send(done, this.test.helper, false, 20, 100);
     });
 
     /**
@@ -573,7 +586,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5a - cipher is set via setOptions instead on channel instantiation
      */
     it('multiple_send_text_20_100', function (done) {
-      _multiple_send(done, true, 20, 100);
+      _multiple_send(done, this.test.helper, true, 20, 100);
     });
 
     /**
@@ -582,7 +595,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5a - cipher is set via setOptions instead on channel instantiation
      */
     it('multiple_send_binary_10_10', function (done) {
-      _multiple_send(done, false, 10, 10);
+      _multiple_send(done, this.test.helper, false, 10, 10);
     });
 
     /**
@@ -591,10 +604,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL5a - cipher is set via setOptions instead on channel instantiation
      */
     it('multiple_send_text_10_10', function (done) {
-      _multiple_send(done, true, 10, 10);
+      _multiple_send(done, this.test.helper, true, 10, 10);
     });
 
-    function _single_send_separate_realtimes(done, txOpts, rxOpts) {
+    function _single_send_separate_realtimes(done, helper, txOpts, rxOpts) {
       if (!Crypto) {
         done(new Error('Encryption not supported'));
         return;
@@ -661,7 +674,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('single_send_binary_text', function (done) {
-      _single_send_separate_realtimes(done, { useBinaryProtocol: true }, { useBinaryProtocol: false });
+      _single_send_separate_realtimes(
+        done,
+        this.test.helper,
+        { useBinaryProtocol: true },
+        { useBinaryProtocol: false },
+      );
     });
 
     /**
@@ -673,7 +691,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('single_send_text_binary', function (done) {
-      _single_send_separate_realtimes(done, { useBinaryProtocol: false }, { useBinaryProtocol: true });
+      _single_send_separate_realtimes(
+        done,
+        this.test.helper,
+        { useBinaryProtocol: false },
+        { useBinaryProtocol: true },
+      );
     });
 
     /**
@@ -687,7 +710,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         return;
       }
 
-      var txRealtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        txRealtime = helper.AblyRealtime(),
         rxRealtime = helper.AblyRealtime(),
         channelName = 'publish_immediately',
         messageText = 'Test message';
@@ -731,6 +755,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         return;
       }
 
+      const helper = this.test.helper;
       var txRealtime = helper.AblyRealtime();
       var rxRealtime = helper.AblyRealtime();
       var channelName = 'single_send_key_mismatch',
@@ -800,6 +825,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         return;
       }
 
+      const helper = this.test.helper;
       var txRealtime = helper.AblyRealtime();
       var rxRealtime = helper.AblyRealtime();
       var channelName = 'single_send_unencrypted',
@@ -846,6 +872,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         return;
       }
 
+      const helper = this.test.helper;
       var txRealtime = helper.AblyRealtime();
       var rxRealtime = helper.AblyRealtime();
       var channelName = 'single_send_encrypted_unhandled',
@@ -894,6 +921,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         return;
       }
 
+      const helper = this.test.helper;
       var txRealtime = helper.AblyRealtime();
       var rxRealtime = helper.AblyRealtime();
       var channelName = 'set_cipher_params',

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var BufferUtils = Ably.Realtime.Platform.BufferUtils;
   var Crypto = Ably.Realtime.Platform.Crypto;
@@ -11,7 +13,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     async.map(
       channels,
       function (channel, cb) {
-        helper.whenPromiseSettles(channel.attach(), cb);
+        Helper.whenPromiseSettles(channel.attach(), cb);
       },
       callback,
     );
@@ -99,7 +101,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSE2a - tests length in bits with explicit keyLength
      */
     it('generateRandomKey0', function (done) {
-      helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -122,7 +124,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSE2a - tests length in bits without keyLength
      */
     it('generateRandomKey1', function (done) {
-      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -142,7 +144,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSE1b - tests only passing key
      */
     it('getDefaultParams_withResultOfGenerateRandomKey', function (done) {
-      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
         }
@@ -160,7 +162,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     /** @specpartial RSE1c - can accept binary key */
     it('getDefaultParams_ArrayBuffer_key', function (done) {
-      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
         }
@@ -177,7 +179,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     /** @specpartial RSE1c - can accept base64 string key */
     it('getDefaultParams_base64_key', function (done) {
-      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -200,7 +202,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RSE1e
      */
     it('getDefaultParams_check_keylength', function (done) {
-      helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -220,7 +222,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSE1b - tests key, algorithm, mode
      */
     it('getDefaultParams_preserves_custom_algorithms', function (done) {
-      helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -251,7 +253,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         true,
         function (channelOpts, testMessage, encryptedMessage) {
           /* encrypt plaintext message; encode() also to handle data that is not already string or buffer */
-          helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+          Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
             /* compare */
             testMessageEquality(done, testMessage, encryptedMessage);
           });
@@ -272,7 +274,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         true,
         function (channelOpts, testMessage, encryptedMessage) {
           /* encrypt plaintext message; encode() also to handle data that is not already string or buffer */
-          helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+          Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
             /* compare */
             testMessageEquality(done, testMessage, encryptedMessage);
           });
@@ -359,7 +361,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           2,
           false,
           function (channelOpts, testMessage, encryptedMessage, msgpackEncodedMessage) {
-            helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+            Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
               var msgpackFromEncoded = msgpack.encode(testMessage);
               var msgpackFromEncrypted = msgpack.encode(encryptedMessage);
               var messageFromMsgpack = Message.fromValues(
@@ -397,7 +399,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           2,
           false,
           function (channelOpts, testMessage, encryptedMessage, msgpackEncodedMessage) {
-            helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+            Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
               var msgpackFromEncoded = msgpack.encode(testMessage);
               var msgpackFromEncrypted = msgpack.encode(encryptedMessage);
               var messageFromMsgpack = Message.fromValues(
@@ -430,7 +432,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         return;
       }
 
-      helper.whenPromiseSettles(Crypto.generateRandomKey(keyLength), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(keyLength), function (err, key) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -442,7 +444,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           channel = realtime.channels.get('single_send', { cipher: { key: key } }),
           messageText = 'Test message for single_send -	' + JSON.stringify(realtimeOpts);
 
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -469,14 +471,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     // Publish and subscribe, various transport, 128 and 256-bit
     /** @specpartial RSL5b - test aes 128 */
-    helper.testOnAllTransports('single_send_128', function (realtimeOpts) {
+    Helper.testOnAllTransports('single_send_128', function (realtimeOpts) {
       return function (done) {
         single_send(done, realtimeOpts, 128);
       };
     });
 
     /** @specpartial RSL5b - test aes 256 */
-    helper.testOnAllTransports('single_send_256', function (realtimeOpts) {
+    Helper.testOnAllTransports('single_send_256', function (realtimeOpts) {
       return function (done) {
         single_send(done, realtimeOpts, 256);
       };
@@ -493,7 +495,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channel = realtime.channels.get(channelName),
         messageText = 'Test message (' + channelName + ')';
 
-      helper.whenPromiseSettles(Crypto.generateRandomKey(128), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(128), function (err, key) {
         channel.setOptions({ cipher: { key: key } });
         try {
           expect(channel.channelOptions.cipher.algorithm).to.equal('aes');
@@ -526,7 +528,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         }
 
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -605,7 +607,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         txChannel = txRealtime.channels.get(channelName),
         rxChannel = rxRealtime.channels.get(channelName);
 
-      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -690,13 +692,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'publish_immediately',
         messageText = 'Test message';
 
-      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
           return;
         }
         var rxChannel = rxRealtime.channels.get(channelName, { cipher: { key: key } });
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           rxChannel.subscribe('event0', function (msg) {
             try {
               expect(msg.data == messageText).to.be.ok;
@@ -739,10 +741,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       async.parallel(
         [
           function (cb) {
-            helper.whenPromiseSettles(Crypto.generateRandomKey(), cb);
+            Helper.whenPromiseSettles(Crypto.generateRandomKey(), cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(Crypto.generateRandomKey(), cb);
+            Helper.whenPromiseSettles(Crypto.generateRandomKey(), cb);
           },
           function (cb) {
             attachChannels([txChannel, rxChannel], cb);
@@ -810,7 +812,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
           return;
         }
-        helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, rxKey) {
+        Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, rxKey) {
           if (err) {
             helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;
@@ -856,7 +858,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
           return;
         }
-        helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, txKey) {
+        Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, txKey) {
           if (err) {
             helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;
@@ -905,7 +907,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         attachChannels([txChannel, rxChannel], cb);
       };
       var setInitialOptions = function (cb) {
-        helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+        Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
           if (err) {
             helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;
@@ -938,7 +940,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       };
 
       var createSecondKey = function (cb) {
-        helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+        Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
           if (err) {
             helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -2,22 +2,16 @@
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
   var expect = chai.expect;
-  var loadTestData = helper.loadTestData;
   var BufferUtils = Ably.Realtime.Platform.BufferUtils;
   var Crypto = Ably.Realtime.Platform.Crypto;
   var Message = Ably.Realtime.Message;
-  var displayError = helper.displayError;
-  var testResourcesPath = helper.testResourcesPath;
   var msgpack = typeof window == 'object' ? Ably.msgpack : require('@ably/msgpack-js');
-  var testOnAllTransports = helper.testOnAllTransports;
-  var closeAndFinish = helper.closeAndFinish;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   function attachChannels(channels, callback) {
     async.map(
       channels,
       function (channel, cb) {
-        whenPromiseSettles(channel.attach(), cb);
+        helper.whenPromiseSettles(channel.attach(), cb);
       },
       callback,
     );
@@ -37,9 +31,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       return;
     }
 
-    loadTestData(testResourcesPath + filename, async function (err, testData) {
+    helper.loadTestData(helper.testResourcesPath + filename, async function (err, testData) {
       if (err) {
-        done(new Error('Unable to get test assets; err = ' + displayError(err)));
+        done(new Error('Unable to get test assets; err = ' + helper.displayError(err)));
         return;
       }
       var realtime = helper.AblyRealtime();
@@ -78,10 +72,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           }
         }
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
   }
 
@@ -105,7 +99,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSE2a - tests length in bits with explicit keyLength
      */
     it('generateRandomKey0', function (done) {
-      whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -128,7 +122,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSE2a - tests length in bits without keyLength
      */
     it('generateRandomKey1', function (done) {
-      whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -148,7 +142,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSE1b - tests only passing key
      */
     it('getDefaultParams_withResultOfGenerateRandomKey', function (done) {
-      whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
         }
@@ -166,7 +160,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     /** @specpartial RSE1c - can accept binary key */
     it('getDefaultParams_ArrayBuffer_key', function (done) {
-      whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
         }
@@ -183,7 +177,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     /** @specpartial RSE1c - can accept base64 string key */
     it('getDefaultParams_base64_key', function (done) {
-      whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -206,7 +200,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RSE1e
      */
     it('getDefaultParams_check_keylength', function (done) {
-      whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -226,7 +220,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSE1b - tests key, algorithm, mode
      */
     it('getDefaultParams_preserves_custom_algorithms', function (done) {
-      whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(64), function (err, key) {
         if (err) {
           done(err);
           return;
@@ -257,7 +251,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         true,
         function (channelOpts, testMessage, encryptedMessage) {
           /* encrypt plaintext message; encode() also to handle data that is not already string or buffer */
-          whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+          helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
             /* compare */
             testMessageEquality(done, testMessage, encryptedMessage);
           });
@@ -278,7 +272,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         true,
         function (channelOpts, testMessage, encryptedMessage) {
           /* encrypt plaintext message; encode() also to handle data that is not already string or buffer */
-          whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+          helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
             /* compare */
             testMessageEquality(done, testMessage, encryptedMessage);
           });
@@ -333,7 +327,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         return;
       }
 
-      loadTestData(testResourcesPath + 'crypto-data-256.json', async function (err, testData) {
+      helper.loadTestData(helper.testResourcesPath + 'crypto-data-256.json', async function (err, testData) {
         if (err) {
           done(err);
           return;
@@ -365,7 +359,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           2,
           false,
           function (channelOpts, testMessage, encryptedMessage, msgpackEncodedMessage) {
-            whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+            helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
               var msgpackFromEncoded = msgpack.encode(testMessage);
               var msgpackFromEncrypted = msgpack.encode(encryptedMessage);
               var messageFromMsgpack = Message.fromValues(
@@ -403,7 +397,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           2,
           false,
           function (channelOpts, testMessage, encryptedMessage, msgpackEncodedMessage) {
-            whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+            helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
               var msgpackFromEncoded = msgpack.encode(testMessage);
               var msgpackFromEncrypted = msgpack.encode(encryptedMessage);
               var messageFromMsgpack = Message.fromValues(
@@ -436,9 +430,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         return;
       }
 
-      whenPromiseSettles(Crypto.generateRandomKey(keyLength), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(keyLength), function (err, key) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
         /* For single_send tests we test the 'shortcut' way of setting the cipher
@@ -448,25 +442,25 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           channel = realtime.channels.get('single_send', { cipher: { key: key } }),
           messageText = 'Test message for single_send -	' + JSON.stringify(realtimeOpts);
 
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           try {
             expect(channel.channelOptions.cipher.algorithm).to.equal('aes');
             expect(channel.channelOptions.cipher.keyLength).to.equal(keyLength);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
           channel.subscribe('event0', function (msg) {
             try {
               expect(msg.data == messageText).to.be.ok;
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           });
           channel.publish('event0', messageText);
         });
@@ -475,14 +469,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
     // Publish and subscribe, various transport, 128 and 256-bit
     /** @specpartial RSL5b - test aes 128 */
-    testOnAllTransports('single_send_128', function (realtimeOpts) {
+    helper.testOnAllTransports('single_send_128', function (realtimeOpts) {
       return function (done) {
         single_send(done, realtimeOpts, 128);
       };
     });
 
     /** @specpartial RSL5b - test aes 256 */
-    testOnAllTransports('single_send_256', function (realtimeOpts) {
+    helper.testOnAllTransports('single_send_256', function (realtimeOpts) {
       return function (done) {
         single_send(done, realtimeOpts, 256);
       };
@@ -499,13 +493,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channel = realtime.channels.get(channelName),
         messageText = 'Test message (' + channelName + ')';
 
-      whenPromiseSettles(Crypto.generateRandomKey(128), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(128), function (err, key) {
         channel.setOptions({ cipher: { key: key } });
         try {
           expect(channel.channelOptions.cipher.algorithm).to.equal('aes');
           expect(channel.channelOptions.cipher.keyLength).to.equal(128);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
         function sendAll(sendCb) {
@@ -532,13 +526,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         }
 
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           async.parallel([sendAll, recvAll], function (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           });
         });
       });
@@ -611,9 +605,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         txChannel = txRealtime.channels.get(channelName),
         rxChannel = rxRealtime.channels.get(channelName);
 
-      whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
         async.parallel(
@@ -629,14 +623,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           ],
           function (err) {
             if (err) {
-              closeAndFinish(done, [txRealtime, rxRealtime], err);
+              helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
               return;
             }
             try {
               expect(txChannel.channelOptions.cipher.algorithm).to.equal('aes');
               expect(rxChannel.channelOptions.cipher.algorithm).to.equal('aes');
             } catch (err) {
-              closeAndFinish(done, [txRealtime, rxRealtime], err);
+              helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             }
 
             attachChannels([txChannel, rxChannel], function () {
@@ -644,10 +638,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 try {
                   expect(msg.data == messageText).to.be.ok;
                 } catch (err) {
-                  closeAndFinish(done, [txRealtime, rxRealtime], err);
+                  helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
                   return;
                 }
-                closeAndFinish(done, [txRealtime, rxRealtime]);
+                helper.closeAndFinish(done, [txRealtime, rxRealtime]);
               });
               txChannel.publish('event0', messageText);
             });
@@ -696,21 +690,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         channelName = 'publish_immediately',
         messageText = 'Test message';
 
-      whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+      helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
-          closeAndFinish(done, [txRealtime, rxRealtime], err);
+          helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
           return;
         }
         var rxChannel = rxRealtime.channels.get(channelName, { cipher: { key: key } });
-        whenPromiseSettles(
+        helper.whenPromiseSettles(
           rxChannel.subscribe('event0', function (msg) {
             try {
               expect(msg.data == messageText).to.be.ok;
             } catch (err) {
-              closeAndFinish(done, [txRealtime, rxRealtime], err);
+              helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
               return;
             }
-            closeAndFinish(done, [txRealtime, rxRealtime]);
+            helper.closeAndFinish(done, [txRealtime, rxRealtime]);
           }),
           function () {
             var txChannel = txRealtime.channels.get(channelName, { cipher: { key: key } });
@@ -745,10 +739,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       async.parallel(
         [
           function (cb) {
-            whenPromiseSettles(Crypto.generateRandomKey(), cb);
+            helper.whenPromiseSettles(Crypto.generateRandomKey(), cb);
           },
           function (cb) {
-            whenPromiseSettles(Crypto.generateRandomKey(), cb);
+            helper.whenPromiseSettles(Crypto.generateRandomKey(), cb);
           },
           function (cb) {
             attachChannels([txChannel, rxChannel], cb);
@@ -756,7 +750,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         ],
         function (err, res) {
           if (err) {
-            closeAndFinish(done, [txRealtime, rxRealtime], err);
+            helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;
           }
           var txKey = res[0],
@@ -778,10 +772,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 try {
                   expect(msg.data != messageText).to.be.ok;
                 } catch (err) {
-                  closeAndFinish(done, [txRealtime, rxRealtime], err);
+                  helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
                   return;
                 }
-                closeAndFinish(done, [txRealtime, rxRealtime]);
+                helper.closeAndFinish(done, [txRealtime, rxRealtime]);
               });
               txChannel.publish('event0', messageText);
             },
@@ -813,12 +807,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       attachChannels([txChannel, rxChannel], function (err) {
         if (err) {
-          closeAndFinish(done, [txRealtime, rxRealtime], err);
+          helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
           return;
         }
-        whenPromiseSettles(Crypto.generateRandomKey(), function (err, rxKey) {
+        helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, rxKey) {
           if (err) {
-            closeAndFinish(done, [txRealtime, rxRealtime], err);
+            helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;
           }
           rxChannel.setOptions({ cipher: { key: rxKey } });
@@ -826,10 +820,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             try {
               expect(msg.data == messageText).to.be.ok;
             } catch (err) {
-              closeAndFinish(done, [txRealtime, rxRealtime], err);
+              helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
               return;
             }
-            closeAndFinish(done, [txRealtime, rxRealtime]);
+            helper.closeAndFinish(done, [txRealtime, rxRealtime]);
           });
           txChannel.publish('event0', messageText);
         });
@@ -859,12 +853,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       attachChannels([txChannel, rxChannel], function (err) {
         if (err) {
-          closeAndFinish(done, [txRealtime, rxRealtime], err);
+          helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
           return;
         }
-        whenPromiseSettles(Crypto.generateRandomKey(), function (err, txKey) {
+        helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, txKey) {
           if (err) {
-            closeAndFinish(done, [txRealtime, rxRealtime], err);
+            helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;
           }
           txChannel.setOptions({ cipher: { key: txKey } });
@@ -872,10 +866,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             try {
               expect(msg.encoding.indexOf('cipher') > -1).to.be.ok;
             } catch (err) {
-              closeAndFinish(done, [txRealtime, rxRealtime], err);
+              helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
               return;
             }
-            closeAndFinish(done, [txRealtime, rxRealtime]);
+            helper.closeAndFinish(done, [txRealtime, rxRealtime]);
           });
           txChannel.publish('event0', messageText);
         });
@@ -911,9 +905,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         attachChannels([txChannel, rxChannel], cb);
       };
       var setInitialOptions = function (cb) {
-        whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+        helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
           if (err) {
-            closeAndFinish(done, [txRealtime, rxRealtime], err);
+            helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;
           }
           firstKey = key;
@@ -944,9 +938,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       };
 
       var createSecondKey = function (cb) {
-        whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
+        helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
           if (err) {
-            closeAndFinish(done, [txRealtime, rxRealtime], err);
+            helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
             return;
           }
           secondKey = key;
@@ -1002,7 +996,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           sendThirdMessage,
         ],
         function (err) {
-          closeAndFinish(done, [txRealtime, rxRealtime], err);
+          helper.closeAndFinish(done, [txRealtime, rxRealtime], err);
         },
       );
     });

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -37,6 +37,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         return;
       }
       var realtime = helper.AblyRealtime();
+      helper.recordPrivateApi('call.BufferUtils.base64Decode');
       var key = BufferUtils.base64Decode(testData.key);
       var iv = BufferUtils.base64Decode(testData.iv);
       var channel = realtime.channels.get(channelName, { cipher: { key: key, iv: iv } });
@@ -63,9 +64,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
           if (testPlaintextVariants) {
             var testMessage = await createTestMessage();
+            helper.recordPrivateApi('call.BufferUtils.isBuffer');
             if (BufferUtils.isBuffer(testMessage.data) && !(testMessage.data instanceof ArrayBuffer)) {
               // Now, check that we can also handle an ArrayBuffer plaintext.
               var testMessageWithArrayBufferData = await createTestMessage();
+              helper.recordPrivateApi('call.BufferUtils.toArrayBuffer');
               testMessageWithArrayBufferData.data = BufferUtils.toArrayBuffer(testMessageWithArrayBufferData.data);
               runTest(testMessageWithArrayBufferData);
             }
@@ -161,13 +164,16 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @specpartial RSE1c - can accept binary key */
     it('getDefaultParams_ArrayBuffer_key', function (done) {
+      const helper = this.test.helper;
       Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
         }
+        helper.recordPrivateApi('call.BufferUtils.toArrayBuffer');
         var arrayBufferKey = Ably.Realtime.Platform.BufferUtils.toArrayBuffer(key);
         var params = Crypto.getDefaultParams({ key: arrayBufferKey });
         try {
+          helper.recordPrivateApi('call.BufferUtils.areBuffersEqual');
           expect(BufferUtils.areBuffersEqual(params.key, key)).to.equal(true);
           done();
         } catch (err) {
@@ -178,14 +184,17 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @specpartial RSE1c - can accept base64 string key */
     it('getDefaultParams_base64_key', function (done) {
+      const helper = this.test.helper;
       Helper.whenPromiseSettles(Crypto.generateRandomKey(), function (err, key) {
         if (err) {
           done(err);
           return;
         }
+        helper.recordPrivateApi('call.BufferUtils.base64Encode');
         var b64key = Ably.Realtime.Platform.BufferUtils.base64Encode(key);
         var params = Crypto.getDefaultParams({ key: b64key });
         try {
+          helper.recordPrivateApi('call.BufferUtils.areBuffersEqual');
           expect(BufferUtils.areBuffersEqual(params.key, key)).to.equal(true);
           done();
         } catch (err) {
@@ -254,6 +263,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         true,
         function (channelOpts, testMessage, encryptedMessage) {
           /* encrypt plaintext message; encode() also to handle data that is not already string or buffer */
+          helper.recordPrivateApi('call.Message.encode');
           Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
             /* compare */
             testMessageEquality(done, helper, testMessage, encryptedMessage);
@@ -277,6 +287,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         true,
         function (channelOpts, testMessage, encryptedMessage) {
           /* encrypt plaintext message; encode() also to handle data that is not already string or buffer */
+          helper.recordPrivateApi('call.Message.encode');
           Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
             /* compare */
             testMessageEquality(done, helper, testMessage, encryptedMessage);
@@ -300,6 +311,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         false,
         async function (channelOpts, testMessage, encryptedMessage) {
           /* decrypt encrypted message; decode() also to handle data that is not string or buffer */
+          helper.recordPrivateApi('call.Message.decode');
           await Message.decode(encryptedMessage, channelOpts);
           /* compare */
           testMessageEquality(done, helper, testMessage, encryptedMessage);
@@ -322,6 +334,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         false,
         async function (channelOpts, testMessage, encryptedMessage) {
           /* decrypt encrypted message; decode() also to handle data that is not string or buffer */
+          helper.recordPrivateApi('call.Message.decode');
           await Message.decode(encryptedMessage, channelOpts);
           /* compare */
           testMessageEquality(done, helper, testMessage, encryptedMessage);
@@ -343,6 +356,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           done(err);
           return;
         }
+        helper.recordPrivateApi('call.BufferUtils.base64Decode');
         var key = BufferUtils.base64Decode(testData.key);
         var iv = BufferUtils.base64Decode(testData.iv);
 
@@ -372,9 +386,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           2,
           false,
           function (channelOpts, testMessage, encryptedMessage, msgpackEncodedMessage) {
+            helper.recordPrivateApi('call.Message.encode');
             Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+              helper.recordPrivateApi('call.msgpack.encode');
               var msgpackFromEncoded = msgpack.encode(testMessage);
               var msgpackFromEncrypted = msgpack.encode(encryptedMessage);
+              helper.recordPrivateApi('call.BufferUtils.base64Decode');
+              helper.recordPrivateApi('call.msgpack.decode');
               var messageFromMsgpack = Message.fromValues(
                 msgpack.decode(BufferUtils.base64Decode(msgpackEncodedMessage)),
               );
@@ -382,6 +400,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               try {
                 /* Mainly testing that we're correctly encoding the direct output from
                  * the platform's ICipher implementation into the msgpack binary type */
+                helper.recordPrivateApi('call.BufferUtils.areBuffersEqual');
                 expect(BufferUtils.areBuffersEqual(msgpackFromEncoded, msgpackFromEncrypted)).to.equal(
                   true,
                   'verify msgpack encodings of newly-encrypted and preencrypted messages identical using areBuffersEqual',
@@ -413,8 +432,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           false,
           function (channelOpts, testMessage, encryptedMessage, msgpackEncodedMessage) {
             Helper.whenPromiseSettles(Message.encode(testMessage, channelOpts), function () {
+              helper.recordPrivateApi('call.msgpack.encode');
               var msgpackFromEncoded = msgpack.encode(testMessage);
               var msgpackFromEncrypted = msgpack.encode(encryptedMessage);
+              helper.recordPrivateApi('call.BufferUtils.base64Decode');
+              helper.recordPrivateApi('call.msgpack.decode');
               var messageFromMsgpack = Message.fromValues(
                 msgpack.decode(BufferUtils.base64Decode(msgpackEncodedMessage)),
               );
@@ -422,6 +444,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               try {
                 /* Mainly testing that we're correctly encoding the direct output from
                  * the platform's ICipher implementation into the msgpack binary type */
+                helper.recordPrivateApi('call.BufferUtils.areBuffersEqual');
                 expect(BufferUtils.areBuffersEqual(msgpackFromEncoded, msgpackFromEncrypted)).to.equal(
                   true,
                   'verify msgpack encodings of newly-encrypted and preencrypted messages identical using areBuffersEqual',
@@ -440,6 +463,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     }
 
     function single_send(done, helper, realtimeOpts, keyLength) {
+      // the _128 and _256 variants both call this so it makes more sense for this to be the parameterisedTestTitle instead of that set by testOnAllTransports
+      helper = helper.withParameterisedTestTitle('single_send');
+
       if (!Crypto) {
         done(new Error('Encryption not supported'));
         return;
@@ -463,6 +489,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
             return;
           }
           try {
+            helper.recordPrivateApi('read.channel.channelOptions.cipher');
             expect(channel.channelOptions.cipher.algorithm).to.equal('aes');
             expect(channel.channelOptions.cipher.keyLength).to.equal(keyLength);
           } catch (err) {
@@ -498,6 +525,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     function _multiple_send(done, helper, text, iterations, delay) {
+      helper = helper.withParameterisedTestTitle('multiple_send');
+
       if (!Crypto) {
         done(new Error('Encryption not supported'));
         return;
@@ -511,6 +540,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       Helper.whenPromiseSettles(Crypto.generateRandomKey(128), function (err, key) {
         channel.setOptions({ cipher: { key: key } });
         try {
+          helper.recordPrivateApi('read.channel.channelOptions.cipher');
           expect(channel.channelOptions.cipher.algorithm).to.equal('aes');
           expect(channel.channelOptions.cipher.keyLength).to.equal(128);
         } catch (err) {
@@ -642,6 +672,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               return;
             }
             try {
+              helper.recordPrivateApi('read.channel.channelOptions.cipher');
               expect(txChannel.channelOptions.cipher.algorithm).to.equal('aes');
               expect(rxChannel.channelOptions.cipher.algorithm).to.equal('aes');
             } catch (err) {

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -484,14 +484,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     // Publish and subscribe, various transport, 128 and 256-bit
     /** @specpartial RSL5b - test aes 128 */
-    Helper.testOnAllTransports('single_send_128', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'single_send_128', function (realtimeOpts) {
       return function (done) {
         single_send(done, this.test.helper, realtimeOpts, 128);
       };
     });
 
     /** @specpartial RSL5b - test aes 256 */
-    Helper.testOnAllTransports('single_send_256', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'single_send_256', function (realtimeOpts) {
       return function (done) {
         single_send(done, this.test.helper, realtimeOpts, 256);
       };

--- a/test/realtime/delta.test.js
+++ b/test/realtime/delta.test.js
@@ -2,10 +2,6 @@
 
 define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, vcdiffDecoder, async, chai) {
   var expect = chai.expect;
-  var displayError = helper.displayError;
-  var closeAndFinish = helper.closeAndFinish;
-  var monitorConnection = helper.monitorConnection;
-  var whenPromiseSettles = helper.whenPromiseSettles;
   var testData = [
     { foo: 'bar', count: 1, status: 'active' },
     { foo: 'bar', count: 2, status: 'active' },
@@ -52,15 +48,16 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         });
         var channel = realtime.channels.get(testName, { params: { delta: 'vcdiff' } });
 
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
 
           channel.on('attaching', function (stateChange) {
             done(
               new Error(
-                'Channel reattaching, presumably due to decode failure; reason =' + displayError(stateChange.reason),
+                'Channel reattaching, presumably due to decode failure; reason =' +
+                  helper.displayError(stateChange.reason),
               ),
             );
           });
@@ -72,21 +69,21 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
 
               if (index === testData.length - 1) {
                 expect(testVcdiffDecoder.numberOfCalls).to.equal(testData.length - 1, 'Check number of delta messages');
-                closeAndFinish(done, realtime);
+                helper.closeAndFinish(done, realtime);
               }
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
 
           async.timesSeries(testData.length, function (i, cb) {
-            whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -106,9 +103,9 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         });
         var channel = realtime.channels.get(testName);
 
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
           channel.subscribe(function (message) {
             try {
@@ -117,21 +114,21 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
 
               if (index === testData.length - 1) {
                 expect(testVcdiffDecoder.numberOfCalls).to.equal(0, 'Check number of delta messages');
-                closeAndFinish(done, realtime);
+                helper.closeAndFinish(done, realtime);
               }
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
 
           async.timesSeries(testData.length, function (i, cb) {
-            whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -151,16 +148,16 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         });
         var channel = realtime.channels.get(testName, { params: { delta: 'vcdiff' } });
 
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
           channel.subscribe(function (message) {
             var index = Number(message.name);
             try {
               expect(equals(testData[index], message.data), 'Check message.data').to.be.ok;
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
 
             if (index === 1) {
@@ -170,14 +167,14 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
                 try {
                   expect(stateChange.reason.code).to.equal(40018, 'Check error code passed through per RTL18c');
                 } catch (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                   return;
                 }
                 channel.on('attaching', function (stateChange) {
-                  closeAndFinish(
+                  helper.closeAndFinish(
                     done,
                     realtime,
-                    new Error('Check no further decode failures; reason =' + displayError(stateChange.reason)),
+                    new Error('Check no further decode failures; reason =' + helper.displayError(stateChange.reason)),
                   );
                 });
               });
@@ -186,21 +183,21 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
                 // RTL18b - one message was discarded due to failed decoding
                 expect(testVcdiffDecoder.numberOfCalls).to.equal(testData.length - 2, 'Check number of delta messages');
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             }
           });
 
           async.timesSeries(testData.length, function (i, cb) {
-            whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -224,15 +221,15 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         });
         var channel = realtime.channels.get(testName, { params: { delta: 'vcdiff' } });
 
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
           channel.on('attaching', function (stateChange) {
             try {
               expect(stateChange.reason.code).to.equal(40018, 'Check error code passed through per RTL18c');
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
           channel.subscribe(function (message) {
@@ -240,22 +237,22 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
             try {
               expect(equals(testData[index], message.data), 'Check message.data').to.be.ok;
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
 
             if (index === testData.length - 1) {
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             }
           });
 
           async.timesSeries(testData.length, function (i, cb) {
-            whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -270,27 +267,27 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         var realtime = helper.AblyRealtime();
         var channel = realtime.channels.get('noPlugin', { params: { delta: 'vcdiff' } });
 
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
           channel.once('failed', function (stateChange) {
             try {
               expect(stateChange.reason.code).to.equal(40019, 'Check error code');
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           });
           async.timesSeries(testData.length, function (i, cb) {
-            whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
   });

--- a/test/realtime/delta.test.js
+++ b/test/realtime/delta.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, vcdiffDecoder, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var testData = [
     { foo: 'bar', count: 1, status: 'active' },
@@ -30,6 +28,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, v
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -40,6 +39,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, v
 
     /** @spec PC3 */
     it('deltaPlugin', function (done) {
+      const helper = this.test.helper;
       var testName = 'deltaPlugin';
       try {
         var testVcdiffDecoder = getTestVcdiffDecoder();
@@ -95,6 +95,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, v
      * @nospec
      */
     it('unusedPlugin', function (done) {
+      const helper = this.test.helper;
       var testName = 'unusedPlugin';
       try {
         var testVcdiffDecoder = getTestVcdiffDecoder();
@@ -140,6 +141,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, v
      * @spec RTL18c
      */
     it('lastMessageNotFoundRecovery', function (done) {
+      const helper = this.test.helper;
       var testName = 'lastMessageNotFoundRecovery';
       try {
         var testVcdiffDecoder = getTestVcdiffDecoder();
@@ -208,6 +210,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, v
      * @spec RTL18c
      */
     it('deltaDecodeFailureRecovery', function (done) {
+      const helper = this.test.helper;
       var testName = 'deltaDecodeFailureRecovery';
       try {
         var failingTestVcdiffDecoder = {
@@ -265,6 +268,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, v
      * @nospec
      */
     it('noPlugin', function (done) {
+      const helper = this.test.helper;
       try {
         var realtime = helper.AblyRealtime();
         var channel = realtime.channels.get('noPlugin', { params: { delta: 'vcdiff' } });

--- a/test/realtime/delta.test.js
+++ b/test/realtime/delta.test.js
@@ -166,6 +166,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, v
 
             if (index === 1) {
               /* Simulate issue */
+              helper.recordPrivateApi('write.channel._lastPayload');
               channel._lastPayload.messageId = null;
               channel.once('attaching', function (stateChange) {
                 try {

--- a/test/realtime/delta.test.js
+++ b/test/realtime/delta.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, vcdiffDecoder, async, chai) {
+define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (Helper, vcdiffDecoder, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var testData = [
     { foo: 'bar', count: 1, status: 'active' },
@@ -48,7 +50,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         });
         var channel = realtime.channels.get(testName, { params: { delta: 'vcdiff' } });
 
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
           }
@@ -77,7 +79,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
           });
 
           async.timesSeries(testData.length, function (i, cb) {
-            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            Helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
@@ -103,7 +105,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         });
         var channel = realtime.channels.get(testName);
 
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
           }
@@ -122,7 +124,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
           });
 
           async.timesSeries(testData.length, function (i, cb) {
-            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            Helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
@@ -148,7 +150,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         });
         var channel = realtime.channels.get(testName, { params: { delta: 'vcdiff' } });
 
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
           }
@@ -191,7 +193,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
           });
 
           async.timesSeries(testData.length, function (i, cb) {
-            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            Helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
@@ -221,7 +223,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         });
         var channel = realtime.channels.get(testName, { params: { delta: 'vcdiff' } });
 
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
           }
@@ -246,7 +248,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
           });
 
           async.timesSeries(testData.length, function (i, cb) {
-            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            Helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 
@@ -267,7 +269,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
         var realtime = helper.AblyRealtime();
         var channel = realtime.channels.get('noPlugin', { params: { delta: 'vcdiff' } });
 
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
           }
@@ -281,7 +283,7 @@ define(['shared_helper', 'vcdiff-decoder', 'async', 'chai'], function (helper, v
             helper.closeAndFinish(done, realtime);
           });
           async.timesSeries(testData.length, function (i, cb) {
-            helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
+            Helper.whenPromiseSettles(channel.publish(i.toString(), testData[i]), cb);
           });
         });
 

--- a/test/realtime/encoding.test.js
+++ b/test/realtime/encoding.test.js
@@ -2,13 +2,12 @@
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
   var expect = chai.expect;
-  var loadTestData = helper.loadTestData;
   var BufferUtils = Ably.Realtime.Platform.BufferUtils;
-  var displayError = helper.displayError;
-  var encodingFixturesPath = helper.testResourcesPath + 'messages-encoding.json';
-  var closeAndFinish = helper.closeAndFinish;
   var Defaults = Ably.Rest.Platform.Defaults;
-  var whenPromiseSettles = helper.whenPromiseSettles;
+
+  function encodingFixturesPath() {
+    return helper.testResourcesPath + 'messages-encoding.json';
+  }
 
   describe('realtime/encoding', function () {
     this.timeout(60 * 1000);
@@ -30,7 +29,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSL6a1 - publish through REST API, receive via realtime for all transports
      */
     it('message_decoding', function (done) {
-      loadTestData(encodingFixturesPath, function (err, testData) {
+      helper.loadTestData(encodingFixturesPath(), function (err, testData) {
         if (err) {
           done(err);
           return;
@@ -45,15 +44,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         async.parallel(
           [
             function (attachCb) {
-              whenPromiseSettles(channel.attach(), attachCb);
+              helper.whenPromiseSettles(channel.attach(), attachCb);
             },
             function (attachCb) {
-              whenPromiseSettles(binarychannel.attach(), attachCb);
+              helper.whenPromiseSettles(binarychannel.attach(), attachCb);
             },
           ],
           function (err) {
             if (err) {
-              closeAndFinish(done, [realtime, binaryrealtime], err);
+              helper.closeAndFinish(done, [realtime, binaryrealtime], err);
               return;
             }
             async.eachOf(
@@ -100,7 +99,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                       });
                     },
                     function (parallelCb) {
-                      whenPromiseSettles(
+                      helper.whenPromiseSettles(
                         realtime.request(
                           'post',
                           channelPath,
@@ -119,7 +118,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 );
               },
               function (err) {
-                closeAndFinish(done, [realtime, binaryrealtime], err);
+                helper.closeAndFinish(done, [realtime, binaryrealtime], err);
               },
             );
           },
@@ -134,9 +133,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSL6a1 - publish through realtime, receive via rest (history) for all transports
      */
     it('message_encoding', function (done) {
-      loadTestData(encodingFixturesPath, function (err, testData) {
+      helper.loadTestData(encodingFixturesPath(), function (err, testData) {
         if (err) {
-          done(new Error('Unable to get test assets; err = ' + displayError(err)));
+          done(new Error('Unable to get test assets; err = ' + helper.displayError(err)));
           return;
         }
         var realtime = helper.AblyRealtime({ useBinaryProtocol: false }),
@@ -149,15 +148,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         async.parallel(
           [
             function (attachCb) {
-              whenPromiseSettles(channel.attach(), attachCb);
+              helper.whenPromiseSettles(channel.attach(), attachCb);
             },
             function (attachCb) {
-              whenPromiseSettles(binarychannel.attach(), attachCb);
+              helper.whenPromiseSettles(binarychannel.attach(), attachCb);
             },
           ],
           function (err) {
             if (err) {
-              closeAndFinish(done, [realtime, binaryrealtime], err);
+              helper.closeAndFinish(done, [realtime, binaryrealtime], err);
               return;
             }
             async.eachOf(
@@ -174,10 +173,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 async.parallel(
                   [
                     function (parallelCb) {
-                      whenPromiseSettles(channel.publish(name, data), parallelCb);
+                      helper.whenPromiseSettles(channel.publish(name, data), parallelCb);
                     },
                     function (parallelCb) {
-                      whenPromiseSettles(binarychannel.publish(name, data), parallelCb);
+                      helper.whenPromiseSettles(binarychannel.publish(name, data), parallelCb);
                     },
                   ],
                   function (err) {
@@ -185,7 +184,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                       eachOfCb(err);
                       return;
                     }
-                    whenPromiseSettles(
+                    helper.whenPromiseSettles(
                       realtime.request('get', channelPath, 3, null, null, null),
                       function (err, resultPage) {
                         if (err) {
@@ -225,7 +224,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 );
               },
               function (err) {
-                closeAndFinish(done, [realtime, binaryrealtime], err);
+                helper.closeAndFinish(done, [realtime, binaryrealtime], err);
               },
             );
           },

--- a/test/realtime/encoding.test.js
+++ b/test/realtime/encoding.test.js
@@ -1,13 +1,11 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var BufferUtils = Ably.Realtime.Platform.BufferUtils;
   var Defaults = Ably.Rest.Platform.Defaults;
 
-  function encodingFixturesPath() {
+  function encodingFixturesPath(helper) {
     return helper.testResourcesPath + 'messages-encoding.json';
   }
 
@@ -15,6 +13,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -31,7 +30,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL6a1 - publish through REST API, receive via realtime for all transports
      */
     it('message_decoding', function (done) {
-      helper.loadTestData(encodingFixturesPath(), function (err, testData) {
+      const helper = this.test.helper;
+      helper.loadTestData(encodingFixturesPath(helper), function (err, testData) {
         if (err) {
           done(err);
           return;
@@ -135,7 +135,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL6a1 - publish through realtime, receive via rest (history) for all transports
      */
     it('message_encoding', function (done) {
-      helper.loadTestData(encodingFixturesPath(), function (err, testData) {
+      const helper = this.test.helper;
+      helper.loadTestData(encodingFixturesPath(helper), function (err, testData) {
         if (err) {
           done(new Error('Unable to get test assets; err = ' + helper.displayError(err)));
           return;

--- a/test/realtime/encoding.test.js
+++ b/test/realtime/encoding.test.js
@@ -68,6 +68,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
                       channel.subscribe(name, function (msg) {
                         try {
                           if (encodingSpec.expectedHexValue) {
+                            helper.recordPrivateApi('call.BufferUtils.hexEncode');
                             expect(BufferUtils.hexEncode(msg.data)).to.equal(
                               encodingSpec.expectedHexValue,
                               'Check data matches',
@@ -86,6 +87,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
                       binarychannel.subscribe(name, function (msg) {
                         try {
                           if (encodingSpec.expectedHexValue) {
+                            helper.recordPrivateApi('call.BufferUtils.hexEncode');
                             expect(BufferUtils.hexEncode(msg.data)).to.equal(
                               encodingSpec.expectedHexValue,
                               'Check data matches',
@@ -169,6 +171,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
                 var data,
                   name = index.toString();
                 if (encodingSpec.expectedHexValue) {
+                  helper.recordPrivateApi('call.BufferUtils.base64Decode');
                   data = BufferUtils.base64Decode(encodingSpec.data);
                 } else {
                   data = encodingSpec.expectedValue;

--- a/test/realtime/encoding.test.js
+++ b/test/realtime/encoding.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var BufferUtils = Ably.Realtime.Platform.BufferUtils;
   var Defaults = Ably.Rest.Platform.Defaults;
@@ -44,10 +46,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         async.parallel(
           [
             function (attachCb) {
-              helper.whenPromiseSettles(channel.attach(), attachCb);
+              Helper.whenPromiseSettles(channel.attach(), attachCb);
             },
             function (attachCb) {
-              helper.whenPromiseSettles(binarychannel.attach(), attachCb);
+              Helper.whenPromiseSettles(binarychannel.attach(), attachCb);
             },
           ],
           function (err) {
@@ -99,7 +101,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                       });
                     },
                     function (parallelCb) {
-                      helper.whenPromiseSettles(
+                      Helper.whenPromiseSettles(
                         realtime.request(
                           'post',
                           channelPath,
@@ -148,10 +150,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         async.parallel(
           [
             function (attachCb) {
-              helper.whenPromiseSettles(channel.attach(), attachCb);
+              Helper.whenPromiseSettles(channel.attach(), attachCb);
             },
             function (attachCb) {
-              helper.whenPromiseSettles(binarychannel.attach(), attachCb);
+              Helper.whenPromiseSettles(binarychannel.attach(), attachCb);
             },
           ],
           function (err) {
@@ -173,10 +175,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 async.parallel(
                   [
                     function (parallelCb) {
-                      helper.whenPromiseSettles(channel.publish(name, data), parallelCb);
+                      Helper.whenPromiseSettles(channel.publish(name, data), parallelCb);
                     },
                     function (parallelCb) {
-                      helper.whenPromiseSettles(binarychannel.publish(name, data), parallelCb);
+                      Helper.whenPromiseSettles(binarychannel.publish(name, data), parallelCb);
                     },
                   ],
                   function (err) {
@@ -184,7 +186,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                       eachOfCb(err);
                       return;
                     }
-                    helper.whenPromiseSettles(
+                    Helper.whenPromiseSettles(
                       realtime.request('get', channelPath, 3, null, null, null),
                       function (err, resultPage) {
                         if (err) {

--- a/test/realtime/event_emitter.test.js
+++ b/test/realtime/event_emitter.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 define(['shared_helper', 'chai'], function (Helper, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
 
   describe('realtime/event_emitter', function () {
     this.timeout(60 * 1000);
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -30,6 +29,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @specpartial RTL2 - RealtimeChannel implements EventEmitter
      */
     it('attachdetach0', function (done) {
+      const helper = this.test.helper;
       try {
         var realtime = helper.AblyRealtime(),
           index,
@@ -78,7 +78,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
     /** @specpartial RTE6 - test exceptions in callbacks do not propagate */
     it('emitCallsAllCallbacksIgnoringExceptions', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         callbackCalled = false,
         eventEmitter = realtime.connection;
 
@@ -104,7 +105,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
     /** @specpartial RTE4 - ensure that each registration is only invoked once */
     it('onceCalledOnlyOnce', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         onCallbackCalled = 0,
         onceCallbackCalled = 0,
         eventEmitter = realtime.connection;
@@ -137,7 +139,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @specpartial RTE4 - same listener is added multiple times listener registry
      */
     it('onceCallbackDoesNotImpactOnCallback', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         callbackCalled = 0,
         eventEmitter = realtime.connection;
 
@@ -164,7 +167,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
     /** @specpartial RTE5 - test remove matching listeners */
     it('offRemovesAllMatchingListeners', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         callbackCalled = 0,
         eventEmitter = realtime.connection;
 
@@ -194,7 +198,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
     /** @specpartial RTE5 - test remove all listeners */
     it('offRemovesAllListeners', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         callbackCalled = 0,
         eventEmitter = realtime.connection;
 
@@ -224,7 +229,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
     /** @specpartial RTE5 - test remove matching both event and listener */
     it('offRemovesAllMatchingEventListeners', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         callbackCalled = 0,
         eventEmitter = realtime.connection;
 
@@ -258,7 +264,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @nospec
      */
     it('offRemovesAllMatchingEvents', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         callbackCalled = 0,
         eventEmitter = realtime.connection;
 
@@ -297,7 +304,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @nospec
      */
     it('offRemovesEmptyEventNameListeners', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         eventEmitter = realtime.connection;
 
       var callback = function () {};
@@ -330,7 +338,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @nospec
      */
     it('arrayOfEvents', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         callbackCalled = 0,
         eventEmitter = realtime.connection;
 
@@ -374,7 +383,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @nospec
      */
     it('arrayOfEventsWithOnce', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         callbackCalled = 0,
         eventEmitter = realtime.connection;
 
@@ -405,7 +415,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @nospec
      */
     it('listenerAddedInListenerCb', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         eventEmitter = realtime.connection,
         firstCbCalled = false,
         secondCbCalled = false;
@@ -436,7 +447,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @nospec
      */
     it('listenerRemovedInListenerCb', function (done) {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         eventEmitter = realtime.connection,
         onCbCalledTimes = 0,
         onceCbCalledTimes = 0,
@@ -481,6 +493,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
     describe('event_emitter_promise', function () {
       /** @specpartial RTN26b - tests only that listener was called, not the params */
       it('whenState', function (done) {
+        const helper = this.test.helper;
         var realtime = helper.AblyRealtime();
         var eventEmitter = realtime.connection;
 
@@ -499,6 +512,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
        * @nospec
        */
       it('once', function (done) {
+        const helper = this.test.helper;
         var realtime = helper.AblyRealtime();
         var eventEmitter = realtime.connection;
 
@@ -514,7 +528,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
       /** @specpartial RTE4 - promise is resolved for the first event that is emitted when no event argument is provided */
       it('anyEventsWithOnce', function (done) {
-        var realtime = helper.AblyRealtime({ autoConnect: false }),
+        var helper = this.test.helper,
+          realtime = helper.AblyRealtime({ autoConnect: false }),
           eventEmitter = realtime.connection;
 
         const p = eventEmitter.once();
@@ -531,7 +546,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
        * @nospec
        */
       it('arrayOfEventsWithOnce', function (done) {
-        var realtime = helper.AblyRealtime({ autoConnect: false }),
+        var helper = this.test.helper,
+          realtime = helper.AblyRealtime({ autoConnect: false }),
           eventEmitter = realtime.connection;
 
         const p = eventEmitter.once(['a', 'b', 'c']);

--- a/test/realtime/event_emitter.test.js
+++ b/test/realtime/event_emitter.test.js
@@ -2,10 +2,6 @@
 
 define(['shared_helper', 'chai'], function (helper, chai) {
   var expect = chai.expect;
-  var displayError = helper.displayError;
-  var utils = helper.Utils;
-  var closeAndFinish = helper.closeAndFinish;
-  var monitorConnection = helper.monitorConnection;
 
   describe('realtime/event_emitter', function () {
     this.timeout(60 * 1000);
@@ -68,13 +64,13 @@ define(['shared_helper', 'chai'], function (helper, chai) {
           });
           channel.attach(function (err) {
             if (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
         });
-        monitorConnection(done, realtime);
+        helper.monitorConnection(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -98,10 +94,10 @@ define(['shared_helper', 'chai'], function (helper, chai) {
       try {
         expect(callbackCalled, 'Last callback should have been called').to.be.ok;
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /** @specpartial RTE4 - ensure that each registration is only invoked once */
@@ -126,11 +122,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         expect(onCallbackCalled).to.equal(3, 'On callback called every time');
         expect(onceCallbackCalled).to.equal(1, 'Once callback called once');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /**
@@ -157,11 +153,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
       try {
         expect(callbackCalled).to.equal(4, 'On callback called both times but once callbacks only called once');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /** @specpartial RTE5 - test remove matching listeners */
@@ -187,11 +183,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(0, 'All callbacks should have been removed');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /** @specpartial RTE5 - test remove all listeners */
@@ -217,11 +213,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(0, 'All callbacks should have been removed');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /** @specpartial RTE5 - test remove matching both event and listener */
@@ -247,11 +243,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(0, 'All callbacks should have been removed');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /**
@@ -281,11 +277,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(0, 'All callbacks should have been removed');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /**
@@ -319,11 +315,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter.off(callback);
         expect(!('custom' in eventEmitter.events), 'event listener array is removed from object').to.be.ok;
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /**
@@ -363,11 +359,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter.emit('c');
         expect(callbackCalled).to.equal(2, 'callbacks b and c should not have been removed');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /**
@@ -393,11 +389,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter.emit('c', 'wrong');
         expect(callbackCalled).to.equal(1, 'listener called back only once, for the first event emitted');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /**
@@ -424,11 +420,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         expect(firstCbCalled, 'check first callback called').to.be.ok;
         expect(!secondCbCalled, 'check second callback not called').to.be.ok;
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     /**
@@ -473,11 +469,11 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         expect(anyCbCalledTimes).to.equal(1, 'check any callback called exactly once');
         expect(anyOnceCbCalledTimes).to.equal(1, 'check anyOnce callback called exactly once');
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
         return;
       }
 
-      closeAndFinish(done, realtime);
+      helper.closeAndFinish(done, realtime);
     });
 
     describe('event_emitter_promise', function () {
@@ -489,10 +485,10 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter
           .whenState('connected')
           .then(function () {
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           })
           .catch(function (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           });
       });
 
@@ -507,10 +503,10 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         eventEmitter
           .once('connected')
           .then(function () {
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           })
           .catch(function (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           });
       });
 
@@ -522,9 +518,9 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         const p = eventEmitter.once();
         eventEmitter.emit('b');
         p.then(function () {
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         }).catch(function (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         });
       });
 
@@ -539,9 +535,9 @@ define(['shared_helper', 'chai'], function (helper, chai) {
         const p = eventEmitter.once(['a', 'b', 'c']);
         eventEmitter.emit('b');
         p.then(function () {
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         }).catch(function (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         });
       });
     });

--- a/test/realtime/event_emitter.test.js
+++ b/test/realtime/event_emitter.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'chai'], function (helper, chai) {
+define(['shared_helper', 'chai'], function (Helper, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
 
   describe('realtime/event_emitter', function () {

--- a/test/realtime/event_emitter.test.js
+++ b/test/realtime/event_emitter.test.js
@@ -93,6 +93,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
         callbackCalled = true;
       });
 
+      helper.recordPrivateApi('call.EventEmitter.emit');
       eventEmitter.emit('custom');
       try {
         expect(callbackCalled, 'Last callback should have been called').to.be.ok;
@@ -118,6 +119,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
         onCallbackCalled += 1;
       });
 
+      helper.recordPrivateApi('call.EventEmitter.emit');
       eventEmitter.emit('custom');
       eventEmitter.emit('custom');
       eventEmitter.emit('custom');
@@ -152,6 +154,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       eventEmitter.once('custom', callback);
       eventEmitter.once('custom', callback);
 
+      helper.recordPrivateApi('call.EventEmitter.emit');
       eventEmitter.emit('custom');
       eventEmitter.emit('custom');
 
@@ -181,11 +184,13 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
         eventEmitter.on('custom', callback);
         eventEmitter.on('custom', callback);
 
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(3, 'The same callback should have been called for every registration');
 
         callbackCalled = 0;
         eventEmitter.off(callback);
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(0, 'All callbacks should have been removed');
       } catch (err) {
@@ -212,11 +217,13 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
         eventEmitter.on('custom', callback);
         eventEmitter.on('custom', callback);
 
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(3, 'The same callback should have been called for every registration');
 
         callbackCalled = 0;
         eventEmitter.off();
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(0, 'All callbacks should have been removed');
       } catch (err) {
@@ -243,11 +250,13 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
         eventEmitter.on('custom', callback);
         eventEmitter.on('custom', callback);
 
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(3, 'The same callback should have been called for every registration');
 
         callbackCalled = 0;
         eventEmitter.off('custom', callback);
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(0, 'All callbacks should have been removed');
       } catch (err) {
@@ -278,11 +287,13 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
         eventEmitter.on('custom', callback);
         eventEmitter.on('custom', callback);
 
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(3, 'The same callback should have been called for every registration');
 
         callbackCalled = 0;
         eventEmitter.off('custom');
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('custom');
         expect(callbackCalled).to.equal(0, 'All callbacks should have been removed');
       } catch (err) {
@@ -313,16 +324,20 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       try {
         eventEmitter.once('custom', callback);
         eventEmitter.on('custom', callback);
+        helper.recordPrivateApi('read.EventEmitter.events');
         expect('custom' in eventEmitter.events, 'custom event array exists').to.be.ok;
 
         eventEmitter.off('custom', callback);
+        helper.recordPrivateApi('read.EventEmitter.events');
         expect(!('custom' in eventEmitter.events), 'custom event listener array is removed from object').to.be.ok;
 
         eventEmitter.once('custom', callback);
         eventEmitter.on('custom', callback);
+        helper.recordPrivateApi('read.EventEmitter.events');
         expect('custom' in eventEmitter.events, 'custom event array exists').to.be.ok;
 
         eventEmitter.off(callback);
+        helper.recordPrivateApi('read.EventEmitter.events');
         expect(!('custom' in eventEmitter.events), 'event listener array is removed from object').to.be.ok;
       } catch (err) {
         helper.closeAndFinish(done, realtime, err);
@@ -348,6 +363,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       };
 
       try {
+        helper.recordPrivateApi('call.EventEmitter.emit');
         callbackCalled = 0;
         eventEmitter.on(['a', 'b', 'c'], callback);
         eventEmitter.emit('a');
@@ -396,6 +412,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       try {
         callbackCalled = 0;
         eventEmitter.once(['a', 'b', 'c'], callback);
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('a', 'expected');
         eventEmitter.emit('b', 'wrong');
         eventEmitter.emit('c', 'wrong');
@@ -427,6 +444,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
           secondCbCalled = true;
         });
       });
+      helper.recordPrivateApi('call.EventEmitter.emit');
       eventEmitter.emit('a');
 
       try {
@@ -475,6 +493,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
         eventEmitter.off();
       });
 
+      helper.recordPrivateApi('call.EventEmitter.emit');
       eventEmitter.emit('a');
 
       try {
@@ -533,6 +552,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
           eventEmitter = realtime.connection;
 
         const p = eventEmitter.once();
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('b');
         p.then(function () {
           helper.closeAndFinish(done, realtime);
@@ -551,6 +571,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
           eventEmitter = realtime.connection;
 
         const p = eventEmitter.once(['a', 'b', 'c']);
+        helper.recordPrivateApi('call.EventEmitter.emit');
         eventEmitter.emit('b');
         p.then(function () {
           helper.closeAndFinish(done, realtime);

--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -603,7 +603,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /** @specpartial RTN14d - last sentence: check that if we received a 5xx disconnected, when we try again we use a fallback host */
-    Helper.testOnAllTransports('try_fallback_hosts_on_placement_constraint', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'try_fallback_hosts_on_placement_constraint', function (realtimeOpts) {
       return function (done) {
         /* Use the echoserver as a fallback host because it doesn't support
          * websockets, so it'll fail to connect, which we can detect */

--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -2,14 +2,8 @@
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
   var expect = chai.expect;
-  var closeAndFinish = helper.closeAndFinish;
-  var utils = helper.Utils;
   var noop = function () {};
-  var simulateDroppedConnection = helper.simulateDroppedConnection;
   var createPM = Ably.protocolMessageFromDeserialized;
-  var availableTransports = helper.availableTransports;
-  var testOnAllTransports = helper.testOnAllTransports;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('realtime/failure', function () {
     this.timeout(60 * 1000);
@@ -59,13 +53,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           };
         };
         async.parallel(
-          availableTransports
+          helper.availableTransports
             .map(function (transport) {
               return failure_test([transport]);
             })
             .concat(failure_test(null)), // to test not specifying a transport (so will use websocket/base mechanism)
           function (err, realtimes) {
-            closeAndFinish(done, realtimes, err);
+            helper.closeAndFinish(done, realtimes, err);
           },
         );
       } catch (err) {
@@ -94,22 +88,22 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   realtime,
                 );
               });
-              simulateDroppedConnection(realtime);
+              helper.simulateDroppedConnection(realtime);
             });
           };
         };
         async.parallel(
-          availableTransports
+          helper.availableTransports
             .map(function (transport) {
               return break_test([transport]);
             })
             .concat(break_test(null)), // to test not specifying a transport (so will use websocket/base mechanism)
           function (err, realtimes) {
-            closeAndFinish(done, realtimes, err);
+            helper.closeAndFinish(done, realtimes, err);
           },
         );
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -179,7 +173,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           };
         };
         async.parallel(
-          availableTransports
+          helper.availableTransports
             .map(function (transport) {
               return lifecycleTest([transport]);
             })
@@ -192,7 +186,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
         );
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -201,7 +195,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       expect(value).to.be.below(max);
     }
 
-    availableTransports.forEach(function (transport) {
+    helper.availableTransports.forEach(function (transport) {
       /**
        * @spec RTB1a
        * @spec RTB1b
@@ -234,14 +228,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               for (var i = 3; i < retryTimeouts.length; i++) {
                 checkIsBetween(retryTimeouts[i], 240, 300);
               }
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
               return;
             }
             try {
               retryTimeouts.push(stateChange.retryIn);
               retryCount += 1;
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           }
         });
@@ -263,7 +257,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       var tests = [
         function (callback) {
-          whenPromiseSettles(failChan.publish('event', 'data'), function (err) {
+          helper.whenPromiseSettles(failChan.publish('event', 'data'), function (err) {
             try {
               expect(err, 'publish failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'publish failure code');
@@ -274,7 +268,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          whenPromiseSettles(failChan.subscribe('event', noop), function (err) {
+          helper.whenPromiseSettles(failChan.subscribe('event', noop), function (err) {
             try {
               expect(err, 'subscribe failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'subscribe failure code');
@@ -285,7 +279,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          whenPromiseSettles(failChan.presence.enterClient('clientId'), function (err) {
+          helper.whenPromiseSettles(failChan.presence.enterClient('clientId'), function (err) {
             try {
               expect(err, 'presence enter failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'presence enter failure code');
@@ -296,7 +290,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          whenPromiseSettles(failChan.presence.leaveClient('clientId'), function (err) {
+          helper.whenPromiseSettles(failChan.presence.leaveClient('clientId'), function (err) {
             try {
               expect(err, 'presence leave failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'presence leave failure code');
@@ -307,7 +301,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          whenPromiseSettles(failChan.presence.subscribe('event', noop), function (err) {
+          helper.whenPromiseSettles(failChan.presence.subscribe('event', noop), function (err) {
             try {
               expect(err, 'presence subscribe failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'subscribe failure code');
@@ -318,7 +312,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          whenPromiseSettles(failChan.presence.subscribe('event', noop), function (err) {
+          helper.whenPromiseSettles(failChan.presence.subscribe('event', noop), function (err) {
             try {
               expect(err, 'presence unsubscribe failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'subscribe failure code');
@@ -329,7 +323,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          whenPromiseSettles(failChan.presence.get(), function (err) {
+          helper.whenPromiseSettles(failChan.presence.get(), function (err) {
             try {
               expect(err, 'presence get failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'presence get failure code');
@@ -344,21 +338,21 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       try {
         realtime.connection.once('connected', function () {
           failChan = realtime.channels.get('::');
-          whenPromiseSettles(failChan.attach(), function (err) {
+          helper.whenPromiseSettles(failChan.attach(), function (err) {
             try {
               expect(err, 'channel attach failed').to.be.ok;
               expect(failChan.state).to.equal('failed', 'channel in failed state');
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
             async.parallel(tests, function (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             });
           });
         });
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -379,28 +373,28 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       };
 
       realtime.connection.once('connected', function () {
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           try {
             expect(err.code).to.equal(90007, 'check channel error code');
             expect(err.statusCode).to.equal(408, 'check timeout statusCode');
             expect(channel.state).to.equal('suspended', 'check channel goes into suspended state');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           channel.once(function (stateChange) {
             try {
               expect(stateChange.current).to.equal('attaching', 'check channel tries to attach again');
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           });
         });
       });
     });
 
-    availableTransports.forEach(function (transport) {
+    helper.availableTransports.forEach(function (transport) {
       /**
        * @spec RTL13b
        * @spec RTB1a
@@ -432,7 +426,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         realtime.connection.on('connected', function () {
           realtime.options.timeouts.realtimeRequestTimeout = 1;
-          whenPromiseSettles(channel.attach(), function (err) {
+          helper.whenPromiseSettles(channel.attach(), function (err) {
             if (err) {
               var lastSuspended = performance.now();
               channel.on(function (stateChange) {
@@ -448,7 +442,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                     for (var i = 3; i < retryTimeouts.length; i++) {
                       checkIsBetween(retryTimeouts[i], 240, 300 + 10);
                     }
-                    closeAndFinish(done, realtime);
+                    helper.closeAndFinish(done, realtime);
                     return;
                   }
                   var elapsedSinceSuspneded = performance.now() - lastSuspended;
@@ -457,12 +451,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                     retryTimeouts.push(elapsedSinceSuspneded);
                     retryCount += 1;
                   } catch (err) {
-                    closeAndFinish(done, realtime, err);
+                    helper.closeAndFinish(done, realtime, err);
                   }
                 }
               });
             } else {
-              closeAndFinish(done, realtime, new Error('Expected channel attach to timeout'));
+              helper.closeAndFinish(done, realtime, new Error('Expected channel attach to timeout'));
             }
           });
         });
@@ -488,7 +482,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               });
             },
             function (cb) {
-              whenPromiseSettles(channel.attach(), cb);
+              helper.whenPromiseSettles(channel.attach(), cb);
             },
             function (cb) {
               var transport = realtime.connection.connectionManager.activeProtocol.transport,
@@ -500,7 +494,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   originalOnProtocolMessage.apply(this, arguments);
                 }
               };
-              whenPromiseSettles(channel.publish('foo', 'bar'), function (err) {
+              helper.whenPromiseSettles(channel.publish('foo', 'bar'), function (err) {
                 try {
                   expect(err, 'Publish failed as expected').to.be.ok;
                   expect(realtime.connection.state).to.equal(
@@ -519,7 +513,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             },
           ],
           function (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           },
         );
       };
@@ -590,10 +584,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             expect(statechange.reason.code).to.equal(80003, 'check code');
             expect(statechange.reason.statusCode).to.equal(408, 'check statusCode');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       });
     });
@@ -603,7 +597,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       return function (done) {
         /* Use the echoserver as a fallback host because it doesn't support
          * websockets, so it'll fail to connect, which we can detect */
-        var realtime = helper.AblyRealtime(utils.mixin({ fallbackHosts: ['echo.ably.io'] }, realtimeOpts)),
+        var realtime = helper.AblyRealtime(helper.Utils.mixin({ fallbackHosts: ['echo.ably.io'] }, realtimeOpts)),
           connection = realtime.connection,
           connectionManager = connection.connectionManager;
 
@@ -616,10 +610,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   'expect next connection attempt to fail due to using the (bad) fallback host',
                 );
               } catch (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             });
           });
           connectionManager.activeProtocol.getTransport().onProtocolMessage(
@@ -649,7 +643,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         sender_channel.subscribe(function (message) {
           if (messageReceived) {
-            closeAndFinish(done, realtime, new Error('Message received when channel not in ATTACHED state.'));
+            helper.closeAndFinish(done, realtime, new Error('Message received when channel not in ATTACHED state.'));
           }
 
           try {
@@ -668,10 +662,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             sender_channel.publish('1', testMessage2);
 
             setTimeout(function () {
-              closeAndFinish(done, sender_realtime);
+              helper.closeAndFinish(done, sender_realtime);
             }, 7000);
           } catch (err) {
-            closeAndFinish(done, sender_realtime, err);
+            helper.closeAndFinish(done, sender_realtime, err);
           }
         });
 
@@ -679,7 +673,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           sender_channel.publish('0', testMessage);
         });
       } catch (err) {
-        closeAndFinish(done, sender_realtime, err);
+        helper.closeAndFinish(done, sender_realtime, err);
       }
     });
   });

--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var noop = function () {};
   var createPM = Ably.protocolMessageFromDeserialized;
@@ -257,7 +259,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       var tests = [
         function (callback) {
-          helper.whenPromiseSettles(failChan.publish('event', 'data'), function (err) {
+          Helper.whenPromiseSettles(failChan.publish('event', 'data'), function (err) {
             try {
               expect(err, 'publish failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'publish failure code');
@@ -268,7 +270,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          helper.whenPromiseSettles(failChan.subscribe('event', noop), function (err) {
+          Helper.whenPromiseSettles(failChan.subscribe('event', noop), function (err) {
             try {
               expect(err, 'subscribe failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'subscribe failure code');
@@ -279,7 +281,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          helper.whenPromiseSettles(failChan.presence.enterClient('clientId'), function (err) {
+          Helper.whenPromiseSettles(failChan.presence.enterClient('clientId'), function (err) {
             try {
               expect(err, 'presence enter failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'presence enter failure code');
@@ -290,7 +292,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          helper.whenPromiseSettles(failChan.presence.leaveClient('clientId'), function (err) {
+          Helper.whenPromiseSettles(failChan.presence.leaveClient('clientId'), function (err) {
             try {
               expect(err, 'presence leave failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'presence leave failure code');
@@ -301,7 +303,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          helper.whenPromiseSettles(failChan.presence.subscribe('event', noop), function (err) {
+          Helper.whenPromiseSettles(failChan.presence.subscribe('event', noop), function (err) {
             try {
               expect(err, 'presence subscribe failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'subscribe failure code');
@@ -312,7 +314,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          helper.whenPromiseSettles(failChan.presence.subscribe('event', noop), function (err) {
+          Helper.whenPromiseSettles(failChan.presence.subscribe('event', noop), function (err) {
             try {
               expect(err, 'presence unsubscribe failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'subscribe failure code');
@@ -323,7 +325,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
         },
         function (callback) {
-          helper.whenPromiseSettles(failChan.presence.get(), function (err) {
+          Helper.whenPromiseSettles(failChan.presence.get(), function (err) {
             try {
               expect(err, 'presence get failed').to.be.ok;
               expect(err.code).to.equal(channelFailedCode, 'presence get failure code');
@@ -338,7 +340,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       try {
         realtime.connection.once('connected', function () {
           failChan = realtime.channels.get('::');
-          helper.whenPromiseSettles(failChan.attach(), function (err) {
+          Helper.whenPromiseSettles(failChan.attach(), function (err) {
             try {
               expect(err, 'channel attach failed').to.be.ok;
               expect(failChan.state).to.equal('failed', 'channel in failed state');
@@ -373,7 +375,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       };
 
       realtime.connection.once('connected', function () {
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           try {
             expect(err.code).to.equal(90007, 'check channel error code');
             expect(err.statusCode).to.equal(408, 'check timeout statusCode');
@@ -426,7 +428,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         realtime.connection.on('connected', function () {
           realtime.options.timeouts.realtimeRequestTimeout = 1;
-          helper.whenPromiseSettles(channel.attach(), function (err) {
+          Helper.whenPromiseSettles(channel.attach(), function (err) {
             if (err) {
               var lastSuspended = performance.now();
               channel.on(function (stateChange) {
@@ -482,7 +484,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               });
             },
             function (cb) {
-              helper.whenPromiseSettles(channel.attach(), cb);
+              Helper.whenPromiseSettles(channel.attach(), cb);
             },
             function (cb) {
               var transport = realtime.connection.connectionManager.activeProtocol.transport,
@@ -494,7 +496,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   originalOnProtocolMessage.apply(this, arguments);
                 }
               };
-              helper.whenPromiseSettles(channel.publish('foo', 'bar'), function (err) {
+              Helper.whenPromiseSettles(channel.publish('foo', 'bar'), function (err) {
                 try {
                   expect(err, 'Publish failed as expected').to.be.ok;
                   expect(realtime.connection.state).to.equal(
@@ -593,7 +595,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
     });
 
     /** @specpartial RTN14d - last sentence: check that if we received a 5xx disconnected, when we try again we use a fallback host */
-    testOnAllTransports('try_fallback_hosts_on_placement_constraint', function (realtimeOpts) {
+    Helper.testOnAllTransports('try_fallback_hosts_on_placement_constraint', function (realtimeOpts) {
       return function (done) {
         /* Use the echoserver as a fallback host because it doesn't support
          * websockets, so it'll fail to connect, which we can detect */

--- a/test/realtime/history.test.js
+++ b/test/realtime/history.test.js
@@ -2,7 +2,6 @@
 
 define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
   var expect = chai.expect;
-  var utils = helper.Utils;
   var indexes = [1, 2, 3, 4, 5];
   var preAttachMessages = indexes.map(function (i) {
     return { name: 'pre-attach-' + i, data: 'some data' };
@@ -10,14 +9,11 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
   var postAttachMessages = indexes.map(function (i) {
     return { name: 'post-attach-' + i, data: 'some data' };
   });
-  var closeAndFinish = helper.closeAndFinish;
-  var monitorConnection = helper.monitorConnection;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   var parallelPublishMessages = function (done, channel, messages, callback) {
     var publishTasks = messages.map(function (event) {
       return function (publishCb) {
-        whenPromiseSettles(channel.publish(event.name, event.data), publishCb);
+        helper.whenPromiseSettles(channel.publish(event.name, event.data), publishCb);
       };
     });
 
@@ -61,11 +57,11 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       parallelPublishMessages(done, restChannel, preAttachMessages, function () {
         /* second, connect and attach to the channel */
         try {
-          whenPromiseSettles(realtime.connection.whenState('connected'), function () {
+          helper.whenPromiseSettles(realtime.connection.whenState('connected'), function () {
             var rtChannel = realtime.channels.get('persisted:history_until_attach');
-            whenPromiseSettles(rtChannel.attach(), function (err) {
+            helper.whenPromiseSettles(rtChannel.attach(), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
                 return;
               }
 
@@ -79,7 +75,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
                 var tests = [
                   function (callback) {
-                    whenPromiseSettles(rtChannel.history(), function (err, resultPage) {
+                    helper.whenPromiseSettles(rtChannel.history(), function (err, resultPage) {
                       if (err) {
                         callback(err);
                       }
@@ -96,7 +92,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                     });
                   },
                   function (callback) {
-                    whenPromiseSettles(rtChannel.history({ untilAttach: false }), function (err, resultPage) {
+                    helper.whenPromiseSettles(rtChannel.history({ untilAttach: false }), function (err, resultPage) {
                       if (err) {
                         callback(err);
                       }
@@ -113,7 +109,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                     });
                   },
                   function (callback) {
-                    whenPromiseSettles(rtChannel.history({ untilAttach: true }), function (err, resultPage) {
+                    helper.whenPromiseSettles(rtChannel.history({ untilAttach: true }), function (err, resultPage) {
                       if (err) {
                         callback(err);
                       }
@@ -140,14 +136,14 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 ];
 
                 async.parallel(tests, function (err) {
-                  closeAndFinish(done, realtime, err);
+                  helper.closeAndFinish(done, realtime, err);
                 });
               });
             });
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
     });

--- a/test/realtime/history.test.js
+++ b/test/realtime/history.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var indexes = [1, 2, 3, 4, 5];
   var preAttachMessages = indexes.map(function (i) {
@@ -36,6 +34,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -51,6 +50,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @specpartial RTL10b - tests only messages prior to the moment that the channel was attached
      */
     it('history_until_attach', function (done) {
+      const helper = this.test.helper;
       var rest = helper.AblyRest();
       var realtime = helper.AblyRealtime();
       var restChannel = rest.channels.get('persisted:history_until_attach');

--- a/test/realtime/history.test.js
+++ b/test/realtime/history.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
+define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var indexes = [1, 2, 3, 4, 5];
   var preAttachMessages = indexes.map(function (i) {
@@ -13,7 +15,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
   var parallelPublishMessages = function (done, channel, messages, callback) {
     var publishTasks = messages.map(function (event) {
       return function (publishCb) {
-        helper.whenPromiseSettles(channel.publish(event.name, event.data), publishCb);
+        Helper.whenPromiseSettles(channel.publish(event.name, event.data), publishCb);
       };
     });
 
@@ -57,9 +59,9 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       parallelPublishMessages(done, restChannel, preAttachMessages, function () {
         /* second, connect and attach to the channel */
         try {
-          helper.whenPromiseSettles(realtime.connection.whenState('connected'), function () {
+          Helper.whenPromiseSettles(realtime.connection.whenState('connected'), function () {
             var rtChannel = realtime.channels.get('persisted:history_until_attach');
-            helper.whenPromiseSettles(rtChannel.attach(), function (err) {
+            Helper.whenPromiseSettles(rtChannel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;
@@ -75,7 +77,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
                 var tests = [
                   function (callback) {
-                    helper.whenPromiseSettles(rtChannel.history(), function (err, resultPage) {
+                    Helper.whenPromiseSettles(rtChannel.history(), function (err, resultPage) {
                       if (err) {
                         callback(err);
                       }
@@ -92,7 +94,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                     });
                   },
                   function (callback) {
-                    helper.whenPromiseSettles(rtChannel.history({ untilAttach: false }), function (err, resultPage) {
+                    Helper.whenPromiseSettles(rtChannel.history({ untilAttach: false }), function (err, resultPage) {
                       if (err) {
                         callback(err);
                       }
@@ -109,7 +111,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                     });
                   },
                   function (callback) {
-                    helper.whenPromiseSettles(rtChannel.history({ untilAttach: true }), function (err, resultPage) {
+                    Helper.whenPromiseSettles(rtChannel.history({ untilAttach: true }), function (err, resultPage) {
                       if (err) {
                         callback(err);
                       }

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
+define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
 
   describe('realtime/init', function () {
@@ -82,7 +84,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         var rest = helper.AblyRest();
         var testKeyOpts = { key: helper.getTestApp().keys[1].keyStr };
 
-        helper.whenPromiseSettles(rest.auth.requestToken(null, testKeyOpts), function (err, tokenDetails) {
+        Helper.whenPromiseSettles(rest.auth.requestToken(null, testKeyOpts), function (err, tokenDetails) {
           if (err) {
             done(err);
             return;

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -2,9 +2,6 @@
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
   var expect = chai.expect;
-  var closeAndFinish = helper.closeAndFinish;
-  var monitorConnection = helper.monitorConnection;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('realtime/init', function () {
     this.timeout(60 * 1000);
@@ -36,14 +33,14 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             try {
               expect(connectUri.indexOf('v=3') > -1, 'Check uri includes v=3').to.be.ok;
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
               return;
             }
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           });
-          monitorConnection(done, realtime);
+          helper.monitorConnection(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
     }
@@ -64,12 +61,12 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           expect(realtime.options.key).to.equal(keyStr);
           expect(realtime.options).to.deep.equal(realtime.connection.connectionManager.options);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
-        closeAndFinish(done, realtime);
+        helper.closeAndFinish(done, realtime);
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -85,7 +82,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         var rest = helper.AblyRest();
         var testKeyOpts = { key: helper.getTestApp().keys[1].keyStr };
 
-        whenPromiseSettles(rest.auth.requestToken(null, testKeyOpts), function (err, tokenDetails) {
+        helper.whenPromiseSettles(rest.auth.requestToken(null, testKeyOpts), function (err, tokenDetails) {
           if (err) {
             done(err);
             return;
@@ -97,9 +94,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           try {
             expect(realtime.options.token).to.equal(tokenStr);
             expect(realtime.options).to.deep.equal(realtime.connection.connectionManager.options);
-            closeAndFinish(done, realtime);
+            helper.closeAndFinish(done, realtime);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           }
         });
       } catch (err) {
@@ -124,13 +121,13 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           try {
             expect(realtime.auth.tokenDetails.clientId).to.equal(undefined);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -155,13 +152,13 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             expect(realtime.auth.clientId).to.equal('*');
             expect(realtime.auth.tokenDetails.expires - realtime.auth.tokenDetails.issued).to.equal(123456);
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -184,13 +181,13 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             expect(realtime.auth.tokenDetails.clientId).to.equal('test');
             expect(realtime.auth.clientId).to.equal('test');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -213,13 +210,13 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             expect(realtime.auth.tokenDetails.clientId).to.equal('yes');
             expect(realtime.auth.clientId).to.equal('yes');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       } catch (err) {
-        closeAndFinish(done, realtime, err);
+        helper.closeAndFinish(done, realtime, err);
       }
     });
 
@@ -296,10 +293,10 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
             'Verify http max retry duration is settable',
           );
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
-        closeAndFinish(done, realtime);
+        helper.closeAndFinish(done, realtime);
       } catch (err) {
         done(err);
       }
@@ -349,10 +346,10 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           try {
             expect(stateChange.reason.code).to.equal(80003, 'Expected error code after no fallback host works');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
         realtime.connection.connect();
       } catch (err) {
@@ -372,9 +369,9 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           realtime = helper.AblyRealtime({ transports: helper.availableTransports });
           expect(realtime.connection.connectionManager.baseTransport).to.equal('comet');
           expect(realtime.connection.connectionManager.webSocketTransportAvailable).to.be.ok;
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         }
       });
     }
@@ -405,7 +402,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
               }
               originalOnProtocolMessage.call(transport, message);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           };
         });
@@ -420,10 +417,10 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
               'connection key from connectionDetails should be used',
             );
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       } catch (err) {
         done(err);
@@ -445,10 +442,10 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
           expect(hosts[0]).to.equal(realtime.options.realtimeHost, 'Check connected realtime host is the first option');
           expect(hosts.length).to.equal(4, 'Check also have three fallbacks');
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
-        closeAndFinish(done, realtime);
+        helper.closeAndFinish(done, realtime);
       });
     });
 
@@ -467,10 +464,10 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         try {
           expect(hosts[0]).to.equal(goodHost, 'Check connected realtime host is the first option');
         } catch (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
           return;
         }
-        closeAndFinish(done, realtime);
+        helper.closeAndFinish(done, realtime);
       });
     });
   });

--- a/test/realtime/init.test.js
+++ b/test/realtime/init.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
 
   describe('realtime/init', function () {
     this.timeout(60 * 1000);
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -19,33 +18,36 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
     /* Restrict to websocket or xhr polling for the v= test as if stream=false the
      * recvRequest may not be the connectRequest by the time we check it. */
-    if (helper.bestTransport === 'web_socket' || helper.bestTransport === 'xhr_polling') {
-      /**
-       * Base init case.
-       * @spec RTN2f
-       */
-      it('initbase0', function (done) {
-        var realtime;
-        try {
-          realtime = helper.AblyRealtime({ transports: ['web_socket', 'xhr_polling'] });
-          realtime.connection.on('connected', function () {
-            /* check api version */
-            var transport = realtime.connection.connectionManager.activeProtocol.transport;
-            var connectUri = helper.isWebsocket(transport) ? transport.uri : transport.recvRequest.recvUri;
-            try {
-              expect(connectUri.indexOf('v=3') > -1, 'Check uri includes v=3').to.be.ok;
-            } catch (err) {
-              helper.closeAndFinish(done, realtime, err);
-              return;
-            }
-            helper.closeAndFinish(done, realtime);
-          });
-          helper.monitorConnection(done, realtime);
-        } catch (err) {
-          helper.closeAndFinish(done, realtime, err);
-        }
-      });
-    }
+    ((testDefinitionHelper) => {
+      if (testDefinitionHelper.bestTransport === 'web_socket' || testDefinitionHelper.bestTransport === 'xhr_polling') {
+        /*
+         * Base init case.
+         * @spec RTN2f
+         */
+        it('initbase0', function (done) {
+          const helper = this.test.helper;
+          var realtime;
+          try {
+            realtime = helper.AblyRealtime({ transports: ['web_socket', 'xhr_polling'] });
+            realtime.connection.on('connected', function () {
+              /* check api version */
+              var transport = realtime.connection.connectionManager.activeProtocol.transport;
+              var connectUri = helper.isWebsocket(transport) ? transport.uri : transport.recvRequest.recvUri;
+              try {
+                expect(connectUri.indexOf('v=3') > -1, 'Check uri includes v=3').to.be.ok;
+              } catch (err) {
+                helper.closeAndFinish(done, realtime, err);
+                return;
+              }
+              helper.closeAndFinish(done, realtime);
+            });
+            helper.monitorConnection(done, realtime);
+          } catch (err) {
+            helper.closeAndFinish(done, realtime, err);
+          }
+        });
+      }
+    })(Helper.forTestDefinition(this, 'initbase0'));
 
     /**
      * Init with key string.
@@ -54,6 +56,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial RSC1c - test Realtime constructor with an API key
      */
     it('init_key_string', function (done) {
+      const helper = this.test.helper;
       var realtime;
       try {
         var keyStr = helper.getTestApp().keys[0].keyStr;
@@ -79,6 +82,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial RSC1c - test Realtime constructor with a token string
      */
     it('init_token_string', function (done) {
+      const helper = this.test.helper;
       try {
         /* first generate a token ... */
         var rest = helper.AblyRest();
@@ -111,6 +115,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec TO3j4
      */
     it('init_key_with_usetokenauth', function (done) {
+      const helper = this.test.helper;
       var realtime;
       try {
         var keyStr = helper.getTestApp().keys[0].keyStr;
@@ -138,6 +143,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec RSA7b4
      */
     it('init_usetokenauth_defaulttokenparams_wildcard', function (done) {
+      const helper = this.test.helper;
       var realtime;
       try {
         var keyStr = helper.getTestApp().keys[0].keyStr;
@@ -169,6 +175,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec RSA7b3
      */
     it('init_defaulttokenparams_nonwildcard', function (done) {
+      const helper = this.test.helper;
       var realtime;
       try {
         var keyStr = helper.getTestApp().keys[0].keyStr;
@@ -198,6 +205,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec RSA7a4
      */
     it('init_conflicting_clientids', function (done) {
+      const helper = this.test.helper;
       var realtime;
       try {
         var keyStr = helper.getTestApp().keys[0].keyStr;
@@ -229,6 +237,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @nospec
      */
     it('init_with_usetokenauth_false_and_a_clientid', function (done) {
+      const helper = this.test.helper;
       try {
         var keyStr = helper.getTestApp().keys[0].keyStr;
         expect(function () {
@@ -245,6 +254,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial RSC11 - tests only default value
      */
     it('init_defaulthost', function (done) {
+      const helper = this.test.helper;
       try {
         /* want to check the default host when no custom environment or custom
          * host set, so not using helpers.realtime this time, which will use a
@@ -268,6 +278,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial TO3l6 - test property can be set
      */
     it('init_timeouts', function (done) {
+      const helper = this.test.helper;
       try {
         var realtime = helper.AblyRealtime({
           key: 'not_a.real:key',
@@ -315,6 +326,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial RSC15a - httpMaxRetryCount has been reached
      */
     it('init_fallbacks', function (done) {
+      const helper = this.test.helper;
       try {
         var realtime = helper.AblyRealtime({
           key: 'not_a.real:key',
@@ -366,6 +378,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @nospec
        */
       it('node_transports', function (done) {
+        const helper = this.test.helper;
         var realtime;
         try {
           realtime = helper.AblyRealtime({ transports: helper.availableTransports });
@@ -389,6 +402,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec RSA7b3
      */
     it('init_and_connection_details', function (done) {
+      const helper = this.test.helper;
       try {
         var keyStr = helper.getTestApp().keys[0].keyStr;
         var realtime = helper.AblyRealtime({ key: keyStr, useTokenAuth: true });
@@ -431,6 +445,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
     /** @spec RTN17b2 */
     it('init_fallbacks_once_connected', function (done) {
+      const helper = this.test.helper;
       var realtime = helper.AblyRealtime({
         httpMaxRetryCount: 3,
         fallbackHosts: ['a', 'b', 'c'],
@@ -453,6 +468,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
     /** @specpartial RTN17e */
     it('init_fallbacks_once_connected_2', function (done) {
+      const helper = this.test.helper;
       var goodHost = helper.AblyRest().options.realtimeHost;
       var realtime = helper.AblyRealtime({
         httpMaxRetryCount: 3,

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -1,13 +1,15 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   let config = Ably.Realtime.Platform.Config;
   var createPM = Ably.protocolMessageFromDeserialized;
 
   var publishIntervalHelper = function (currentMessageNum, channel, dataFn, onPublish) {
     return function () {
-      helper.whenPromiseSettles(channel.publish('event0', dataFn()), function () {
+      Helper.whenPromiseSettles(channel.publish('event0', dataFn()), function () {
         onPublish();
       });
     };
@@ -44,7 +46,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         realtime.connection.on('connected', function () {
           var testMsg = 'Hello world';
           var rtChannel = realtime.channels.get('publishonce');
-          helper.whenPromiseSettles(rtChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(rtChannel.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -76,13 +78,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * Test publishes in quick succession (on successive ticks of the event loop)
      * @spec RTL6b
      */
-    helper.testOnAllTransports('publishfast', function (realtimeOpts) {
+    Helper.testOnAllTransports('publishfast', function (realtimeOpts) {
       return function (done) {
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
             var channel = realtime.channels.get('publishfast_' + String(Math.random()).substr(2));
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;
@@ -100,7 +102,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   function (cb) {
                     var ackd = 0;
                     var publish = function (i) {
-                      helper.whenPromiseSettles(channel.publish('event', i.toString()), function (err) {
+                      Helper.whenPromiseSettles(channel.publish('event', i.toString()), function (err) {
                         try {
                           expect(
                             !err,
@@ -142,7 +144,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL6c2
      * @specpartial RTL3d - test processing queued messages
      */
-    helper.testOnAllTransports('publishQueued', function (realtimeOpts) {
+    Helper.testOnAllTransports('publishQueued', function (realtimeOpts) {
       return function (done) {
         var txRealtime, rxRealtime;
         try {
@@ -159,7 +161,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 });
               },
               function (cb) {
-                helper.whenPromiseSettles(rxChannel.attach(), function (err) {
+                Helper.whenPromiseSettles(rxChannel.attach(), function (err) {
                   cb(err);
                 });
               },
@@ -183,7 +185,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                     function (parCb) {
                       var ackd = 0;
                       var publish = function (i) {
-                        helper.whenPromiseSettles(txChannel.publish('event', { num: i }), function (err) {
+                        Helper.whenPromiseSettles(txChannel.publish('event', { num: i }), function (err) {
                           try {
                             expect(
                               !err,
@@ -265,7 +267,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       };
 
       // attach rtNoEchoChannel
-      helper.whenPromiseSettles(rtNoEchoChannel.attach(), function (err) {
+      Helper.whenPromiseSettles(rtNoEchoChannel.attach(), function (err) {
         try {
           expect(!err, 'Attached to rtNoEchoChannel with no error').to.be.ok;
         } catch (err) {
@@ -281,7 +283,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         });
 
         // attach rtEchoChannel
-        helper.whenPromiseSettles(rtEchoChannel.attach(), function (err) {
+        Helper.whenPromiseSettles(rtEchoChannel.attach(), function (err) {
           try {
             expect(!err, 'Attached to rtEchoChannel with no error').to.be.ok;
           } catch (err) {
@@ -297,7 +299,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           });
 
           // publish testMsg1 via rtNoEcho
-          helper.whenPromiseSettles(rtNoEchoChannel.publish('event0', testMsg1), function () {
+          Helper.whenPromiseSettles(rtNoEchoChannel.publish('event0', testMsg1), function () {
             // publish testMsg2 via rtEcho
             rtEchoChannel.publish('event0', testMsg2);
           });
@@ -341,7 +343,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         /* connect and attach */
         realtime.connection.on('connected', function () {
           var rtChannel = realtime.channels.get('publishVariations');
-          helper.whenPromiseSettles(rtChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(rtChannel.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -411,7 +413,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             async.eachSeries(
               testArguments,
               function iterator(args, callback) {
-                helper.whenPromiseSettles(restChannel.publish.apply(restChannel, args), callback);
+                Helper.whenPromiseSettles(restChannel.publish.apply(restChannel, args), callback);
               },
               function (err) {
                 if (err) {
@@ -447,7 +449,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         /* connect and attach */
         realtime.connection.on('connected', function () {
           var rtChannel = realtime.channels.get('publishDisallowed');
-          helper.whenPromiseSettles(rtChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(rtChannel.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -507,7 +509,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         /* connect and attach */
         realtime.connection.on('connected', function () {
           var rtChannel = realtime.channels.get('publishEncodings');
-          helper.whenPromiseSettles(rtChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(rtChannel.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -554,7 +556,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 testArguments,
                 function iterator(item, callback) {
                   try {
-                    helper.whenPromiseSettles(restChannel.publish(item), function (err) {
+                    Helper.whenPromiseSettles(restChannel.publish(item), function (err) {
                       try {
                         expect(!err, 'Successfully published').to.be.ok;
                       } catch (err) {
@@ -617,7 +619,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec RTL6
      * @spec RTL6b
      */
-    helper.testOnAllTransports('publish', function (realtimeOpts) {
+    Helper.testOnAllTransports('publish', function (realtimeOpts) {
       return function (done) {
         var count = 10;
         var cbCount = 10;
@@ -633,7 +635,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var realtime = helper.AblyRealtime(realtimeOpts);
         var channel = realtime.channels.get('publish ' + JSON.stringify(realtimeOpts));
         /* subscribe to event */
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           channel.subscribe('event0', function () {
             --count;
             checkFinish();
@@ -719,7 +721,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
         var channel = realtime.channels.get('explicit_client_id_0');
         /* subscribe to event */
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err) {
             try {
               expect(!err, err && helper.displayError(err)).to.be.ok;
@@ -743,7 +745,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 });
               },
               function (cb) {
-                helper.whenPromiseSettles(channel.publish({ name: 'event0', clientId: clientId }), function (err) {
+                Helper.whenPromiseSettles(channel.publish({ name: 'event0', clientId: clientId }), function (err) {
                   cb(err);
                 });
               },
@@ -767,7 +769,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         invalidClientId = 'invalid',
         rest = helper.AblyRest();
 
-      helper.whenPromiseSettles(rest.auth.requestToken({ clientId: clientId }), function (err, token) {
+      Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: clientId }), function (err, token) {
         if (err) {
           done(err);
           return;
@@ -784,7 +786,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           channel = realtime.channels.get('explicit_client_id_1');
 
         // Publish before authentication to ensure the client library does not reject the message as the clientId is not known
-        helper.whenPromiseSettles(channel.publish({ name: 'event0', clientId: invalidClientId }), function (err) {
+        Helper.whenPromiseSettles(channel.publish({ name: 'event0', clientId: invalidClientId }), function (err) {
           try {
             expect(err, 'Message was not published').to.be.ok;
           } catch (err) {
@@ -835,7 +837,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), function (err) {
+            Helper.whenPromiseSettles(channel.attach(), function (err) {
               cb(err);
             });
           },
@@ -861,7 +863,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   });
                 },
                 function (innercb) {
-                  helper.whenPromiseSettles(
+                  Helper.whenPromiseSettles(
                     channel.publish([{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }]),
                     function (err) {
                       innercb(err);
@@ -894,7 +896,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       const channel = realtime.channels.get('subscribe_with_filter_object');
 
       function send(cb) {
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           channel.publish([
             {
               name: 'correct',
@@ -957,7 +959,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            return helper.whenPromiseSettles(channel.attach(), cb);
+            return Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             return async.parallel([subscribe, send], cb);
@@ -984,7 +986,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       const channel = realtime.channels.get('unsubscribe_with_filter_object');
 
       function send(cb) {
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           channel.publish([
             {
               name: 'incorrect',
@@ -1026,7 +1028,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            return helper.whenPromiseSettles(channel.attach(), cb);
+            return Helper.whenPromiseSettles(channel.attach(), cb);
           },
           unsubscribe,
           send,
@@ -1051,7 +1053,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (outercb) {
             async.parallel(
@@ -1069,7 +1071,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                   });
                 },
                 function (innercb) {
-                  helper.whenPromiseSettles(channel.publish([{ name: 'a', extras: extras }]), innercb);
+                  Helper.whenPromiseSettles(channel.publish([{ name: 'a', extras: extras }]), innercb);
                 },
               ],
               outercb,
@@ -1094,7 +1096,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
 
       realtime.connection.once('connected', function () {
         connectionManager.once('connectiondetails', function (details) {
-          helper.whenPromiseSettles(
+          Helper.whenPromiseSettles(
             channel.publish('foo', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
             function (err) {
               try {
@@ -1201,7 +1203,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var realtime = helper.AblyRealtime(),
         channel = realtime.channels.get('idempotentRealtimePublishing');
 
-      helper.whenPromiseSettles(channel.attach(), function (err) {
+      Helper.whenPromiseSettles(channel.attach(), function (err) {
         if (err) {
           helper.closeAndFinish(done, realtime, err);
           return;
@@ -1303,7 +1305,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           var filteredMessages = [];
           var unFilteredMessages = [];
           /* subscribe to event */
-          helper.whenPromiseSettles(rtFilteredChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(rtFilteredChannel.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, realtime, err);
               return;
@@ -1318,7 +1320,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               }
             });
 
-            helper.whenPromiseSettles(rtUnfilteredChannel.attach(), function (err) {
+            Helper.whenPromiseSettles(rtUnfilteredChannel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
                 return;

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -151,6 +151,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           txRealtime,
           rxRealtime;
         try {
+          helper.recordPrivateApi('call.Utils.mixin');
           txRealtime = helper.AblyRealtime(helper.Utils.mixin(realtimeOpts, { autoConnect: false }));
           rxRealtime = helper.AblyRealtime();
           var txChannel = txRealtime.channels.get('publishQueued_' + String(Math.random()).substr(2));
@@ -671,9 +672,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         realtime = helper.AblyRealtime({ clientId: clientId });
 
       realtime.connection.once('connected', function () {
+        helper.recordPrivateApi('read.connectionManager.activeProtocol.transport');
         var transport = realtime.connection.connectionManager.activeProtocol.transport,
           originalSend = transport.send;
 
+        helper.recordPrivateApi('replace.transport.send');
         transport.send = function (message) {
           try {
             if (message.action === 15) {
@@ -681,6 +684,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               expect(!message.messages[0].clientId, 'client ID is not added by the client library as it is implicit').to
                 .be.ok;
             }
+            helper.recordPrivateApi('call.transport.send');
             originalSend.apply(transport, arguments);
           } catch (err) {
             helper.closeAndFinish(done, realtime, err);
@@ -715,15 +719,18 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         realtime = helper.AblyRealtime({ clientId: clientId, transports: [helper.bestTransport] });
 
       realtime.connection.once('connected', function () {
+        helper.recordPrivateApi('read.connectionManager.activeProtocol.transport');
         var transport = realtime.connection.connectionManager.activeProtocol.transport,
           originalSend = transport.send;
 
+        helper.recordPrivateApi('replace.transport.send');
         transport.send = function (message) {
           try {
             if (message.action === 15) {
               expect(message.messages[0].name === 'event0', 'Outgoing message interecepted').to.be.ok;
               expect(message.messages[0].clientId === clientId, 'client ID is present when published to Ably').to.be.ok;
             }
+            helper.recordPrivateApi('call.transport.send');
             originalSend.apply(transport, arguments);
           } catch (err) {
             helper.closeAndFinish(done, realtime, err);
@@ -809,9 +816,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           }, 500); // ensure that the message is not published
         });
 
+        helper.recordPrivateApi('listen.connectionManager.transport.pending');
         realtime.connection.connectionManager.on('transport.pending', function (transport) {
           var originalSend = transport.send;
 
+          helper.recordPrivateApi('replace.transport.send');
           transport.send = function (message) {
             try {
               if (message.action === 15) {
@@ -819,6 +828,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
                 expect(message.messages[0].clientId === invalidClientId, 'client ID is present when published to Ably')
                   .to.be.ok;
               }
+              helper.recordPrivateApi('call.transport.send');
               originalSend.apply(transport, arguments);
             } catch (err) {
               helper.closeAndFinish(done, realtime, err);
@@ -869,6 +879,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
                     ++received;
                     if (received === 2) {
                       /* wait a tick to make sure no more messages come in */
+                      helper.recordPrivateApi('call.Platform.nextTick');
                       config.nextTick(function () {
                         innercb();
                       });
@@ -960,6 +971,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               return cb(e);
             }
             // Wait for any errant messages to arrive before continuing
+            helper.recordPrivateApi('call.Platform.nextTick');
             config.nextTick(cb);
           },
         );
@@ -1023,12 +1035,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
             return expect.fail('Listener should not fire');
           };
           channel.subscribe({ refType: 'com.ably.test', refTimeserial: '0123456789' }, listener);
+          helper.recordPrivateApi('call.filteredSubscriptions.has');
           expect(channel.filteredSubscriptions.has(listener), 'Listener should initially be present').to.be.true;
           channel.unsubscribe(listener);
           expect(
             channel.filteredSubscriptions.has(listener),
             'Listener should no longer be present after unsubscribing',
           ).to.be.false;
+          helper.recordPrivateApi('call.Platform.nextTick');
           config.nextTick(cb);
         } catch (e) {
           cb(e);
@@ -1112,6 +1126,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channel = realtime.channels.get('maxMessageSize');
 
       realtime.connection.once('connected', function () {
+        helper.recordPrivateApi('listen.connectionManager.connectiondetails');
         connectionManager.once('connectiondetails', function (details) {
           Helper.whenPromiseSettles(
             channel.publish('foo', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
@@ -1128,7 +1143,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           );
         });
         var connectionDetails = connectionManager.connectionDetails;
+        helper.recordPrivateApi('write.connectionManager.connectionDetails.maxMessageSize');
         connectionDetails.maxMessageSize = 64;
+        helper.recordPrivateApi('call.connectionManager.activeProtocol.getTransport');
+        helper.recordPrivateApi('call.protocolMessageFromDeserialized');
+        helper.recordPrivateApi('call.transport.onProtocolMessage');
         connectionManager.activeProtocol.getTransport().onProtocolMessage(
           createPM({
             action: 4,
@@ -1183,6 +1202,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       channelOne.publish({ name: 'm', id: 'bundle_m', data: { expectedBundle: 9 } });
       channelOne.publish('z_last', { expectedBundle: 10 });
 
+      helper.recordPrivateApi('call.transport.onProtocolMessage');
       var queue = realtime.connection.connectionManager.queuedMessages;
       var messages;
       try {

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   let config = Ably.Realtime.Platform.Config;
   var createPM = Ably.protocolMessageFromDeserialized;
@@ -24,6 +22,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
   describe('realtime/message', function () {
     this.timeout(60 * 1000);
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -37,6 +36,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL7b
      */
     it('publishonce', function (done) {
+      const helper = this.test.helper;
       try {
         /* set up realtime */
         var realtime = helper.AblyRealtime();
@@ -80,6 +80,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('publishfast', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         try {
           var realtime = helper.AblyRealtime(realtimeOpts);
           realtime.connection.once('connected', function () {
@@ -146,7 +147,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('publishQueued', function (realtimeOpts) {
       return function (done) {
-        var txRealtime, rxRealtime;
+        var helper = this.test.helper,
+          txRealtime,
+          rxRealtime;
         try {
           txRealtime = helper.AblyRealtime(helper.Utils.mixin(realtimeOpts, { autoConnect: false }));
           rxRealtime = helper.AblyRealtime();
@@ -239,7 +242,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it('publishEcho', function (done) {
       // set up two realtimes
-      var rtNoEcho = helper.AblyRealtime({ echoMessages: false }),
+      var helper = this.test.helper,
+        rtNoEcho = helper.AblyRealtime({ echoMessages: false }),
         rtEcho = helper.AblyRealtime({ echoMessages: true }),
         rtNoEchoChannel = rtNoEcho.channels.get('publishecho'),
         rtEchoChannel = rtEcho.channels.get('publishecho'),
@@ -315,6 +319,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL1a - doesn't test array of Message objects
      */
     it('publishVariations', function (done) {
+      const helper = this.test.helper;
       var testData = 'Some data';
       var testArguments = [
         [{ name: 'objectWithName' }],
@@ -432,6 +437,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RSL4a */
     it('publishDisallowed', function (done) {
+      const helper = this.test.helper;
       var testArguments = [
         [{ name: 'objectAndBoolData', data: false }],
         ['nameAndBoolData', false],
@@ -489,6 +495,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL6b
      */
     it('publishEncodings', function (done) {
+      const helper = this.test.helper;
       var testData = 'testData';
       var testArguments = [
         // valid
@@ -588,6 +595,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL7b
      */
     it('restpublish', function (done) {
+      const helper = this.test.helper;
       var count = 10;
       var rest = helper.AblyRest();
       var realtime = helper.AblyRealtime();
@@ -621,6 +629,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     Helper.testOnAllTransports('publish', function (realtimeOpts) {
       return function (done) {
+        const helper = this.test.helper;
         var count = 10;
         var cbCount = 10;
         var checkFinish = function () {
@@ -657,7 +666,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL1m1 - in the context of RealtimeChannel
      */
     it('implicit_client_id_0', function (done) {
-      var clientId = 'implicit_client_id_0',
+      var helper = this.test.helper,
+        clientId = 'implicit_client_id_0',
         realtime = helper.AblyRealtime({ clientId: clientId });
 
       realtime.connection.once('connected', function () {
@@ -699,7 +709,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL1m2 - in the context of RealtimeChannel
      */
     it('explicit_client_id_0', function (done) {
-      var clientId = 'explicit_client_id_0',
+      var helper = this.test.helper,
+        clientId = 'explicit_client_id_0',
         /* Use a fixed transport as intercepting transport.send */
         realtime = helper.AblyRealtime({ clientId: clientId, transports: [helper.bestTransport] });
 
@@ -765,7 +776,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL1m4 - in the context of RealtimeChannel
      */
     it('explicit_client_id_1', function (done) {
-      var clientId = 'explicit_client_id_1',
+      var helper = this.test.helper,
+        clientId = 'explicit_client_id_1',
         invalidClientId = 'invalid',
         rest = helper.AblyRest();
 
@@ -826,7 +838,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('subscribe_with_event_array', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         channel = realtime.channels.get('subscribe_with_event_array');
 
       async.series(
@@ -892,6 +905,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTL22a - doesn't test for name
      */
     it('subscribe_with_filter_object', function (done) {
+      const helper = this.test.helper;
       const realtime = helper.AblyRealtime();
       const channel = realtime.channels.get('subscribe_with_filter_object');
 
@@ -982,6 +996,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTL22a - doesn't test for name
      */
     it('unsubscribe_with_filter_object', function (done) {
+      const helper = this.test.helper;
       const realtime = helper.AblyRealtime();
       const channel = realtime.channels.get('unsubscribe_with_filter_object');
 
@@ -1041,7 +1056,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @spec RSL6a2 */
     it('extras_field', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         channel = realtime.channels.get('extras_field'),
         extras = { headers: { some: 'metadata' } };
 
@@ -1090,7 +1106,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSL1i
      */
     it('maxMessageSize', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         connectionManager = realtime.connection.connectionManager,
         channel = realtime.channels.get('maxMessageSize');
 
@@ -1134,7 +1151,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specskip
      */
     it.skip('bundling', function (done) {
-      var realtime = helper.AblyRealtime({ maxMessageSize: 256, autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ maxMessageSize: 256, autoConnect: false }),
         channelOne = realtime.channels.get('bundlingOne'),
         channelTwo = realtime.channels.get('bundlingTwo');
 
@@ -1200,7 +1218,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSL1k5
      */
     it('idempotentRealtimePublishing', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         channel = realtime.channels.get('idempotentRealtimePublishing');
 
       Helper.whenPromiseSettles(channel.attach(), function (err) {
@@ -1241,6 +1260,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec DO2a
      */
     it('subscribes to filtered channel', function (done) {
+      const helper = this.test.helper;
+
       var testData = [
         {
           name: 'filtered',

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -78,7 +78,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * Test publishes in quick succession (on successive ticks of the event loop)
      * @spec RTL6b
      */
-    Helper.testOnAllTransports('publishfast', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'publishfast', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -145,7 +145,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL6c2
      * @specpartial RTL3d - test processing queued messages
      */
-    Helper.testOnAllTransports('publishQueued', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'publishQueued', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           txRealtime,
@@ -627,7 +627,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL6
      * @spec RTL6b
      */
-    Helper.testOnAllTransports('publish', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'publish', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var count = 10;

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var createPM = Ably.protocolMessageFromDeserialized;
   var PresenceMessage = Ably.Realtime.PresenceMessage;
@@ -25,7 +23,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
   var testClientId = 'testclient',
     testClientId2 = 'testclient2';
 
-  var createListenerChannel = function (channelName, callback) {
+  var createListenerChannel = function (helper, channelName, callback) {
     var channel, realtime;
     try {
       realtime = helper.AblyRealtime();
@@ -55,9 +53,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     };
   };
 
-  var runTestWithEventListener = function (done, channel, eventListener, testRunner) {
+  var runTestWithEventListener = function (done, helper, channel, eventListener, testRunner) {
     try {
-      createListenerChannel(channel, function (err, listenerRealtime, presenceChannel) {
+      createListenerChannel(helper, channel, function (err, listenerRealtime, presenceChannel) {
         if (err) {
           helper.closeAndFinish(done, listenerRealtime, err);
           return;
@@ -93,6 +91,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
   describe('realtime/presence', function () {
     this.timeout(60 * 1000);
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -145,6 +144,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specskip
      */
     it.skip('presenceAttachAndEnter', function (done) {
+      const helper = this.test.helper;
       var channelName = 'attachAndEnter';
       var attachAndEnter = function (cb) {
         /* set up authenticated connection */
@@ -165,7 +165,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('enter'), attachAndEnter);
+      runTestWithEventListener(done, helper, channelName, listenerFor('enter'), attachAndEnter);
     });
 
     /**
@@ -175,6 +175,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP8a - doesn't test entering with data
      */
     it('presenceEnterWithoutAttach', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterWithoutAttach';
       var enterWithoutAttach = function (cb) {
         var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -191,7 +192,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('enter'), enterWithoutAttach);
+      runTestWithEventListener(done, helper, channelName, listenerFor('enter'), enterWithoutAttach);
     });
 
     /**
@@ -200,6 +201,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('presenceEnterWithoutConnect', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterWithoutConnect';
       var enterWithoutConnect = function (cb) {
         var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -213,7 +215,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('enter'), enterWithoutConnect);
+      runTestWithEventListener(done, helper, channelName, listenerFor('enter'), enterWithoutConnect);
     });
 
     /**
@@ -225,6 +227,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specskip
      */
     it.skip('presenceEnterDetachRace', function (done) {
+      const helper = this.test.helper;
       // Can't use runTestWithEventListener helper as one of the successful
       // outcomes is an error in presence enter, in which case listenForEventOn
       // will not run its callback
@@ -233,7 +236,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       try {
         /* listen for the enter event, test is complete when received */
 
-        createListenerChannel(channelName, function (err, listenerRealtime, presenceChannel) {
+        createListenerChannel(helper, channelName, function (err, listenerRealtime, presenceChannel) {
           if (err) {
             helper.closeAndFinish(done, listenerRealtime, err);
             return;
@@ -290,6 +293,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP8b - test successful callback
      */
     it('presenceEnterWithCallback', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterWithCallback';
       var enterWithCallback = function (cb) {
         /* set up authenticated connection */
@@ -310,7 +314,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('enter'), enterWithCallback);
+      runTestWithEventListener(done, helper, channelName, listenerFor('enter'), enterWithCallback);
     });
 
     /**
@@ -318,6 +322,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP8a - test entering presence without data and callback
      */
     it('presenceEnterWithNothing', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterWithNothing';
       var enterWithNothing = function (cb) {
         var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -336,7 +341,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('enter'), enterWithNothing);
+      runTestWithEventListener(done, helper, channelName, listenerFor('enter'), enterWithNothing);
     });
 
     /**
@@ -345,6 +350,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP8a - test entering presence with data
      */
     it('presenceEnterWithData', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterWithData';
       var enterWithData = function (cb) {
         var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -363,7 +369,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('enter'), enterWithData);
+      runTestWithEventListener(done, helper, channelName, listenerFor('enter'), enterWithData);
     });
 
     /**
@@ -373,6 +379,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP8c - test sending ENTER action
      */
     it('presenceMessageAction', function (done) {
+      const helper = this.test.helper;
       var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
       var channelName = 'presenceMessageAction';
       var clientChannel = clientRealtime.channels.get(channelName);
@@ -406,6 +413,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP8e - doesn't test leaving without extras
      */
     it('presenceMessageExtras', function (done) {
+      const helper = this.test.helper;
       var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
       var channelName = 'presenceEnterWithExtras';
       var clientChannel = clientRealtime.channels.get(channelName);
@@ -478,6 +486,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('presenceEnterDetachEnter', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterDetachEnter';
       var secondEventListener = function (channel, callback) {
         var presenceHandler = function (presenceMsg) {
@@ -515,7 +524,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, secondEventListener, enterDetachEnter);
+      runTestWithEventListener(done, helper, channelName, secondEventListener, enterDetachEnter);
     });
 
     /**
@@ -525,6 +534,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP8d - test throwing error if channel in DETACHED or FAILED state
      */
     it('presenceEnterInvalid', function (done) {
+      const helper = this.test.helper;
       var clientRealtime;
       try {
         clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -556,6 +566,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP10
      */
     it('presenceEnterAndLeave', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterAndLeave';
       var enterAndLeave = function (cb) {
         var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -581,7 +592,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('leave'), enterAndLeave);
+      runTestWithEventListener(done, helper, channelName, listenerFor('leave'), enterAndLeave);
     });
 
     /**
@@ -591,6 +602,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP9a - tests passing new data
      */
     it('presenceEnterUpdate', function (done) {
+      const helper = this.test.helper;
       var newData = 'New data';
       var channelName = 'enterUpdate';
       var eventListener = function (channel, callback) {
@@ -632,7 +644,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, eventListener, enterUpdate);
+      runTestWithEventListener(done, helper, channelName, eventListener, enterUpdate);
     });
 
     /**
@@ -640,6 +652,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP11a
      */
     it('presenceEnterGet', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterGet';
       var testData = 'some data for presenceEnterGet';
       var eventListener = function (channel, callback) {
@@ -681,7 +694,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, eventListener, enterGet);
+      runTestWithEventListener(done, helper, channelName, eventListener, enterGet);
     });
 
     /**
@@ -689,6 +702,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP6c
      */
     it('presenceSubscribeUnattached', function (done) {
+      const helper = this.test.helper;
       var channelName = 'subscribeUnattached';
       var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
       var clientRealtime2;
@@ -720,6 +734,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP11c1 - tests default behavior waitForSync=true
      */
     it('presenceGetUnattached', function (done) {
+      const helper = this.test.helper;
       var channelName = 'getUnattached';
       var testData = 'some data';
       var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
@@ -764,6 +779,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP10c
      */
     it('presenceEnterLeaveGet', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterLeaveGet';
       var eventListener = function (channel, callback) {
         var presenceHandler = function () {
@@ -811,7 +827,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, eventListener, enterLeaveGet);
+      runTestWithEventListener(done, helper, channelName, eventListener, enterLeaveGet);
     });
 
     /**
@@ -820,6 +836,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP12c
      */
     it('presenceHistory', function (done) {
+      const helper = this.test.helper;
       var clientRealtime;
       var channelName = 'history';
       var testClientData = 'Test client data (history0)';
@@ -895,6 +912,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('presenceSecondConnection', function (done) {
+      const helper = this.test.helper;
       var clientRealtime1, clientRealtime2;
       var channelName = 'secondConnection';
       try {
@@ -978,6 +996,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP11c3
      */
     it('presenceTwoMembers', function (done) {
+      const helper = this.test.helper;
       var clientRealtime1, clientRealtime2, clientChannel1, clientChannel2;
       var channelName = 'twoMembers';
       try {
@@ -1147,6 +1166,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('presenceEnterAfterClose', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enterAfterClose';
       var secondEnterListener = function (channel, callback) {
         var presenceHandler = function (presenceMsg) {
@@ -1182,7 +1202,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, clientRealtime);
       };
 
-      runTestWithEventListener(done, channelName, secondEnterListener, enterAfterClose);
+      runTestWithEventListener(done, helper, channelName, secondEnterListener, enterAfterClose);
     });
 
     /**
@@ -1190,6 +1210,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP15e - tests only enterClient
      */
     it('presenceEnterClosed', function (done) {
+      const helper = this.test.helper;
       var clientRealtime;
       var channelName = 'enterClosed';
       try {
@@ -1222,7 +1243,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP10c
      */
     it('presenceClientIdIsImplicit', function (done) {
-      var clientId = 'implicitClient',
+      var helper = this.test.helper,
+        clientId = 'implicitClient',
         client = helper.AblyRealtime({ clientId: clientId });
 
       var channel = client.channels.get('presenceClientIdIsImplicit'),
@@ -1267,7 +1289,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP8e - test encoding of message and data
      */
     it('presenceEncoding', function (done) {
-      var data = { foo: 'bar' },
+      var helper = this.test.helper,
+        data = { foo: 'bar' },
         encodedData = JSON.stringify(data),
         options = {
           clientId: testClientId,
@@ -1333,6 +1356,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('presence_enter_inherited_clientid', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enter_inherited_clientid';
 
       var authCallback = function (tokenParams, callback) {
@@ -1362,7 +1386,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         helper.monitorConnection(done, realtime);
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('enter', testClientId), enterInheritedClientId);
+      runTestWithEventListener(done, helper, channelName, listenerFor('enter', testClientId), enterInheritedClientId);
     });
 
     /**
@@ -1374,6 +1398,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('presence_enter_before_know_clientid', function (done) {
+      const helper = this.test.helper;
       var channelName = 'enter_before_know_clientid';
 
       var enterInheritedClientId = function (cb) {
@@ -1404,7 +1429,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         });
       };
 
-      runTestWithEventListener(done, channelName, listenerFor('enter', testClientId), enterInheritedClientId);
+      runTestWithEventListener(done, helper, channelName, listenerFor('enter', testClientId), enterInheritedClientId);
     });
 
     /**
@@ -1414,6 +1439,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP15b
      */
     it('presence_refresh_on_detach', function (done) {
+      const helper = this.test.helper;
       var channelName = 'presence_refresh_on_detach';
       var realtime = helper.AblyRealtime();
       var observer = helper.AblyRealtime();
@@ -1529,6 +1555,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     /** @nospec */
     it('presence_detach_during_sync', function (done) {
+      const helper = this.test.helper;
       var channelName = 'presence_detach_during_sync';
       var enterer = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
       var detacher = helper.AblyRealtime();
@@ -1591,6 +1618,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP17i - tests simple re-entry, no RESUMED flag test
      */
     it('presence_auto_reenter', function (done) {
+      const helper = this.test.helper;
       var channelName = 'presence_auto_reenter';
       var realtime = helper.AblyRealtime();
       var channel = realtime.channels.get(channelName);
@@ -1704,7 +1732,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specskip
      */
     it.skip('presence_failed_auto_reenter', function (done) {
-      var channelName = 'presence_failed_auto_reenter',
+      var helper = this.test.helper,
+        channelName = 'presence_failed_auto_reenter',
         realtime,
         channel,
         token;
@@ -1804,7 +1833,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('multiple_pending', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         channel = realtime.channels.get('multiple_pending'),
         originalAttachImpl = channel.attachImpl;
 
@@ -1859,7 +1889,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP19
      */
     it('leave_published_for_member_missing_from_sync', function (done) {
-      var realtime = helper.AblyRealtime({ transports: helper.availableTransports }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ transports: helper.availableTransports }),
         continuousClientId = 'continuous',
         goneClientId = 'gone',
         continuousRealtime = helper.AblyRealtime({ clientId: continuousClientId }),
@@ -1977,7 +2008,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP19a
      */
     it('leave_published_for_members_on_presenceless_attached', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         channelName = 'leave_published_for_members_on_presenceless_attached',
         channel = realtime.channels.get(channelName),
         fakeClientId = 'faker';
@@ -2073,7 +2105,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP11d
      */
     it('suspended_preserves_presence', function (done) {
-      var mainRealtime = helper.AblyRealtime({ clientId: 'main' }),
+      var helper = this.test.helper,
+        mainRealtime = helper.AblyRealtime({ clientId: 'main' }),
         continuousRealtime = helper.AblyRealtime({ clientId: 'continuous' }),
         leavesRealtime = helper.AblyRealtime({ clientId: 'leaves' }),
         channelName = 'suspended_preserves_presence',
@@ -2213,6 +2246,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP9a
      */
     it('presence_many_updates', function (done) {
+      const helper = this.test.helper;
       var client = helper.AblyRealtime({ clientId: testClientId });
 
       var channel = client.channels.get('presence_many_updates'),

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var createPM = Ably.protocolMessageFromDeserialized;
   var PresenceMessage = Ably.Realtime.PresenceMessage;
@@ -29,7 +31,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       realtime = helper.AblyRealtime();
       realtime.connection.on('connected', function () {
         channel = realtime.channels.get(channelName);
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           callback(err, realtime, channel);
         });
       });
@@ -99,7 +101,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         // Create authTokens associated with specific clientIds
         try {
           rest = helper.AblyRest();
-          helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+          Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
             if (err) {
               done(err);
               return;
@@ -112,7 +114,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               return;
             }
 
-            helper.whenPromiseSettles(
+            Helper.whenPromiseSettles(
               rest.auth.requestToken({ clientId: testClientId2 }),
               function (err, tokenDetails) {
                 if (err) {
@@ -150,12 +152,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
             }
-            helper.whenPromiseSettles(clientChannel.presence.enter('Test client data (enter0)'), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.enter('Test client data (enter0)'), function (err) {
               cb(err, clientRealtime);
             });
           });
@@ -179,7 +181,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(
+          Helper.whenPromiseSettles(
             clientChannel.presence.enter('Test client data (enterWithoutAttach)'),
             function (err) {
               cb(err, clientRealtime);
@@ -202,7 +204,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var enterWithoutConnect = function (cb) {
         var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
         var clientChannel = clientRealtime.channels.get(channelName);
-        helper.whenPromiseSettles(
+        Helper.whenPromiseSettles(
           clientChannel.presence.enter('Test client data (enterWithoutConnect)'),
           function (err) {
             cb(err, clientRealtime);
@@ -249,19 +251,19 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           clientRealtime.connection.on('connected', function () {
             /* get channel, attach, and enter */
             var clientChannel = clientRealtime.channels.get(channelName);
-            helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+            Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
               if (err) {
                 helper.closeAndFinish(done, [listenerRealtime, clientRealtime], err);
                 return;
               }
-              helper.whenPromiseSettles(clientChannel.detach(), function (err) {
+              Helper.whenPromiseSettles(clientChannel.detach(), function (err) {
                 if (err) {
                   helper.closeAndFinish(done, [listenerRealtime, clientRealtime], err);
                   return;
                 }
               });
             });
-            helper.whenPromiseSettles(clientChannel.presence.enter('Test client data (enter3)'), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.enter('Test client data (enter3)'), function (err) {
               // Note: either an error (pending messages failed to send due to detach)
               //   or a success (pending messages were pushed out before the detach)
               //   is an acceptable result. Throwing an uncaught exception (the behaviour
@@ -295,12 +297,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
             }
-            helper.whenPromiseSettles(clientChannel.presence.enter(), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.enter(), function (err) {
               cb(err, clientRealtime);
             });
           });
@@ -322,7 +324,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
@@ -349,7 +351,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
@@ -375,7 +377,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var channelName = 'presenceMessageAction';
       var clientChannel = clientRealtime.channels.get(channelName);
       var presence = clientChannel.presence;
-      helper.whenPromiseSettles(
+      Helper.whenPromiseSettles(
         presence.subscribe(function (presenceMessage) {
           try {
             expect(presenceMessage.action).to.equal('enter', 'Action should contain string "enter"');
@@ -412,7 +414,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       async.series(
         [
           function (cb) {
-            helper.whenPromiseSettles(clientChannel.attach(), cb);
+            Helper.whenPromiseSettles(clientChannel.attach(), cb);
           },
           // Test entering with extras
           function (cb) {
@@ -494,17 +496,17 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         }); // NB remove besttransport in 1.1 spec, see attachdetach0
         var clientChannel = clientRealtime.channels.get(channelName);
         clientRealtime.connection.once('connected', function () {
-          helper.whenPromiseSettles(clientChannel.presence.enter('first'), function (err) {
+          Helper.whenPromiseSettles(clientChannel.presence.enter('first'), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
             }
-            helper.whenPromiseSettles(clientChannel.detach(), function (err) {
+            Helper.whenPromiseSettles(clientChannel.detach(), function (err) {
               if (err) {
                 cb(err, clientRealtime);
                 return;
               }
-              helper.whenPromiseSettles(clientChannel.presence.enter('second'), function (err) {
+              Helper.whenPromiseSettles(clientChannel.presence.enter('second'), function (err) {
                 cb(err, clientRealtime);
               });
             });
@@ -528,7 +530,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
         var clientChannel = clientRealtime.channels.get('');
         clientRealtime.connection.once('connected', function () {
-          helper.whenPromiseSettles(clientChannel.presence.enter('clientId'), function (err) {
+          Helper.whenPromiseSettles(clientChannel.presence.enter('clientId'), function (err) {
             if (err) {
               try {
                 expect(err.code).to.equal(40010, 'Correct error code');
@@ -560,18 +562,18 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
             }
-            helper.whenPromiseSettles(clientChannel.presence.enter('Test client data (leave0)'), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.enter('Test client data (leave0)'), function (err) {
               if (err) {
                 cb(err, clientRealtime);
                 return;
               }
             });
-            helper.whenPromiseSettles(clientChannel.presence.leave(), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.leave(), function (err) {
               cb(err, clientRealtime);
             });
           });
@@ -611,17 +613,17 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var clientRealtime = helper.AblyRealtime({ clientId: testClientId, tokenDetails: authToken });
         clientRealtime.connection.on('connected', function () {
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
             }
-            helper.whenPromiseSettles(clientChannel.presence.enter('Original data'), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.enter('Original data'), function (err) {
               if (err) {
                 cb(err, clientRealtime);
                 return;
               }
-              helper.whenPromiseSettles(clientChannel.presence.update(newData), function (err) {
+              Helper.whenPromiseSettles(clientChannel.presence.update(newData), function (err) {
                 cb(err, clientRealtime);
               });
             });
@@ -643,7 +645,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var eventListener = function (channel, callback) {
         var presenceHandler = function () {
           /* Should be ENTER, but may be PRESENT in a race */
-          helper.whenPromiseSettles(channel.presence.get(), function (err, presenceMembers) {
+          Helper.whenPromiseSettles(channel.presence.get(), function (err, presenceMembers) {
             if (err) {
               callback(err);
               return;
@@ -666,12 +668,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
             }
-            helper.whenPromiseSettles(clientChannel.presence.enter(testData), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.enter(testData), function (err) {
               cb(err, clientRealtime);
             });
           });
@@ -724,7 +726,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       clientRealtime.connection.on('connected', function () {
         /* get channel, attach, and enter */
         var clientChannel = clientRealtime.channels.get(channelName);
-        helper.whenPromiseSettles(clientChannel.presence.enter(testData), function (err) {
+        Helper.whenPromiseSettles(clientChannel.presence.enter(testData), function (err) {
           if (err) {
             helper.closeAndFinish(done, clientRealtime, err);
             return;
@@ -733,7 +735,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           clientRealtime2.connection.on('connected', function () {
             var clientChannel2 = clientRealtime2.channels.get(channelName);
             /* GET without attaching */
-            helper.whenPromiseSettles(clientChannel2.presence.get(), function (err, presenceMembers) {
+            Helper.whenPromiseSettles(clientChannel2.presence.get(), function (err, presenceMembers) {
               if (err) {
                 helper.closeAndFinish(done, [clientRealtime, clientRealtime2], err);
                 return;
@@ -767,7 +769,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var presenceHandler = function () {
           // Ignore the first (enter) event
           if (this.event == 'leave') {
-            helper.whenPromiseSettles(channel.presence.get(), function (err, presenceMembers) {
+            Helper.whenPromiseSettles(channel.presence.get(), function (err, presenceMembers) {
               if (err) {
                 callback(err);
                 return;
@@ -790,17 +792,17 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
             }
-            helper.whenPromiseSettles(clientChannel.presence.enter('testClientData'), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.enter('testClientData'), function (err) {
               if (err) {
                 cb(err, clientRealtime);
                 return;
               }
-              helper.whenPromiseSettles(clientChannel.presence.leave(), function (err) {
+              Helper.whenPromiseSettles(clientChannel.presence.leave(), function (err) {
                 cb(err, clientRealtime);
               });
             });
@@ -822,7 +824,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var channelName = 'history';
       var testClientData = 'Test client data (history0)';
       var queryPresenceHistory = function (channel) {
-        helper.whenPromiseSettles(channel.presence.history(), function (err, resultPage) {
+        Helper.whenPromiseSettles(channel.presence.history(), function (err, resultPage) {
           if (err) {
             helper.closeAndFinish(done, clientRealtime, err);
             return;
@@ -849,22 +851,22 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel = clientRealtime.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, clientRealtime, err);
               return;
             }
-            helper.whenPromiseSettles(clientChannel.presence.enter(testClientData), function (err) {
+            Helper.whenPromiseSettles(clientChannel.presence.enter(testClientData), function (err) {
               if (err) {
                 helper.closeAndFinish(done, clientRealtime, err);
                 return;
               }
-              helper.whenPromiseSettles(clientChannel.presence.leave(), function (err) {
+              Helper.whenPromiseSettles(clientChannel.presence.leave(), function (err) {
                 if (err) {
                   helper.closeAndFinish(done, clientRealtime, err);
                   return;
                 }
-                helper.whenPromiseSettles(clientChannel.detach(), function (err) {
+                Helper.whenPromiseSettles(clientChannel.detach(), function (err) {
                   if (err) {
                     helper.closeAndFinish(done, clientRealtime, err);
                     return;
@@ -901,19 +903,19 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         clientRealtime1.connection.on('connected', function () {
           /* get channel, attach, and enter */
           var clientChannel1 = clientRealtime1.channels.get(channelName);
-          helper.whenPromiseSettles(clientChannel1.attach(), function (err) {
+          Helper.whenPromiseSettles(clientChannel1.attach(), function (err) {
             if (err) {
               helper.closeAndFinish(done, clientRealtime1, err);
               return;
             }
-            helper.whenPromiseSettles(clientChannel1.presence.enter('Test client data (attach0)'), function (err) {
+            Helper.whenPromiseSettles(clientChannel1.presence.enter('Test client data (attach0)'), function (err) {
               if (err) {
                 helper.closeAndFinish(done, clientRealtime1, err);
                 return;
               }
             });
             clientChannel1.presence.subscribe('enter', function () {
-              helper.whenPromiseSettles(clientChannel1.presence.get(), function (err, presenceMembers1) {
+              Helper.whenPromiseSettles(clientChannel1.presence.get(), function (err, presenceMembers1) {
                 if (err) {
                   helper.closeAndFinish(done, clientRealtime1, err);
                   return;
@@ -930,14 +932,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 clientRealtime2.connection.on('connected', function () {
                   /* get channel, attach */
                   var clientChannel2 = clientRealtime2.channels.get(channelName);
-                  helper.whenPromiseSettles(clientChannel2.attach(), function (err) {
+                  Helper.whenPromiseSettles(clientChannel2.attach(), function (err) {
                     if (err) {
                       helper.closeAndFinish(done, [clientRealtime1, clientRealtime2], err);
                       return;
                     }
                     clientChannel2.presence.subscribe('present', function () {
                       /* get the channel members and verify testclient is there */
-                      helper.whenPromiseSettles(clientChannel2.presence.get(), function (err, presenceMembers2) {
+                      Helper.whenPromiseSettles(clientChannel2.presence.get(), function (err, presenceMembers2) {
                         if (err) {
                           helper.closeAndFinish(done, [clientRealtime1, clientRealtime2], err);
                           return;
@@ -988,12 +990,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               clientRealtime1.connection.on('connected', function () {
                 /* get channel, attach, and enter */
                 clientChannel1 = clientRealtime1.channels.get(channelName);
-                helper.whenPromiseSettles(clientChannel1.attach(), function (err) {
+                Helper.whenPromiseSettles(clientChannel1.attach(), function (err) {
                   if (err) {
                     cb1(err);
                     return;
                   }
-                  helper.whenPromiseSettles(clientChannel1.presence.enter(data), function (err) {
+                  Helper.whenPromiseSettles(clientChannel1.presence.enter(data), function (err) {
                     if (err) {
                       cb1(err);
                       return;
@@ -1010,13 +1012,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               clientRealtime2.connection.on('connected', function () {
                 /* get channel, attach */
                 clientChannel2 = clientRealtime2.channels.get(channelName);
-                helper.whenPromiseSettles(clientChannel2.attach(), function (err) {
+                Helper.whenPromiseSettles(clientChannel2.attach(), function (err) {
                   if (err) {
                     cb2(err);
                     return;
                   }
                   var enterPresence = function (onEnterCB) {
-                    helper.whenPromiseSettles(clientChannel2.presence.enter(data), function (err) {
+                    Helper.whenPromiseSettles(clientChannel2.presence.enter(data), function (err) {
                       if (err) {
                         cb2(err);
                         return;
@@ -1060,7 +1062,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               [
                 /* First test: no filters */
                 function (cb) {
-                  helper.whenPromiseSettles(clientChannel2.presence.get(), function (err, members) {
+                  Helper.whenPromiseSettles(clientChannel2.presence.get(), function (err, members) {
                     if (err) {
                       return cb(err);
                     }
@@ -1079,7 +1081,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 },
                 /* Second test: filter by clientId */
                 function (cb) {
-                  helper.whenPromiseSettles(
+                  Helper.whenPromiseSettles(
                     clientChannel2.presence.get({ clientId: testClientId }),
                     function (err, members) {
                       if (err) {
@@ -1098,7 +1100,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 },
                 /* Third test: filter by connectionId */
                 function (cb) {
-                  helper.whenPromiseSettles(
+                  Helper.whenPromiseSettles(
                     clientChannel2.presence.get({ connectionId: clientRealtime1.connection.id }),
                     function (err, members) {
                       if (err) {
@@ -1160,16 +1162,16 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var clientChannel = clientRealtime.channels.get(channelName);
         clientRealtime.connection.once('connected', function () {
           /* get channel and enter (should automatically attach) */
-          helper.whenPromiseSettles(clientChannel.presence.enter('first'), function (err) {
+          Helper.whenPromiseSettles(clientChannel.presence.enter('first'), function (err) {
             if (err) {
               cb(err, clientRealtime);
               return;
             }
             clientRealtime.close();
-            helper.whenPromiseSettles(clientRealtime.connection.whenState('closed'), function () {
+            Helper.whenPromiseSettles(clientRealtime.connection.whenState('closed'), function () {
               clientRealtime.connection.once('connected', function () {
                 //Should automatically reattach
-                helper.whenPromiseSettles(clientChannel.presence.enter('second'), function (err) {
+                Helper.whenPromiseSettles(clientChannel.presence.enter('second'), function (err) {
                   cb(err, clientRealtime);
                 });
               });
@@ -1195,7 +1197,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var clientChannel = clientRealtime.channels.get(channelName);
         clientRealtime.connection.on('connected', function () {
           clientRealtime.close();
-          helper.whenPromiseSettles(clientChannel.presence.enterClient('clientId'), function (err) {
+          Helper.whenPromiseSettles(clientChannel.presence.enterClient('clientId'), function (err) {
             try {
               expect(err.code).to.equal(80017, 'presence enter failed with correct code');
               expect(err.statusCode).to.equal(400, 'presence enter failed with correct statusCode');
@@ -1237,17 +1239,17 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         originalSendPresence.apply(channel, arguments);
       };
 
-      helper.whenPromiseSettles(presence.enter(null), function (err) {
+      Helper.whenPromiseSettles(presence.enter(null), function (err) {
         if (err) {
           helper.closeAndFinish(done, client, err);
           return;
         }
-        helper.whenPromiseSettles(presence.update(null), function (err) {
+        Helper.whenPromiseSettles(presence.update(null), function (err) {
           if (err) {
             helper.closeAndFinish(done, client, err);
             return;
           }
-          helper.whenPromiseSettles(presence.leave(null), function (err) {
+          Helper.whenPromiseSettles(presence.leave(null), function (err) {
             if (err) {
               helper.closeAndFinish(done, client, err);
               return;
@@ -1334,7 +1336,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var channelName = 'enter_inherited_clientid';
 
       var authCallback = function (tokenParams, callback) {
-        helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+        Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
           if (err) {
             done(err);
             return;
@@ -1353,7 +1355,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             cb(err);
             return;
           }
-          helper.whenPromiseSettles(channel.presence.enter('test data'), function (err) {
+          Helper.whenPromiseSettles(channel.presence.enter('test data'), function (err) {
             cb(err, realtime);
           });
         });
@@ -1375,7 +1377,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       var channelName = 'enter_before_know_clientid';
 
       var enterInheritedClientId = function (cb) {
-        helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
+        Helper.whenPromiseSettles(rest.auth.requestToken({ clientId: testClientId }), function (err, tokenDetails) {
           if (err) {
             done(err);
             return;
@@ -1388,7 +1390,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             helper.closeAndFinish(done, realtime, err);
             return;
           }
-          helper.whenPromiseSettles(channel.presence.enter('test data'), function (err) {
+          Helper.whenPromiseSettles(channel.presence.enter('test data'), function (err) {
             try {
               expect(realtime.auth.clientId).to.equal(testClientId, 'clientId has been set by the time we entered');
             } catch (err) {
@@ -1438,10 +1440,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         async.parallel(
           [
             function (enterCb) {
-              helper.whenPromiseSettles(realtimeChannel.presence.enterClient('one'), enterCb);
+              Helper.whenPromiseSettles(realtimeChannel.presence.enterClient('one'), enterCb);
             },
             function (enterCb) {
-              helper.whenPromiseSettles(realtimeChannel.presence.enterClient('two'), enterCb);
+              Helper.whenPromiseSettles(realtimeChannel.presence.enterClient('two'), enterCb);
             },
           ],
           cb,
@@ -1449,7 +1451,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       }
 
       function checkPresence(first, second, cb) {
-        helper.whenPromiseSettles(observerChannel.presence.get(), function (err, presenceMembers) {
+        Helper.whenPromiseSettles(observerChannel.presence.get(), function (err, presenceMembers) {
           var clientIds = presenceMembers
             .map(function (msg) {
               return msg.clientId;
@@ -1471,10 +1473,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         async.parallel(
           [
             function (innerCb) {
-              helper.whenPromiseSettles(realtimeChannel.presence.leaveClient('two'), innerCb);
+              Helper.whenPromiseSettles(realtimeChannel.presence.leaveClient('two'), innerCb);
             },
             function (innerCb) {
-              helper.whenPromiseSettles(realtimeChannel.presence.enterClient('three'), innerCb);
+              Helper.whenPromiseSettles(realtimeChannel.presence.enterClient('three'), innerCb);
             },
           ],
           cb,
@@ -1501,17 +1503,17 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         [
           waitForBothConnect,
           function (cb) {
-            helper.whenPromiseSettles(realtimeChannel.attach(), cb);
+            Helper.whenPromiseSettles(realtimeChannel.attach(), cb);
           },
           enterOneAndTwo,
           function (cb) {
-            helper.whenPromiseSettles(observerChannel.attach(), cb);
+            Helper.whenPromiseSettles(observerChannel.attach(), cb);
           },
           function (cb) {
             checkPresence('one', 'two', cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(observerChannel.detach(), cb);
+            Helper.whenPromiseSettles(observerChannel.detach(), cb);
           },
           swapTwoForThree,
           attachAndListen,
@@ -1553,13 +1555,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         [
           waitForBothConnect,
           function (cb) {
-            helper.whenPromiseSettles(entererChannel.presence.enter(), cb);
+            Helper.whenPromiseSettles(entererChannel.presence.enter(), cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(detacherChannel.attach(), cb);
+            Helper.whenPromiseSettles(detacherChannel.attach(), cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(detacherChannel.detach(), cb);
+            Helper.whenPromiseSettles(detacherChannel.detach(), cb);
           },
           function (cb) {
             try {
@@ -1601,7 +1603,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             if (!channel.presence.syncComplete) {
@@ -1670,7 +1672,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
+            Helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
               if (err) {
                 cb(err);
                 return;
@@ -1713,7 +1715,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             /* Request a token without the capabilities to be in the presence set */
             var tokenParams = { clientId: 'me', capability: {} };
             tokenParams.capability[channelName] = ['publish', 'subscribe'];
-            helper.whenPromiseSettles(rest.auth.requestToken(tokenParams), function (err, tokenDetails) {
+            Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams), function (err, tokenDetails) {
               token = tokenDetails;
               cb(err);
             });
@@ -1726,7 +1728,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             if (!channel.presence.syncComplete) {
@@ -1736,7 +1738,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             }
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
+            Helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
               try {
                 expect(members.length).to.equal(0, 'Check no-one in presence set');
               } catch (err) {
@@ -1778,7 +1780,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
+            Helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
               try {
                 expect(members.length).to.equal(0, 'Check no-one in presence set');
               } catch (err) {
@@ -1833,7 +1835,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
+            Helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
               try {
                 expect(results.length).to.equal(10, 'Check all ten clients are there');
               } catch (err) {
@@ -1870,26 +1872,26 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       async.series(
         [
           function (cb) {
-            helper.whenPromiseSettles(continuousRealtime.connection.whenState('connected'), function () {
+            Helper.whenPromiseSettles(continuousRealtime.connection.whenState('connected'), function () {
               cb();
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(continuousChannel.attach(), cb);
+            Helper.whenPromiseSettles(continuousChannel.attach(), cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(continuousChannel.presence.enter(), cb);
+            Helper.whenPromiseSettles(continuousChannel.presence.enter(), cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(realtime.connection.whenState('connected'), function () {
+            Helper.whenPromiseSettles(realtime.connection.whenState('connected'), function () {
               cb();
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get({ waitForSync: true }), function (err, members) {
+            Helper.whenPromiseSettles(channel.presence.get({ waitForSync: true }), function (err, members) {
               try {
                 expect(members && members.length).to.equal(1, 'Check one member present');
               } catch (err) {
@@ -1922,7 +1924,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
+            Helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
               try {
                 expect(members && members.length).to.equal(2, 'Check two members present');
               } catch (err) {
@@ -1947,7 +1949,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             channel.sync();
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get({ waitForSync: true }), function (err, members) {
+            Helper.whenPromiseSettles(channel.presence.get({ waitForSync: true }), function (err, members) {
               try {
                 expect(members && members.length).to.equal(1, 'Check back to one member present');
                 expect(members && members[0] && members[0].clientId).to.equal(
@@ -1984,12 +1986,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
       async.series(
         [
           function (cb) {
-            helper.whenPromiseSettles(realtime.connection.whenState('connected'), function () {
+            Helper.whenPromiseSettles(realtime.connection.whenState('connected'), function () {
               cb();
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.attach(), cb);
+            Helper.whenPromiseSettles(channel.attach(), cb);
           },
           function (cb) {
             /* Inject a member locally */
@@ -2014,7 +2016,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               });
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
+            Helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
               try {
                 expect(members && members.length).to.equal(1, 'Check one member present');
               } catch (err) {
@@ -2045,7 +2047,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             );
           },
           function (cb) {
-            helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
+            Helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
               try {
                 expect(members && members.length).to.equal(0, 'Check no members present');
               } catch (err) {
@@ -2085,15 +2087,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           async.series(
             [
               function (cb) {
-                helper.whenPromiseSettles(rt.connection.whenState('connected'), function () {
+                Helper.whenPromiseSettles(rt.connection.whenState('connected'), function () {
                   cb();
                 });
               },
               function (cb) {
-                helper.whenPromiseSettles(channel.attach(), cb);
+                Helper.whenPromiseSettles(channel.attach(), cb);
               },
               function (cb) {
-                helper.whenPromiseSettles(channel.presence.enter(), cb);
+                Helper.whenPromiseSettles(channel.presence.enter(), cb);
               },
             ],
             outerCb,
@@ -2122,7 +2124,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             async.parallel([waitFor('leaves'), enter(leavesRealtime)], cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(mainChannel.presence.get(), function (err, members) {
+            Helper.whenPromiseSettles(mainChannel.presence.get(), function (err, members) {
               try {
                 expect(members.length).to.equal(3, 'Check all three expected members here');
               } catch (err) {
@@ -2136,7 +2138,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             helper.becomeSuspended(mainRealtime, cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(mainChannel.presence.get(), function (err) {
+            Helper.whenPromiseSettles(mainChannel.presence.get(), function (err) {
               /* Check RTP11d: get() returns an error by default */
               try {
                 expect(err, 'Check error returned by get() while suspended').to.be.ok;
@@ -2149,7 +2151,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(mainChannel.presence.get({ waitForSync: false }), function (err, members) {
+            Helper.whenPromiseSettles(mainChannel.presence.get({ waitForSync: false }), function (err, members) {
               /* Check RTP11d: get() works while suspended if waitForSync: false */
               try {
                 expect(!err, 'Check no error returned by get() while suspended if waitForSync: false').to.be.ok;
@@ -2162,7 +2164,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             });
           },
           function (cb) {
-            helper.whenPromiseSettles(leavesRealtime.connection.whenState('closed'), function () {
+            Helper.whenPromiseSettles(leavesRealtime.connection.whenState('closed'), function () {
               cb();
             });
             leavesRealtime.close();
@@ -2186,7 +2188,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             setTimeout(cb, 1000);
           },
           function (cb) {
-            helper.whenPromiseSettles(mainChannel.presence.get(), function (err, members) {
+            Helper.whenPromiseSettles(mainChannel.presence.get(), function (err, members) {
               try {
                 expect(members && members.length).to.equal(3, 'Check three expected members here');
               } catch (err) {
@@ -2217,7 +2219,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         presence = channel.presence,
         numUpdates = 0;
 
-      helper.whenPromiseSettles(channel.attach(), function (err) {
+      Helper.whenPromiseSettles(channel.attach(), function (err) {
         if (err) {
           helper.closeAndFinish(done, client, err);
         }
@@ -2228,7 +2230,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         async.timesSeries(
           15,
           function (i, cb) {
-            helper.whenPromiseSettles(presence.update(i.toString()), cb);
+            Helper.whenPromiseSettles(presence.update(i.toString()), cb);
           },
           function (err) {
             if (err) {

--- a/test/realtime/reauth.test.js
+++ b/test/realtime/reauth.test.js
@@ -177,8 +177,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       };
     }
 
-    function testCase(name, createSteps) {
-      Helper.testOnAllTransports(name, function (realtimeOpts) {
+    function testCase(thisInDescribe, name, createSteps) {
+      Helper.testOnAllTransports(thisInDescribe, name, function (realtimeOpts) {
         return function (done) {
           const helper = this.test.helper;
           var _steps = createSteps(helper).slice();
@@ -203,7 +203,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      ****************/
 
     /** @specpartial RTC8a1 - change capability without loss of continuity */
-    testCase('reauthCapabilityUpgradeNewChannel', (helper) => [
+    testCase(this, 'reauthCapabilityUpgradeNewChannel', (helper) => [
       getToken(helper, { clientId: clientId, capability: { wrongchannel: ['*'] } }),
       connectWithToken(helper),
       monitorConnectionContinuity(helper),
@@ -215,7 +215,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     ]);
 
     /** @specpartial RTC8a1 - capability downgrade leads to an error an failed channel state */
-    testCase('reauthCapabilityDowngradeFullChannel', (helper) => [
+    testCase(this, 'reauthCapabilityDowngradeFullChannel', (helper) => [
       getToken(helper, { clientId: clientId, capability: { channel: ['*'], another: ['*'] } }),
       connectWithToken(helper),
       monitorConnectionContinuity(helper),
@@ -232,7 +232,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Related to RTC8a1.
      * @nospec
      */
-    testCase('reauthCapabilityUpgradeAddPublish', (helper) => [
+    testCase(this, 'reauthCapabilityUpgradeAddPublish', (helper) => [
       getToken(helper, { clientId: clientId, capability: { channel: ['subscribe'] } }),
       connectWithToken(helper),
       monitorConnectionContinuity(helper),
@@ -249,7 +249,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Related to RTC8a1.
      * @nospec
      */
-    testCase('reauthCapabilityDowngradePublish', (helper) => [
+    testCase(this, 'reauthCapabilityDowngradePublish', (helper) => [
       getToken(helper, { clientId: clientId, capability: { channel: ['subscribe', 'publish'] } }),
       connectWithToken(helper),
       monitorConnectionContinuity(helper),

--- a/test/realtime/reauth.test.js
+++ b/test/realtime/reauth.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
+define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var clientId = 'testClientId';
   var rest;
@@ -23,7 +25,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
     function getToken(tokenParams) {
       return function (state, callback) {
-        helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, token) {
+        Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, token) {
           callback(err, helper.Utils.mixin(state, { token: token }));
         });
       };
@@ -70,7 +72,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
         async.parallel(
           [
             function (cb) {
-              helper.whenPromiseSettles(state.realtime.auth.authorize(null, { token: state.token }), cb);
+              Helper.whenPromiseSettles(state.realtime.auth.authorize(null, { token: state.token }), cb);
             },
             function (cb) {
               state.realtime.connection.on('update', function (stateChange) {
@@ -88,7 +90,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     function attach(channelName) {
       return function (state, callback) {
         var channel = state.realtime.channels.get(channelName);
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           callback(err, state);
         });
       };
@@ -144,7 +146,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     function checkCantAttach(channelName) {
       return function (state, callback) {
         var channel = state.realtime.channels.get(channelName);
-        helper.whenPromiseSettles(channel.attach(), function (err) {
+        Helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err && err.code === 40160) {
             callback(null, state);
           } else {
@@ -157,7 +159,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     function checkCanPublish(channelName) {
       return function (state, callback) {
         var channel = state.realtime.channels.get(channelName);
-        helper.whenPromiseSettles(channel.publish(null, null), function (err) {
+        Helper.whenPromiseSettles(channel.publish(null, null), function (err) {
           callback(err, state);
         });
       };
@@ -166,7 +168,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     function checkCantPublish(channelName) {
       return function (state, callback) {
         var channel = state.realtime.channels.get(channelName);
-        helper.whenPromiseSettles(channel.publish(null, null), function (err) {
+        Helper.whenPromiseSettles(channel.publish(null, null), function (err) {
           if (err && err.code === 40160) {
             callback(null, state);
           } else {
@@ -177,7 +179,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     }
 
     function testCase(name, steps) {
-      helper.testOnAllTransports(name, function (realtimeOpts) {
+      Helper.testOnAllTransports(name, function (realtimeOpts) {
         return function (done) {
           var _steps = steps.slice();
           _steps.unshift(function (cb) {

--- a/test/realtime/reauth.test.js
+++ b/test/realtime/reauth.test.js
@@ -4,10 +4,6 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
   var expect = chai.expect;
   var clientId = 'testClientId';
   var rest;
-  var mixin = helper.Utils.mixin;
-  var displayError = helper.displayError;
-  var testOnAllTransports = helper.testOnAllTransports;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('realtime/reauth', function () {
     this.timeout(60 * 1000);
@@ -27,8 +23,8 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
     function getToken(tokenParams) {
       return function (state, callback) {
-        whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, token) {
-          callback(err, mixin(state, { token: token }));
+        helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, token) {
+          callback(err, helper.Utils.mixin(state, { token: token }));
         });
       };
     }
@@ -45,9 +41,9 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
     function connectWithToken() {
       return function (state, callback) {
-        var realtime = helper.AblyRealtime(mixin({ token: state.token }, state.realtimeOpts));
+        var realtime = helper.AblyRealtime(helper.Utils.mixin({ token: state.token }, state.realtimeOpts));
         realtime.connection.once('connected', function () {
-          callback(null, mixin(state, { realtime: realtime }));
+          callback(null, helper.Utils.mixin(state, { realtime: realtime }));
         });
       };
     }
@@ -61,7 +57,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
           }
         };
         state.realtime.connection.on(listener);
-        callback(null, mixin(state, { connectionMonitor: listener }));
+        callback(null, helper.Utils.mixin(state, { connectionMonitor: listener }));
       };
     }
 
@@ -74,7 +70,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
         async.parallel(
           [
             function (cb) {
-              whenPromiseSettles(state.realtime.auth.authorize(null, { token: state.token }), cb);
+              helper.whenPromiseSettles(state.realtime.auth.authorize(null, { token: state.token }), cb);
             },
             function (cb) {
               state.realtime.connection.on('update', function (stateChange) {
@@ -92,7 +88,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     function attach(channelName) {
       return function (state, callback) {
         var channel = state.realtime.channels.get(channelName);
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           callback(err, state);
         });
       };
@@ -148,7 +144,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     function checkCantAttach(channelName) {
       return function (state, callback) {
         var channel = state.realtime.channels.get(channelName);
-        whenPromiseSettles(channel.attach(), function (err) {
+        helper.whenPromiseSettles(channel.attach(), function (err) {
           if (err && err.code === 40160) {
             callback(null, state);
           } else {
@@ -161,7 +157,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     function checkCanPublish(channelName) {
       return function (state, callback) {
         var channel = state.realtime.channels.get(channelName);
-        whenPromiseSettles(channel.publish(null, null), function (err) {
+        helper.whenPromiseSettles(channel.publish(null, null), function (err) {
           callback(err, state);
         });
       };
@@ -170,7 +166,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     function checkCantPublish(channelName) {
       return function (state, callback) {
         var channel = state.realtime.channels.get(channelName);
-        whenPromiseSettles(channel.publish(null, null), function (err) {
+        helper.whenPromiseSettles(channel.publish(null, null), function (err) {
           if (err && err.code === 40160) {
             callback(null, state);
           } else {
@@ -181,7 +177,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     }
 
     function testCase(name, steps) {
-      testOnAllTransports(name, function (realtimeOpts) {
+      helper.testOnAllTransports(name, function (realtimeOpts) {
         return function (done) {
           var _steps = steps.slice();
           _steps.unshift(function (cb) {
@@ -189,7 +185,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
           });
           async.waterfall(_steps, function (err) {
             try {
-              expect(!err, err && name + ': ' + displayError(err)).to.be.ok;
+              expect(!err, err && name + ': ' + helper.displayError(err)).to.be.ok;
             } catch (err) {
               done(err);
               return;

--- a/test/realtime/reauth.test.js
+++ b/test/realtime/reauth.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var clientId = 'testClientId';
   var rest;
@@ -11,6 +9,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -23,7 +22,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
 
     /* Waterfall helpers */
 
-    function getToken(tokenParams) {
+    function getToken(helper, tokenParams) {
       return function (state, callback) {
         Helper.whenPromiseSettles(rest.auth.requestToken(tokenParams, null), function (err, token) {
           callback(err, helper.Utils.mixin(state, { token: token }));
@@ -41,7 +40,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       };
     }
 
-    function connectWithToken() {
+    function connectWithToken(helper) {
       return function (state, callback) {
         var realtime = helper.AblyRealtime(helper.Utils.mixin({ token: state.token }, state.realtimeOpts));
         realtime.connection.once('connected', function () {
@@ -51,7 +50,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     }
 
     /* For when connection should stay connected right through till it's closed */
-    function monitorConnectionContinuity() {
+    function monitorConnectionContinuity(helper) {
       return function (state, callback) {
         var listener = function () {
           if (this.event !== 'update') {
@@ -178,10 +177,11 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       };
     }
 
-    function testCase(name, steps) {
+    function testCase(name, createSteps) {
       Helper.testOnAllTransports(name, function (realtimeOpts) {
         return function (done) {
-          var _steps = steps.slice();
+          const helper = this.test.helper;
+          var _steps = createSteps(helper).slice();
           _steps.unshift(function (cb) {
             cb(null, { realtimeOpts: realtimeOpts });
           });
@@ -203,24 +203,24 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      ****************/
 
     /** @specpartial RTC8a1 - change capability without loss of continuity */
-    testCase('reauthCapabilityUpgradeNewChannel', [
-      getToken({ clientId: clientId, capability: { wrongchannel: ['*'] } }),
-      connectWithToken(),
-      monitorConnectionContinuity(),
+    testCase('reauthCapabilityUpgradeNewChannel', (helper) => [
+      getToken(helper, { clientId: clientId, capability: { wrongchannel: ['*'] } }),
+      connectWithToken(helper),
+      monitorConnectionContinuity(helper),
       checkCantAttach('rightchannel'),
-      getToken({ clientId: clientId, capability: { wrongchannel: ['*'], rightchannel: ['*'] } }),
+      getToken(helper, { clientId: clientId, capability: { wrongchannel: ['*'], rightchannel: ['*'] } }),
       reauthWithToken(),
       attach('rightchannel'),
       close(),
     ]);
 
     /** @specpartial RTC8a1 - capability downgrade leads to an error an failed channel state */
-    testCase('reauthCapabilityDowngradeFullChannel', [
-      getToken({ clientId: clientId, capability: { channel: ['*'], another: ['*'] } }),
-      connectWithToken(),
-      monitorConnectionContinuity(),
+    testCase('reauthCapabilityDowngradeFullChannel', (helper) => [
+      getToken(helper, { clientId: clientId, capability: { channel: ['*'], another: ['*'] } }),
+      connectWithToken(helper),
+      monitorConnectionContinuity(helper),
       attach('channel'),
-      getToken({ clientId: clientId, capability: { another: ['*'] } }),
+      getToken(helper, { clientId: clientId, capability: { another: ['*'] } }),
       reauthWithToken(),
       waitChannelState('channel', 'failed'),
       checkChannelErrorCode('channel', 40160),
@@ -232,13 +232,13 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Related to RTC8a1.
      * @nospec
      */
-    testCase('reauthCapabilityUpgradeAddPublish', [
-      getToken({ clientId: clientId, capability: { channel: ['subscribe'] } }),
-      connectWithToken(),
-      monitorConnectionContinuity(),
+    testCase('reauthCapabilityUpgradeAddPublish', (helper) => [
+      getToken(helper, { clientId: clientId, capability: { channel: ['subscribe'] } }),
+      connectWithToken(helper),
+      monitorConnectionContinuity(helper),
       attach('channel'),
       checkCantPublish('channel'),
-      getToken({ clientId: clientId, capability: { channel: ['subscribe', 'publish'] } }),
+      getToken(helper, { clientId: clientId, capability: { channel: ['subscribe', 'publish'] } }),
       reauthWithToken(),
       checkAttached('channel'),
       checkCanPublish('channel'),
@@ -249,13 +249,13 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Related to RTC8a1.
      * @nospec
      */
-    testCase('reauthCapabilityDowngradePublish', [
-      getToken({ clientId: clientId, capability: { channel: ['subscribe', 'publish'] } }),
-      connectWithToken(),
-      monitorConnectionContinuity(),
+    testCase('reauthCapabilityDowngradePublish', (helper) => [
+      getToken(helper, { clientId: clientId, capability: { channel: ['subscribe', 'publish'] } }),
+      connectWithToken(helper),
+      monitorConnectionContinuity(helper),
       attach('channel'),
       checkCanPublish('channel'),
-      getToken({ clientId: clientId, capability: { channel: ['subscribe'] } }),
+      getToken(helper, { clientId: clientId, capability: { channel: ['subscribe'] } }),
       reauthWithToken(),
       attach('channel'),
       checkAttached('channel'),

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -138,7 +138,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Related to RTN15b, RTN15c.
      * @nospec
      */
-    Helper.testOnAllTransports('resume_inactive', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'resume_inactive', function (realtimeOpts) {
       return function (done) {
         resume_inactive(done, this.test.helper, 'resume_inactive' + String(Math.random()), {}, realtimeOpts);
       };
@@ -262,7 +262,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Related to RTN15b, RTN15c.
      * @nospec
      */
-    Helper.testOnAllTransports('resume_active', function (realtimeOpts) {
+    Helper.testOnAllTransports(this, 'resume_active', function (realtimeOpts) {
       return function (done) {
         resume_active(done, this.test.helper, 'resume_active' + String(Math.random()), {}, realtimeOpts);
       };
@@ -273,6 +273,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RTN15c7
      */
     Helper.testOnAllTransports(
+      this,
       'resume_lost_continuity',
       function (realtimeOpts) {
         return function (done) {
@@ -341,6 +342,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RTN15c5
      */
     Helper.testOnAllTransports(
+      this,
       'resume_token_error',
       function (realtimeOpts) {
         return function (done) {
@@ -396,6 +398,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RTN15c4
      */
     Helper.testOnAllTransports(
+      this,
       'resume_fatal_error',
       function (realtimeOpts) {
         return function (done) {

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -1,14 +1,13 @@
 'use strict';
 
 define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
 
   describe('realtime/resume', function () {
     this.timeout(120 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -38,7 +37,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Empty resume case
      * Send 5 messages; disconnect; reconnect; send 5 messages
      */
-    function resume_inactive(done, channelName, txOpts, rxOpts) {
+    function resume_inactive(done, helper, channelName, txOpts, rxOpts) {
       var count = 5;
 
       var txRest = helper.AblyRest(mixin(txOpts));
@@ -141,7 +140,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      */
     Helper.testOnAllTransports('resume_inactive', function (realtimeOpts) {
       return function (done) {
-        resume_inactive(done, 'resume_inactive' + String(Math.random()), {}, realtimeOpts);
+        resume_inactive(done, this.test.helper, 'resume_inactive' + String(Math.random()), {}, realtimeOpts);
       };
     });
 
@@ -149,7 +148,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Simple resume case
      * Send 5 messages; disconnect; send 5 messages; reconnect
      */
-    function resume_active(done, channelName, txOpts, rxOpts) {
+    function resume_active(done, helper, channelName, txOpts, rxOpts) {
       var count = 5;
 
       var txRest = helper.AblyRest(mixin(txOpts));
@@ -265,7 +264,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      */
     Helper.testOnAllTransports('resume_active', function (realtimeOpts) {
       return function (done) {
-        resume_active(done, 'resume_active' + String(Math.random()), {}, realtimeOpts);
+        resume_active(done, this.test.helper, 'resume_active' + String(Math.random()), {}, realtimeOpts);
       };
     });
 
@@ -277,7 +276,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       'resume_lost_continuity',
       function (realtimeOpts) {
         return function (done) {
-          var realtime = helper.AblyRealtime(realtimeOpts),
+          var helper = this.test.helper,
+            realtime = helper.AblyRealtime(realtimeOpts),
             connection = realtime.connection,
             attachedChannelName = 'resume_lost_continuity_attached',
             suspendedChannelName = 'resume_lost_continuity_suspended',
@@ -344,7 +344,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       'resume_token_error',
       function (realtimeOpts) {
         return function (done) {
-          var realtime = helper.AblyRealtime(mixin(realtimeOpts, { useTokenAuth: true })),
+          var helper = this.test.helper,
+            realtime = helper.AblyRealtime(mixin(realtimeOpts, { useTokenAuth: true })),
             badtoken,
             connection = realtime.connection;
 
@@ -398,7 +399,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       'resume_fatal_error',
       function (realtimeOpts) {
         return function (done) {
-          var realtime = helper.AblyRealtime(realtimeOpts),
+          var helper = this.test.helper,
+            realtime = helper.AblyRealtime(realtimeOpts),
             connection = realtime.connection;
 
           async.series(
@@ -450,7 +452,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RTL2f
      */
     it('channel_resumed_flag', function (done) {
-      var realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ transports: [helper.bestTransport] }),
         realtimeTwo,
         recoveryKey,
         connection = realtime.connection,
@@ -517,7 +520,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @nospec
      */
     it('no_resume_once_suspended', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         connection = realtime.connection,
         channelName = 'no_resume_once_suspended';
 
@@ -557,7 +561,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RTN15g
      */
     it('no_resume_last_activity', function (done) {
-      var realtime = helper.AblyRealtime(),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime(),
         connection = realtime.connection,
         connectionManager = connection.connectionManager;
 
@@ -581,6 +586,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
 
     /** @spec RTL4j2 */
     it('resume_rewind_1', function (done) {
+      const helper = this.test.helper;
       var testName = 'resume_rewind_1';
       var testMessage = { foo: 'bar', count: 1, status: 'active' };
       try {
@@ -644,6 +650,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RTN15a
      */
     it('recover multiple channels', function (done) {
+      const helper = this.test.helper;
       const NUM_MSGS = 5;
 
       const txRest = helper.AblyRest();

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
+define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
 
   describe('realtime/resume', function () {
@@ -27,7 +29,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
         receivingChannel.unsubscribe(event);
         callback();
       });
-      helper.whenPromiseSettles(sendingChannel.publish(event, message), function (err) {
+      Helper.whenPromiseSettles(sendingChannel.publish(event, message), function (err) {
         if (err) callback(err);
       });
     }
@@ -47,7 +49,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       var rxCount = 0;
 
       function phase0(callback) {
-        helper.whenPromiseSettles(rxChannel.attach(), callback);
+        Helper.whenPromiseSettles(rxChannel.attach(), callback);
       }
 
       function phase1(callback) {
@@ -137,7 +139,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Related to RTN15b, RTN15c.
      * @nospec
      */
-    helper.testOnAllTransports('resume_inactive', function (realtimeOpts) {
+    Helper.testOnAllTransports('resume_inactive', function (realtimeOpts) {
       return function (done) {
         resume_inactive(done, 'resume_inactive' + String(Math.random()), {}, realtimeOpts);
       };
@@ -158,7 +160,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       var rxCount = 0;
 
       function phase0(callback) {
-        helper.whenPromiseSettles(rxChannel.attach(), callback);
+        Helper.whenPromiseSettles(rxChannel.attach(), callback);
       }
 
       function phase1(callback) {
@@ -184,7 +186,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
         var txCount = 0;
 
         function ph2TxOnce() {
-          helper.whenPromiseSettles(
+          Helper.whenPromiseSettles(
             txChannel.publish('sentWhileDisconnected', 'phase 2, message ' + txCount),
             function (err) {
               if (err) callback(err);
@@ -261,7 +263,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Related to RTN15b, RTN15c.
      * @nospec
      */
-    helper.testOnAllTransports('resume_active', function (realtimeOpts) {
+    Helper.testOnAllTransports('resume_active', function (realtimeOpts) {
       return function (done) {
         resume_active(done, 'resume_active' + String(Math.random()), {}, realtimeOpts);
       };
@@ -271,7 +273,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Resume with loss of continuity
      * @spec RTN15c7
      */
-    helper.testOnAllTransports(
+    Helper.testOnAllTransports(
       'resume_lost_continuity',
       function (realtimeOpts) {
         return function (done) {
@@ -291,7 +293,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
               },
               function (cb) {
                 suspendedChannel.state = 'suspended';
-                helper.whenPromiseSettles(attachedChannel.attach(), cb);
+                Helper.whenPromiseSettles(attachedChannel.attach(), cb);
               },
               function (cb) {
                 /* Sabotage the resume */
@@ -338,7 +340,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Resume with token error
      * @spec RTN15c5
      */
-    helper.testOnAllTransports(
+    Helper.testOnAllTransports(
       'resume_token_error',
       function (realtimeOpts) {
         return function (done) {
@@ -354,7 +356,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 });
               },
               function (cb) {
-                helper.whenPromiseSettles(realtime.auth.requestToken({ ttl: 1 }, null), function (err, token) {
+                Helper.whenPromiseSettles(realtime.auth.requestToken({ ttl: 1 }, null), function (err, token) {
                   badtoken = token;
                   cb(err);
                 });
@@ -392,7 +394,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Resume with fatal error
      * @spec RTN15c4
      */
-    helper.testOnAllTransports(
+    Helper.testOnAllTransports(
       'resume_fatal_error',
       function (realtimeOpts) {
         return function (done) {
@@ -658,7 +660,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       const rxChannels = channelNames.map((name) => rxRealtime.channels.get(name));
 
       function attachChannels(callback) {
-        async.each(rxChannels, (channel, cb) => helper.whenPromiseSettles(channel.attach(), cb), callback);
+        async.each(rxChannels, (channel, cb) => Helper.whenPromiseSettles(channel.attach(), cb), callback);
       }
 
       function publishSubscribeWhileConnectedOnce(callback) {
@@ -688,7 +690,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
           channelNames,
           (name, cb) => {
             const tx = txRest.channels.get(name);
-            helper.whenPromiseSettles(tx.publish('sentWhileDisconnected', null), cb);
+            Helper.whenPromiseSettles(tx.publish('sentWhileDisconnected', null), cb);
           },
           callback,
         );

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -2,11 +2,6 @@
 
 define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
   var expect = chai.expect;
-  var closeAndFinish = helper.closeAndFinish;
-  var simulateDroppedConnection = helper.simulateDroppedConnection;
-  var testOnAllTransports = helper.testOnAllTransports;
-  var bestTransport = helper.bestTransport;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('realtime/resume', function () {
     this.timeout(120 * 1000);
@@ -32,7 +27,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
         receivingChannel.unsubscribe(event);
         callback();
       });
-      whenPromiseSettles(sendingChannel.publish(event, message), function (err) {
+      helper.whenPromiseSettles(sendingChannel.publish(event, message), function (err) {
         if (err) callback(err);
       });
     }
@@ -52,7 +47,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       var rxCount = 0;
 
       function phase0(callback) {
-        whenPromiseSettles(rxChannel.attach(), callback);
+        helper.whenPromiseSettles(rxChannel.attach(), callback);
       }
 
       function phase1(callback) {
@@ -70,7 +65,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       }
 
       function phase2(callback) {
-        simulateDroppedConnection(rxRealtime);
+        helper.simulateDroppedConnection(rxRealtime);
         /* continue in 5 seconds */
         setTimeout(callback, 5000);
       }
@@ -107,30 +102,30 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
       phase0(function (err) {
         if (err) {
-          closeAndFinish(done, rxRealtime, err);
+          helper.closeAndFinish(done, rxRealtime, err);
           return;
         }
         phase1(function (err) {
           if (err) {
-            closeAndFinish(done, rxRealtime, err);
+            helper.closeAndFinish(done, rxRealtime, err);
             return;
           }
           phase2(function (err) {
             if (err) {
-              closeAndFinish(done, rxRealtime, err);
+              helper.closeAndFinish(done, rxRealtime, err);
               return;
             }
             phase3(function (err) {
               if (err) {
-                closeAndFinish(done, rxRealtime, err);
+                helper.closeAndFinish(done, rxRealtime, err);
                 return;
               }
               phase4(function (err) {
                 if (err) {
-                  closeAndFinish(done, rxRealtime, err);
+                  helper.closeAndFinish(done, rxRealtime, err);
                   return;
                 }
-                closeAndFinish(done, rxRealtime);
+                helper.closeAndFinish(done, rxRealtime);
               });
             });
           });
@@ -142,7 +137,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Related to RTN15b, RTN15c.
      * @nospec
      */
-    testOnAllTransports('resume_inactive', function (realtimeOpts) {
+    helper.testOnAllTransports('resume_inactive', function (realtimeOpts) {
       return function (done) {
         resume_inactive(done, 'resume_inactive' + String(Math.random()), {}, realtimeOpts);
       };
@@ -163,7 +158,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       var rxCount = 0;
 
       function phase0(callback) {
-        whenPromiseSettles(rxChannel.attach(), callback);
+        helper.whenPromiseSettles(rxChannel.attach(), callback);
       }
 
       function phase1(callback) {
@@ -185,13 +180,16 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
          * NOTE: this uses knowledge of the internal operation
          * of the client library to simulate a dropped connection
          * without explicitly closing the connection */
-        simulateDroppedConnection(rxRealtime);
+        helper.simulateDroppedConnection(rxRealtime);
         var txCount = 0;
 
         function ph2TxOnce() {
-          whenPromiseSettles(txChannel.publish('sentWhileDisconnected', 'phase 2, message ' + txCount), function (err) {
-            if (err) callback(err);
-          });
+          helper.whenPromiseSettles(
+            txChannel.publish('sentWhileDisconnected', 'phase 2, message ' + txCount),
+            function (err) {
+              if (err) callback(err);
+            },
+          );
           if (++txCount == count) {
             /* sent all messages */
             setTimeout(function () {
@@ -234,25 +232,25 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
       phase0(function (err) {
         if (err) {
-          closeAndFinish(done, rxRealtime, err);
+          helper.closeAndFinish(done, rxRealtime, err);
           return;
         }
         phase1(function (err) {
           if (err) {
-            closeAndFinish(done, rxRealtime, err);
+            helper.closeAndFinish(done, rxRealtime, err);
             return;
           }
           phase2(function (err) {
             if (err) {
-              closeAndFinish(done, rxRealtime, err);
+              helper.closeAndFinish(done, rxRealtime, err);
               return;
             }
             phase3(function (err) {
               if (err) {
-                closeAndFinish(done, rxRealtime, err);
+                helper.closeAndFinish(done, rxRealtime, err);
                 return;
               }
-              closeAndFinish(done, rxRealtime);
+              helper.closeAndFinish(done, rxRealtime);
             });
           });
         });
@@ -263,7 +261,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Related to RTN15b, RTN15c.
      * @nospec
      */
-    testOnAllTransports('resume_active', function (realtimeOpts) {
+    helper.testOnAllTransports('resume_active', function (realtimeOpts) {
       return function (done) {
         resume_active(done, 'resume_active' + String(Math.random()), {}, realtimeOpts);
       };
@@ -273,7 +271,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Resume with loss of continuity
      * @spec RTN15c7
      */
-    testOnAllTransports(
+    helper.testOnAllTransports(
       'resume_lost_continuity',
       function (realtimeOpts) {
         return function (done) {
@@ -293,7 +291,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
               },
               function (cb) {
                 suspendedChannel.state = 'suspended';
-                whenPromiseSettles(attachedChannel.attach(), cb);
+                helper.whenPromiseSettles(attachedChannel.attach(), cb);
               },
               function (cb) {
                 /* Sabotage the resume */
@@ -328,7 +326,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
               },
             ],
             function (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             },
           );
         };
@@ -340,7 +338,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Resume with token error
      * @spec RTN15c5
      */
-    testOnAllTransports(
+    helper.testOnAllTransports(
       'resume_token_error',
       function (realtimeOpts) {
         return function (done) {
@@ -356,7 +354,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 });
               },
               function (cb) {
-                whenPromiseSettles(realtime.auth.requestToken({ ttl: 1 }, null), function (err, token) {
+                helper.whenPromiseSettles(realtime.auth.requestToken({ ttl: 1 }, null), function (err, token) {
                   badtoken = token;
                   cb(err);
                 });
@@ -382,7 +380,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
               },
             ],
             function (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             },
           );
         };
@@ -394,7 +392,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * Resume with fatal error
      * @spec RTN15c4
      */
-    testOnAllTransports(
+    helper.testOnAllTransports(
       'resume_fatal_error',
       function (realtimeOpts) {
         return function (done) {
@@ -435,7 +433,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
               },
             ],
             function (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             },
           );
         };
@@ -505,7 +503,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
           },
         ],
         function (err) {
-          closeAndFinish(done, [realtime, realtimeTwo], err);
+          helper.closeAndFinish(done, [realtime, realtimeTwo], err);
         },
       );
     });
@@ -545,7 +543,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
           },
         ],
         function (err) {
-          closeAndFinish(done, realtime, err);
+          helper.closeAndFinish(done, realtime, err);
         },
       );
     });
@@ -570,10 +568,10 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
           try {
             expect(transportParams.mode).to.equal('clean', 'Check library didn’t try to resume');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         };
         connectionManager.disconnectAllTransports();
       });
@@ -598,7 +596,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
                 'Check rewind message.data',
               ).to.be.ok;
             } catch (err) {
-              closeAndFinish(done, [sender_realtime, receiver_realtime], err);
+              helper.closeAndFinish(done, [sender_realtime, receiver_realtime], err);
               return;
             }
 
@@ -615,7 +613,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
             resumed_receiver_channel.subscribe(function (message) {
               clearTimeout(success);
-              closeAndFinish(
+              helper.closeAndFinish(
                 done,
                 [sender_realtime, receiver_realtime, resumed_receiver_realtime],
                 new Error('rewind message arrived on attach resume'),
@@ -623,7 +621,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
             });
 
             var success = setTimeout(function () {
-              closeAndFinish(done, [sender_realtime, receiver_realtime, resumed_receiver_realtime]);
+              helper.closeAndFinish(done, [sender_realtime, receiver_realtime, resumed_receiver_realtime]);
             }, 7000);
           });
         });
@@ -632,7 +630,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
           sender_channel.publish('0', testMessage);
         });
       } catch (err) {
-        closeAndFinish(done, [sender_realtime, receiver_realtime, resumed_receiver_realtime], err);
+        helper.closeAndFinish(done, [sender_realtime, receiver_realtime, resumed_receiver_realtime], err);
       }
     });
 
@@ -660,7 +658,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       const rxChannels = channelNames.map((name) => rxRealtime.channels.get(name));
 
       function attachChannels(callback) {
-        async.each(rxChannels, (channel, cb) => whenPromiseSettles(channel.attach(), cb), callback);
+        async.each(rxChannels, (channel, cb) => helper.whenPromiseSettles(channel.attach(), cb), callback);
       }
 
       function publishSubscribeWhileConnectedOnce(callback) {
@@ -690,7 +688,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
           channelNames,
           (name, cb) => {
             const tx = txRest.channels.get(name);
-            whenPromiseSettles(tx.publish('sentWhileDisconnected', null), cb);
+            helper.whenPromiseSettles(tx.publish('sentWhileDisconnected', null), cb);
           },
           callback,
         );
@@ -735,13 +733,13 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
       attachChannels(function (err) {
         if (err) {
-          closeAndFinish(done, rxRealtime, err);
+          helper.closeAndFinish(done, rxRealtime, err);
           return;
         }
 
         publishSubscribeWhileConnected(function (err) {
           if (err) {
-            closeAndFinish(done, rxRealtime, err);
+            helper.closeAndFinish(done, rxRealtime, err);
             return;
           }
 
@@ -751,7 +749,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
           publishSubscribeWhileDisconnected(function (err) {
             if (err) {
-              closeAndFinish(done, rxRealtime, err);
+              helper.closeAndFinish(done, rxRealtime, err);
               return;
             }
 
@@ -760,7 +758,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
 
             subscribeRecoveredMessages(function (err) {
               if (err) {
-                closeAndFinish(done, [rxRealtime, rxRealtimeRecover], err);
+                helper.closeAndFinish(done, [rxRealtime, rxRealtimeRecover], err);
                 return;
               }
 
@@ -769,7 +767,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
               expect(rxRealtimeRecover.connection.id).to.equal(connectionId);
               expect(rxRealtimeRecover.connection.key).to.not.equal(connectionKey);
 
-              closeAndFinish(done, [rxRealtime, rxRealtimeRecover]);
+              helper.closeAndFinish(done, [rxRealtime, rxRealtimeRecover]);
             });
           });
         });

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -75,8 +75,10 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
         /* re-open the connection, verify resume mode */
         rxRealtime.connection.connect();
         var connectionManager = rxRealtime.connection.connectionManager;
+        helper.recordPrivateApi('listen.connectionManager.transport.active');
         connectionManager.once('transport.active', function (transport) {
           try {
+            helper.recordPrivateApi('read.transport.params.mode');
             expect(transport.params.mode).to.equal('resume', 'Verify reconnect is resume mode');
           } catch (err) {
             callback(err);
@@ -212,8 +214,10 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
         rxCount = 0;
         rxRealtime.connection.connect();
         var connectionManager = rxRealtime.connection.connectionManager;
+        helper.recordPrivateApi('listen.connectionManager.transport.active');
         connectionManager.on('transport.active', function (transport) {
           try {
+            helper.recordPrivateApi('read.transport.params.mode');
             expect(transport.params.mode).to.equal('resume', 'Verify reconnect is resume mode');
           } catch (err) {
             callback(err);
@@ -293,17 +297,23 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
                 });
               },
               function (cb) {
+                helper.recordPrivateApi('write.channel.state');
                 suspendedChannel.state = 'suspended';
                 Helper.whenPromiseSettles(attachedChannel.attach(), cb);
               },
               function (cb) {
                 /* Sabotage the resume */
-                (connection.connectionManager.connectionKey = '_____!ablyjs_test_fake-key____'),
+                helper.recordPrivateApi('write.connectionManager.connectionKey');
+                helper.recordPrivateApi('write.connectionManager.connectionId');
+                helper.recordPrivateApi('write.connectionManager.msgSerial')(
+                  (connection.connectionManager.connectionKey = '_____!ablyjs_test_fake-key____'),
+                ),
                   (connection.connectionManager.connectionId = 'ablyjs_tes');
                 connection.connectionManager.msgSerial = 15;
                 connection.once('disconnected', function () {
                   cb();
                 });
+                helper.recordPrivateApi('call.connectionManager.disconnectAllTransports');
                 connection.connectionManager.disconnectAllTransports();
               },
               function (cb) {
@@ -315,7 +325,9 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
                     );
                     expect(attachedChannel.state).to.equal('attaching', 'Attached channel went into attaching');
                     expect(suspendedChannel.state).to.equal('attaching', 'Suspended channel went into attaching');
+                    helper.recordPrivateApi('read.connectionManager.msgSerial');
                     expect(connection.connectionManager.msgSerial).to.equal(0, 'Check msgSerial is reset to 0');
+                    helper.recordPrivateApi('read.connectionManager.connectionId');
                     expect(
                       connection.connectionManager.connectionId !== 'ablyjs_tes',
                       'Check connectionId is set by the new CONNECTED',
@@ -366,6 +378,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
               },
               function (cb) {
                 /* Sabotage the resume - use a valid but now-expired token */
+                helper.recordPrivateApi('write.auth.tokenDetails.token');
                 realtime.auth.tokenDetails.token = badtoken.token;
                 connection.once(function (stateChange) {
                   try {
@@ -376,6 +389,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
                   }
                   cb();
                 });
+                helper.recordPrivateApi('call.connectionManager.disconnectAllTransports');
                 connection.connectionManager.disconnectAllTransports();
               },
               function (cb) {
@@ -414,7 +428,9 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
                 });
               },
               function (cb) {
+                helper.recordPrivateApi('read.auth.key');
                 var keyName = realtime.auth.key.split(':')[0];
+                helper.recordPrivateApi('write.auth.key');
                 realtime.auth.key = keyName + ':wrong';
                 connection.once(function (stateChange) {
                   try {
@@ -425,6 +441,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
                   }
                   cb();
                 });
+                helper.recordPrivateApi('call.connectionManager.disconnectAllTransports');
+
                 connection.connectionManager.disconnectAllTransports();
               },
               function (cb) {
@@ -539,6 +557,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
             helper.becomeSuspended(realtime, cb);
           },
           function (cb) {
+            helper.recordPrivateApi('replace.connectionManager.tryATransport');
             realtime.connection.connectionManager.tryATransport = function (transportParams) {
               try {
                 expect(transportParams.mode).to.equal('clean', 'Check library didn’t try to resume');
@@ -570,10 +589,14 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
         connectionManager = connection.connectionManager;
 
       connection.once('connected', function () {
+        helper.recordPrivateApi('write.connectionManager.lastActivity');
         connectionManager.lastActivity = Date.now() - 10000000;
         /* noop-out onProtocolMessage so that a DISCONNECTED message doesn't
          * reset the last activity timer */
+        helper.recordPrivateApi('call.connectionManager.activeProtocol.getTransport');
+        helper.recordPrivateApi('replace.transport.onProtocolMessage');
         connectionManager.activeProtocol.getTransport().onProtocolMessage = function () {};
+        helper.recordPrivateApi('replace.connectionManager.tryATransport');
         connectionManager.tryATransport = function (transportParams) {
           try {
             expect(transportParams.mode).to.equal('clean', 'Check library didn’t try to resume');
@@ -583,6 +606,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
           }
           helper.closeAndFinish(done, realtime);
         };
+        helper.recordPrivateApi('call.connectionManager.disconnectAllTransports');
         connectionManager.disconnectAllTransports();
       });
     });
@@ -614,9 +638,12 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
             var resumed_receiver_realtime = helper.AblyRealtime();
             var connectionManager = resumed_receiver_realtime.connection.connectionManager;
 
+            helper.recordPrivateApi('replace.connectionManager.send');
             var sendOrig = connectionManager.send;
             connectionManager.send = function (msg, queueEvent, callback) {
+              helper.recordPrivateApi('call.ProtocolMessage.setFlag');
               msg.setFlag('ATTACH_RESUME');
+              helper.recordPrivateApi('call.connectionManager.send');
               sendOrig.call(connectionManager, msg, queueEvent, callback);
             };
 

--- a/test/realtime/sync.test.js
+++ b/test/realtime/sync.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var createPM = Ably.protocolMessageFromDeserialized;
 
@@ -93,7 +95,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 });
             },
             function (cb) {
-              helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
+              Helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
                 try {
                   expect(results.length).to.equal(2, 'Check correct number of results');
                   expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
@@ -136,7 +138,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 });
             },
             function (cb) {
-              helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
+              Helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
                 try {
                   expect(results.length).to.equal(2, 'Check correct number of results');
                   expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
@@ -245,7 +247,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           err ? reject(err) : resolve();
         };
 
-        helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
+        Helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -334,7 +336,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           err ? reject(err) : resolve();
         };
 
-        helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
+        Helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -420,7 +422,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           err ? reject(err) : resolve();
         };
 
-        helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
+        Helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -578,7 +580,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var done = function (err) {
           err ? reject(err) : resolve();
         };
-        helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
+        Helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
           if (err) {
             helper.closeAndFinish(done, realtime, err);
             return;
@@ -632,13 +634,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         [
           waitForBothConnect,
           function (cb) {
-            helper.whenPromiseSettles(entererChannel.attach(), cb);
+            Helper.whenPromiseSettles(entererChannel.attach(), cb);
           },
           function (cb) {
             async.times(
               110,
               function (i, presCb) {
-                helper.whenPromiseSettles(entererChannel.presence.enterClient(i.toString(), null), presCb);
+                Helper.whenPromiseSettles(entererChannel.presence.enterClient(i.toString(), null), presCb);
               },
               cb,
             );
@@ -664,10 +666,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 });
               }
             };
-            helper.whenPromiseSettles(syncerChannel.attach(), cb);
+            Helper.whenPromiseSettles(syncerChannel.attach(), cb);
           },
           function (cb) {
-            helper.whenPromiseSettles(syncerChannel.presence.get(), function (err, presenceSet) {
+            Helper.whenPromiseSettles(syncerChannel.presence.get(), function (err, presenceSet) {
               try {
                 expect(presenceSet && presenceSet.length).to.equal(111, 'Check everyone’s in presence set');
               } catch (err) {

--- a/test/realtime/sync.test.js
+++ b/test/realtime/sync.test.js
@@ -50,6 +50,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channelName = 'syncexistingset',
         channel = realtime.channels.get(channelName);
 
+      helper.recordPrivateApi('call.protocolMessageFromDeserialized');
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage(
         createPM({
           action: 11,
@@ -66,6 +68,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         async.series(
           [
             function (cb) {
+              helper.recordPrivateApi('call.channel.processMessage');
               channel
                 .processMessage({
                   action: 16,
@@ -109,6 +112,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
             },
             function (cb) {
               /* Trigger another sync. Two has gone without so much as a `leave` message! */
+              helper.recordPrivateApi('call.channel.processMessage');
               channel
                 .processMessage({
                   action: 16,
@@ -175,6 +179,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channelName = 'sync_member_arrives_in_middle',
         channel = realtime.channels.get(channelName);
 
+      helper.recordPrivateApi('call.protocolMessageFromDeserialized');
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage(
         createPM({
           action: 11,
@@ -184,6 +190,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       );
 
       /* First sync */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 16,
         channel: channelName,
@@ -199,6 +206,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
 
       /* A second sync, this time in multiple parts, with a presence message in the middle */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 16,
         channel: channelName,
@@ -214,6 +222,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         ],
       });
 
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -228,6 +237,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         ],
       });
 
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 16,
         channel: channelName,
@@ -281,6 +291,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channelName = 'sync_member_arrives_normally_after_came_in_sync',
         channel = realtime.channels.get(channelName);
 
+      helper.recordPrivateApi('call.protocolMessageFromDeserialized');
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage(
         createPM({
           action: 11,
@@ -289,6 +301,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         }),
       );
 
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 16,
         channel: channelName,
@@ -304,6 +317,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         ],
       });
 
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -318,6 +332,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         ],
       });
 
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 16,
         channel: channelName,
@@ -368,6 +383,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channelName = 'sync_member_arrives_normally_before_comes_in_sync',
         channel = realtime.channels.get(channelName);
 
+      helper.recordPrivateApi('call.protocolMessageFromDeserialized');
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage(
         createPM({
           action: 11,
@@ -376,6 +393,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         }),
       );
 
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 16,
         channel: channelName,
@@ -391,6 +409,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         ],
       });
 
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -405,6 +424,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         ],
       });
 
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 16,
         channel: channelName,
@@ -459,6 +479,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channelName = 'sync_ordering',
         channel = realtime.channels.get(channelName);
 
+      helper.recordPrivateApi('call.protocolMessageFromDeserialized');
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage(
         createPM({
           action: 11,
@@ -467,6 +489,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       );
 
       /* One enters */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -482,6 +505,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
 
       /* An earlier leave from one (should be ignored) */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -497,6 +521,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
 
       /* One adds some data in a newer msgSerial */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -513,6 +538,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
 
       /* Two enters */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -528,6 +554,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
 
       /* Two updates twice in the same message */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -549,6 +576,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
 
       /* Three enters */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -565,6 +593,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
       /* Synthesized leave for three (with earlier msgSerial, incompatible id,
        * and later timestamp) */
+      helper.recordPrivateApi('call.channel.processMessage');
       await channel.processMessage({
         action: 14,
         channel: channelName,
@@ -652,11 +681,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           },
           function (cb) {
             var originalProcessMessage = syncerChannel.processMessage;
+            helper.recordPrivateApi('replace.channel.processMessage');
             syncerChannel.processMessage = async function (message) {
+              helper.recordPrivateApi('call.channel.processMessage');
               await originalProcessMessage.apply(this, arguments);
               /* Inject an additional presence message after the first sync */
               if (message.action === 16) {
+                helper.recordPrivateApi('replace.channel.processMessage');
                 syncerChannel.processMessage = originalProcessMessage;
+                helper.recordPrivateApi('call.channel.processMessage');
                 await syncerChannel.processMessage({
                   action: 14,
                   id: 'messageid:0',

--- a/test/realtime/sync.test.js
+++ b/test/realtime/sync.test.js
@@ -1,14 +1,13 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var createPM = Ably.protocolMessageFromDeserialized;
 
   describe('realtime/sync', function () {
     this.timeout(60 * 1000);
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -46,7 +45,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP19
      */
     it('sync_existing_set', async function () {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'syncexistingset',
         channel = realtime.channels.get(channelName);
 
@@ -170,7 +170,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('sync_member_arrives_in_middle', async function () {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'sync_member_arrives_in_middle',
         channel = realtime.channels.get(channelName);
 
@@ -275,7 +276,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('sync_member_arrives_normally_after_came_in_sync', async function () {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'sync_member_arrives_normally_after_came_in_sync',
         channel = realtime.channels.get(channelName);
 
@@ -361,7 +363,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @nospec
      */
     it('sync_member_arrives_normally_before_comes_in_sync', async function () {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'sync_member_arrives_normally_before_comes_in_sync',
         channel = realtime.channels.get(channelName);
 
@@ -451,7 +454,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTP2c
      */
     it('presence_ordering', async function () {
-      var realtime = helper.AblyRealtime({ autoConnect: false }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRealtime({ autoConnect: false }),
         channelName = 'sync_ordering',
         channel = realtime.channels.get(channelName);
 
@@ -607,6 +611,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTP4 - not enough members tested, should be 250
      */
     it('presence_sync_interruptus', function (done) {
+      const helper = this.test.helper;
       var channelName = 'presence_sync_interruptus';
       var interrupterClientId = 'dark_horse';
       var enterer = helper.AblyRealtime();

--- a/test/realtime/sync.test.js
+++ b/test/realtime/sync.test.js
@@ -2,12 +2,7 @@
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
   var expect = chai.expect;
-  var displayError = helper.displayError;
-  var utils = helper.Utils;
-  var closeAndFinish = helper.closeAndFinish;
   var createPM = Ably.protocolMessageFromDeserialized;
-  var monitorConnection = helper.monitorConnection;
-  var whenPromiseSettles = helper.whenPromiseSettles;
 
   describe('realtime/sync', function () {
     this.timeout(60 * 1000);
@@ -98,7 +93,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 });
             },
             function (cb) {
-              whenPromiseSettles(channel.presence.get(), function (err, results) {
+              helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
                 try {
                   expect(results.length).to.equal(2, 'Check correct number of results');
                   expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
@@ -141,7 +136,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 });
             },
             function (cb) {
-              whenPromiseSettles(channel.presence.get(), function (err, results) {
+              helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
                 try {
                   expect(results.length).to.equal(2, 'Check correct number of results');
                   expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
@@ -158,7 +153,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             },
           ],
           function (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
           },
         );
       });
@@ -250,9 +245,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           err ? reject(err) : resolve();
         };
 
-        whenPromiseSettles(channel.presence.get(), function (err, results) {
+        helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           try {
@@ -263,10 +258,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
               'check expected presence members',
             );
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       });
     });
@@ -339,9 +334,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           err ? reject(err) : resolve();
         };
 
-        whenPromiseSettles(channel.presence.get(), function (err, results) {
+        helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           try {
@@ -349,10 +344,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
             expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check expected presence members');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       });
     });
@@ -425,9 +420,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           err ? reject(err) : resolve();
         };
 
-        whenPromiseSettles(channel.presence.get(), function (err, results) {
+        helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           try {
@@ -435,10 +430,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             expect(channel.presence.syncComplete, 'Check in sync').to.be.ok;
             expect(extractClientIds(results)).to.deep.equal(['one', 'two'], 'check expected presence members');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       });
     });
@@ -583,9 +578,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         var done = function (err) {
           err ? reject(err) : resolve();
         };
-        whenPromiseSettles(channel.presence.get(), function (err, results) {
+        helper.whenPromiseSettles(channel.presence.get(), function (err, results) {
           if (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
           try {
@@ -595,10 +590,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
             expect(extractMember(results, 'one').data).to.equal('onedata', 'check correct data on one');
             expect(extractMember(results, 'two').data).to.equal('twodata', 'check correct data on two');
           } catch (err) {
-            closeAndFinish(done, realtime, err);
+            helper.closeAndFinish(done, realtime, err);
             return;
           }
-          closeAndFinish(done, realtime);
+          helper.closeAndFinish(done, realtime);
         });
       });
     });
@@ -637,13 +632,13 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
         [
           waitForBothConnect,
           function (cb) {
-            whenPromiseSettles(entererChannel.attach(), cb);
+            helper.whenPromiseSettles(entererChannel.attach(), cb);
           },
           function (cb) {
             async.times(
               110,
               function (i, presCb) {
-                whenPromiseSettles(entererChannel.presence.enterClient(i.toString(), null), presCb);
+                helper.whenPromiseSettles(entererChannel.presence.enterClient(i.toString(), null), presCb);
               },
               cb,
             );
@@ -669,10 +664,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
                 });
               }
             };
-            whenPromiseSettles(syncerChannel.attach(), cb);
+            helper.whenPromiseSettles(syncerChannel.attach(), cb);
           },
           function (cb) {
-            whenPromiseSettles(syncerChannel.presence.get(), function (err, presenceSet) {
+            helper.whenPromiseSettles(syncerChannel.presence.get(), function (err, presenceSet) {
               try {
                 expect(presenceSet && presenceSet.length).to.equal(111, 'Check everyone’s in presence set');
               } catch (err) {
@@ -684,7 +679,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
           },
         ],
         function (err) {
-          closeAndFinish(done, [enterer, syncer], err);
+          helper.closeAndFinish(done, [enterer, syncer], err);
         },
       );
     });

--- a/test/realtime/transports.test.js
+++ b/test/realtime/transports.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'async', 'chai', 'ably'], function (helper, async, chai, Ably) {
+define(['shared_helper', 'async', 'chai', 'ably'], function (Helper, async, chai, Ably) {
+  const helper = new Helper();
+
   const expect = chai.expect;
   const Defaults = Ably.Rest.Platform.Defaults;
   const originialWsCheckUrl = Defaults.wsConnectivityUrl;

--- a/test/realtime/utils.test.js
+++ b/test/realtime/utils.test.js
@@ -10,6 +10,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       var retryAttempts = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
       var initialTimeout = 15;
 
+      helper.recordPrivateApi('call.Utils.getRetryTime');
       var retryTimeouts = retryAttempts.map((attempt) => helper.Utils.getRetryTime(initialTimeout, attempt));
       expect(retryTimeouts.filter((timeout) => timeout >= 30).length).to.equal(0);
 

--- a/test/realtime/utils.test.js
+++ b/test/realtime/utils.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'chai'], function (helper, chai) {
+define(['shared_helper', 'chai'], function (Helper, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
 
   describe('incremental backoff and jitter', function () {

--- a/test/realtime/utils.test.js
+++ b/test/realtime/utils.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 define(['shared_helper', 'chai'], function (Helper, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
 
   describe('incremental backoff and jitter', function () {
     /** @spec RTB1 */
     it('should calculate retry timeouts using incremental backoff and jitter', function () {
+      const helper = this.test.helper;
       var retryAttempts = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
       var initialTimeout = 15;
 

--- a/test/realtime/utils.test.js
+++ b/test/realtime/utils.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'chai'], function (helper, chai) {
-  var utils = helper.Utils;
   var expect = chai.expect;
 
   describe('incremental backoff and jitter', function () {
@@ -10,7 +9,7 @@ define(['shared_helper', 'chai'], function (helper, chai) {
       var retryAttempts = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
       var initialTimeout = 15;
 
-      var retryTimeouts = retryAttempts.map((attempt) => utils.getRetryTime(initialTimeout, attempt));
+      var retryTimeouts = retryAttempts.map((attempt) => helper.Utils.getRetryTime(initialTimeout, attempt));
       expect(retryTimeouts.filter((timeout) => timeout >= 30).length).to.equal(0);
 
       function checkIsBetween(value, min, max) {

--- a/test/rest/auth.test.js
+++ b/test/rest/auth.test.js
@@ -4,7 +4,6 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, as
   var currentTime;
   var rest;
   var expect = chai.expect;
-  var utils = helper.Utils;
   var echoServer = 'https://echo.ably.io';
 
   describe('rest/auth', function () {
@@ -370,8 +369,8 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, as
       it(description, async function () {
         var currentKey = helper.getTestApp().keys[0];
         var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
-        var authParams = utils.mixin(keys, params);
-        var authUrl = echoServer + '/createJWT' + utils.toQueryString(authParams);
+        var authParams = helper.Utils.mixin(keys, params);
+        var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(authParams);
         var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
 
         var tokenDetails = await restJWTRequester.auth.requestToken();
@@ -400,7 +399,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, as
      */
     it('JWT request with invalid key', async function () {
       var keys = { keyName: 'invalid.invalid', keySecret: 'invalidinvalid' };
-      var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
+      var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
       var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
 
       var tokenDetails = await restJWTRequester.auth.requestToken();
@@ -419,7 +418,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, as
     it('Rest JWT with authCallback', async function () {
       var currentKey = helper.getTestApp().keys[0];
       var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
-      var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
+      var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
       var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
 
       var authCallback = function (tokenParams, callback) {
@@ -438,7 +437,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, as
      */
     it('Rest JWT with authCallback and invalid keys', async function () {
       var keys = { keyName: 'invalid.invalid', keySecret: 'invalidinvalid' };
-      var authUrl = echoServer + '/createJWT' + utils.toQueryString(keys);
+      var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
       var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
 
       var authCallback = function (tokenParams, callback) {

--- a/test/rest/auth.test.js
+++ b/test/rest/auth.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['chai', 'shared_helper', 'async', 'globals'], function (chai, helper, async, globals) {
+define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, async, globals) {
+  const helper = new Helper();
+
   var currentTime;
   var rest;
   var expect = chai.expect;

--- a/test/rest/auth.test.js
+++ b/test/rest/auth.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, async, globals) {
-  const helper = new Helper();
-
   var currentTime;
   var rest;
   var expect = chai.expect;
@@ -12,6 +10,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function () {
         rest = helper.AblyRest({ queryTime: true });
         rest
@@ -55,6 +54,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @specpartial TO3j2 - test passing token in ClientOptions for Rest client
      */
     it('Generate token and init library with it', async function () {
+      const helper = this.test.helper;
       var tokenDetails = await rest.auth.requestToken();
       expect(tokenDetails.token, 'Verify token value').to.be.ok;
       helper.AblyRest({ token: tokenDetails.token });
@@ -162,6 +162,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @specpartial RSA6 - infer capability from provided key
      */
     it('Token generation with specified key', async function () {
+      const helper = this.test.helper;
       var testKeyOpts = { key: helper.getTestApp().keys[1].keyStr };
       var testCapability = JSON.parse(helper.getTestApp().keys[1].capability);
       var tokenDetails = await rest.auth.requestToken(null, testKeyOpts);
@@ -174,6 +175,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
 
     /** @nospec */
     it('Token generation with explicit auth', async function () {
+      const helper = this.test.helper;
       const authHeaders = await rest.auth.getAuthHeaders();
       rest.auth.authOptions.requestHeaders = authHeaders;
       var tokenDetails = await rest.auth.requestToken();
@@ -189,6 +191,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @nospec
      */
     it('Token generation with explicit auth, different key', async function () {
+      const helper = this.test.helper;
       const authHeaders = await rest.auth.getAuthHeaders();
       var testKeyOpts = { key: helper.getTestApp().keys[1].keyStr };
       var testCapability = JSON.parse(helper.getTestApp().keys[1].capability);
@@ -216,6 +219,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
 
     /** @spec TO3j11 */
     it('Token generation with defaultTokenParams set and no tokenParams passed in', async function () {
+      const helper = this.test.helper;
       var rest1 = helper.AblyRest({ defaultTokenParams: { ttl: 123, clientId: 'foo' } });
       var tokenDetails = await rest1.auth.requestToken();
       expect(tokenDetails.token, 'Verify token value').to.be.ok;
@@ -228,6 +232,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @specpartial RSA8e - test passing any options overrides library default
      */
     it('Token generation: if tokenParams passed in, defaultTokenParams should be ignored altogether, not merged', async function () {
+      const helper = this.test.helper;
       var rest1 = helper.AblyRest({ defaultTokenParams: { ttl: 123, clientId: 'foo' } });
       var tokenDetails = await rest1.auth.requestToken({ clientId: 'bar' }, null);
       expect(tokenDetails.clientId).to.equal(
@@ -320,6 +325,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @specpartial RSA9h - test passing null for TokenParams and AuthOptions
      */
     it('createTokenRequest without authOptions', async function () {
+      const helper = this.test.helper;
       var tokenRequest = await rest.auth.createTokenRequest(null, null);
       expect('mac' in tokenRequest, 'check tokenRequest contains a mac').to.be.ok;
       expect('nonce' in tokenRequest, 'check tokenRequest contains a nonce').to.be.ok;
@@ -334,6 +340,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @nospec
      */
     it('createTokenRequest uses the key it was initialized with if authOptions does not have a "key" key', async function () {
+      const helper = this.test.helper;
       var tokenRequest = await rest.auth.createTokenRequest();
       expect(tokenRequest.keyName).to.equal(helper.getTestApp().keys[0].keyName);
     });
@@ -369,6 +376,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
        * @specpartial RSA3d - test JWT is correctly passed in REST request
        */
       it(description, async function () {
+        const helper = this.test.helper;
         var currentKey = helper.getTestApp().keys[0];
         var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
         var authParams = helper.Utils.mixin(keys, params);
@@ -400,6 +408,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @nospec
      */
     it('JWT request with invalid key', async function () {
+      const helper = this.test.helper;
       var keys = { keyName: 'invalid.invalid', keySecret: 'invalidinvalid' };
       var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
       var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
@@ -418,6 +427,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
 
     /** @specpartial RSA8g - test using authCallback with JWT */
     it('Rest JWT with authCallback', async function () {
+      const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[0];
       var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
       var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
@@ -438,6 +448,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @nospec
      */
     it('Rest JWT with authCallback and invalid keys', async function () {
+      const helper = this.test.helper;
       var keys = { keyName: 'invalid.invalid', keySecret: 'invalidinvalid' };
       var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
       var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
@@ -464,6 +475,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      * @nospec
      */
     it('authCallback is only invoked once on concurrent auth', async function () {
+      const helper = this.test.helper;
       var authCallbackInvocations = 0;
       function authCallback(tokenParams, callback) {
         authCallbackInvocations++;

--- a/test/rest/auth.test.js
+++ b/test/rest/auth.test.js
@@ -176,9 +176,12 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
     /** @nospec */
     it('Token generation with explicit auth', async function () {
       const helper = this.test.helper;
+      helper.recordPrivateApi('call.auth.getAuthHeaders');
       const authHeaders = await rest.auth.getAuthHeaders();
+      helper.recordPrivateApi('write.auth.authOptions.requestHeaders');
       rest.auth.authOptions.requestHeaders = authHeaders;
       var tokenDetails = await rest.auth.requestToken();
+      helper.recordPrivateApi('delete.auth.authOptions.requestHeaders');
       delete rest.auth.authOptions.requestHeaders;
       expect(tokenDetails.token, 'Verify token value').to.be.ok;
       expect(tokenDetails.issued && tokenDetails.issued >= currentTime, 'Verify token issued').to.be.ok;
@@ -192,6 +195,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
      */
     it('Token generation with explicit auth, different key', async function () {
       const helper = this.test.helper;
+      helper.recordPrivateApi('call.auth.getAuthHeaders');
       const authHeaders = await rest.auth.getAuthHeaders();
       var testKeyOpts = { key: helper.getTestApp().keys[1].keyStr };
       var testCapability = JSON.parse(helper.getTestApp().keys[1].capability);
@@ -379,7 +383,9 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
         const helper = this.test.helper;
         var currentKey = helper.getTestApp().keys[0];
         var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
+        helper.recordPrivateApi('call.Utils.mixin');
         var authParams = helper.Utils.mixin(keys, params);
+        helper.recordPrivateApi('call.Utils.toQueryString');
         var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(authParams);
         var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
 
@@ -410,6 +416,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
     it('JWT request with invalid key', async function () {
       const helper = this.test.helper;
       var keys = { keyName: 'invalid.invalid', keySecret: 'invalidinvalid' };
+      helper.recordPrivateApi('call.Utils.toQueryString');
       var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
       var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
 
@@ -430,6 +437,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
       const helper = this.test.helper;
       var currentKey = helper.getTestApp().keys[0];
       var keys = { keyName: currentKey.keyName, keySecret: currentKey.keySecret };
+      helper.recordPrivateApi('call.Utils.toQueryString');
       var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
       var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
 
@@ -450,6 +458,7 @@ define(['chai', 'shared_helper', 'async', 'globals'], function (chai, Helper, as
     it('Rest JWT with authCallback and invalid keys', async function () {
       const helper = this.test.helper;
       var keys = { keyName: 'invalid.invalid', keySecret: 'invalidinvalid' };
+      helper.recordPrivateApi('call.Utils.toQueryString');
       var authUrl = echoServer + '/createJWT' + helper.Utils.toQueryString(keys);
       var restJWTRequester = helper.AblyRest({ authUrl: authUrl });
 

--- a/test/rest/batch.test.js
+++ b/test/rest/batch.test.js
@@ -1,14 +1,13 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
 
   describe('rest/batchPublish', function () {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -33,6 +32,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @specpartial RSC22b - test returns an array of BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>
        */
       it('performs a batch publish and returns an array of results', async function () {
+        const helper = this.test.helper;
         const testApp = helper.getTestApp();
         const rest = helper.AblyRest({
           promises: true,
@@ -123,6 +123,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
        * @specpartial RSC22b - test returns a single BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>
        */
       it('performs a batch publish and returns a single result', async function () {
+        const helper = this.test.helper;
         const testApp = helper.getTestApp();
         const rest = helper.AblyRest({
           promises: true,
@@ -168,6 +169,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -187,6 +189,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec BGF2b
      */
     it('performs a batch presence fetch and returns a result', async function () {
+      const helper = this.test.helper;
       const testApp = helper.getTestApp();
       const rest = helper.AblyRest({
         promises: true,
@@ -239,6 +242,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -263,6 +267,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial RSA17g - test passing an array of TokenRevocationTargetSpecifier
      */
     it('revokes tokens matching the given specifiers', async function () {
+      const helper = this.test.helper;
       const testApp = helper.getTestApp();
       const rest = helper.AblyRest({
         promises: true,
@@ -359,6 +364,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec TRS2c
      */
     it('accepts optional issuedBefore and allowReauthMargin parameters', async function () {
+      const helper = this.test.helper;
       const testApp = helper.getTestApp();
       const rest = helper.AblyRest({
         promises: true,
@@ -387,6 +393,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec RSA17d
      */
     it('throws an error when using token auth', async function () {
+      const helper = this.test.helper;
       const rest = helper.AblyRest({
         useTokenAuth: true,
       });

--- a/test/rest/batch.test.js
+++ b/test/rest/batch.test.js
@@ -2,8 +2,6 @@
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
   var expect = chai.expect;
-  var closeAndFinish = helper.closeAndFinish;
-  var randomString = helper.randomString;
 
   describe('rest/batchPublish', function () {
     this.timeout(60 * 1000);
@@ -228,7 +226,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       expect('error' in batchResult.results[1]).to.be.false;
 
       await new Promise((resolve, reject) => {
-        closeAndFinish((err) => {
+        helper.closeAndFinish((err) => {
           err ? reject(err) : resolve();
         }, presenceEnterRealtime);
       });
@@ -269,8 +267,8 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         key: testApp.keys[4].keyStr /* this key has revocableTokens enabled */,
       });
 
-      const clientId1 = `clientId1-${randomString()}`;
-      const clientId2 = `clientId2-${randomString()}`;
+      const clientId1 = `clientId1-${helper.randomString()}`;
+      const clientId2 = `clientId2-${helper.randomString()}`;
 
       // First, we fetch tokens for a couple of different clientIds...
       const [clientId1TokenDetails, clientId2TokenDetails] = await Promise.all([
@@ -341,7 +339,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
       await Promise.all(
         [clientId1Realtime, clientId2Realtime].map((realtime) => {
           new Promise((resolve, reject) => {
-            closeAndFinish((err) => {
+            helper.closeAndFinish((err) => {
               err ? reject(err) : resolve();
             }, realtime);
           });
@@ -365,7 +363,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         key: testApp.keys[4].keyStr /* this key has revocableTokens enabled */,
       });
 
-      const clientId = `clientId-${randomString()}`;
+      const clientId = `clientId-${helper.randomString()}`;
 
       const serverTimeAtStartOfTest = await rest.time();
       const issuedBefore = serverTimeAtStartOfTest - 20 * 60 * 1000; // i.e. ~20 minutes ago (arbitrarily chosen)

--- a/test/rest/batch.test.js
+++ b/test/rest/batch.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
+define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
 
   describe('rest/batchPublish', function () {
@@ -267,8 +269,8 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         key: testApp.keys[4].keyStr /* this key has revocableTokens enabled */,
       });
 
-      const clientId1 = `clientId1-${helper.randomString()}`;
-      const clientId2 = `clientId2-${helper.randomString()}`;
+      const clientId1 = `clientId1-${Helper.randomString()}`;
+      const clientId2 = `clientId2-${Helper.randomString()}`;
 
       // First, we fetch tokens for a couple of different clientIds...
       const [clientId1TokenDetails, clientId2TokenDetails] = await Promise.all([
@@ -363,7 +365,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
         key: testApp.keys[4].keyStr /* this key has revocableTokens enabled */,
       });
 
-      const clientId = `clientId-${helper.randomString()}`;
+      const clientId = `clientId-${Helper.randomString()}`;
 
       const serverTimeAtStartOfTest = await rest.time();
       const issuedBefore = serverTimeAtStartOfTest - 20 * 60 * 1000; // i.e. ~20 minutes ago (arbitrarily chosen)

--- a/test/rest/capability.test.js
+++ b/test/rest/capability.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'chai'], function (Helper, chai) {
-  const helper = new Helper();
-
   var currentTime;
   var rest;
   var testApp;
@@ -21,6 +19,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function () {
         rest = helper.AblyRest({ queryTime: true });
         testApp = helper.getTestApp();

--- a/test/rest/capability.test.js
+++ b/test/rest/capability.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'chai'], function (helper, chai) {
+define(['shared_helper', 'chai'], function (Helper, chai) {
+  const helper = new Helper();
+
   var currentTime;
   var rest;
   var testApp;

--- a/test/rest/defaults.test.js
+++ b/test/rest/defaults.test.js
@@ -19,6 +19,9 @@ define(['ably', 'chai'], function (Ably, chai) {
      * @specpartial RTN17a - primary host for realtime is realtimeHost
      */
     it('Init with no endpoint-related options', function () {
+      const helper = this.test.helper;
+
+      helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions({}, null, null);
 
       expect(normalisedOptions.restHost).to.equal('rest.ably.io');
@@ -28,11 +31,14 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.FALLBACK_HOSTS.sort());
       expect(normalisedOptions.tls).to.equal(true);
 
+      helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions).length).to.equal(4);
       expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
+      helper.recordPrivateApi('call.Defaults.getHost');
       expect(Defaults.getHost(normalisedOptions, 'rest.ably.io', false)).to.deep.equal('rest.ably.io');
       expect(Defaults.getHost(normalisedOptions, 'rest.ably.io', true)).to.equal('realtime.ably.io');
 
+      helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
     });
 
@@ -54,6 +60,9 @@ define(['ably', 'chai'], function (Ably, chai) {
      * @specpartial RTC1e - test with environment set to 'production'
      */
     it('Init with production environment', function () {
+      const helper = this.test.helper;
+
+      helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions({ environment: 'production' }, null, null);
 
       expect(normalisedOptions.restHost).to.equal('rest.ably.io');
@@ -63,11 +72,14 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.FALLBACK_HOSTS.sort());
       expect(normalisedOptions.tls).to.equal(true);
 
+      helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions).length).to.deep.equal(4);
       expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
+      helper.recordPrivateApi('call.Defaults.getHost');
       expect(Defaults.getHost(normalisedOptions, 'rest.ably.io', false)).to.deep.equal('rest.ably.io');
       expect(Defaults.getHost(normalisedOptions, 'rest.ably.io', true)).to.deep.equal('realtime.ably.io');
 
+      helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
     });
 
@@ -86,6 +98,9 @@ define(['ably', 'chai'], function (Ably, chai) {
      * @specpartial RTC1e - test with environment set other than 'production'
      */
     it('Init with given environment', function () {
+      const helper = this.test.helper;
+
+      helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions({ environment: 'sandbox' }, null, null);
 
       expect(normalisedOptions.restHost).to.equal('sandbox-rest.ably.io');
@@ -95,13 +110,16 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.environmentFallbackHosts('sandbox').sort());
       expect(normalisedOptions.tls).to.equal(true);
 
+      helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions).length).to.deep.equal(4);
       expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
+      helper.recordPrivateApi('call.Defaults.getHost');
       expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', false)).to.deep.equal('sandbox-rest.ably.io');
       expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', true)).to.deep.equal(
         'sandbox-realtime.ably.io',
       );
 
+      helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
     });
 
@@ -120,6 +138,9 @@ define(['ably', 'chai'], function (Ably, chai) {
      * @specpartial RTC1e - test with environment set other than 'production'
      */
     it('Init with local environment and non-default ports', function () {
+      const helper = this.test.helper;
+
+      helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions(
         { environment: 'local', port: 8080, tlsPort: 8081 },
         null,
@@ -133,10 +154,13 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(normalisedOptions.fallbackHosts).to.equal(undefined);
       expect(normalisedOptions.tls).to.equal(true);
 
+      helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions)).to.deep.equal([normalisedOptions.restHost]);
+      helper.recordPrivateApi('call.Defaults.getHost');
       expect(Defaults.getHost(normalisedOptions, 'local-rest.ably.io', false)).to.deep.equal('local-rest.ably.io');
       expect(Defaults.getHost(normalisedOptions, 'local-rest.ably.io', true)).to.deep.equal('local-realtime.ably.io');
 
+      helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(8081);
     });
 
@@ -154,6 +178,9 @@ define(['ably', 'chai'], function (Ably, chai) {
      * @specpartial RSC11 - test restHost is overridden by custom value
      */
     it('Init with given host', function () {
+      const helper = this.test.helper;
+
+      helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions({ restHost: 'test.org' }, null, null);
 
       expect(normalisedOptions.restHost).to.equal('test.org');
@@ -163,10 +190,13 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(normalisedOptions.fallbackHosts).to.equal(undefined);
       expect(normalisedOptions.tls).to.equal(true);
 
+      helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions)).to.deep.equal([normalisedOptions.restHost]);
+      helper.recordPrivateApi('call.Defaults.getHost');
       expect(Defaults.getHost(normalisedOptions, 'test.org', false)).to.deep.equal('test.org');
       expect(Defaults.getHost(normalisedOptions, 'test.org', true)).to.deep.equal('test.org');
 
+      helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
     });
 
@@ -183,6 +213,9 @@ define(['ably', 'chai'], function (Ably, chai) {
      * @specpartial RTN17a - primary host for realtime can be overridden by realtimeHost
      */
     it('Init with given restHost and realtimeHost', function () {
+      const helper = this.test.helper;
+
+      helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions(
         { restHost: 'test.org', realtimeHost: 'ws.test.org' },
         null,
@@ -196,10 +229,13 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(normalisedOptions.fallbackHosts).to.equal(undefined);
       expect(normalisedOptions.tls).to.equal(true);
 
+      helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions)).to.deep.equal([normalisedOptions.restHost]);
+      helper.recordPrivateApi('call.Defaults.getHost');
       expect(Defaults.getHost(normalisedOptions, 'test.org', false)).to.deep.equal('test.org');
       expect(Defaults.getHost(normalisedOptions, 'test.org', true)).to.deep.equal('ws.test.org');
 
+      helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
     });
 
@@ -216,7 +252,11 @@ define(['ably', 'chai'], function (Ably, chai) {
      * @specpartial RSC15g2 - test with environment set other than 'production'
      */
     it('Init with no endpoint-related options and given default environment', function () {
+      const helper = this.test.helper;
+
+      helper.recordPrivateApi('write.Defaults.ENVIRONMENT');
       Defaults.ENVIRONMENT = 'sandbox';
+      helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions({}, null, null);
 
       expect(normalisedOptions.restHost).to.equal('sandbox-rest.ably.io');
@@ -226,14 +266,18 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.environmentFallbackHosts('sandbox').sort());
       expect(normalisedOptions.tls).to.equal(true);
 
+      helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions).length).to.equal(4);
       expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
+      helper.recordPrivateApi('call.Defaults.getHost');
       expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', false)).to.deep.equal('sandbox-rest.ably.io');
       expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', true)).to.deep.equal(
         'sandbox-realtime.ably.io',
       );
 
+      helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
+      helper.recordPrivateApi('write.Defaults.ENVIRONMENT');
       Defaults.ENVIRONMENT = '';
     });
 
@@ -242,8 +286,10 @@ define(['ably', 'chai'], function (Ably, chai) {
       if (Ably.Realtime.Platform.Config.supportsBinary) {
         describe('given MsgPack implementation', () => {
           /** @spec TO3f */
-          it('maintains useBinaryProtocol as true', () => {
+          it('maintains useBinaryProtocol as true', function () {
+            const helper = this.test.helper;
             const StubMsgPack = {};
+            helper.recordPrivateApi('call.Defaults.normaliseOptions');
             var normalisedOptions = Defaults.normaliseOptions({ useBinaryProtocol: true }, StubMsgPack, null);
 
             expect(normalisedOptions.useBinaryProtocol).to.be.true;
@@ -253,7 +299,9 @@ define(['ably', 'chai'], function (Ably, chai) {
 
       describe('given no MsgPack implementation', () => {
         /** @spec TO3f */
-        it('changes useBinaryProtocol to false', () => {
+        it('changes useBinaryProtocol to false', function () {
+          const helper = this.test.helper;
+          helper.recordPrivateApi('call.Defaults.normaliseOptions');
           var normalisedOptions = Defaults.normaliseOptions({ useBinaryProtocol: true }, null, null);
 
           expect(normalisedOptions.useBinaryProtocol).to.be.false;
@@ -266,7 +314,10 @@ define(['ably', 'chai'], function (Ably, chai) {
      * @nospec
      */
     it('closeOnUnload', function () {
+      const helper = this.test.helper;
       var options;
+
+      helper.recordPrivateApi('call.Defaults.normaliseOptions');
 
       /* Default to true */
       options = Defaults.normaliseOptions({}, null, null);

--- a/test/rest/fallbacks.test.js
+++ b/test/rest/fallbacks.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var goodHost;
 
@@ -10,6 +8,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -22,6 +21,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
 
     /** @spec RSC15f */
     it('Store working fallback', async function () {
+      const helper = this.test.helper;
       var rest = helper.AblyRest({
         restHost: helper.unroutableHost,
         fallbackHosts: [goodHost],
@@ -56,6 +56,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     describe('Max elapsed time for host retries', function () {
       /** @spec TO3l6 */
       it('can timeout after default host', async function () {
+        const helper = this.test.helper;
         const httpRequestTimeout = 1000;
         // set httpMaxRetryDuration lower than httpRequestTimeout so it would timeout after default host attempt
         const httpMaxRetryDuration = Math.floor(httpRequestTimeout / 2);
@@ -82,6 +83,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
 
       /** @spec TO3l6 */
       it('can timeout after fallback host retries', async function () {
+        const helper = this.test.helper;
         const httpRequestTimeout = 1000;
         // set httpMaxRetryDuration higher than httpRequestTimeout and lower than 2*httpRequestTimeout so it would timeout after first fallback host retry attempt
         const httpMaxRetryDuration = Math.floor(httpRequestTimeout * 1.5);

--- a/test/rest/fallbacks.test.js
+++ b/test/rest/fallbacks.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
+define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var goodHost;
 

--- a/test/rest/fallbacks.test.js
+++ b/test/rest/fallbacks.test.js
@@ -30,26 +30,34 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       var validUntil;
       var serverTime = await rest.time();
       expect(serverTime, 'Check serverTime returned').to.be.ok;
+      helper.recordPrivateApi('read.rest._currentFallback');
       var currentFallback = rest._currentFallback;
       expect(currentFallback, 'Check current fallback stored').to.be.ok;
+      helper.recordPrivateApi('read.rest._currentFallback.host');
       expect(currentFallback && currentFallback.host).to.equal(goodHost, 'Check good host set');
+      helper.recordPrivateApi('read.rest._currentFallback.validUntil');
       validUntil = currentFallback.validUntil;
       /* now try again, check that this time it uses the remembered good endpoint straight away */
       var serverTime = await rest.time();
       expect(serverTime, 'Check serverTime returned').to.be.ok;
       var currentFallback = rest._currentFallback;
+      helper.recordPrivateApi('read.rest._currentFallback.validUntil');
       expect(currentFallback.validUntil).to.equal(
         validUntil,
         'Check validUntil is the same (implying currentFallback has not been re-set)',
       );
       /* set the validUntil to the past and check that the stored fallback is forgotten */
       var now = Date.now();
+      helper.recordPrivateApi('write.rest._currentFallback.validUntil');
       rest._currentFallback.validUntil = now - 1000;
       var serverTime = await rest.time();
       expect(serverTime, 'Check serverTime returned').to.be.ok;
+      helper.recordPrivateApi('read.rest._currentFallback');
       var currentFallback = rest._currentFallback;
       expect(currentFallback, 'Check current fallback re-stored').to.be.ok;
+      helper.recordPrivateApi('read.rest._currentFallback.host');
       expect(currentFallback && currentFallback.host).to.equal(goodHost, 'Check good host set again');
+      helper.recordPrivateApi('read.rest._currentFallback.validUntil');
       expect(currentFallback.validUntil > now, 'Check validUntil has been re-set').to.be.ok;
     });
 

--- a/test/rest/history.test.js
+++ b/test/rest/history.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
+define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
+  const helper = new Helper();
+
   var rest;
   var expect = chai.expect;
   var exports = {};
@@ -30,7 +32,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * @spec RSL2
      * @spec RSL2a
      */
-    helper.restTestOnJsonMsgpack('history_simple', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('history_simple', async function (rest, channelName) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -61,7 +63,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * @spec RSL2
      * @spec RSL2a
      */
-    helper.restTestOnJsonMsgpack('history_multiple', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('history_multiple', async function (rest, channelName) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -89,7 +91,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * @spec RSL2b2
      * @specpartial RSL2b3 - should also test maximum supported limit of 1000
      */
-    helper.restTestOnJsonMsgpack('history_simple_paginated_b', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('history_simple_paginated_b', async function (rest, channelName) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -251,7 +253,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     });
 
     /** @nospec */
-    helper.restTestOnJsonMsgpack('history_encoding_errors', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('history_encoding_errors', async function (rest, channelName) {
       var testchannel = rest.channels.get('persisted:' + channelName);
       var badMessage = { name: 'jsonUtf8string', encoding: 'json/utf-8', data: '{"foo":"bar"}' };
       testchannel.publish(badMessage);
@@ -264,7 +266,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     });
 
     /** @specpartial TG4 - in the context of RestChannel#history */
-    helper.restTestOnJsonMsgpack('history_no_next_page', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('history_no_next_page', async function (rest, channelName) {
       const channel = rest.channels.get(channelName);
 
       const firstPage = await channel.history();

--- a/test/rest/history.test.js
+++ b/test/rest/history.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
-  const helper = new Helper();
-
   var rest;
   var expect = chai.expect;
   var exports = {};
@@ -21,6 +19,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function () {
         rest = helper.AblyRest();
         done();
@@ -32,7 +31,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RSL2
      * @spec RSL2a
      */
-    Helper.restTestOnJsonMsgpack('history_simple', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('history_simple', async function (rest, channelName, helper) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -63,7 +62,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RSL2
      * @spec RSL2a
      */
-    Helper.restTestOnJsonMsgpack('history_multiple', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('history_multiple', async function (rest, channelName, helper) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -91,7 +90,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RSL2b2
      * @specpartial RSL2b3 - should also test maximum supported limit of 1000
      */
-    Helper.restTestOnJsonMsgpack('history_simple_paginated_b', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('history_simple_paginated_b', async function (rest, channelName, helper) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -134,6 +133,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @specpartial RSL2b3 - should also test maximum supported limit of 1000
      */
     it('history_simple_paginated_f', async function () {
+      const helper = this.test.helper;
       var testchannel = rest.channels.get('persisted:history_simple_paginated_f');
 
       /* first, send a number of events to this channel */
@@ -215,6 +215,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @specpartial RSL2b3 - should also test maximum supported limit of 1000
      */
     it('history_multiple_paginated_f', async function () {
+      const helper = this.test.helper;
       var testchannel = rest.channels.get('persisted:history_multiple_paginated_f');
 
       /* first, send a number of events to this channel */

--- a/test/rest/history.test.js
+++ b/test/rest/history.test.js
@@ -4,8 +4,6 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
   var rest;
   var expect = chai.expect;
   var exports = {};
-  var restTestOnJsonMsgpack = helper.restTestOnJsonMsgpack;
-  var utils = helper.Utils;
   var testMessages = [
     { name: 'event0', data: 'some data' },
     { name: 'event1', data: 'some more data' },
@@ -32,7 +30,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * @spec RSL2
      * @spec RSL2a
      */
-    restTestOnJsonMsgpack('history_simple', async function (rest, channelName) {
+    helper.restTestOnJsonMsgpack('history_simple', async function (rest, channelName) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -52,7 +50,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       messages.forEach(function (msg) {
         ids[msg.id] = msg;
       });
-      expect(utils.keysArray(ids).length).to.equal(
+      expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
       );
@@ -63,7 +61,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * @spec RSL2
      * @spec RSL2a
      */
-    restTestOnJsonMsgpack('history_multiple', async function (rest, channelName) {
+    helper.restTestOnJsonMsgpack('history_multiple', async function (rest, channelName) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -80,7 +78,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       messages.forEach(function (msg) {
         ids[msg.id] = msg;
       });
-      expect(utils.keysArray(ids).length).to.equal(
+      expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
       );
@@ -91,7 +89,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
      * @spec RSL2b2
      * @specpartial RSL2b3 - should also test maximum supported limit of 1000
      */
-    restTestOnJsonMsgpack('history_simple_paginated_b', async function (rest, channelName) {
+    helper.restTestOnJsonMsgpack('history_simple_paginated_b', async function (rest, channelName) {
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -123,7 +121,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
         }
       }
       /* verify message ids are unique */
-      expect(utils.keysArray(ids).length).to.equal(
+      expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
       );
@@ -166,7 +164,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       }
 
       /* verify message ids are unique */
-      expect(utils.keysArray(ids).length).to.equal(
+      expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
       );
@@ -246,14 +244,14 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
       }
 
       /* verify message ids are unique */
-      expect(utils.keysArray(ids).length).to.equal(
+      expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
       );
     });
 
     /** @nospec */
-    restTestOnJsonMsgpack('history_encoding_errors', async function (rest, channelName) {
+    helper.restTestOnJsonMsgpack('history_encoding_errors', async function (rest, channelName) {
       var testchannel = rest.channels.get('persisted:' + channelName);
       var badMessage = { name: 'jsonUtf8string', encoding: 'json/utf-8', data: '{"foo":"bar"}' };
       testchannel.publish(badMessage);
@@ -266,7 +264,7 @@ define(['shared_helper', 'async', 'chai'], function (helper, async, chai) {
     });
 
     /** @specpartial TG4 - in the context of RestChannel#history */
-    restTestOnJsonMsgpack('history_no_next_page', async function (rest, channelName) {
+    helper.restTestOnJsonMsgpack('history_no_next_page', async function (rest, channelName) {
       const channel = rest.channels.get(channelName);
 
       const firstPage = await channel.history();

--- a/test/rest/history.test.js
+++ b/test/rest/history.test.js
@@ -51,6 +51,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       messages.forEach(function (msg) {
         ids[msg.id] = msg;
       });
+      helper.recordPrivateApi('call.Utils.keysArray');
       expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
@@ -79,6 +80,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       messages.forEach(function (msg) {
         ids[msg.id] = msg;
       });
+      helper.recordPrivateApi('call.Utils.keysArray');
       expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
@@ -122,6 +124,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
         }
       }
       /* verify message ids are unique */
+      helper.recordPrivateApi('call.Utils.keysArray');
       expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
@@ -166,6 +169,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       }
 
       /* verify message ids are unique */
+      helper.recordPrivateApi('call.Utils.keysArray');
       expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',
@@ -247,6 +251,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
       }
 
       /* verify message ids are unique */
+      helper.recordPrivateApi('call.Utils.keysArray');
       expect(helper.Utils.keysArray(ids).length).to.equal(
         testMessages.length,
         'Verify correct number of distinct message ids found',

--- a/test/rest/http.test.js
+++ b/test/rest/http.test.js
@@ -24,6 +24,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial RSC7d2 - tests Ably-Agent only for http
      */
     it('Should send X-Ably-Version and Ably-Agent headers in get/post requests', async function () {
+      const helper = this.test.helper;
       var originalDo = rest.http.do;
 
       // Intercept Http.do with test
@@ -34,6 +35,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
         // This test should not directly validate version against Defaults.version, as
         // ultimately the version header has been derived from that value.
         expect(headers['X-Ably-Version']).to.equal('3', 'Verify current version number');
+        helper.recordPrivateApi('read.Defaults.version');
         expect(headers['Ably-Agent'].indexOf('ably-js/' + Defaults.version) > -1, 'Verify agent').to.be.ok;
         expect(headers['Ably-Agent'].indexOf('custom-agent/0.1.2') > -1, 'Verify custom agent').to.be.ok;
 
@@ -49,9 +51,11 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
           expect(headers['Ably-Agent'].indexOf('nodejs') > -1, 'Verify agent').to.be.ok;
         }
 
+        helper.recordPrivateApi('call.rest.http.do');
         return originalDo.call(rest.http, method, path, headers, body, params);
       }
 
+      helper.recordPrivateApi('replace.rest.http.do');
       rest.http.do = testRequestHandler;
 
       // Call all methods that use rest http calls
@@ -65,12 +69,14 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
 
     /** @nospec */
     it('Should handle no content responses', async function () {
+      const helper = this.test.helper;
       //Intercept Http.do with test
 
       async function testRequestHandler() {
         return { error: null, body: null, headers: { 'X-Ably-Foo': 'headerValue' }, unpacked: false, statusCode: 204 };
       }
 
+      helper.recordPrivateApi('replace.rest.http.do');
       rest.http.do = testRequestHandler;
 
       const response = await rest.request('GET', '/foo', {}, null, {});

--- a/test/rest/http.test.js
+++ b/test/rest/http.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
-  const helper = new Helper();
-
   var rest;
   var expect = chai.expect;
   var Defaults = Ably.Rest.Platform.Defaults;
@@ -10,6 +8,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
   describe('rest/http', function () {
     this.timeout(60 * 1000);
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function () {
         rest = helper.AblyRest({
           agents: {

--- a/test/rest/http.test.js
+++ b/test/rest/http.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
+define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
+  const helper = new Helper();
+
   var rest;
   var expect = chai.expect;
   var Defaults = Ably.Rest.Platform.Defaults;

--- a/test/rest/init.test.js
+++ b/test/rest/init.test.js
@@ -26,6 +26,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       var keyStr = helper.getTestApp().keys[0].keyStr;
       var rest = new helper.Ably.Rest(keyStr);
 
+      helper.recordPrivateApi('read.rest.options.key');
       expect(rest.options.key).to.equal(keyStr);
     });
 
@@ -43,6 +44,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       var tokenStr = tokenDetails.token,
         rest = new helper.Ably.Rest(tokenStr);
 
+      helper.recordPrivateApi('read.rest.options.token');
       expect(rest.options.token).to.equal(tokenStr);
     });
 
@@ -55,6 +57,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
     it('Init with tls: false', function () {
       const helper = this.test.helper;
       var rest = helper.AblyRest({ tls: false, port: 123, tlsPort: 456 });
+      helper.recordPrivateApi('call.rest.baseUri');
       expect(rest.baseUri('example.com')).to.equal('http://example.com:123');
     });
 
@@ -66,6 +69,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
     it('Init with tls: true', function () {
       const helper = this.test.helper;
       var rest = helper.AblyRest({ tls: true, port: 123, tlsPort: 456 });
+      helper.recordPrivateApi('call.rest.baseUri');
       expect(rest.baseUri('example.com')).to.equal('https://example.com:456');
     });
 
@@ -80,6 +84,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
     it('Init without any tls key should enable tls', function () {
       const helper = this.test.helper;
       var rest = helper.AblyRest({ port: 123, tlsPort: 456 });
+      helper.recordPrivateApi('call.rest.baseUri');
       expect(rest.baseUri('example.com')).to.equal('https://example.com:456');
     });
 

--- a/test/rest/init.test.js
+++ b/test/rest/init.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai'], function (Ably, helper, chai) {
+define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
 
   describe('rest/init', function () {

--- a/test/rest/init.test.js
+++ b/test/rest/init.test.js
@@ -1,14 +1,13 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
 
   describe('rest/init', function () {
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -23,6 +22,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial RSC1c - test with key string
      */
     it('Init with key string', function () {
+      const helper = this.test.helper;
       var keyStr = helper.getTestApp().keys[0].keyStr;
       var rest = new helper.Ably.Rest(keyStr);
 
@@ -34,6 +34,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @specpartial RSC1c - test with token string
      */
     it('Init with token string', async function () {
+      const helper = this.test.helper;
       /* first generate a token ... */
       var rest = helper.AblyRest();
       var testKeyOpts = { key: helper.getTestApp().keys[1].keyStr };
@@ -52,6 +53,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec TO3k5
      */
     it('Init with tls: false', function () {
+      const helper = this.test.helper;
       var rest = helper.AblyRest({ tls: false, port: 123, tlsPort: 456 });
       expect(rest.baseUri('example.com')).to.equal('http://example.com:123');
     });
@@ -62,6 +64,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec TO3k5
      */
     it('Init with tls: true', function () {
+      const helper = this.test.helper;
       var rest = helper.AblyRest({ tls: true, port: 123, tlsPort: 456 });
       expect(rest.baseUri('example.com')).to.equal('https://example.com:456');
     });
@@ -75,6 +78,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      */
 
     it('Init without any tls key should enable tls', function () {
+      const helper = this.test.helper;
       var rest = helper.AblyRest({ port: 123, tlsPort: 456 });
       expect(rest.baseUri('example.com')).to.equal('https://example.com:456');
     });
@@ -85,6 +89,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
      * @spec RSA15c
      */
     it("Init with clientId set to '*' or anything other than a string or null should error", function () {
+      const helper = this.test.helper;
       expect(function () {
         var rest = helper.AblyRest({ clientId: '*' });
       }, 'Check can’t init library with a wildcard clientId').to.throw;

--- a/test/rest/message.test.js
+++ b/test/rest/message.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var noop = function () {};
 

--- a/test/rest/message.test.js
+++ b/test/rest/message.test.js
@@ -30,10 +30,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channel = rest.channels.get('rest_implicit_client_id_0');
 
       var originalPublish = channel._publish;
+      helper.recordPrivateApi('replace.restChannel._publish');
       channel._publish = async function (requestBody) {
         var message = JSON.parse(requestBody)[0];
         expect(message.name === 'event0', 'Outgoing message interecepted').to.be.ok;
         expect(!message.clientId, 'client ID is not added by the client library as it is implicit').to.be.ok;
+        helper.recordPrivateApi('call.restChannel._publish');
         return originalPublish.apply(channel, arguments);
       };
 
@@ -57,6 +59,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channel = rest.channels.get('rest_explicit_client_id_0');
 
       var originalPublish = channel._publish;
+      helper.recordPrivateApi('replace.restChannel._publish');
       channel._publish = async function (requestBody) {
         var message = JSON.parse(requestBody)[0];
         expect(message.name === 'event0', 'Outgoing message interecepted').to.be.ok;
@@ -64,6 +67,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           message.clientId == clientId,
           'client ID is added by the client library as it is explicit in the publish',
         ).to.be.ok;
+        helper.recordPrivateApi('call.restChannel._publish');
         return originalPublish.apply(channel, arguments);
       };
 
@@ -92,6 +96,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channel = rest.channels.get('rest_explicit_client_id_1');
 
       var originalPublish = channel._publish;
+      helper.recordPrivateApi('replace.restChannel._publish');
       channel._publish = async function (requestBody) {
         var message = JSON.parse(requestBody)[0];
         expect(message.name === 'event0', 'Outgoing message interecepted').to.be.ok;
@@ -99,6 +104,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           message.clientId == invalidClientId,
           'invalid client ID is added by the client library as it is explicit in the publish',
         ).to.be.ok;
+        helper.recordPrivateApi('call.restChannel._publish');
         return originalPublish.apply(channel, arguments);
       };
 
@@ -180,6 +186,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         originalPublish = channel._publish,
         originalDoUri = Ably.Realtime._Http.doUri;
 
+      helper.recordPrivateApi('replace.restChannel._publish');
       channel._publish = async function (requestBody) {
         var messageOne = JSON.parse(requestBody)[0];
         var messageTwo = JSON.parse(requestBody)[1];
@@ -191,11 +198,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         expect(idTwo, 'id set on message 2').to.be.ok;
         expect(idOne && idOne.split(':')[1]).to.equal('0', 'check zero-based index');
         expect(idTwo && idTwo.split(':')[1]).to.equal('1', 'check zero-based index');
+        helper.recordPrivateApi('call.restChannel._publish');
         return originalPublish.apply(channel, arguments);
       };
 
+      helper.recordPrivateApi('replace.http.doUri');
       Ably.Rest._Http.doUri = async function (method, uri, headers, body, params) {
+        helper.recordPrivateApi('call.http.doUri');
         const resultPromise = originalDoUri(method, uri, headers, body, params);
+        helper.recordPrivateApi('replace.http.doUri');
         Ably.Rest._Http.doUri = originalDoUri;
         const result = await resultPromise;
         if (result.error) {
@@ -232,8 +243,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       var originalPublish = channel._publish;
 
       /* Stub out _publish to check params */
+      helper.recordPrivateApi('replace.restChannel._publish');
       channel._publish = async function (requestBody, headers, params) {
         expect(params && params.testParam).to.equal('testParamValue');
+        helper.recordPrivateApi('call.restChannel._publish');
         return originalPublish.apply(channel, arguments);
       };
 

--- a/test/rest/message.test.js
+++ b/test/rest/message.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var expect = chai.expect;
   var noop = function () {};
 
@@ -10,6 +8,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -25,7 +24,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSL1m1
      */
     it('Should implicitly send clientId when authenticated with clientId', async function () {
-      var clientId = 'implicit_client_id_0',
+      var helper = this.test.helper,
+        clientId = 'implicit_client_id_0',
         rest = helper.AblyRest({ clientId: clientId, useBinaryProtocol: false }),
         channel = rest.channels.get('rest_implicit_client_id_0');
 
@@ -51,7 +51,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSL1m2
      */
     it('Should publish clientId when provided explicitly in message', async function () {
-      var clientId = 'explicit_client_id_0',
+      var helper = this.test.helper,
+        clientId = 'explicit_client_id_0',
         rest = helper.AblyRest({ clientId: clientId, useBinaryProtocol: false }),
         channel = rest.channels.get('rest_explicit_client_id_0');
 
@@ -79,7 +80,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSL1m4
      */
     it('Should error when clientId sent in message is different than authenticated clientId', async function () {
-      var clientId = 'explicit_client_id_0',
+      var helper = this.test.helper,
+        clientId = 'explicit_client_id_0',
         invalidClientId = 'invalid';
 
       var token = await helper.AblyRest().auth.requestToken({ clientId: clientId });
@@ -118,7 +120,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it('Should error when publishing message larger than maxMessageSize', async function () {
       /* No connectionDetails mechanism for REST, so just pass the override into the constructor */
-      var realtime = helper.AblyRest({ maxMessageSize: 64 }),
+      var helper = this.test.helper,
+        realtime = helper.AblyRest({ maxMessageSize: 64 }),
         channel = realtime.channels.get('maxMessageSize');
 
       try {
@@ -140,7 +143,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSL1k5
      */
     it('Should send correct IDs when idempotentRestPublishing set to false', async function () {
-      var rest = helper.AblyRest({ idempotentRestPublishing: false, useBinaryProtocol: false }),
+      var helper = this.test.helper,
+        rest = helper.AblyRest({ idempotentRestPublishing: false, useBinaryProtocol: false }),
         channel = rest.channels.get('idempotent_rest_publishing'),
         message = { name: 'test', id: 'idempotent-msg-id:0' };
 
@@ -160,7 +164,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      */
     it('Should add IDs when automatic idempotent rest publishing option enabled', async function () {
       /* easiest way to get the host we're using for tests */
-      var dummyRest = helper.AblyRest(),
+      var helper = this.test.helper,
+        dummyRest = helper.AblyRest(),
         host = dummyRest.options.restHost,
         /* Add the same host as a bunch of fallback hosts, so after the first
          * request 'fails' we retry on the same host using the fallback mechanism */
@@ -220,7 +225,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSL1e - test only passing null to the function
      */
     it('Rest publish params', async function () {
-      var rest = helper.AblyRest(),
+      var helper = this.test.helper,
+        rest = helper.AblyRest(),
         channel = rest.channels.get('publish_params');
 
       var originalPublish = channel._publish;

--- a/test/rest/presence.test.js
+++ b/test/rest/presence.test.js
@@ -7,13 +7,15 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
   var Crypto = Ably.Realtime.Platform.Crypto;
   var BufferUtils = Ably.Realtime.Platform.BufferUtils;
 
-  function cipherParamsFromConfig(cipherConfig) {
+  function cipherParamsFromConfig(cipherConfig, helper) {
+    helper.recordPrivateApi('new.Crypto.CipherParams');
     var cipherParams = new Crypto.CipherParams();
     for (var prop in cipherConfig) {
       cipherParams[prop] = cipherConfig[prop];
     }
     cipherParams.keyLength = cipherConfig.keylength;
     delete cipherParams.keylength; // grr case differences
+    helper.recordPrivateApi('call.BufferUtils.base64Decode');
     cipherParams.key = BufferUtils.base64Decode(cipherParams.key);
     cipherParams.iv = BufferUtils.base64Decode(cipherParams.iv);
     return cipherParams;
@@ -33,7 +35,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     function presence_simple(operation) {
       return async function () {
-        var cipherParams = cipherParamsFromConfig(cipherConfig);
+        const helper = this.test.helper.withParameterisedTestTitle('presence_simple');
+        var cipherParams = cipherParamsFromConfig(cipherConfig, helper);
         var channel = rest.channels.get('persisted:presence_fixtures', { cipher: cipherParams });
         var resultPage = await channel.presence[operation]();
         var presenceMessages = resultPage.items;

--- a/test/rest/presence.test.js
+++ b/test/rest/presence.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var rest;
   var cipherConfig;
   var expect = chai.expect;

--- a/test/rest/presence.test.js
+++ b/test/rest/presence.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var rest;
   var cipherConfig;
   var expect = chai.expect;
@@ -25,6 +23,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function () {
         rest = helper.AblyRest();
         cipherConfig = helper.getTestApp().cipherConfig;

--- a/test/rest/push.test.js
+++ b/test/rest/push.test.js
@@ -2,12 +2,14 @@
 
 define(['ably', 'shared_helper', 'async', 'chai', 'test/support/push_channel_transport', 'push'], function (
   Ably,
-  helper,
+  Helper,
   async,
   chai,
   pushChannelTransport,
   PushPlugin,
 ) {
+  const helper = new Helper();
+
   var expect = chai.expect;
   var originalPushConfig = Ably.Realtime.Platform.Config.push;
 
@@ -405,7 +407,7 @@ define(['ably', 'shared_helper', 'async', 'chai', 'test/support/push_channel_tra
             }
           })
           .then(() => {
-            helper.whenPromiseSettles(realtime.push.admin.publish(pushRecipient, pushPayload), function (err) {
+            Helper.whenPromiseSettles(realtime.push.admin.publish(pushRecipient, pushPayload), function (err) {
               if (err) {
                 helper.closeAndFinish(done, realtime, err);
               }

--- a/test/rest/push.test.js
+++ b/test/rest/push.test.js
@@ -8,10 +8,7 @@ define(['ably', 'shared_helper', 'async', 'chai', 'test/support/push_channel_tra
   pushChannelTransport,
   PushPlugin,
 ) {
-  var Utils = helper.Utils;
   var expect = chai.expect;
-  var closeAndFinish = helper.closeAndFinish;
-  var whenPromiseSettles = helper.whenPromiseSettles;
   var originalPushConfig = Ably.Realtime.Platform.Config.push;
 
   function PushRealtime(options) {
@@ -402,15 +399,15 @@ define(['ably', 'shared_helper', 'async', 'chai', 'test/support/push_channel_tra
               expect(receivedPushPayload.data).to.deep.equal(pushPayload.data);
               expect(receivedPushPayload.notification.title).to.equal(pushPayload.notification.title);
               expect(receivedPushPayload.notification.body).to.equal(pushPayload.notification.body);
-              closeAndFinish(done, realtime);
+              helper.closeAndFinish(done, realtime);
             } catch (err) {
-              closeAndFinish(done, realtime, err);
+              helper.closeAndFinish(done, realtime, err);
             }
           })
           .then(() => {
-            whenPromiseSettles(realtime.push.admin.publish(pushRecipient, pushPayload), function (err) {
+            helper.whenPromiseSettles(realtime.push.admin.publish(pushRecipient, pushPayload), function (err) {
               if (err) {
-                closeAndFinish(done, realtime, err);
+                helper.closeAndFinish(done, realtime, err);
               }
             });
           });

--- a/test/rest/request.test.js
+++ b/test/rest/request.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
+define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
+  const helper = new Helper();
+
   var rest;
   var expect = chai.expect;
   var echoServerHost = 'echo.ably.io';
@@ -27,7 +29,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSC7e - tests providing a version value in .request parameters
      * @specpartial CSV2c - tests version is provided in http requests
      */
-    helper.restTestOnJsonMsgpack('request_version', function (rest) {
+    Helper.restTestOnJsonMsgpack('request_version', function (rest) {
       const version = 150; // arbitrarily chosen
 
       async function testRequestHandler(_, __, headers) {
@@ -54,7 +56,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec HP5
      * @specpartial RSC19f - basic test for passing a http method, path and version parameters
      */
-    helper.restTestOnJsonMsgpack('request_time', async function (rest) {
+    Helper.restTestOnJsonMsgpack('request_time', async function (rest) {
       const res = await rest.request('get', '/time', 3, null, null, null);
       expect(res.statusCode).to.equal(200, 'Check statusCode');
       expect(res.success).to.equal(true, 'Check success');
@@ -70,7 +72,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec HP6
      * @spec HP7
      */
-    helper.restTestOnJsonMsgpack('request_404', async function (rest) {
+    Helper.restTestOnJsonMsgpack('request_404', async function (rest) {
       /* NB: can't just use /invalid or something as the CORS preflight will
        * fail. Need something superficially a valid path but where the actual
        * request fails */
@@ -107,7 +109,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial HP2 - tests overriden .next method only
      * @specpartial RSC19f - more tests with passing other methods, body and parameters
      */
-    helper.restTestOnJsonMsgpack('request_post_get_messages', async function (rest, channelName) {
+    Helper.restTestOnJsonMsgpack('request_post_get_messages', async function (rest, channelName) {
       var channelPath = '/channels/' + channelName + '/messages',
         msgone = { name: 'faye', data: 'whittaker' },
         msgtwo = { name: 'martin', data: 'reed' };
@@ -152,7 +154,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec HP7
      * @specpartial RSC19f - more tests with POST method and passing body
      */
-    helper.restTestOnJsonMsgpack('request_batch_api_success', async function (rest, name) {
+    Helper.restTestOnJsonMsgpack('request_batch_api_success', async function (rest, name) {
       var body = { channels: [name + '1', name + '2'], messages: { data: 'foo' } };
 
       const res = await rest.request('POST', '/messages', 2, {}, body, {});
@@ -183,7 +185,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSC19f - more tests with POST method and passing body
      * @specskip
      */
-    helper.restTestOnJsonMsgpack.skip('request_batch_api_partial_success', async function (rest, name) {
+    Helper.restTestOnJsonMsgpack.skip('request_batch_api_partial_success', async function (rest, name) {
       var body = { channels: [name, '[invalid', ''], messages: { data: 'foo' } };
 
       var res = await rest.request('POST', '/messages', 2, {}, body, {});

--- a/test/rest/request.test.js
+++ b/test/rest/request.test.js
@@ -28,7 +28,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSC7e - tests providing a version value in .request parameters
      * @specpartial CSV2c - tests version is provided in http requests
      */
-    Helper.restTestOnJsonMsgpack('request_version', function (rest) {
+    Helper.restTestOnJsonMsgpack('request_version', function (rest, _, helper) {
       const version = 150; // arbitrarily chosen
 
       async function testRequestHandler(_, __, headers) {
@@ -42,6 +42,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         return new Promise(() => {});
       }
 
+      helper.recordPrivateApi('replace.rest.http.do');
       rest.http.do = testRequestHandler;
 
       rest.request('get', '/time' /* arbitrarily chosen */, version, null, null, null);
@@ -212,7 +213,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     ['put', 'patch', 'delete'].forEach(function (method) {
       /** @specpartial RSC19f - tests put, patch, delete methods are supported */
       it('check' + method, async function () {
-        const helper = this.test.helper;
+        const helper = this.test.helper.withParameterisedTestTitle('check');
         var restEcho = helper.AblyRest({ useBinaryProtocol: false, restHost: echoServerHost, tls: true });
         var res = await restEcho.request(method, '/methods', 3, {}, {}, {});
         expect(res.items[0] && res.items[0].method).to.equal(method);

--- a/test/rest/request.test.js
+++ b/test/rest/request.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const helper = new Helper();
-
   var rest;
   var expect = chai.expect;
   var echoServerHost = 'echo.ably.io';
@@ -12,6 +10,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     this.timeout(60 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);
@@ -88,6 +87,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSC19e
      */
     it('request_network_error', async function () {
+      const helper = this.test.helper;
       rest = helper.AblyRest({ restHost: helper.unroutableAddress });
       try {
         var res = await rest.request('get', '/time', 3, null, null, null);
@@ -212,6 +212,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     ['put', 'patch', 'delete'].forEach(function (method) {
       /** @specpartial RSC19f - tests put, patch, delete methods are supported */
       it('check' + method, async function () {
+        const helper = this.test.helper;
         var restEcho = helper.AblyRest({ useBinaryProtocol: false, restHost: echoServerHost, tls: true });
         var res = await restEcho.request(method, '/methods', 3, {}, {}, {});
         expect(res.items[0] && res.items[0].method).to.equal(method);

--- a/test/rest/request.test.js
+++ b/test/rest/request.test.js
@@ -3,9 +3,7 @@
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async, chai) {
   var rest;
   var expect = chai.expect;
-  var utils = helper.Utils;
   var echoServerHost = 'echo.ably.io';
-  var restTestOnJsonMsgpack = helper.restTestOnJsonMsgpack;
   var Defaults = Ably.Rest.Platform.Defaults;
 
   describe('rest/request', function () {
@@ -29,7 +27,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSC7e - tests providing a version value in .request parameters
      * @specpartial CSV2c - tests version is provided in http requests
      */
-    restTestOnJsonMsgpack('request_version', function (rest) {
+    helper.restTestOnJsonMsgpack('request_version', function (rest) {
       const version = 150; // arbitrarily chosen
 
       async function testRequestHandler(_, __, headers) {
@@ -56,7 +54,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec HP5
      * @specpartial RSC19f - basic test for passing a http method, path and version parameters
      */
-    restTestOnJsonMsgpack('request_time', async function (rest) {
+    helper.restTestOnJsonMsgpack('request_time', async function (rest) {
       const res = await rest.request('get', '/time', 3, null, null, null);
       expect(res.statusCode).to.equal(200, 'Check statusCode');
       expect(res.success).to.equal(true, 'Check success');
@@ -72,7 +70,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec HP6
      * @spec HP7
      */
-    restTestOnJsonMsgpack('request_404', async function (rest) {
+    helper.restTestOnJsonMsgpack('request_404', async function (rest) {
       /* NB: can't just use /invalid or something as the CORS preflight will
        * fail. Need something superficially a valid path but where the actual
        * request fails */
@@ -109,7 +107,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial HP2 - tests overriden .next method only
      * @specpartial RSC19f - more tests with passing other methods, body and parameters
      */
-    restTestOnJsonMsgpack('request_post_get_messages', async function (rest, channelName) {
+    helper.restTestOnJsonMsgpack('request_post_get_messages', async function (rest, channelName) {
       var channelPath = '/channels/' + channelName + '/messages',
         msgone = { name: 'faye', data: 'whittaker' },
         msgtwo = { name: 'martin', data: 'reed' };
@@ -154,7 +152,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @spec HP7
      * @specpartial RSC19f - more tests with POST method and passing body
      */
-    restTestOnJsonMsgpack('request_batch_api_success', async function (rest, name) {
+    helper.restTestOnJsonMsgpack('request_batch_api_success', async function (rest, name) {
       var body = { channels: [name + '1', name + '2'], messages: { data: 'foo' } };
 
       const res = await rest.request('POST', '/messages', 2, {}, body, {});
@@ -185,7 +183,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, helper, async
      * @specpartial RSC19f - more tests with POST method and passing body
      * @specskip
      */
-    restTestOnJsonMsgpack.skip('request_batch_api_partial_success', async function (rest, name) {
+    helper.restTestOnJsonMsgpack.skip('request_batch_api_partial_success', async function (rest, name) {
       var body = { channels: [name, '[invalid', ''], messages: { data: 'foo' } };
 
       var res = await rest.request('POST', '/messages', 2, {}, body, {});

--- a/test/rest/stats.test.js
+++ b/test/rest/stats.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'chai'], function (helper, chai) {
+define(['shared_helper', 'chai'], function (Helper, chai) {
+  const helper = new Helper();
+
   var rest;
   var expect = chai.expect;
 

--- a/test/rest/stats.test.js
+++ b/test/rest/stats.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'chai'], function (Helper, chai) {
-  const helper = new Helper();
-
   var rest;
   var expect = chai.expect;
 
@@ -65,6 +63,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
 
     before(function (done) {
       // force a new app to be created with first argument true so that stats are not effected by other tests
+      const helper = Helper.forHook(this);
       helper.setupApp(true, function () {
         rest = helper.AblyRest();
         helper.createStats(helper.getTestApp(), statsFixtures, function (err) {

--- a/test/rest/status.test.js
+++ b/test/rest/status.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 define(['shared_helper', 'chai'], function (Helper, chai) {
-  const helper = new Helper();
-
   var rest;
   var expect = chai.expect;
 
@@ -10,6 +8,7 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
     this.timeout(30 * 1000);
 
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);

--- a/test/rest/status.test.js
+++ b/test/rest/status.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'chai'], function (helper, chai) {
+define(['shared_helper', 'chai'], function (Helper, chai) {
+  const helper = new Helper();
+
   var rest;
   var expect = chai.expect;
 
@@ -33,7 +35,7 @@ define(['shared_helper', 'chai'], function (helper, chai) {
      * @spec CHM2e
      * @spec CHM2f
      */
-    helper.restTestOnJsonMsgpack('status0', async function (rest) {
+    Helper.restTestOnJsonMsgpack('status0', async function (rest) {
       var channel = rest.channels.get('status0');
       var channelDetails = await channel.status();
       expect(channelDetails.channelId).to.equal('status0');

--- a/test/rest/status.test.js
+++ b/test/rest/status.test.js
@@ -2,9 +2,7 @@
 
 define(['shared_helper', 'chai'], function (helper, chai) {
   var rest;
-  var utils = helper.Utils;
   var expect = chai.expect;
-  var restTestOnJsonMsgpack = helper.restTestOnJsonMsgpack;
 
   describe('rest/status', function () {
     this.timeout(30 * 1000);
@@ -35,7 +33,7 @@ define(['shared_helper', 'chai'], function (helper, chai) {
      * @spec CHM2e
      * @spec CHM2f
      */
-    restTestOnJsonMsgpack('status0', async function (rest) {
+    helper.restTestOnJsonMsgpack('status0', async function (rest) {
       var channel = rest.channels.get('status0');
       var channelDetails = await channel.status();
       expect(channelDetails.channelId).to.equal('status0');

--- a/test/rest/time.test.js
+++ b/test/rest/time.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 define(['shared_helper', 'chai'], function (Helper, chai) {
-  const helper = new Helper();
-
   var rest;
   var expect = chai.expect;
 
   describe('rest/time', function () {
     before(function (done) {
+      const helper = Helper.forHook(this);
       helper.setupApp(function (err) {
         if (err) {
           done(err);

--- a/test/rest/time.test.js
+++ b/test/rest/time.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-define(['shared_helper', 'chai'], function (helper, chai) {
+define(['shared_helper', 'chai'], function (Helper, chai) {
+  const helper = new Helper();
+
   var rest;
   var expect = chai.expect;
 

--- a/test/support/junit_directory_path.js
+++ b/test/support/junit_directory_path.js
@@ -1,3 +1,0 @@
-const path = require('path');
-
-module.exports = path.join(__dirname, '..', '..', 'junit');

--- a/test/support/mocha_reporter.js
+++ b/test/support/mocha_reporter.js
@@ -1,7 +1,7 @@
 const Mocha = require('mocha');
 const MochaJUnitReporter = require('mocha-junit-reporter');
 const path = require('path');
-const jUnitDirectoryPath = require('./junit_directory_path');
+const outputDirectoryPaths = require('./output_directory_paths');
 
 /**
  * Logs test results to the console (by extending the default `Spec` reporter) and also emits a JUnit XML file.
@@ -12,7 +12,7 @@ class Reporter extends Mocha.reporters.Spec {
   constructor(runner, options) {
     super(runner, options);
     const jUnitFileName = `node-${process.version.split('.')[0]}.junit`;
-    const jUnitFilePath = path.join(jUnitDirectoryPath, jUnitFileName);
+    const jUnitFilePath = path.join(outputDirectoryPaths.jUnit, jUnitFileName);
     this.jUnitReporter = new MochaJUnitReporter(runner, { reporterOptions: { mochaFile: jUnitFilePath } });
   }
 }

--- a/test/support/output_directory_paths.js
+++ b/test/support/output_directory_paths.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  jUnit: path.join(__dirname, '..', '..', 'junit'),
+  privateApiUsage: path.join(__dirname, '..', '..', 'private-api-usage'),
+};

--- a/test/support/playwrightSetup.js
+++ b/test/support/playwrightSetup.js
@@ -17,6 +17,7 @@ class CustomEventReporter extends Mocha.reporters.HTML {
   jUnitReporter;
   jUnitReport;
   testResultStats;
+  privateApiUsageData;
 
   constructor(runner) {
     super(runner);
@@ -53,6 +54,11 @@ class CustomEventReporter extends Mocha.reporters.HTML {
         this.testResultStats = runner.stats;
         this.gotResults();
       });
+
+    window.addEventListener('privateApiUsageData', ({ detail }) => {
+      this.privateApiUsageData = detail;
+      this.gotResults();
+    });
   }
 
   logToNodeConsole(text) {
@@ -72,7 +78,7 @@ class CustomEventReporter extends Mocha.reporters.HTML {
   }
 
   gotResults() {
-    if (!this.testResultStats || !this.jUnitReport) {
+    if (!this.testResultStats || !this.jUnitReport || !this.privateApiUsageData) {
       return;
     }
 
@@ -83,6 +89,7 @@ class CustomEventReporter extends Mocha.reporters.HTML {
           passes: this.testResultStats.passes,
           total: this.testResultStats.passes + this.testResultStats.failures,
           jUnitReport: this.jUnitReport,
+          privateApiUsageData: this.privateApiUsageData,
         },
       }),
     );

--- a/test/support/root_hooks.js
+++ b/test/support/root_hooks.js
@@ -1,4 +1,6 @@
-define(['shared_helper'], function (helper) {
+define(['shared_helper'], function (Helper) {
+  const helper = new Helper();
+
   after(function (done) {
     this.timeout(10 * 1000);
     helper.tearDownApp(function (err) {
@@ -10,8 +12,16 @@ define(['shared_helper'], function (helper) {
     });
   });
 
-  afterEach(helper.closeActiveClients);
-  afterEach(helper.logTestResults);
-  afterEach(helper.flushTestLogs);
-  beforeEach(helper.clearTransportPreference);
+  afterEach(function () {
+    helper.closeActiveClients();
+  });
+  afterEach(function () {
+    helper.logTestResults(this);
+  });
+  afterEach(function () {
+    helper.flushTestLogs();
+  });
+  beforeEach(function () {
+    helper.clearTransportPreference();
+  });
 });

--- a/test/support/root_hooks.js
+++ b/test/support/root_hooks.js
@@ -9,6 +9,7 @@ define(['shared_helper'], function (Helper) {
       }
       done();
     });
+    helper.dumpPrivateApiUsage();
   });
 
   afterEach(function () {
@@ -22,6 +23,7 @@ define(['shared_helper'], function (Helper) {
   });
   beforeEach(function () {
     this.currentTest.helper = Helper.forTest(this);
+    this.currentTest.helper.recordTestStart();
   });
   beforeEach(function () {
     this.currentTest.helper.clearTransportPreference();

--- a/test/support/root_hooks.js
+++ b/test/support/root_hooks.js
@@ -1,7 +1,6 @@
 define(['shared_helper'], function (Helper) {
-  const helper = new Helper();
-
   after(function (done) {
+    const helper = Helper.forHook(this);
     this.timeout(10 * 1000);
     helper.tearDownApp(function (err) {
       if (err) {
@@ -13,15 +12,18 @@ define(['shared_helper'], function (Helper) {
   });
 
   afterEach(function () {
-    helper.closeActiveClients();
+    this.currentTest.helper.closeActiveClients();
   });
   afterEach(function () {
-    helper.logTestResults(this);
+    this.currentTest.helper.logTestResults(this);
   });
   afterEach(function () {
-    helper.flushTestLogs();
+    this.currentTest.helper.flushTestLogs();
   });
   beforeEach(function () {
-    helper.clearTransportPreference();
+    this.currentTest.helper = Helper.forTest(this);
+  });
+  beforeEach(function () {
+    this.currentTest.helper.clearTransportPreference();
   });
 });

--- a/test/support/runPlaywrightTests.js
+++ b/test/support/runPlaywrightTests.js
@@ -2,7 +2,7 @@ const playwright = require('playwright');
 const path = require('path');
 const MochaServer = require('../web_server');
 const fs = require('fs');
-const jUnitDirectoryPath = require('./junit_directory_path');
+const outputDirectoryPaths = require('./output_directory_paths');
 
 const port = process.env.PORT || 3000;
 const host = 'localhost';
@@ -33,13 +33,28 @@ const runTests = async (browserType) => {
       console.log(`${browserType.name()} tests complete: ${detail.passes}/${detail.total} passed`);
 
       try {
-        if (!fs.existsSync(jUnitDirectoryPath)) {
-          fs.mkdirSync(jUnitDirectoryPath);
+        if (!fs.existsSync(outputDirectoryPaths.jUnit)) {
+          fs.mkdirSync(outputDirectoryPaths.jUnit);
         }
         const filename = `playwright-${browserType.name()}.junit`;
-        fs.writeFileSync(path.join(jUnitDirectoryPath, filename), detail.jUnitReport, { encoding: 'utf-8' });
+        fs.writeFileSync(path.join(outputDirectoryPaths.jUnit, filename), detail.jUnitReport, { encoding: 'utf-8' });
       } catch (err) {
         console.log('Failed to write JUnit report, exiting with code 2: ', err);
+        process.exit(2);
+      }
+
+      try {
+        if (!fs.existsSync(outputDirectoryPaths.privateApiUsage)) {
+          fs.mkdirSync(outputDirectoryPaths.privateApiUsage);
+        }
+        const filename = `playwright-${browserType.name()}.json`;
+        fs.writeFileSync(
+          path.join(outputDirectoryPaths.privateApiUsage, filename),
+          JSON.stringify(detail.privateApiUsageData),
+          { encoding: 'utf-8' },
+        );
+      } catch (err) {
+        console.log('Failed to write private API usage data, exiting with code 2: ', err);
         process.exit(2);
       }
 


### PR DESCRIPTION
This PR collects data about the usage of private APIs in the test suite, and uses this data to generate some reports. We’ll use these reports to guide our work of converting the ably-js test suite into a unified test suite for all of our client libraries. See commit messages for more details.

Resolves [ECO-4821](https://ably.atlassian.net/browse/ECO-4821), resolves [ECO-4834](https://ably.atlassian.net/browse/ECO-4834).

[ECO-4821]: https://ably.atlassian.net/browse/ECO-4821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ECO-4834]: https://ably.atlassian.net/browse/ECO-4834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ