### PR TITLE
LiveObjects SYNC sequence tests

### DIFF
--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -60,6 +60,10 @@ export class LiveMap extends LiveObject<LiveMapData> {
     }
   }
 
+  size(): number {
+    return this._dataRef.data.size;
+  }
+
   protected _getZeroValueData(): LiveMapData {
     return { data: new Map<string, MapEntry>() };
   }

--- a/test/common/globals/named_dependencies.js
+++ b/test/common/globals/named_dependencies.js
@@ -26,5 +26,9 @@ define(function () {
       browser: 'test/common/modules/private_api_recorder',
       node: 'test/common/modules/private_api_recorder',
     },
+    live_objects_helper: {
+      browser: 'test/common/modules/live_objects_helper',
+      node: 'test/common/modules/live_objects_helper',
+    },
   });
 });

--- a/test/common/modules/live_objects_helper.js
+++ b/test/common/modules/live_objects_helper.js
@@ -1,0 +1,171 @@
+'use strict';
+
+/**
+ * LiveObjects helper to create pre-determined state tree on channels
+ */
+define(['shared_helper'], function (Helper) {
+  const ACTIONS = {
+    MAP_CREATE: 0,
+    MAP_SET: 1,
+    MAP_REMOVE: 2,
+    COUNTER_CREATE: 3,
+    COUNTER_INC: 4,
+  };
+
+  function nonce() {
+    return Helper.randomString();
+  }
+
+  class LiveObjectsHelper {
+    /**
+     * Creates next LiveObjects state tree on a provided channel name:
+     *
+     * root "emptyMap" -> Map#1 {} -- empty map
+     * root "referencedMap" -> Map#2 { "counterKey": <object id Counter#3> }
+     * root "valuesMap" -> Map#3 { "stringKey": "stringValue", "emptyStringKey": "", "bytesKey": <byte array for "{"productId": "001", "productName": "car"}", encoded in base64>, "emptyBytesKey": <empty byte array>, "numberKey": 1, "zeroKey": 0, "trueKey": true, "falseKey": false, "mapKey": <objectId of Map#2> }
+     * root "emptyCounter" -> Counter#1 -- no initial value counter, should be 0
+     * root "initialValueCounter" -> Counter#2 count=10
+     * root "referencedCounter" -> Counter#3 count=20
+     */
+    async initForChannel(helper, channelName) {
+      const rest = helper.AblyRest({ useBinaryProtocol: false });
+
+      const emptyCounter = await this._createAndSetOnMap(rest, channelName, {
+        mapObjectId: 'root',
+        key: 'emptyCounter',
+        createOp: this._counterCreateOp(),
+      });
+      const initialValueCounter = await this._createAndSetOnMap(rest, channelName, {
+        mapObjectId: 'root',
+        key: 'initialValueCounter',
+        createOp: this._counterCreateOp({ count: 10 }),
+      });
+      const referencedCounter = await this._createAndSetOnMap(rest, channelName, {
+        mapObjectId: 'root',
+        key: 'referencedCounter',
+        createOp: this._counterCreateOp({ count: 20 }),
+      });
+
+      const emptyMap = await this._createAndSetOnMap(rest, channelName, {
+        mapObjectId: 'root',
+        key: 'emptyMap',
+        createOp: this._mapCreateOp(),
+      });
+      const referencedMap = await this._createAndSetOnMap(rest, channelName, {
+        mapObjectId: 'root',
+        key: 'referencedMap',
+        createOp: this._mapCreateOp({ entries: { counterKey: { data: { objectId: referencedCounter.objectId } } } }),
+      });
+      const valuesMap = await this._createAndSetOnMap(rest, channelName, {
+        mapObjectId: 'root',
+        key: 'valuesMap',
+        createOp: this._mapCreateOp({
+          entries: {
+            stringKey: { data: { value: 'stringValue' } },
+            emptyStringKey: { data: { value: '' } },
+            bytesKey: {
+              data: { value: 'eyJwcm9kdWN0SWQiOiAiMDAxIiwgInByb2R1Y3ROYW1lIjogImNhciJ9', encoding: 'base64' },
+            },
+            emptyBytesKey: { data: { value: '', encoding: 'base64' } },
+            numberKey: { data: { value: 1 } },
+            zeroKey: { data: { value: 0 } },
+            trueKey: { data: { value: true } },
+            falseKey: { data: { value: false } },
+            mapKey: { data: { objectId: referencedMap.objectId } },
+          },
+        }),
+      });
+    }
+
+    async _createAndSetOnMap(rest, channelName, opts) {
+      const { mapObjectId, key, createOp } = opts;
+
+      const createResult = await this._stateRequest(rest, channelName, createOp);
+      await this._stateRequest(
+        rest,
+        channelName,
+        this._mapSetOp({ objectId: mapObjectId, key, data: { objectId: createResult.objectId } }),
+      );
+
+      return createResult;
+    }
+
+    _mapCreateOp(opts) {
+      const { objectId, entries } = opts ?? {};
+      const op = {
+        operation: {
+          action: ACTIONS.MAP_CREATE,
+          nonce: nonce(),
+          objectId,
+        },
+      };
+
+      if (entries) {
+        op.operation.map = { entries };
+      }
+
+      return op;
+    }
+
+    _mapSetOp(opts) {
+      const { objectId, key, data } = opts ?? {};
+      const op = {
+        operation: {
+          action: ACTIONS.MAP_SET,
+          objectId,
+        },
+      };
+
+      if (key && data) {
+        op.operation.mapOp = {
+          key,
+          data,
+        };
+      }
+
+      return op;
+    }
+
+    _counterCreateOp(opts) {
+      const { objectId, count } = opts ?? {};
+      const op = {
+        operation: {
+          action: ACTIONS.COUNTER_CREATE,
+          nonce: nonce(),
+          objectId,
+        },
+      };
+
+      if (count != null) {
+        op.operation.counter = { count };
+      }
+
+      return op;
+    }
+
+    async _stateRequest(rest, channelName, opBody) {
+      if (Array.isArray(opBody)) {
+        throw new Error(`Only single object state requests are supported`);
+      }
+
+      const method = 'post';
+      const path = `/channels/${channelName}/state`;
+
+      const response = await rest.request(method, path, 3, null, opBody, null);
+
+      if (response.success) {
+        // only one operation in request, so need only first item.
+        const result = response.items[0];
+        // extract object id if present
+        result.objectId = result.objectIds?.[0];
+        return result;
+      }
+
+      throw new Error(
+        `${method}: ${path} FAILED; http code = ${response.statusCode}, error code = ${response.errorCode}, message = ${response.errorMessage}; operation = ${JSON.stringify(opBody)}`,
+      );
+    }
+  }
+
+  return (module.exports = new LiveObjectsHelper());
+});

