### PR TITLE
[ECO-4841] Add README section to explain "Connection limit exceeded" error and solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,26 @@ The issue is coming from the fact that when using App Router specifically depend
 Using `serverComponentsExternalPackages` opt-outs from using Next.js bundling for specific packages and uses native Node.js `require` instead.
 This is a common problem in App Router for a number of packages (for example, see next.js issue [vercel/next.js#52876](https://github.com/vercel/next.js/issues/52876)), and using `serverComponentsExternalPackages` is the recommended approach here.
 
+#### "Connection limit exceeded" error during development
+
+If you're encountering a "Connection limit exceeded" error when trying to connect to Ably servers during the development of your application, and you notice spikes or linear increases in the connection count on the Ably dashboard for your app, this may be due to one of the following reasons:
+
+- If you're using Next.js, your `Ably.Realtime` client instance may be created multiple times on the server side (i.e., in a Node.js process) as you're developing your app, due to Next.js server side rendering your components. Note that even for "Client Components" (i.e., components with the 'use client' directive), [Next.js may still run the component code on the server in order to pre-render HTML](https://nextjs.org/docs/app/building-your-application/rendering/client-components#how-are-client-components-rendered). Depending on your client configuration options, those clients may also successfully open a connection to Ably servers from that Node.js process, which won't close until you restart your development server.
+
+  The simplest fix is to use the `autoConnect` client option and check if the client is created on the server side with a simple window object check, like this:
+
+  ```typescript
+  const client = new Ably.Realtime({ key: 'your-ably-api-key', autoConnect: typeof window !== 'undefined' });
+  ```
+
+  This will prevent the client from connecting to Ably servers if it is created on the server side, while not affecting your client side components.
+
+- If you're using any React-based framework, you may be recreating the `Ably.Realtime` client instance on every component re-render. To avoid this, and to prevent potentially reaching the maximum connections limit on your account, move the client instantiation (`new Ably.Realtime`) outside of your components. You can find an example in our [React docs](./docs/react.md#Usage).
+
+- The connection limit error can be caused by the Hot Reloading mechanism of your development environment (called Fast Refresh in newer Next.js versions, or more generally, Hot Module Replacement - HMR). When you edit and save a file that contains a `new Ably.Realtime()` call in an environment that supports HMR (such as React, Vite, or Next.js apps), the file gets refreshed and creates a new `Ably.Realtime` client instance. However, the previous client remains in memory, unaware of the replacement, and stays connected to Ably's realtime systems. As a result, your connection count will keep increasing with each file edit as new clients are created. This only resets when you manually refresh the browser page, which closes all clients. This behavior applies to any development environment with an HMR mechanism implemented.
+
+  The solution is simple: move the `new Ably.Realtime()` call to a separate file, such as `ably-client.js`, and export the client instance from there. This way, the client instance will only be recreated when you specifically make changes to the `ably-client.js` file, which should be far less frequent than changes in the rest of the codebase.
+
 ## Contributing
 
 For guidance on how to contribute to this project, see the [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/react.md
+++ b/docs/react.md
@@ -36,6 +36,7 @@ The hooks are compatible with all versions of React above 16.8.0
 Start by connecting your app to Ably using the `AblyProvider` component. See the [`ClientOptions` documentation](https://ably.com/docs/api/realtime-sdk/types?lang=javascript) for information about what options are available when creating an Ably client. If you want to use the `usePresence` or `usePresenceListener` hooks, you'll need to explicitly provide a `clientId`.
 
 The `AblyProvider` should be high in your component tree, wrapping every component which needs to access Ably.
+Also, ensure that the `Ably.Realtime` instance is created outside of components to prevent it from being recreated on component re-renders. This will help avoid opening extra unnecessary connections to the Ably servers and potentially reaching the maximum connections limit on your account.
 
 ```jsx
 import { AblyProvider } from 'ably/react';


### PR DESCRIPTION
Resolves [ECO-4841](https://ably.atlassian.net/browse/ECO-4841)

This is based on the "max connections errors" research done in [ECO-4841](https://ably.atlassian.net/browse/ECO-4841) (see comments), "[Ably-js max connections issue overview and possible solutions](https://ably.atlassian.net/wiki/spaces/SDK/pages/3381854247/Ably-js+max+connections+issue+overview+and+possible+solutions)", and solutions found in https://github.com/ably-labs/react-hooks/issues/8#issuecomment-1697410212 and https://github.com/ably/ably-js/issues/1742#issuecomment-2066179610

Related: https://github.com/ably/ably-js/issues/1779, https://github.com/ably/ably-js/issues/1742

[ECO-4841]: https://ably.atlassian.net/browse/ECO-4841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ECO-4841]: https://ably.atlassian.net/browse/ECO-4841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added guidance for managing the "Connection limit exceeded" error in the README.
	- Introduced new hooks: `useConnectionStateListener`, `useChannelStateListener`, and `useAbly`.
	- New parameter `skip` added to `useChannel`, `usePresence`, and `usePresenceListener` hooks for better control over attachment behavior.
  
- **Documentation**
	- Enhanced clarity and expanded usage examples for `ably-js React Hooks`.
	- Updated error handling section with detailed management strategies for connection and channel errors.
	- Added a section addressing common warnings when using the library with Next.js.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->