### PR TITLE
materialisation: Added new message fields.

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2335,12 +2335,104 @@ export interface Message {
    * Timestamp of when the message was received by Ably, as milliseconds since the Unix epoch.
    */
   timestamp?: number;
+  /**
+   * The action type of the message, one of the {@link MessageAction} enum values.
+   */
+  action?: MessageAction;
+  /**
+   * This message's unique serial.
+   */
+  serial?: string;
+  /**
+   * The serial of the message that this message is a reference to.
+   */
+  refSerial?: string;
+  /**
+   * The type of reference this message is, in relation to the message it references.
+   */
+  refType?: string;
+  /**
+   * If an `update` operation was applied to this message, this will be the timestamp the update occurred.
+   */
+  updatedAt?: number;
+  /**
+   * If a `deletion` operation was applied to this message, this will be the timestamp the deletion occurred.
+   */
+  deletedAt?: number;
+  /**
+   * If this message resulted from an operation, this will contain the operation details.
+   */
+  operation?: Operation;
 }
+
+/**
+ * Contains the details of an operation, such as update or deletion, supplied by the actioning client.
+ */
+export interface Operation {
+  /**
+   * The client ID of the client that initiated the operation.
+   */
+  clientId?: string;
+  /**
+   * The description provided by the client that initiated the operation.
+   */
+  description?: string;
+  /**
+   * A JSON object of string key-value pairs that may contain metadata associated with the operation.
+   */
+  metadata?: Record<string, string>;
+}
+
+/**
+ * The namespace containing the different types of message actions.
+ */
+declare namespace MessageActions {
+  /**
+   * Message action has not been set.
+   */
+  type MESSAGE_UNSET = 'message.unset';
+  /**
+   * Message action for a newly created message.
+   */
+  type MESSAGE_CREATE = 'message.create';
+  /**
+   * Message action for an updated message.
+   */
+  type MESSAGE_UPDATE = 'message.update';
+  /**
+   * Message action for a deleted message.
+   */
+  type MESSAGE_DELETE = 'message.delete';
+  /**
+   * Message action for a newly created annotation.
+   */
+  type ANNOTATION_CREATE = 'annotation.create';
+  /**
+   * Message action for a deleted annotation.
+   */
+  type ANNOTATION_DELETE = 'annotation.delete';
+  /**
+   * Message action for a meta-message that contains channel occupancy information.
+   */
+  type META_OCCUPANCY = 'meta.occupancy';
+}
+
+/**
+ * Describes the possible action types used on an {@link Message}.
+ */
+export type MessageAction =
+  | MessageActions.MESSAGE_UNSET
+  | MessageActions.MESSAGE_CREATE
+  | MessageActions.MESSAGE_UPDATE
+  | MessageActions.MESSAGE_DELETE
+  | MessageActions.ANNOTATION_CREATE
+  | MessageActions.ANNOTATION_DELETE
+  | MessageActions.META_OCCUPANCY;
 
 /**
  * A message received from Ably.
  */
