### PR TITLE
[ECO-4852] Gather spec items coverage information

### DIFF
--- a/.github/workflows/spec-coverage-report.yml
+++ b/.github/workflows/spec-coverage-report.yml
@@ -1,0 +1,25 @@
+name: Spec coverage report
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  spec-coverage-report:
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20.x
+      - run: npm ci
+      - run: npm run speccoveragereport

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-security": "^1.4.0",
         "express": "^4.17.1",
-        "glob": "~4.4",
+        "glob": "^10.4.2",
         "grunt": "^1.6.1",
         "grunt-cli": "~1.2.0",
         "grunt-shell": "~1.1",
@@ -1232,6 +1232,102 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -1323,6 +1419,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -3354,6 +3460,12 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4893,6 +5005,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -5069,18 +5197,26 @@
       }
     },
     "node_modules/glob": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.2.tgz",
-      "integrity": "sha512-uDfQml82dlkWsiYk+CdoOdJe09vfPUjTFBM23krHsaFuaC5/o4A5bLX95h7ccc/Fs/JjC5DuMwPgiIzTBV5WpA==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dev": true,
       "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^2.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -5101,17 +5237,28 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-      "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.0.0"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-modules": {
@@ -6406,6 +6553,24 @@
         "set-function-name": "^2.0.1"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jake": {
       "version": "10.8.7",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
@@ -7087,6 +7252,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
@@ -7671,6 +7845,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7785,6 +7965,31 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
+      "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/path-to-regexp": {
@@ -8884,6 +9089,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -9094,6 +9311,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
@@ -9160,6 +9392,19 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -10739,6 +10984,24 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -11621,6 +11884,71 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -11695,6 +12023,13 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true
     },
     "@rollup/pluginutils": {
       "version": "4.2.1",
@@ -13249,6 +13584,12 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -14374,6 +14715,16 @@
         "for-in": "^1.0.1"
       }
     },
+    "foreground-child": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      }
+    },
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -14495,24 +14846,35 @@
       "dev": true
     },
     "glob": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.2.tgz",
-      "integrity": "sha512-uDfQml82dlkWsiYk+CdoOdJe09vfPUjTFBM23krHsaFuaC5/o4A5bLX95h7ccc/Fs/JjC5DuMwPgiIzTBV5WpA==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dev": true,
       "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^2.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "dependencies": {
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         }
       }
@@ -15470,6 +15832,16 @@
         "set-function-name": "^2.0.1"
       }
     },
+    "jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dev": true,
+      "requires": {
+        "@isaacs/cliui": "^8.0.2",
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "jake": {
       "version": "10.8.7",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
@@ -15990,6 +16362,12 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
+    "minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true
+    },
     "mkdirp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
@@ -16418,6 +16796,12 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -16503,6 +16887,24 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
       "dev": true
+    },
+    "path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
+          "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
+          "dev": true
+        }
+      }
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -17293,6 +17695,12 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true
+    },
     "skin-tone": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -17464,6 +17872,17 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "string.prototype.matchall": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
@@ -17516,6 +17935,15 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
@@ -18592,6 +19020,17 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "chai": "^4.2.0",
         "cli-table": "^0.3.11",
         "cors": "^2.8.5",
+        "dox": "^1.0.0",
         "esbuild": "^0.18.10",
         "esbuild-plugin-umd-wrapper": "ably-forks/esbuild-plugin-umd-wrapper#1.0.7-optional-amd-named-module",
         "esbuild-runner": "^2.2.2",
@@ -3324,6 +3325,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/dox": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dox/-/dox-1.0.0.tgz",
+      "integrity": "sha512-y0borLgGiqcXigOItzeBvWEPtZ5tkKMZ7MTa/9xhVCUz6sU1quXTTvbJGOLFZAu/4/nlj2Ui02A/tLqQFBXo+w==",
+      "dev": true,
+      "dependencies": {
+        "commander": "9.4.0",
+        "jsdoctypeparser": "^9.0.0",
+        "markdown-it": "13.0.1"
+      },
+      "bin": {
+        "dox": "bin/dox"
+      }
+    },
+    "node_modules/dox/node_modules/commander": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -6472,6 +6496,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "dev": true,
+      "bin": {
+        "jsdoctypeparser": "bin/jsdoctypeparser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jsdom": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
@@ -6687,6 +6723,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -6833,6 +6878,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/marked": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
@@ -6887,6 +6966,12 @@
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -9731,6 +9816,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "node_modules/ulid": {
       "version": "2.3.0",
@@ -13133,6 +13224,25 @@
         "webidl-conversions": "^7.0.0"
       }
     },