--- a/test/common/modules/testapp_manager.js
+++ b/test/common/modules/testapp_manager.js
@@ -133,6 +133,7 @@ define(['globals', 'ably'], function (ablyGlobals, ably) {
         callback(err);
         return;
       }
+      testData.post_apps.featureFlags = ['enableChannelState'];
       var postData = JSON.stringify(testData.post_apps);
       var postOptions = {
         host: restHost,

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -8,6 +8,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
   LiveObjectsHelper,
 ) {
   const expect = chai.expect;
+  const BufferUtils = Ably.Realtime.Platform.BufferUtils;
   const createPM = Ably.makeProtocolMessageFromDeserialized({ LiveObjectsPlugin });
   const liveObjectsFixturesChannel = 'liveobjects_fixtures';
   const nextTick = Ably.Realtime.Platform.Config.nextTick;
@@ -175,6 +176,167 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
           await new Promise((res) => nextTick(res));
 
           expect(resolvedImmediately, 'Check getRoot() is resolved on next tick').to.be.true;
+        }, client);
+      });
+
+      it('builds state object tree from STATE_SYNC sequence on channel attachment', async function () {
+        const helper = this.test.helper;
+        const client = RealtimeWithLiveObjects(helper);
+
+        await helper.monitorConnectionThenCloseAndFinish(async () => {
+          const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
+          const liveObjects = channel.liveObjects;
+
+          await channel.attach();
+          const root = await liveObjects.getRoot();
+
+          const counterKeys = ['emptyCounter', 'initialValueCounter', 'referencedCounter'];
+          const mapKeys = ['emptyMap', 'referencedMap', 'valuesMap'];
+          const rootKeysCount = counterKeys.length + mapKeys.length;
+
+          expect(root, 'Check getRoot() is resolved when STATE_SYNC sequence ends').to.exist;
+          expect(root.size()).to.equal(rootKeysCount, 'Check root has correct number of keys');
+
+          counterKeys.forEach((key) => {
+            const counter = root.get(key);
+            expect(counter, `Check counter at key="${key}" in root exists`).to.exist;
+            expect(counter.constructor.name).to.equal(
+              'LiveCounter',
+              `Check counter at key="${key}" in root is of type LiveCounter`,
+            );
+          });
+
+          mapKeys.forEach((key) => {
+            const map = root.get(key);
+            expect(map, `Check map at key="${key}" in root exists`).to.exist;
+            expect(map.constructor.name).to.equal('LiveMap', `Check map at key="${key}" in root is of type LiveMap`);
+          });
+
+          const valuesMap = root.get('valuesMap');
+          const valueMapKeys = [
+            'stringKey',
+            'emptyStringKey',
+            'bytesKey',
+            'emptyBytesKey',
+            'numberKey',
+            'zeroKey',
+            'trueKey',
+            'falseKey',
+            'mapKey',
+          ];
+          expect(valuesMap.size()).to.equal(valueMapKeys.length, 'Check nested map has correct number of keys');
+          valueMapKeys.forEach((key) => {
+            const value = valuesMap.get(key);
+            expect(value, `Check value at key="${key}" in nested map exists`).to.exist;
+          });
+        }, client);
+      });
+
+      it('LiveCounter is initialized with initial value from STATE_SYNC sequence', async function () {
+        const helper = this.test.helper;
+        const client = RealtimeWithLiveObjects(helper);
+
+        await helper.monitorConnectionThenCloseAndFinish(async () => {
+          const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
+          const liveObjects = channel.liveObjects;
+
+          await channel.attach();
+          const root = await liveObjects.getRoot();
+
+          const counters = [
+            { key: 'emptyCounter', value: 0 },
+            { key: 'initialValueCounter', value: 10 },
+            { key: 'referencedCounter', value: 20 },
+          ];
+
+          counters.forEach((x) => {
+            const counter = root.get(x.key);
+            expect(counter.value()).to.equal(x.value, `Check counter at key="${x.key}" in root has correct value`);
+          });
+        }, client);
+      });
+
+      it('LiveMap is initialized with initial value from STATE_SYNC sequence', async function () {
+        const helper = this.test.helper;
+        const client = RealtimeWithLiveObjects(helper);
+
+        await helper.monitorConnectionThenCloseAndFinish(async () => {
+          const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
+          const liveObjects = channel.liveObjects;
+
+          await channel.attach();
+          const root = await liveObjects.getRoot();
+
+          const emptyMap = root.get('emptyMap');
+          expect(emptyMap.size()).to.equal(0, 'Check empty map in root has no keys');
+
+          const referencedMap = root.get('referencedMap');
+          expect(referencedMap.size()).to.equal(1, 'Check referenced map in root has correct number of keys');
+
+          const counterFromReferencedMap = referencedMap.get('counterKey');
+          expect(counterFromReferencedMap.value()).to.equal(20, 'Check nested counter has correct value');
+
+          const valuesMap = root.get('valuesMap');
+          expect(valuesMap.size()).to.equal(9, 'Check values map in root has correct number of keys');
+
+          expect(valuesMap.get('stringKey')).to.equal('stringValue', 'Check values map has correct string value key');
+          expect(valuesMap.get('emptyStringKey')).to.equal('', 'Check values map has correct empty string value key');
+          expect(
+            BufferUtils.areBuffersEqual(
+              valuesMap.get('bytesKey'),
+              BufferUtils.base64Decode('eyJwcm9kdWN0SWQiOiAiMDAxIiwgInByb2R1Y3ROYW1lIjogImNhciJ9'),
+            ),
+            'Check values map has correct bytes value key',
+          ).to.be.true;
+          expect(
+            BufferUtils.areBuffersEqual(valuesMap.get('emptyBytesKey'), BufferUtils.base64Decode('')),
+            'Check values map has correct empty bytes value key',
+          ).to.be.true;
+          expect(valuesMap.get('numberKey')).to.equal(1, 'Check values map has correct number value key');
+          expect(valuesMap.get('zeroKey')).to.equal(0, 'Check values map has correct zero number value key');
+          expect(valuesMap.get('trueKey')).to.equal(true, `Check values map has correct 'true' value key`);
+          expect(valuesMap.get('falseKey')).to.equal(false, `Check values map has correct 'false' value key`);
+
+          const mapFromValuesMap = valuesMap.get('mapKey');
+          expect(mapFromValuesMap.size()).to.equal(1, 'Check nested map has correct number of keys');
+        }, client);
+      });
+
+      it('LiveMaps can reference the same object in their keys', async function () {
+        const helper = this.test.helper;
+        const client = RealtimeWithLiveObjects(helper);
+
+        await helper.monitorConnectionThenCloseAndFinish(async () => {
+          const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
+          const liveObjects = channel.liveObjects;
+
+          await channel.attach();
+          const root = await liveObjects.getRoot();
+
+          const referencedCounter = root.get('referencedCounter');
+          const referencedMap = root.get('referencedMap');
+          const valuesMap = root.get('valuesMap');
+
+          const counterFromReferencedMap = referencedMap.get('counterKey');
+          expect(counterFromReferencedMap, 'Check nested counter exists at a key in a map').to.exist;
+          expect(counterFromReferencedMap.constructor.name).to.equal(
+            'LiveCounter',
+            'Check nested counter is of type LiveCounter',
+          );
+          expect(counterFromReferencedMap).to.equal(
+            referencedCounter,
+            'Check nested counter is the same object instance as counter on the root',
+          );
+          expect(counterFromReferencedMap.value()).to.equal(20, 'Check nested counter has correct value');
+
+          const mapFromValuesMap = valuesMap.get('mapKey');
+          expect(mapFromValuesMap, 'Check nested map exists at a key in a map').to.exist;
+          expect(mapFromValuesMap.constructor.name).to.equal('LiveMap', 'Check nested map is of type LiveMap');
+          expect(mapFromValuesMap.size()).to.equal(1, 'Check nested map has correct number of keys');
+          expect(mapFromValuesMap).to.equal(
+            referencedMap,
+            'Check nested map is the same object instance as map on the root',
+          );
         }, client);
       });
     });

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -1,13 +1,15 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'chai', 'live_objects'], function (
+define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'], function (
   Ably,
   Helper,
   chai,
   LiveObjectsPlugin,
+  LiveObjectsHelper,
 ) {
   const expect = chai.expect;
   const createPM = Ably.makeProtocolMessageFromDeserialized({ LiveObjectsPlugin });
+  const liveObjectsFixturesChannel = 'liveobjects_fixtures';
 
   function RealtimeWithLiveObjects(helper, options) {
     return helper.AblyRealtime({ ...options, plugins: { LiveObjects: LiveObjectsPlugin } });
@@ -24,7 +26,10 @@ define(['ably', 'shared_helper', 'chai', 'live_objects'], function (
           done(err);
           return;
         }
-        done();
+
+        LiveObjectsHelper.initForChannel(helper, liveObjectsFixturesChannel)
+          .then(done)
+          .catch((err) => done(err));
       });
     });
 

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -1,16 +1,15 @@
 'use strict';
 
