### PR TITLE
[ECO-4913] Fix fetchRequest implementation does not add 'rnd' query parameter so some HTTP requests get cached in browser

### DIFF
--- a/src/platform/web/lib/http/request/fetchrequest.ts
+++ b/src/platform/web/lib/http/request/fetchrequest.ts
@@ -65,7 +65,10 @@ export default async function fetchRequest(
 
   const resultPromise = (async (): Promise<RequestResult> => {
     try {
-      const res = await Utils.getGlobalObject().fetch(uri + '?' + new URLSearchParams(params || {}), requestInit);
+      const urlParams = new URLSearchParams(params || {});
+      urlParams.set('rnd', Utils.cheapRandStr());
+      const preparedURI = uri + '?' + urlParams;
+      const res = await Utils.getGlobalObject().fetch(preparedURI, requestInit);
 
       clearTimeout(timeout!);
 


### PR DESCRIPTION
Add `rnd` query param like we do for XHR requests:
 https://github.com/ably/ably-js/blob/bd6629336f97dff51b407e9ea342b7b390c625dc/src/platform/web/lib/http/request/xhrrequest.ts#L77

Resolves #1843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced query parameter construction for fetch requests, improving clarity and maintainability.
	- Added a random string to query parameters to prevent caching and ensure uniqueness in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->