+    "dox": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dox/-/dox-1.0.0.tgz",
+      "integrity": "sha512-y0borLgGiqcXigOItzeBvWEPtZ5tkKMZ7MTa/9xhVCUz6sU1quXTTvbJGOLFZAu/4/nlj2Ui02A/tLqQFBXo+w==",
+      "dev": true,
+      "requires": {
+        "commander": "9.4.0",
+        "jsdoctypeparser": "^9.0.0",
+        "markdown-it": "13.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.4.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+          "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+          "dev": true
+        }
+      }
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -15430,6 +15540,12 @@
       "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true
     },
+    "jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "dev": true
+    },
     "jsdom": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
@@ -15599,6 +15715,15 @@
         }
       }
     },
+    "linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -15712,6 +15837,33 @@
       "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true
     },
+    "markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        }
+      }
+    },
     "marked": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
@@ -15750,6 +15902,12 @@
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -17834,6 +17992,12 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "ulid": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-security": "^1.4.0",
     "express": "^4.17.1",
-    "glob": "~4.4",
+    "glob": "^10.4.2",
     "grunt": "^1.6.1",
     "grunt-cli": "~1.2.0",
     "grunt-shell": "~1.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "chai": "^4.2.0",
     "cli-table": "^0.3.11",
     "cors": "^2.8.5",
+    "dox": "^1.0.0",
     "esbuild": "^0.18.10",
     "esbuild-plugin-umd-wrapper": "ably-forks/esbuild-plugin-umd-wrapper#1.0.7-optional-amd-named-module",
     "esbuild-runner": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "format:check": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore src test ably.d.ts modular.d.ts webpack.config.js Gruntfile.js scripts/*.[jt]s docs/**/*.md grunt",
     "sourcemap": "source-map-explorer build/ably.min.js",
     "modulereport": "tsc --noEmit --esModuleInterop scripts/moduleReport.ts && esr scripts/moduleReport.ts",
+    "speccoveragereport": "tsc --noEmit --esModuleInterop --target ES2017 --moduleResolution node scripts/specCoverageReport.ts && esr scripts/specCoverageReport.ts",
     "docs": "typedoc"
   }
 }

