### PR TITLE
Add Push plugin to cdn

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,7 +125,11 @@ module.exports = function (grunt) {
   grunt.registerTask('build:push', function () {
     var done = this.async();
 
-    Promise.all([esbuild.build(esbuildConfig.pushPluginConfig), esbuild.build(esbuildConfig.pushPluginCdnConfig)])
+    Promise.all([
+      esbuild.build(esbuildConfig.pushPluginConfig),
+      esbuild.build(esbuildConfig.pushPluginCdnConfig),
+      esbuild.build(esbuildConfig.minifiedPushPluginCdnConfig),
+    ])
       .then(() => {
         done(true);
       })

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,8 +125,7 @@ module.exports = function (grunt) {
   grunt.registerTask('build:push', function () {
     var done = this.async();
 
-    esbuild
-      .build(esbuildConfig.pushPluginConfig)
+    Promise.all([esbuild.build(esbuildConfig.pushPluginConfig), esbuild.build(esbuildConfig.pushPluginCdnConfig)])
       .then(() => {
         done(true);
       })

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Include the Ably library in your HTML:
 <script src="https://cdn.ably.com/lib/ably.min-1.js"></script>
 ```
 
-The Ably client library follows [Semantic Versioning](http://semver.org/). To lock into a major or minor version of the client library, you can specify a specific version number such as https://cdn.ably.com/lib/ably.min-1.js for all v1._ versions, or https://cdn.ably.com/lib/ably.min-1.0.js for all v1.0._ versions, or you can lock into a single release with https://cdn.ably.com/lib/ably.min-1.0.9.js. Note you can load the non-minified version by omitting `min-` from the URL such as https://cdn.ably.com/lib/ably-1.0.js. See https://github.com/ably/ably-js/tags for a list of tagged releases.
+The Ably client library follows [Semantic Versioning](http://semver.org/). To lock into a major or minor version of the client library, you can specify a specific version number such as https://cdn.ably.com/lib/ably.min-1.js for all v1._ versions, or https://cdn.ably.com/lib/ably.min-1.0.js for all v1.0._ versions, or you can lock into a single release with https://cdn.ably.com/lib/ably.min-1.0.9.js. Note you can load the non-minified version by omitting `.min` from the URL such as https://cdn.ably.com/lib/ably-1.0.js. See https://github.com/ably/ably-js/tags for a list of tagged releases.
 
 For usage, jump to [Using the Realtime API](#using-the-realtime-api) or [Using the REST API](#using-the-rest-api).
 
@@ -566,6 +566,23 @@ await channel.push.unsubscribeClient();
 ```
 
 Push activation works with the [Modular variant](#modular-tree-shakable-variant) of the library, but requires you to be using the Rest plugin.
+
+Alternatively, you can load the Push plugin directly in your HTML using `script` tag (in case you can't use a package manager):
+
+```html
+<script src="https://cdn.ably.com/lib/push.umd.min-2.js"></script>
+```
+
+When loaded this way, the Push plugin will be available on the global object via the `AblyPushPlugin` property, so you will need to pass it to the Ably instance as follows:
+
+```javascript
+const client = new Ably.Rest({
+  ...options,
+  plugins: { Push: AblyPushPlugin },
+});
+```
+
+The Push plugin is developed as part of the Ably client library, so it is available for the same versions as the Ably client library itself. It also means that it follows the same semantic versioning rules as they were defined for [the Ably client library](#for-browsers). For example, to lock into a major or minor version of the Push plugin, you can specify a specific version number such as https://cdn.ably.com/lib/push.umd.min-2.js for all v2._ versions, or https://cdn.ably.com/lib/push.umd.min-2.3.js for all v2.3._ versions, or you can lock into a single release with https://cdn.ably.com/lib/push.umd.min-2.3.2.js. Note you can load the non-minified version by omitting `.min` from the URL such as https://cdn.ably.com/lib/push.umd-2.js.
 
 For more information on publishing push notifcations over Ably, see the [Ably push documentation](https://ably.com/docs/push).
 

--- a/grunt/esbuild/build.js
+++ b/grunt/esbuild/build.js
@@ -69,6 +69,14 @@ const pushPluginCdnConfig = {
   outfile: 'build/push.umd.js',
 };
 
+const minifiedPushPluginCdnConfig = {
+  ...createBaseConfig(),
+  entryPoints: ['src/plugins/push/index.ts'],
+  plugins: [umdWrapper.default({ libraryName: 'AblyPushPlugin', amdNamedModule: false })],
+  outfile: 'build/push.umd.min.js',
+  minify: true,
+};
+
 module.exports = {
   webConfig,
   minifiedWebConfig,
@@ -76,4 +84,5 @@ module.exports = {
   nodeConfig,
   pushPluginConfig,
   pushPluginCdnConfig,
+  minifiedPushPluginCdnConfig,
 };

--- a/grunt/esbuild/build.js
+++ b/grunt/esbuild/build.js
@@ -62,10 +62,18 @@ const pushPluginConfig = {
   external: ['ulid'],
 };
 
+const pushPluginCdnConfig = {
+  ...createBaseConfig(),
+  entryPoints: ['src/plugins/push/index.ts'],
+  plugins: [umdWrapper.default({ libraryName: 'AblyPushPlugin', amdNamedModule: false })],
+  outfile: 'build/push.umd.js',
+};
+
 module.exports = {
   webConfig,
   minifiedWebConfig,
   modularConfig,
   nodeConfig,
   pushPluginConfig,
+  pushPluginCdnConfig,
 };

--- a/scripts/cdn_deploy.js
+++ b/scripts/cdn_deploy.js
@@ -12,7 +12,7 @@ async function run() {
   let config = {
     // The S3 Bucket to upload into
     bucket: S3_DEFAULT_BUCKET,
-    // The root folder inside the S3 bucket where the files should be places
+    // The root folder inside the S3 bucket where the files should be placed
     root: S3_DEFAULT_ROOT,
     // Local path to start from
     path: '.',
@@ -21,7 +21,7 @@ async function run() {
     // Comma separated directories (relative to `path`) to exclude from upload
     excludeDirs: 'node_modules,.git',
     // Regex to match files against for upload
-    fileRegex: '^ably?(\\.min)?\\.js$',
+    fileRegex: '^(ably|push\\.umd)?(\\.min)?\\.js$',
     ...argv,
   };
 


### PR DESCRIPTION
See internal slack discussion: https://ably-real-time.slack.com/archives/CURL4U2FP/p1723454752656739.

We can't use existing push plugin build output as it has `ulid` as external and it tries to import it as a commonjs module. Found the reasoning for this [here](https://stackoverflow.com/a/73771968), with ref to the [esbuild docs](https://esbuild.github.io/api/#external):
> `External` ... Instead of being bundled, the import will be preserved (using require for the iife and cjs formats and using import for the esm format) and will be evaluated at run time instead.

This means that for the use of push plugin via script tag from CDN, we would need to either polyfill the `require` call, or add some wrapper/replace `require('ulid')` call with `window.ulid` (potentially doable with https://github.com/yanm1ng/esbuild-plugin-external-global#readme, but quick test locally didn't produce expected result - it end up calling `require` anyway).

All of the above would mean having a separate file for push plugin for CDN use anyway, so at this point it's just easier to bundle `ulid` together with push plugin for CDN specifically, and publish that.
This way CDN users get easy use of the Push plugin (no need to also include `ulid` via CDN), and users that use npm still have access to the push plugin file without extra code (saves ~1kb gzipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new CDN configuration for the push plugin, enhancing the build process.
	- Expanded the file matching criteria for S3 uploads to include "push" files.
	- Added documentation for loading the Push plugin directly in HTML and instantiating it with the Ably client.

- **Bug Fixes**
	- Corrected a comment for clarity in the S3 upload configuration.

- **Performance Improvements**
	- Enhanced build efficiency by allowing concurrent execution of multiple build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->