### PR TITLE
[Dependabot] limit number of pull requests and add sdk team as reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     schedule:
       interval: 'daily' # weekdays (Monday to Friday)
     labels: [] # prevent the default `dependencies` label from being added to pull requests
+    reviewers:
+      - "ably/team-sdk"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
I have been speaking to other teams around how they keep on top of dependabot PRs and they have suggested we limit the number which are raised at any one time and start auto assigning the team as reviewers. It also helps to keep our PR list cleaner which is important for open source repos.

If people are happy with this approach I will address in the other libraries. 