--- a/scripts/dox.d.ts
+++ b/scripts/dox.d.ts
@@ -1,0 +1,168 @@
+declare module 'dox' {
+  export interface ParseCommentOptions {
+    skipSingleStar?: boolean;
+    skipPrefixes?: string[];
+    raw?: boolean;
+  }
+
+  export interface CommentDescription {
+    full: string;
+    summary: string;
+    body: string;
+  }
+
+  export interface Comment {
+    /** array of tag objects */
+    tags: Tag[];
+    /** the first line of the comment */
+    description: CommentDescription;
+    /** true when "@api private" is used */
+    isPrivate: boolean;
+    isConstructor: boolean;
+    line: number;
+    /** lines following the description */
+    body: any;
+    /** both the description and the body */
+    content: any;
+    codeStart: number;
+    code: string;
+    ctx: ContextPatternMatchersCtx;
+    ignore: boolean;
+  }
+
+  export interface Tag {
+    string: string;
+    /** from "@param"/"@property"/"@template", name of parameter/property */
+    name?: string;
+    /** text after various tags */
+    description?: string;
+    /** from "@see", everything before "http" */
+    title?: string;
+    /** from "@see" */
+    url?: string;
+    /** from "@see" */
+    local?: string;
+    /** when "@api private" this field will be "private" (what is after "@api") and in case of "@protected"/"@public"/"@private" will be the tag itself */
+    visibility?: string;
+    /** the string after "@memberOf"/"@lends" */
+    parent?: string;
+    /** the string after "@extends"/"@implements"/"@augments" */
+    otherClass?: string;
+    /** from "@borrows" */
+    otherMemberName?: string;
+    /** from "@borrows" */
+    thisMemberName?: string;
+    /** all parsed types from tags that support it, like "@param" */
+    types?: string[];
+    /** from "@description" */
+    full?: string;
+    /** from "@description" */
+    summary?: string;
+    /** from "@description" */
+    body?: string;
+    typesDescription?: string;
+    /**
+     * "true" when the property is marked optional
+     * @example
+     * @param {string} [optionalProperty]
+     * @param {string} nonOptionalProperty
+     */
+    optional?: boolean;
+    /**
+     * "true" when the property is marked nullable
+     * @example
+     * @param {?string} nullable
+     * @param {string} normal
+     * @param {!string} nonNullable
+     */
+    nullable?: boolean;
+    /**
+     * "true" when the property is marked non-nullable
+     * @example
+     * @param {?string} nullable
+     * @param {string} normal
+     * @param {!string} nonNullable
+     */
+    nonNullable?: boolean;
+    /**
+     * "true" when using the spread type
+     * @example
+     * @param {...string} spread
+     * @param {string} nonSpread
+     */
+    variable?: boolean;
+  }
+
+  export function api(comments: Comment[]): string;
+  /** Parse comments in the given string of `js`. */
+  export function parseComments(js: string, options: ParseCommentOptions): Comment[];
+  /** Removes excess indentation from string of code. */
+  export function trimIndentation(str: string): string;
+  /**
+   * Parse the given comment `str`.
+   *
+   * The comment object returned contains the following
+   */
+  export function parseComment(str: string, options: ParseCommentOptions): any;
+  /**
+   * Extracts different parts of a tag by splitting string into pieces separated by whitespace. If the white spaces are
+   * somewhere between curly braces (which is used to indicate param/return type in JSDoc) they will not be used to split
+   * the string. This allows to specify jsdoc tags without the need to eliminate all white spaces i.e. {number | string}
+   */
+  export function extractTagParts(str: any): string[];
+  /** Parse tag string "@param {Array} name description" etc. */
+  export function parseTag(str: any): Tag;
+  /**
+   * Parse tag type string "{Array|Object}" etc.
+   * This function also supports complex type descriptors like in jsDoc or even the enhanced syntax used by the
+   * [google closure compiler](https://developers.google.com/closure/compiler/docs/js-for-compiler#types)
+   *
+   * The resulting array from the type descriptor `{number|string|{name:string,age:number|date}}` would look like this:
+   */
+  export function parseTagTypes(str: string, tag: Tag): string[];
+  /**
+   * Determine if a parameter is optional.
+   *
+   * Examples:
+   * JSDoc: {Type} [name]
+   * Google: {Type=} name
+   * TypeScript: {Type?} name
+   */
+  export function parseParamOptional(tag: Tag): boolean;
+  /**
+   * Parse the context from the given `str` of js.
+   *
+   * This method attempts to discover the context
+   * for the comment based on it's code. Currently
+   * supports:
+   *
+   *   - classes
+   *   - class constructors
+   *   - class methods
+   *   - function statements
+   *   - function expressions
+   *   - prototype methods
+   *   - prototype properties
+   *   - methods
+   *   - properties
+   *   - declarations
+   */
+  export function parseCodeContext(str: string, parentContext?: any | undefined): any;
+
+  export interface ContextPatternMatchersCtx {
+    type: 'class' | 'constructor' | 'method' | 'function' | 'property' | 'prototype' | 'declaration';
+    constructor?: string;
+    cons?: string;
+    name: string;
+    string: string;
+    extends?: string;
+    value?: string;
+  }
+
+  export type ContextPatternMatchersFn = (
+    str: string,
+    parentContext?: ContextPatternMatchersCtx,
+  ) => ContextPatternMatchersCtx;
+
+  export let contextPatternMatchers: ContextPatternMatchersFn[];
+}

