### PR TITLE
[ECO-4914] Fix websocket reconnection can get stuck in disconnected/connecting cycle

### DIFF
--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1101,27 +1101,25 @@ class ConnectionManager extends EventEmitter {
         'ConnectionManager WebSocket slow timer',
         'checking connectivity',
       );
-      if (this.wsCheckResult === null) {
-        this.checkWsConnectivity()
-          .then(() => {
-            Logger.logAction(
-              this.logger,
-              Logger.LOG_MINOR,
-              'ConnectionManager WebSocket slow timer',
-              'ws connectivity check succeeded',
-            );
-            this.wsCheckResult = true;
-          })
-          .catch(() => {
-            Logger.logAction(
-              this.logger,
-              Logger.LOG_MAJOR,
-              'ConnectionManager WebSocket slow timer',
-              'ws connectivity check failed',
-            );
-            this.wsCheckResult = false;
-          });
-      }
+      this.checkWsConnectivity()
+        .then(() => {
+          Logger.logAction(
+            this.logger,
+            Logger.LOG_MINOR,
+            'ConnectionManager WebSocket slow timer',
+            'ws connectivity check succeeded',
+          );
+          this.wsCheckResult = true;
+        })
+        .catch(() => {
+          Logger.logAction(
+            this.logger,
+            Logger.LOG_MAJOR,
+            'ConnectionManager WebSocket slow timer',
+            'ws connectivity check failed',
+          );
+          this.wsCheckResult = false;
+        });
       if (this.realtime.http.checkConnectivity) {
         Utils.whenPromiseSettles(this.realtime.http.checkConnectivity(), (err, connectivity) => {
           if (err || !connectivity) {
@@ -1450,8 +1448,6 @@ class ConnectionManager extends EventEmitter {
     if (transportPreference && transportPreference === this.baseTransport && this.webSocketTransportAvailable) {
       this.checkWsConnectivity()
         .then(() => {
-          this.wsCheckResult = true;
-          this.abandonedWebSocket = false;
           this.unpersistTransportPreference();
           if (this.state === this.states.connecting) {
             Logger.logAction(
@@ -1493,6 +1489,8 @@ class ConnectionManager extends EventEmitter {
    */
   connectWs(transportParams: TransportParams, connectCount: number) {
     Logger.logAction(this.logger, Logger.LOG_MICRO, 'ConnectionManager.connectWs()');
+    this.wsCheckResult = null;
+    this.abandonedWebSocket = false;
     this.startWebSocketSlowTimer();
     this.startWebSocketGiveUpTimer(transportParams);
 

--- a/test/common/modules/private_api_recorder.js
+++ b/test/common/modules/private_api_recorder.js
@@ -68,6 +68,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'pass.clientOption.disableConnectivityCheck', // actually ably-js public API (i.e. it’s in the TypeScript typings) but no other SDK has it and it doesn’t enable ably-js-specific functionality
     'pass.clientOption.pushRecipientChannel',
     'pass.clientOption.webSocketConnectTimeout',
+    'pass.clientOption.webSocketSlowTimeout',
     'read.Defaults.version',
     'read.EventEmitter.events',
     'read.Platform.Config.push',
@@ -97,6 +98,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'read.realtime.options',
     'read.realtime.options.key',
     'read.realtime.options.maxMessageSize',
+    'read.realtime.options.realtimeHost',
     'read.realtime.options.token',
     'read.rest._currentFallback',
     'read.rest._currentFallback.host',
@@ -123,6 +125,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'replace.transport.send',
     'serialize.recoveryKey',
     'write.Defaults.ENVIRONMENT',
+    'write.Defaults.wsConnectivityUrl',
     'write.Platform.Config.push', // This implies using a mock implementation of the internal IPlatformPushConfig interface. Our mock (in push_channel_transport.js) then interacts with internal objects and private APIs of public objects to implement this interface; I haven’t added annotations for that private API usage, since there wasn’t an easy way to pass test context information into the mock. I think that for now we can just say that if we wanted to get rid of this private API usage, then we’d need to remove this mock entirely.
     'write.auth.authOptions.requestHeaders',
     'write.auth.key',
@@ -134,6 +137,8 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'write.connectionManager.connectionKey',
     'write.connectionManager.lastActivity',
     'write.connectionManager.msgSerial',
+    'write.connectionManager.wsHosts',
+    'write.realtime.options.realtimeHost',
     'write.realtime.options.timeouts.realtimeRequestTimeout',
     'write.rest._currentFallback.validUntil',
   ];


### PR DESCRIPTION
This fixes a regression introduced in ably-js v2 in this [PR](https://github.com/ably/ably-js/pull/1645).
Under certain network conditions (internet down) a race condition could
occur in the connection manager. Specifically, websocket connectivity
check in the `startWebSocketSlowTimer` function needed to set the
`wsCheckResult` flag to `false` before the timer was cleared by other
code branches. If that happened, it then caused an endless loop of
websocket connection retries, even after the network conditions
stabilized. A websocket transport would successfully open but then be
immediately disposed due to the `wsCheckResult` flag still being set to
`false`, without any mechanism to reset it in this scenario.

Upon closer look, it makes sense that the websocket connection health
flags (`wsCheckResult` and `abandonedWebSocket`) should be reset when
attempting a new websocket connection. The previous solution did not
explicitly reset these flags in the `connectWs` function, leading to the
described race condition and endless loop. Thus, `wsCheckResult` and
`abandonedWebSocket` are now reset to their neutral values upon entering
the `connectWs` function.

The websocket reconnection test that was added now checks such condition. You can see it fail on all envrionments on a library version without the aforementioned fix: [node](https://github.com/ably/ably-js/actions/runs/10741768647/job/29792927662?pr=1855), [browsers](https://github.com/ably/ably-js/actions/runs/10741768651/job/29792928367?pr=1855)

Resolves https://github.com/ably/ably-js/issues/1844


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Added a new test case to verify WebSocket reconnection behavior after connectivity failures, enhancing the reliability of the WebSocket transport mechanism.
- **Improvements**
	- Refined the handling of WebSocket connectivity checks to improve the reliability and clarity of connection state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->