-define(['ably', 'shared_helper', 'async', 'chai', 'live_objects'], function (
+define(['ably', 'shared_helper', 'chai', 'live_objects'], function (
   Ably,
   Helper,
-  async,
   chai,
   LiveObjectsPlugin,
 ) {
-  var expect = chai.expect;
-  var createPM = Ably.makeProtocolMessageFromDeserialized({ LiveObjectsPlugin });
+  const expect = chai.expect;
+  const createPM = Ably.makeProtocolMessageFromDeserialized({ LiveObjectsPlugin });
 
-  function LiveObjectsRealtime(helper, options) {
+  function RealtimeWithLiveObjects(helper, options) {
     return helper.AblyRealtime({ ...options, plugins: { LiveObjects: LiveObjectsPlugin } });
   }
 
@@ -41,44 +40,44 @@ define(['ably', 'shared_helper', 'async', 'chai', 'live_objects'], function (
 
     describe('Realtime with LiveObjects plugin', () => {
       /** @nospec */
-      it("returns LiveObjects instance when accessing channel's `liveObjects` property", async function () {
+      it("returns LiveObjects class instance when accessing channel's `liveObjects` property", async function () {
         const helper = this.test.helper;
-        const client = LiveObjectsRealtime(helper, { autoConnect: false });
+        const client = RealtimeWithLiveObjects(helper, { autoConnect: false });
         const channel = client.channels.get('channel');
         expect(channel.liveObjects.constructor.name).to.equal('LiveObjects');
       });
 
-      describe('LiveObjects instance', () => {
-        /** @nospec */
-        it('getRoot() returns LiveMap instance', async function () {
-          const helper = this.test.helper;
-          const client = LiveObjectsRealtime(helper);
+      /** @nospec */
+      it('getRoot() returns LiveMap instance', async function () {
+        const helper = this.test.helper;
+        const client = RealtimeWithLiveObjects(helper);
 
-          await helper.monitorConnectionThenCloseAndFinish(async () => {
-            const channel = client.channels.get('channel');
-            const liveObjects = channel.liveObjects;
-            await channel.attach();
-            const root = await liveObjects.getRoot();
+        await helper.monitorConnectionThenCloseAndFinish(async () => {
+          const channel = client.channels.get('channel');
+          const liveObjects = channel.liveObjects;
 
-            expect(root.constructor.name).to.equal('LiveMap');
-          }, client);
-        });
+          await channel.attach();
+          const root = await liveObjects.getRoot();
 
-        /** @nospec */
-        it('getRoot() returns live object with id "root"', async function () {
-          const helper = this.test.helper;
-          const client = LiveObjectsRealtime(helper);
+          expect(root.constructor.name).to.equal('LiveMap');
+        }, client);
+      });
 
-          await helper.monitorConnectionThenCloseAndFinish(async () => {
-            const channel = client.channels.get('channel');
-            const liveObjects = channel.liveObjects;
-            await channel.attach();
-            const root = await liveObjects.getRoot();
+      /** @nospec */
+      it('getRoot() returns live object with id "root"', async function () {
+        const helper = this.test.helper;
+        const client = RealtimeWithLiveObjects(helper);
 
-            helper.recordPrivateApi('call.LiveObject.getObjectId');
-            expect(root.getObjectId()).to.equal('root');
-          }, client);
-        });
+        await helper.monitorConnectionThenCloseAndFinish(async () => {
+          const channel = client.channels.get('channel');
+          const liveObjects = channel.liveObjects;
+
+          await channel.attach();
+          const root = await liveObjects.getRoot();
+
+          helper.recordPrivateApi('call.LiveObject.getObjectId');
+          expect(root.getObjectId()).to.equal('root');
+        }, client);
       });
     });
   });

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -446,5 +446,22 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         }, client);
       });
     });
+
+    it('can attach to channel with LiveObjects state modes', async function () {
+      const helper = this.test.helper;
+      const client = helper.AblyRealtime();
+
+      await helper.monitorConnectionThenCloseAndFinish(async () => {
+        const liveObjectsModes = ['state_subscribe', 'state_publish'];
+        const channelOptions = { modes: liveObjectsModes };
+        const channel = client.channels.get('channel', channelOptions);
+
+        await channel.attach();
+
+        helper.recordPrivateApi('read.channel.channelOptions');
+        expect(channel.channelOptions).to.deep.equal(channelOptions, 'Check expected channel options');
+        expect(channel.modes).to.deep.equal(liveObjectsModes, 'Check expected modes');
+      }, client);
+    });
   });
 });


