### PR TITLE
[DTP-952, DTP-953] Add base implementation for abstract LiveObject, concrete LiveMap/LiveCounter classes

### DIFF
--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -311,6 +311,7 @@ async function checkLiveObjectsPluginFiles() {
   const allowedFiles = new Set([
     'src/plugins/liveobjects/index.ts',
     'src/plugins/liveobjects/liveobject.ts',
+    'src/plugins/liveobjects/liveobjects.ts',
     'src/plugins/liveobjects/liveobjectspool.ts',
   ]);
 

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -308,7 +308,11 @@ async function checkLiveObjectsPluginFiles() {
   const pluginBundleInfo = getBundleInfo('./build/liveobjects.js');
 
   // These are the files that are allowed to contribute >= `threshold` bytes to the LiveObjects bundle.
-  const allowedFiles = new Set(['src/plugins/liveobjects/index.ts', 'src/plugins/liveobjects/liveobject.ts']);
+  const allowedFiles = new Set([
+    'src/plugins/liveobjects/index.ts',
+    'src/plugins/liveobjects/liveobject.ts',
+    'src/plugins/liveobjects/liveobjectspool.ts',
+  ]);
 
   return checkBundleFiles(pluginBundleInfo, allowedFiles, 100);
 }

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -308,7 +308,7 @@ async function checkLiveObjectsPluginFiles() {
   const pluginBundleInfo = getBundleInfo('./build/liveobjects.js');
 
   // These are the files that are allowed to contribute >= `threshold` bytes to the LiveObjects bundle.
-  const allowedFiles = new Set(['src/plugins/liveobjects/index.ts']);
+  const allowedFiles = new Set(['src/plugins/liveobjects/index.ts', 'src/plugins/liveobjects/liveobject.ts']);
 
   return checkBundleFiles(pluginBundleInfo, allowedFiles, 100);
 }

--- a/src/plugins/liveobjects/livecounter.ts
+++ b/src/plugins/liveobjects/livecounter.ts
@@ -1,0 +1,11 @@
+import { LiveObject } from './liveobject';
+
+export interface LiveCounterData {
+  data: number;
+}
+
+export class LiveCounter extends LiveObject<LiveCounterData> {
+  protected _getZeroValueData(): LiveCounterData {
+    return { data: 0 };
+  }
+}

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -1,0 +1,34 @@
+import { LiveObject } from './liveobject';
+
+export type StateValue = string | number | boolean | Uint8Array;
+
+export interface ObjectIdStateData {
+  /**
+   * A reference to another state object, used to support composable state objects.
+   */
+  objectId: string;
+}
+
+export interface ValueStateData {
+  /**
+   * A concrete leaf value in the state object graph.
+   */
+  value: StateValue;
+}
+
+export type StateData = ObjectIdStateData | ValueStateData;
+
+export interface MapEntry {
+  // TODO: add tombstone, timeserial
+  data: StateData;
+}
+
+export interface LiveMapData {
+  data: Map<string, MapEntry>;
+}
+
+export class LiveMap extends LiveObject<LiveMapData> {
+  protected _getZeroValueData(): LiveMapData {
+    return { data: new Map<string, MapEntry>() };
+  }
+}

--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -1,0 +1,33 @@
+import { LiveObjects } from './liveobjects';
+
+interface LiveObjectData {
+  data: any;
+}
+
+export abstract class LiveObject<T extends LiveObjectData = LiveObjectData> {
+  protected _dataRef: T;
+  protected _objectId: string;
+
+  constructor(
+    protected _liveObjects: LiveObjects,
+    initialData?: T | null,
+    objectId?: string,
+  ) {
+    this._dataRef = initialData ?? this._getZeroValueData();
+    this._objectId = objectId ?? this._createObjectId();
+  }
+
+  /**
+   * @internal
+   */
+  getObjectId(): string {
+    return this._objectId;
+  }
+
+  private _createObjectId(): string {
+    // TODO: implement object id generation based on live object type and initial value
+    return Math.random().toString().substring(2);
+  }
+
+  protected abstract _getZeroValueData(): T;
+}

--- a/src/plugins/liveobjects/liveobjects.ts
+++ b/src/plugins/liveobjects/liveobjects.ts
@@ -1,12 +1,21 @@
 import type BaseClient from 'common/lib/client/baseclient';
 import type RealtimeChannel from 'common/lib/client/realtimechannel';
+import { LiveMap } from './livemap';
+import { LiveObjectsPool, ROOT_OBJECT_ID } from './liveobjectspool';
 
 export class LiveObjects {
   private _client: BaseClient;
   private _channel: RealtimeChannel;
+  private _liveObjectsPool: LiveObjectsPool;
 
   constructor(channel: RealtimeChannel) {
     this._channel = channel;
     this._client = channel.client;
+    this._liveObjectsPool = new LiveObjectsPool(this);
+  }
+
+  async getRoot(): Promise<LiveMap> {
+    // TODO: wait for SYNC sequence to finish to return root
+    return this._liveObjectsPool.get(ROOT_OBJECT_ID) as LiveMap;
   }
 }

--- a/src/plugins/liveobjects/liveobjectspool.ts
+++ b/src/plugins/liveobjects/liveobjectspool.ts
@@ -1,0 +1,25 @@
+import { LiveMap } from './livemap';
+import { LiveObject } from './liveobject';
+import { LiveObjects } from './liveobjects';
+
+export type ObjectId = string;
+export const ROOT_OBJECT_ID = 'root';
+
+export class LiveObjectsPool {
+  private _pool: Map<ObjectId, LiveObject>;
+
+  constructor(private _liveObjects: LiveObjects) {
+    this._pool = this._getInitialPool();
+  }
+
+  get(objectId: ObjectId): LiveObject | undefined {
+    return this._pool.get(objectId);
+  }
+
+  private _getInitialPool(): Map<ObjectId, LiveObject> {
+    const pool = new Map<ObjectId, LiveObject>();
+    const root = new LiveMap(this._liveObjects, null, ROOT_OBJECT_ID);
+    pool.set(root.getObjectId(), root);
+    return pool;
+  }
+}

--- a/test/common/modules/private_api_recorder.js
+++ b/test/common/modules/private_api_recorder.js
@@ -44,6 +44,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'call.http._getHosts',
     'call.http.checkConnectivity',
     'call.http.doUri',
+    'call.LiveObject.getObjectId',
     'call.msgpack.decode',
     'call.msgpack.encode',
     'call.presence._myMembers.put',

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -47,6 +47,37 @@ define(['ably', 'shared_helper', 'async', 'chai', 'live_objects'], function (
         const channel = client.channels.get('channel');
         expect(channel.liveObjects.constructor.name).to.equal('LiveObjects');
       });
+
+      describe('LiveObjects instance', () => {
+        /** @nospec */
+        it('getRoot() returns LiveMap instance', async function () {
+          const helper = this.test.helper;
+          const client = LiveObjectsRealtime(helper);
+
+          await helper.monitorConnectionThenCloseAndFinish(async () => {
+            const channel = client.channels.get('channel');
+            const liveObjects = channel.liveObjects;
+            const root = await liveObjects.getRoot();
+
+            expect(root.constructor.name).to.equal('LiveMap');
+          }, client);
+        });
+
+        /** @nospec */
+        it('getRoot() returns live object with id "root"', async function () {
+          const helper = this.test.helper;
+          const client = LiveObjectsRealtime(helper);
+
+          await helper.monitorConnectionThenCloseAndFinish(async () => {
+            const channel = client.channels.get('channel');
+            const liveObjects = channel.liveObjects;
+            const root = await liveObjects.getRoot();
+
+            helper.recordPrivateApi('call.LiveObject.getObjectId');
+            expect(root.getObjectId()).to.equal('root');
+          }, client);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This PR is based on https://github.com/ably/ably-js/pull/1880, please review it first.

Resolves [DTP-952](https://ably.atlassian.net/browse/DTP-952), [DTP-953](https://ably.atlassian.net/browse/DTP-953)

[DTP-952]: https://ably.atlassian.net/browse/DTP-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DTP-953]: https://ably.atlassian.net/browse/DTP-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `LiveCounter` and `LiveMap` classes for managing live data with enhanced type safety.
  - Added `LiveObjectsPool` to manage collections of live objects efficiently.
  - Implemented a new asynchronous method `getRoot()` in `LiveObjects` to retrieve the root live object.

- **Tests**
  - Added new test cases for the `LiveObjects` plugin to validate the functionality of the `getRoot()` method.

- **Chores**
  - Updated the `PrivateApiRecorder` to track new private API calls related to `LiveObject`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->