### PR TITLE
fix: add missing `ablyId` argument to  `useConnectionStateListener`

### DIFF
--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -48,7 +48,7 @@ export function usePresence<T = any>(
   const [connectionState, setConnectionState] = useState(ably.connection.state);
   useConnectionStateListener((stateChange) => {
     setConnectionState(stateChange.current);
-  });
+  }, params.ablyId);
 
   // similar to connection states, we should only attempt to enter presence when in certain
   // channel states.


### PR DESCRIPTION
Resolves https://github.com/ably/ably-js/issues/1820

Adds missing `ablyId` argument to  `useConnectionStateListener` in `usePresence` implementation