### PR TITLE
Ignore instance id when comparing connections keys

### DIFF
--- a/test/browser/connection.test.js
+++ b/test/browser/connection.test.js
@@ -213,10 +213,24 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
         });
       });
 
+      // strip instanceID and handleID from connectionKey */
+      function connectionHmac(key) {
+        /* connectionKey has the form <instanceID>!<hmac>-<handleID> */
+
+        /* remove the handleID from the end of key */
+        let k = key.split('-')[0];
+
+        /* skip the server instanceID if present, as reconnects may be routed to different frontends */
+        if (k.includes('!')) {
+          k = k.split('!')[1];
+        }
+        return k;
+      }
+
       /* uses internal realtime knowledge of the format of the connection key to
        * check if a connection key is the result of a successful recovery of another */
       function sameConnection(keyA, keyB) {
-        return keyA.split('-')[0] === keyB.split('-')[0];
+        return connectionHmac(keyA) === connectionHmac(keyB);
       }
 
       /**


### PR DESCRIPTION
The connection key returned by frontdoor has the form

`<instance-id>!<hmac>-<handleID>`

where `<hmac>` is a hash of connectionID, appID, and clientID.

The test `page_refresh_with_recovery` checks that the connection ID which we get when a connection is recovered, 
it gets the same connectionID. It does this by stripping the handleID off the end of the connection key.
But in frontdoor, requests are handled by an arbitrary frontdoor instance, which is not necessarily the same instance
as the previous connection. So this PR ignores the instance id when performing the comparison.

Fixes https://ably.atlassian.net/browse/RAR-712


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a function for improved handling of connection keys, enhancing the accuracy of connection comparisons.

- **Bug Fixes**
	- Enhanced logic for determining if two connection keys represent the same connection by utilizing a new extraction method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->