--- a/scripts/dox.d.ts
+++ b/scripts/dox.d.ts
@@ -52,6 +52,8 @@ declare module 'dox' {
     otherMemberName?: string;
     /** from "@borrows" */
     thisMemberName?: string;
+    /** parsed tag name */
+    type: string;
     /** all parsed types from tags that support it, like "@param" */
     types?: string[];
     /** from "@description" */

--- a/scripts/specCoverageReport.ts
+++ b/scripts/specCoverageReport.ts
@@ -1,0 +1,424 @@
+import Table from 'cli-table';
+import dox from 'dox';
+import fs from 'fs';
+import { glob } from 'glob';
+
+const ABLY_FEATURES_SPEC_URL = 'https://raw.githubusercontent.com/ably/specification/main/textile/features.textile';
+const PATHS_TO_LOOK_FOR_TESTS = ['./test', './src/platform/react-hooks'];
+const PATHS_TO_IGNORE_FOR_TESTS = ['./test/common/ably-common'];
+
+enum SpecCoverageType {
+  spec = 'spec',
+  specpartial = 'specpartial',
+  nospec = 'nospec',
+  specskip = 'specskip',
+}
+
+interface SpecItem {
+  level: number;
+  key: string;
+  description: string;
+}
+
+interface TestSpecCoverage {
+  coverageType: SpecCoverageType.spec | SpecCoverageType.specpartial | SpecCoverageType.nospec;
+  /**
+   * Spec item key covered by the test, if applicable based on {@link coverageType} value.
+   */
+  specKey?: string;
+  /**
+   * An optional comment for tagged spec item. Looks like this in test docstrings:
+   *
+   * `@spec ID123 - [comment]`
+   */
+  coverageDescription?: string;
+  testCode: string;
+}
+
+class SpecItemNode implements SpecItem {
+  public level: number;
+  public key: string;
+  public description: string;
+  public parentNode: SpecItemNode | null = null;
+  public childNodes: SpecItemNode[] = [];
+  public specCoverages: TestSpecCoverage[] = [];
+  private _coveragePercentage: number | null = null;
+
+  constructor(specItem: SpecItem) {
+    this.level = specItem.level;
+    this.key = specItem.key;
+    this.description = specItem.description;
+  }
+
+  public isRoot(): boolean {
+    return this.parentNode == null;
+  }
+
+  public isLeaf(): boolean {
+    return this.childNodes.length === 0;
+  }
+
+  public getCoveragePercentage(): number {
+    // general rules for coverage:
+    // if the spec item is covered by the test with @spec tag - it contributes a weigth of 1 (100%).
+    // if the spec item is covered by the test with @specpartial tag - it contributes a weigth of 0.5 (50%).
+    // otherwise it contributes a weigth of 0 (0%).
+    // when multiple nodes are contributing to coverage calculation (like for parent nodes),
+    // then their coverage percentages are added and then divided by the number of nodes to calculate the average coverage for the node.
+
+    // memoize coverage percentage
+    if (this._coveragePercentage != null) {
+      return this._coveragePercentage;
+    }
+
+    // leaf nodes calculate coverage percentage only based on their own spec coverage
+    if (this.isLeaf()) {
+      this._coveragePercentage = this._getCoveragePercentageForLeaf();
+      return this._coveragePercentage;
+    }
+
+    // parent nodes calculate coverage percentage based on their own and children's coverages
+    this._coveragePercentage = this._getCoveragePercentageForParent();
+    return this._coveragePercentage;
+  }
+
+  public getLinkToSpecItem(): string {
+    return `https://sdk.ably.com/builds/ably/specification/main/features/#${this.key}`;
+  }
+
+  public toSpecItemView(): SpecItem {
+    return {
+      level: this.level,
+      key: this.key,
+      description: this.description,
+    };
+  }
+
+  public toStringView(): string {
+    let specItemLine = '';
+
+    specItemLine += new Array(this.level - 1).fill('    ').join('');
+    specItemLine += `(${this.key})`;
+    specItemLine += ` ${this.description}`;
+
+    return specItemLine;
+  }
+
+  public toJSON(): object {
+    return {
+      ...this.toSpecItemView(),
+      parentNode: this.parentNode?.toSpecItemView(),
+      childNodes: this.childNodes,
+      specCoverages: this.specCoverages,
+    };
+  }
+
+  private _getCoveragePercentageForLeaf(): number {
+    if (this.specCoverages.findIndex((x) => x.coverageType === SpecCoverageType.spec) !== -1) {
+      return 1;
+    }
+
+    if (this.specCoverages.findIndex((x) => x.coverageType === SpecCoverageType.specpartial) !== -1) {
+      return 0.5;
+    }
+
+    return 0;
+  }
+
+  private _getCoveragePercentageForParent(): number {
+    // here we use the next assumption:
+    // if all children spec items are covered by the test (average coverage is 1), then we can consider the parent covered too,
+    // even if there is no test covering this parent spec item specifically.
+    const childNodesCoveragePercentagesSum = this.childNodes.reduce((acc, v) => acc + v.getCoveragePercentage(), 0);
+    const childNodesCount = this.childNodes.length;
+    const childNodesAverageCoveragePercentage = childNodesCoveragePercentagesSum / childNodesCount;
+    if (childNodesAverageCoveragePercentage === 1) {
+      return childNodesAverageCoveragePercentage;
+    }
+
+    // otherwise (children spec items are not fully covered), we should also include parent's own
+    // spec item coverage contribution, but only if there tests covering parent spec item
+    if (this.specCoverages.length === 0) {
+      return childNodesAverageCoveragePercentage;
+    }
+
+    const averageCoveragePercentageWithParentContribution =
+      (childNodesCoveragePercentagesSum + this._getCoveragePercentageForLeaf()) / (childNodesCount + 1);
+    return averageCoveragePercentageWithParentContribution;
+  }
+}
+
+class SpecItemNodesCollection {
+  public allNodesByKeyMap: Map<string, SpecItemNode> = new Map();
+
+  constructor(specItems: SpecItem[]) {
+    this._createNodesCollection(specItems);
+  }
+
+  public getRootNodes(): SpecItemNode[] {
+    const rootNodes: SpecItemNode[] = [];
+    for (const node of this.allNodesByKeyMap.values()) {
+      if (node.isRoot()) {
+        rootNodes.push(node);
+      }
+    }
+    return rootNodes;
+  }
+
+  public getSpecItemLinesView(): string[] {
+    return [...this.allNodesByKeyMap.values()].map((x) => x.toStringView());
+  }
+
+  public toJSON(): Record<string, SpecItemNode> {
+    return [...this.allNodesByKeyMap.entries()].reduce((acc, [key, node]) => {
+      acc[key] = node;
+      return acc;
+    }, {} as Record<string, SpecItemNode>);
+  }
+
+  private _createNodesCollection(specItems: SpecItem[]): void {
+    let previousNode: SpecItemNode | null = null;
+
+    for (const specItem of specItems) {
+      // we always add new spec item node to the map with all nodes
+      const node = new SpecItemNode(specItem);
+      this.allNodesByKeyMap.set(specItem.key, node);
+
+      // and then use spec item's levels to create correct connections between nodes
+      if (!previousNode) {
+        // first ever spec item, it's always root level without a parent, do nothing
+      } else if (specItem.level > previousNode.level) {
+        // new spec item has higher level value, it means we found a child node for a previous node
+        node.parentNode = previousNode;
+        node.parentNode.childNodes.push(node);
+      } else if (specItem.level === previousNode.level) {
+        // spec items with the same level are added to the same parent node if it exists
+        node.parentNode = previousNode.parentNode;
+        node.parentNode?.childNodes.push(node);
+      } else {
+        // new spec item has lower level value, it means we ended adding child nodes to the current parent
+        // and need to go a number of levels up depending on the difference between current and previous node levels.
+        // for example, previous node may have been at level 4 (**** spec item), and now we are back to root level (* spec item)
+        const levelDifference = previousNode.level - node.level;
+        let newParentNode: SpecItemNode | null = previousNode.parentNode;
+        // go up in parents N times, where N = difference between node levels
+        new Array(levelDifference).fill(0).forEach(() => (newParentNode = newParentNode?.parentNode ?? null));
+
+        node.parentNode = newParentNode;
+        node.parentNode?.childNodes.push(node);
+      }
+
+      previousNode = node;
+    }
+  }
+}
+
+async function loadSpecTextile(): Promise<string> {
+  const response = await fetch(ABLY_FEATURES_SPEC_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load Ably features spec from url: ${ABLY_FEATURES_SPEC_URL}, response status: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const spec = await response.text();
+  console.log(`Successfully loaded Ably features spec textile from url: ${ABLY_FEATURES_SPEC_URL}`);
+
+  return spec;
+}
+
+function specTextileToOrderedSpecItems(specTextile: string): SpecItem[] {
+  // regexp below matches any lines that look like this:
+  // * @(TB2)@ Some description
+  // this is how all spec items are formatted in the spec textile file
+  const specItemRegexp = /^(\*+)\s*@\((\w+)\)@\s*(.*)/;
+  const specLines = specTextile.split('\n');
+  const specItems: SpecItem[] = [];
+
+  specLines.forEach((x) => {
+    const regexpResult = specItemRegexp.exec(x);
+    if (!regexpResult) {
+      return;
+    }
+
+    const [_, levelAsAsterisks, key, description] = regexpResult;
+    // spec item level in the textile is formatted as the sequence of asterisks "*"
+    // we use the number of asterisks as the spec item level, which then can be used to build a spec hierarchy
+    const parsedLevel = levelAsAsterisks.length;
+
+    specItems.push({
+      level: parsedLevel,
+      key,
+      description,
+    });
+  });
+
+  console.log(`Parsed ${specItems.length} spec items from the Ably features specification textile file`);
+
+  return specItems;
+}
+
+async function getTestFilePaths(): Promise<string[]> {
+  const globPatterns = PATHS_TO_LOOK_FOR_TESTS.map((path) => `${path}/**/*.test.{js,ts,jsx,tsx}`);
+  const ignorePatterns = PATHS_TO_IGNORE_FOR_TESTS.map((path) => `${path}/**`);
+  const testFiles = await glob(globPatterns, {
+    ignore: ignorePatterns,
+  });
+
+  console.log(`Found ${testFiles.length} test files matching glob patterns`, testFiles);
+
+  return testFiles;
+}
+
+function parseDocstringsForFile(filePath: string): dox.Comment[] {
+  const fileContent = fs.readFileSync(filePath).toString();
+  const docstrings = dox.parseComments(fileContent, {});
+  return docstrings;
+}
+
+function getSpecCoveragesFromDocstrings(docstrings: dox.Comment[]): TestSpecCoverage[] {
+  const specCoverages: TestSpecCoverage[] = [];
+
+  for (const docstring of docstrings) {
+    if (docstring.tags.findIndex((x) => x.type === SpecCoverageType.specskip) !== -1) {
+      // tests marked with `@specskip` tag should not contribute to spec coverage metrics, so skip them
+      continue;
+    }
+    specCoverages.push(...docstringToSpecCoverages(docstring));
+  }
+
+  return specCoverages;
+}
+
+function docstringToSpecCoverages(docstring: dox.Comment): TestSpecCoverage[] {
+  const parseableTags = new Set(Object.values(SpecCoverageType) as string[]);
+  const specCoverages: TestSpecCoverage[] = [];
+
+  for (const tag of docstring.tags) {
+    if (!parseableTags.has(tag.type)) {
+      continue;
+    }
+
+    const tagType = tag.type;
+    switch (tagType) {
+      case SpecCoverageType.spec:
+      case SpecCoverageType.specpartial:
+        const { specKey, coverageDescription } = parseSpecTagString(tag.string);
+        specCoverages.push({
+          coverageType: tagType,
+          specKey,
+          coverageDescription,
+          testCode: docstring.code,
+        });
+        break;
+
+      case SpecCoverageType.nospec:
+        specCoverages.push({
+          coverageType: tagType,
+          testCode: docstring.code,
+        });
+        break;
+
+      case SpecCoverageType.specskip:
+        throw new Error(
+          `Converting docstring to spec coverages which is marked with '@${
+            SpecCoverageType.specskip
+          }' is not allowed: ${JSON.stringify(docstring)}`,
+        );
+    }
+  }
+
+  return specCoverages;
+}
+
+function parseSpecTagString(str: string): { specKey: string; coverageDescription?: string } {
+  // spec tags strings are written in format:
+  // RSC19f[ - optional description]
+  const specTagStringRegexp = /(\w+)(\s+-\s+(.*))?/;
+  const regexpResult = specTagStringRegexp.exec(str);
+  if (!regexpResult) {
+    throw new Error(
+      `Unexpected spec tag string format received: ${str}. Expected it to be in the format: SPEC_ITEM_ID[ - OPTIONAL_DESCRIPTION]`,
+    );
+  }
+
+  const [_, specKey, __, coverageDescription] = regexpResult;
+  return {
+    specKey,
+    coverageDescription,
+  };
+}
+
+function applySpecCoveragesToSpecItemsCollection(
+  collection: SpecItemNodesCollection,
+  specCoverages: TestSpecCoverage[],
+): void {
+  for (const specCoverage of specCoverages) {
+    if (specCoverage.coverageType === SpecCoverageType.nospec) {
+      continue;
+    }
+
+    const node = collection.allNodesByKeyMap.get(specCoverage.specKey!);
+    if (!node) {
+      throw new Error(
+        `Unknown spec item key found in tests' docstrings: ${specCoverage.specKey}, for test code string: ${specCoverage.testCode}`,
+      );
+    }
+
+    node.specCoverages.push(specCoverage);
+  }
+}
+
+function specItemsCollectionToTable(collection: SpecItemNodesCollection): Table {
+  const table = new Table({
+    style: { head: ['green'] },
+    head: ['Spec', 'Coverage', 'Tests w/ full cvrg.', 'Tests w/ partial cvrg.', 'Spec Link'],
+    rows: collection.getRootNodes().flatMap((node) => specItemNodeToTableRows(node, [])),
+  });
+  return table;
+}
+
+function specItemNodeToTableRows(node: SpecItemNode, tableRows: [string, string, string, string, string][]) {
+  const indentation = new Array(node.level - 1).fill('  ').join('');
+  const coveragePercentage = node.getCoveragePercentage();
+  const coveragePercentageEmoji = coveragePercentage === 1 ? '✔️' : coveragePercentage === 0 ? '🔴' : '🟡';
+
+  tableRows.push([
+    `${indentation}${node.key}`,
+    `${coveragePercentageEmoji} ${roundTo(coveragePercentage * 100, 2)}%`,
+    node.specCoverages.filter((x) => x.coverageType === SpecCoverageType.spec).length.toString(),
+    node.specCoverages.filter((x) => x.coverageType === SpecCoverageType.specpartial).length.toString(),
+    node.getLinkToSpecItem(),
+  ]);
+  node.childNodes.forEach((x) => specItemNodeToTableRows(x, tableRows));
+
+  return tableRows;
+}
+
+function roundTo(num: number, digits: number): number {
+  const multiplicator = Math.pow(10, digits);
+  const multiplied = parseFloat((num * multiplicator).toFixed(11));
+  const res = Math.round(multiplied) / multiplicator;
+  return res;
+}
+
+(async function main() {
+  try {
+    const specTextile = await loadSpecTextile();
+    const specItems = specTextileToOrderedSpecItems(specTextile);
+    const collection = new SpecItemNodesCollection(specItems);
+    const paths = await getTestFilePaths();
+
+    for (const path of paths) {
+      const docstrings = parseDocstringsForFile(path);
+      const specCoverages = getSpecCoveragesFromDocstrings(docstrings);
+      applySpecCoveragesToSpecItemsCollection(collection, specCoverages);
+    }
+
+    const table = specItemsCollectionToTable(collection);
+    console.log(`Overall spec items coverage:`);
+    console.log(table.toString());
+  } catch (error) {
+    console.error('Spec coverage report failed with error:', error);
+  }
+})();


### PR DESCRIPTION
This PR is based on https://github.com/ably/ably-js/pull/1806, please review that one first.

This PR introduces new `specCoverageReport.ts` script to gather spec items coverage by ably-js tests (from docstring tags) and compare them with the [Ably features specification](https://sdk.ably.com/builds/ably/specification/main/features/).
Script fetches the latest spec from Ably specification repo using link to the textile file: https://raw.githubusercontent.com/ably/specification/main/textile/features.textile. Then parses textile file and docstrings in ably-js tests to output spec item coverage table.

This PR also adds new `Spec coverage report` workflow, which simply runs `npm run speccoveragereport` to output spec coverage report. See [job output here](https://github.com/ably/ably-js/actions/runs/9811467632/job/27093676079?pr=1811).

Here's the unformatted spec coverage data gathered based on test suite state for a1229af5325b28257b8ad35510e4d45b8bd80d94 commit: 
[spec-coverage-result.json](https://github.com/user-attachments/files/16097642/spec-coverage-result.json)