### PR DESCRIPTION
This PR is based on https://github.com/ably/ably-js/pull/1891, please review it first.

Adds LiveObjects integration tests for functionality introduced in https://github.com/ably/ably-js/pull/1887, https://github.com/ably/ably-js/pull/1890 and https://github.com/ably/ably-js/pull/1891.

NOTE: next Live Objects tests are expected to fail until https://ably.atlassian.net/browse/DTP-982 is fixed:
- builds state object tree from STATE_SYNC sequence on channel attachment
- LiveMap is initialized with initial value from STATE_SYNC sequence
- LiveMaps can reference the same object in their keys

Failure is due to missing state object in STATE_SYNC sequence for a [map which has _zero values_](https://github.com/ably/ably-js/pull/1894/files#diff-23d7bf6e77df254abc51fa6462a6c52fc7e6ee5bc15943edfec578a3ab2c3123R69-R73).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a `size()` method to the `LiveMap` class for retrieving the size of the data map.
	- Added a new `live_objects_helper` dependency for testing.
	- Implemented a `LiveObjectsHelper` class to manage LiveObjects state on channels.
	- Added a feature flag `enableChannelState` for new app creation.
	- Enhanced the test suite with a new helper function for channel options related to LiveObjects.

- **Bug Fixes**
	- Improved error handling in the test suite for scenarios when the LiveObjects plugin is absent.

- **Documentation**
	- Updated test suite structure for improved clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->