-export type InboundMessage = Message & Required<Pick<Message, 'id' | 'timestamp'>>;
+export type InboundMessage = Message & Required<Pick<Message, 'id' | 'timestamp' | 'serial' | 'action'>>;
 
 /**
  * Static utilities related to messages.

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "grunt": "grunt",
     "test": "npm run test:node",
     "test:node": "npm run build:node && npm run build:push && mocha",
+    "test:grep": "npm run build:node && npm run build:push && mocha --grep",
     "test:node:skip-build": "mocha",
     "test:webserver": "grunt test:webserver",
     "test:playwright": "node test/support/runPlaywrightTests.js",

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -6,7 +6,7 @@ import { gzip } from 'zlib';
 import Table from 'cli-table';
 
 // The maximum size we allow for a minimal useful Realtime bundle (i.e. one that can subscribe to a channel)
-const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 98, gzip: 30 };
+const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 100, gzip: 31 };
 
 const baseClientNames = ['BaseRest', 'BaseRealtime'];
 

--- a/src/common/lib/client/restchannel.ts
+++ b/src/common/lib/client/restchannel.ts
@@ -2,12 +2,12 @@ import * as Utils from '../util/utils';
 import Logger from '../util/logger';
 import RestPresence from './restpresence';
 import Message, {
-  fromValues as messageFromValues,
-  fromValuesArray as messagesFromValuesArray,
   encodeArray as encodeMessagesArray,
   serialize as serializeMessage,
   getMessagesSize,
   CipherOptions,
+  fromValues as messageFromValues,
+  fromValuesArray as messagesFromValuesArray,
 } from '../types/message';
 import ErrorInfo from '../types/errorinfo';
 import { PaginatedResult } from './paginatedresource';

--- a/src/common/lib/types/defaultmessage.ts
+++ b/src/common/lib/types/defaultmessage.ts
@@ -1,10 +1,11 @@
 import Message, {
   CipherOptions,
+  decode,
+  encode,
+  EncodingDecodingContext,
   fromEncoded,
   fromEncodedArray,
-  encode,
-  decode,
-  EncodingDecodingContext,
+  fromValues,
 } from './message';
 import * as API from '../../../../ably';
 import Platform from 'common/platform';
@@ -25,8 +26,8 @@ export class DefaultMessage extends Message {
   }
 
   // Used by tests
-  static fromValues(values: unknown): Message {
-    return Object.assign(new Message(), values);
+  static fromValues(values: Message | Record<string, unknown>, options?: { stringifyAction?: boolean }): Message {
+    return fromValues(values, options);
   }
 
   // Used by tests

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -81,16 +81,26 @@ export function fromDeserialized(
   presenceMessagePlugin: PresenceMessagePlugin | null,
 ): ProtocolMessage {
   const error = deserialized.error;
-  if (error) deserialized.error = ErrorInfo.fromValues(error as ErrorInfo);
+  if (error) {
+    deserialized.error = ErrorInfo.fromValues(error as ErrorInfo);
+  }
+
   const messages = deserialized.messages as Message[];
-  if (messages) for (let i = 0; i < messages.length; i++) messages[i] = messageFromValues(messages[i]);
+  if (messages) {
+    for (let i = 0; i < messages.length; i++) {
+      messages[i] = messageFromValues(messages[i], { stringifyAction: true });
+    }
+  }
 
   const presence = presenceMessagePlugin ? (deserialized.presence as PresenceMessage[]) : undefined;
   if (presenceMessagePlugin) {
-    if (presence && presenceMessagePlugin)
-      for (let i = 0; i < presence.length; i++)
+    if (presence && presenceMessagePlugin) {
+      for (let i = 0; i < presence.length; i++) {
         presence[i] = presenceMessagePlugin.presenceMessageFromValues(presence[i], true);
+      }
+    }
   }
+
   return Object.assign(new ProtocolMessage(), { ...deserialized, presence });
 }
 

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -395,6 +395,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               helper.recordPrivateApi('call.msgpack.decode');
               var messageFromMsgpack = Message.fromValues(
                 msgpack.decode(BufferUtils.base64Decode(msgpackEncodedMessage)),
+                { stringifyAction: true },
               );
 
               try {
@@ -439,6 +440,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               helper.recordPrivateApi('call.msgpack.decode');
               var messageFromMsgpack = Message.fromValues(
                 msgpack.decode(BufferUtils.base64Decode(msgpackEncodedMessage)),
+                { stringifyAction: true },
               );
 
               try {

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -4,6 +4,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
   var expect = chai.expect;
   let config = Ably.Realtime.Platform.Config;
   var createPM = Ably.protocolMessageFromDeserialized;
+  var Message = Ably.Realtime.Message;
 
   var publishIntervalHelper = function (currentMessageNum, channel, dataFn, onPublish) {
     return function () {
@@ -1269,6 +1270,56 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         channel.publish({ name: 'event0', id: 'some_msg_id' });
         channel.publish({ name: 'event0', id: 'some_msg_id' });
         channel.publish('end', null);
+      });
+    });
+    /**
+     * @spec TM2j
+     */
+    describe('DefaultMessage.fromValues stringify action', function () {
+      const testCases = [
+        {
+          description: 'should stringify the numeric action',
+          action: 1,
+          options: { stringifyAction: true },
+          expectedString: '[Message; action=message.create]',
+          expectedJSON: { action: 1 },
+        },
+        {
+          description: 'should not stringify the numeric action',
+          action: 1,
+          options: { stringifyAction: false },
+          expectedString: '[Message; action=1]',
+          expectedJSON: { action: 1 },
+        },
+        {
+          description: 'should accept an already stringified action',
+          action: 'message.update',
+          options: { stringifyAction: true },
+          expectedString: '[Message; action=message.update]',
+          expectedJSON: { action: 2 },
+        },
+        {
+          description: 'should handle no action provided',
+          action: undefined,
+          options: { stringifyAction: true },
+          expectedString: '[Message]',
+          expectedJSON: { action: undefined },
+        },
+        {
+          description: 'should handle unknown action provided',
+          action: 10,
+          options: { stringifyAction: true },
+          expectedString: '[Message; action=10]',
+          expectedJSON: { action: 10 },
+        },
+      ];
+      testCases.forEach(({ description, action, options, expectedString, expectedJSON }) => {
+        it(description, function () {
+          const values = { action };
+          const message = Message.fromValues(values, options);
+          expect(message.toString()).to.equal(expectedString);
+          expect(message.toJSON()).to.deep.contains(expectedJSON);
+        });
       });
     });
 

