### PR TITLE
[ECO-5002] Fix usePresence won't leave presence if unmount triggered during channel attaching

### DIFF
--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -73,9 +73,11 @@ export function usePresence<T = any>(
     return () => {
       // here we use the ably.connection.state property, which upon this cleanup function call
       // will have the current connection state for that connection, thanks to us accessing the Ably instance here by reference.
-      // if the connection is in one of the inactive states or the channel is not attached, a presence.leave call will produce an exception.
-      // so we only leave presence in other cases.
-      if (channel.state === 'attached' && !INACTIVE_CONNECTION_STATES.includes(ably.connection.state)) {
+      // if the connection is in one of the inactive states or the channel is not attached/attaching, a presence.leave call will produce an exception.
+      // so we should only leave presence in other cases.
+      const canLeaveFromConnectionState = !INACTIVE_CONNECTION_STATES.includes(ably.connection.state);
+      const canLeaveFromChannelState = ['attached', 'attaching'].includes(channel.state);
+      if (canLeaveFromChannelState && canLeaveFromConnectionState) {
         channel.presence.leave();
       }
     };


### PR DESCRIPTION
This fixes a race condition issue, where a React app might trigger a component unmount while channel is still in the `attaching` state, thus `presence.leave` was never called for a channel and member would remain there until app reload.

Partially fixes https://ably.atlassian.net/browse/ECO-5002, see more context in the [internal slack thread](https://ably-real-time.slack.com/archives/CURL4U2FP/p1727284637623509).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic for leaving presence, ensuring it only occurs under specific channel states ('attached' or 'attaching') and when the connection is active.
- **Documentation**
	- Updated comments for clarity on conditions affecting presence status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->