### PR TITLE
Export EventEmitter so we can use it in other SDKs

### DIFF
--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -24,6 +24,9 @@ class BaseRealtime extends BaseClient {
   _channels: any;
   connection: Connection;
 
+  // internal API to make EventEmitter usable in other SDKs
+  static readonly EventEmitter = EventEmitter;
+
   /*
    * The public typings declare that this only accepts an object, but since we want to emit a good error message in the case where a non-TypeScript user does one of these things:
    *


### PR DESCRIPTION
Make EventEmitter a static field on BaseRealtime so it can be used in other SDKs.

This means the public API doesn't change but we can still make use of EventEmitter without duplicating the code in other SDKs. We'll use this in Chat.

https://ably.atlassian.net/browse/CHA-390

The PR in chat to use this https://github.com/ably/ably-chat-js/pull/304