--- a/test/support/runPlaywrightTests.js
+++ b/test/support/runPlaywrightTests.js
@@ -68,14 +68,20 @@ const runTests = async (browserType) => {
 
     // Use page.evaluate to add these functions as event listeners to the 'testLog' and 'testResult' Custom Events.
     // These events are fired by the custom mocha reporter in playwrightSetup.js
-    page.evaluate(() => {
+    const grep = process.env.MOCHA_GREP;
+    page.evaluate((grep) => {
       window.addEventListener('testLog', ({ type, detail }) => {
         onTestLog({ type, detail });
       });
       window.addEventListener('testResult', ({ type, detail }) => {
         onTestResult({ type, detail });
       });
-    });
+      // Set grep pattern in the browser context
+      // allows easy filtering of tests.
+      if (grep) {
+        window.mocha.grep(new RegExp(grep));
+      }
+    }, grep);
   });
 };
 


### PR DESCRIPTION
To support the work related to materialization, this pull request introduces new message fields and actions handling.

Added `MessageAction` enum to represent different message `actions`.
Added `serial` to the message, this is the unique serial (including index) of the message.
Publish now correctly sets the message action to `message_create`

- Added the following fields related to message annotations
  - `refSerial`
  - `refType` 
- Added the following fields related to message updates/deletes
  - `operation`
  - `updatedAt`
  - `deletedAt`

This PR will need to wait until the related realtime work is done to support the new action fields in published messages. (ongoing)

Related to [CHA-575]

[CHA-575]: https://ably.atlassian.net/browse/CHA-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced messaging capabilities with new properties in the Message interface for better tracking.
	- Introduced an Operation interface to carry additional information about message operations.
	- Added a new script for selective test execution using grep.
	- New tests validate the stringification behavior of the action property in messages.
	- Improved functionality of the test runner to allow dynamic filtering of tests based on environment variables.

- **Bug Fixes**
	- Improved error handling in message encoding/decoding tests.

- **Documentation**
	- Updated type definitions and method signatures for clarity and functionality.

- **Chores**
	- Adjusted bundle size thresholds for Realtime functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->