### PR TITLE
types: ErrorInfo should implement Error

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2769,7 +2769,7 @@ export declare class Realtime implements RealtimeClient {
 /**
  * A generic Ably error object that contains an Ably-specific status code, and a generic status code. Errors returned from the Ably server are compatible with the `ErrorInfo` structure and should result in errors that inherit from `ErrorInfo`.
  */
-export declare class ErrorInfo {
+export declare class ErrorInfo extends Error {
   /**
    * Ably [error code](https://github.com/ably/ably-common/blob/main/protocol/errors.json).
    */


### PR DESCRIPTION
Changes our type defs so that `ErrorInfo` implements `Error`. This will allow us to `throw ErrorInfo` in stricter typescript environments that require anything thrown to implement `Error`.