### PR TITLE
[ECO-4941] Add `wsConnectivityCheckUrl` client option

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -507,6 +507,15 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
   connectivityCheckUrl?: string;
 
   /**
+   * Override the URL used by the realtime client to check if WebSocket connections are available.
+   *
+   * If the client suspects that WebSocket connections are unavailable on the current network,
+   * it will attempt to open a WebSocket connection to this URL to check WebSocket connectivity.
+   * If this fails, the client will attempt to connect to Ably systems using fallback transports, if available.
+   */
+  wsConnectivityCheckUrl?: string;
+
+  /**
    * Disable the check used by the realtime client to check if the internet
    * is available before connecting to a fallback host.
    */

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -2023,7 +2023,8 @@ class ConnectionManager extends EventEmitter {
   }
 
   checkWsConnectivity() {
-    const ws = new Platform.Config.WebSocket(Defaults.wsConnectivityUrl);
+    const wsConnectivityCheckUrl = this.options.wsConnectivityCheckUrl || Defaults.wsConnectivityCheckUrl;
+    const ws = new Platform.Config.WebSocket(wsConnectivityCheckUrl);
     return new Promise<void>((resolve, reject) => {
       let finished = false;
       ws.onopen = () => {

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -311,6 +311,11 @@ export function normaliseOptions(
     connectivityCheckUrl = uri;
   }
 
+  let wsConnectivityCheckUrl = options.wsConnectivityCheckUrl;
+  if (wsConnectivityCheckUrl && wsConnectivityCheckUrl.indexOf('://') === -1) {
+    wsConnectivityCheckUrl = 'wss://' + wsConnectivityCheckUrl;
+  }
+
   return {
     ...options,
     realtimeHost,
@@ -319,6 +324,7 @@ export function normaliseOptions(
     timeouts,
     connectivityCheckParams,
     connectivityCheckUrl,
+    wsConnectivityCheckUrl,
     headers,
   };
 }

--- a/src/common/types/IDefaults.d.ts
+++ b/src/common/types/IDefaults.d.ts
@@ -3,7 +3,7 @@ import { RestAgentOptions } from './ClientOptions';
 
 export default interface IDefaults {
   connectivityCheckUrl: string;
-  wsConnectivityUrl: string;
+  wsConnectivityCheckUrl: string;
   defaultTransports: TransportName[];
   restAgentOptions?: RestAgentOptions;
 }

--- a/src/platform/nodejs/lib/util/defaults.ts
+++ b/src/platform/nodejs/lib/util/defaults.ts
@@ -3,7 +3,7 @@ import { TransportNames } from '../../../../common/constants/TransportName';
 
 const Defaults: IDefaults = {
   connectivityCheckUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
-  wsConnectivityUrl: 'wss://ws-up.ably-realtime.com',
+  wsConnectivityCheckUrl: 'wss://ws-up.ably-realtime.com',
   /* Note: order matters here: the base transport is the leftmost one in the
    * intersection of baseTransportOrder and the transports clientOption that's supported. */
   defaultTransports: [TransportNames.WebSocket],

--- a/src/platform/web/lib/util/defaults.ts
+++ b/src/platform/web/lib/util/defaults.ts
@@ -3,7 +3,7 @@ import { TransportNames } from 'common/constants/TransportName';
 
 const Defaults: IDefaults = {
   connectivityCheckUrl: 'https://internet-up.ably-realtime.com/is-the-internet-up.txt',
-  wsConnectivityUrl: 'wss://ws-up.ably-realtime.com',
+  wsConnectivityCheckUrl: 'wss://ws-up.ably-realtime.com',
   /* Order matters here: the base transport is the leftmost one in the
    * intersection of baseTransportOrder and the transports clientOption that's
    * supported. */

--- a/test/common/modules/private_api_recorder.js
+++ b/test/common/modules/private_api_recorder.js
@@ -69,6 +69,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'pass.clientOption.pushRecipientChannel',
     'pass.clientOption.webSocketConnectTimeout',
     'pass.clientOption.webSocketSlowTimeout',
+    'pass.clientOption.wsConnectivityCheckUrl', // actually ably-js public API (i.e. it’s in the TypeScript typings) but no other SDK has it. At the same time it's not entirely clear if websocket connectivity check should be considered an ably-js-specific functionality (as for other params above), so for the time being we consider it as private API
     'read.Defaults.version',
     'read.EventEmitter.events',
     'read.Platform.Config.push',
@@ -125,7 +126,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'replace.transport.send',
     'serialize.recoveryKey',
     'write.Defaults.ENVIRONMENT',
-    'write.Defaults.wsConnectivityUrl',
+    'write.Defaults.wsConnectivityCheckUrl',
     'write.Platform.Config.push', // This implies using a mock implementation of the internal IPlatformPushConfig interface. Our mock (in push_channel_transport.js) then interacts with internal objects and private APIs of public objects to implement this interface; I haven’t added annotations for that private API usage, since there wasn’t an easy way to pass test context information into the mock. I think that for now we can just say that if we wanted to get rid of this private API usage, then we’d need to remove this mock entirely.
     'write.auth.authOptions.requestHeaders',
     'write.auth.key',
@@ -139,6 +140,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'write.connectionManager.msgSerial',
     'write.connectionManager.wsHosts',
     'write.realtime.options.realtimeHost',
+    'write.realtime.options.wsConnectivityCheckUrl',
     'write.realtime.options.timeouts.realtimeRequestTimeout',
     'write.rest._currentFallback.validUntil',
   ];

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -19,6 +19,7 @@ define([
   /* IANA reserved; requests to it will hang forever */
   var unroutableHost = '10.255.255.1';
   var unroutableAddress = 'http://' + unroutableHost + '/';
+  var unroutableWssAddress = 'wss://' + unroutableHost + '/';
 
   class SharedHelper {
     getTestApp = testAppModule.getTestApp;
@@ -31,6 +32,7 @@ define([
 
     unroutableHost = unroutableHost;
     unroutableAddress = unroutableAddress;
+    unroutableWssAddress = unroutableWssAddress;
     flushTestLogs = globals.flushLogs;
 
     constructor(context) {


### PR DESCRIPTION
Also renames `wsConnectivityUrl` to `wsConnectivityCheckUrl` in the code for consistency with `connectivityCheckUrl`.
The most interesting part here is the jsdoc for `wsConnectivityCheckUrl` client option. Let me know if you would like to add/change something in there

Resolves #1850 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional property `wsConnectivityCheckUrl` for enhanced WebSocket connectivity checks.
	- Added support for custom WebSocket connectivity check URLs, improving flexibility in various network environments.

- **Bug Fixes**
	- Updated references to the WebSocket connectivity URL to ensure consistency with the new naming convention.

- **Documentation**
	- Improved documentation for the new `wsConnectivityCheckUrl` property, clarifying its purpose and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->