### PR TITLE
[DTP-955] Buffer and flush state operations during a STATE_SYNC sequence

### DIFF
--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -649,7 +649,7 @@ class RealtimeChannel extends EventEmitter {
           }
         }
 
-        this._liveObjects.handleStateMessages(stateMessages);
+        this._liveObjects.handleStateMessages(stateMessages, message.channelSerial);
 
         break;
       }

--- a/src/plugins/liveobjects/livecounter.ts
+++ b/src/plugins/liveobjects/livecounter.ts
@@ -1,6 +1,7 @@
 import { LiveObject, LiveObjectData } from './liveobject';
 import { LiveObjects } from './liveobjects';
-import { StateCounter, StateCounterOp, StateOperation, StateOperationAction } from './statemessage';
+import { StateCounter, StateCounterOp, StateMessage, StateOperation, StateOperationAction } from './statemessage';
+import { Timeserial } from './timeserial';
 
 export interface LiveCounterData extends LiveObjectData {
   data: number;
@@ -12,8 +13,9 @@ export class LiveCounter extends LiveObject<LiveCounterData> {
     private _created: boolean,
     initialData?: LiveCounterData | null,
     objectId?: string,
+    regionalTimeserial?: Timeserial,
   ) {
-    super(liveObjects, initialData, objectId);
+    super(liveObjects, initialData, objectId, regionalTimeserial);
   }
 
   /**
@@ -21,8 +23,13 @@ export class LiveCounter extends LiveObject<LiveCounterData> {
    *
    * @internal
    */
-  static zeroValue(liveobjects: LiveObjects, isCreated: boolean, objectId?: string): LiveCounter {
-    return new LiveCounter(liveobjects, isCreated, null, objectId);
+  static zeroValue(
+    liveobjects: LiveObjects,
+    isCreated: boolean,
+    objectId?: string,
+    regionalTimeserial?: Timeserial,
+  ): LiveCounter {
+    return new LiveCounter(liveobjects, isCreated, null, objectId, regionalTimeserial);
   }
 
   value(): number {
@@ -46,7 +53,7 @@ export class LiveCounter extends LiveObject<LiveCounterData> {
   /**
    * @internal
    */
-  applyOperation(op: StateOperation): void {
+  applyOperation(op: StateOperation, msg: StateMessage, opRegionalTimeserial: Timeserial): void {
     if (op.objectId !== this.getObjectId()) {
       throw new this._client.ErrorInfo(
         `Cannot apply state operation with objectId=${op.objectId}, to this LiveCounter with objectId=${this.getObjectId()}`,
@@ -75,6 +82,8 @@ export class LiveCounter extends LiveObject<LiveCounterData> {
           500,
         );
     }
+
+    this.setRegionalTimeserial(opRegionalTimeserial);
   }
 
   protected _getZeroValueData(): LiveCounterData {

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -46,8 +46,9 @@ export class LiveMap extends LiveObject<LiveMapData> {
     private _semantics: MapSemantics,
     initialData?: LiveMapData | null,
     objectId?: string,
+    regionalTimeserial?: Timeserial,
   ) {
-    super(liveObjects, initialData, objectId);
+    super(liveObjects, initialData, objectId, regionalTimeserial);
   }
 
   /**
@@ -55,8 +56,8 @@ export class LiveMap extends LiveObject<LiveMapData> {
    *
    * @internal
    */
-  static zeroValue(liveobjects: LiveObjects, objectId?: string): LiveMap {
-    return new LiveMap(liveobjects, MapSemantics.LWW, null, objectId);
+  static zeroValue(liveobjects: LiveObjects, objectId?: string, regionalTimeserial?: Timeserial): LiveMap {
+    return new LiveMap(liveobjects, MapSemantics.LWW, null, objectId, regionalTimeserial);
   }
 
   static liveMapDataFromMapEntries(client: BaseClient, entries: Record<string, StateMapEntry>): LiveMapData {
@@ -134,7 +135,7 @@ export class LiveMap extends LiveObject<LiveMapData> {
   /**
    * @internal
    */
-  applyOperation(op: StateOperation, msg: StateMessage): void {
+  applyOperation(op: StateOperation, msg: StateMessage, opRegionalTimeserial: Timeserial): void {
     if (op.objectId !== this.getObjectId()) {
       throw new this._client.ErrorInfo(
         `Cannot apply state operation with objectId=${op.objectId}, to this LiveMap with objectId=${this.getObjectId()}`,
@@ -171,6 +172,8 @@ export class LiveMap extends LiveObject<LiveMapData> {
           500,
         );
     }
+
+    this.setRegionalTimeserial(opRegionalTimeserial);
   }
 
   protected _getZeroValueData(): LiveMapData {

--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -1,6 +1,7 @@
 import type BaseClient from 'common/lib/client/baseclient';
 import { LiveObjects } from './liveobjects';
 import { StateMessage, StateOperation } from './statemessage';
+import { DefaultTimeserial, Timeserial } from './timeserial';
 
 export interface LiveObjectData {
   data: any;
@@ -10,16 +11,19 @@ export abstract class LiveObject<T extends LiveObjectData = LiveObjectData> {
   protected _client: BaseClient;
   protected _dataRef: T;
   protected _objectId: string;
-  protected _regionalTimeserial?: string;
+  protected _regionalTimeserial: Timeserial;
 
   constructor(
     protected _liveObjects: LiveObjects,
     initialData?: T | null,
     objectId?: string,
+    regionalTimeserial?: Timeserial,
   ) {
     this._client = this._liveObjects.getClient();
     this._dataRef = initialData ?? this._getZeroValueData();
     this._objectId = objectId ?? this._createObjectId();
+    // use zero value timeserial by default, so any future operation can be applied for this object
+    this._regionalTimeserial = regionalTimeserial ?? DefaultTimeserial.zeroValueTimeserial(this._client);
   }
 
   /**
@@ -32,7 +36,7 @@ export abstract class LiveObject<T extends LiveObjectData = LiveObjectData> {
   /**
    * @internal
    */
-  getRegionalTimeserial(): string | undefined {
+  getRegionalTimeserial(): Timeserial {
     return this._regionalTimeserial;
   }
 
@@ -46,7 +50,7 @@ export abstract class LiveObject<T extends LiveObjectData = LiveObjectData> {
   /**
    * @internal
    */
-  setRegionalTimeserial(regionalTimeserial: string): void {
+  setRegionalTimeserial(regionalTimeserial: Timeserial): void {
     this._regionalTimeserial = regionalTimeserial;
   }
 
@@ -58,6 +62,6 @@ export abstract class LiveObject<T extends LiveObjectData = LiveObjectData> {
   /**
    * @internal
    */
-  abstract applyOperation(op: StateOperation, msg: StateMessage): void;
+  abstract applyOperation(op: StateOperation, msg: StateMessage, opRegionalTimeserial: Timeserial): void;
   protected abstract _getZeroValueData(): T;
 }


### PR DESCRIPTION
This PR is based on https://github.com/ably/ably-js/pull/1908, please review it first.

See commits for more details.

Resolves [DTP-955](https://ably.atlassian.net/browse/DTP-955)

[DTP-955]: https://ably.atlassian.net/browse/DTP-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced handling of state messages and synchronization across various components.
	- Introduced `BufferedStateMessage` for improved state message management during synchronization.
	- Added methods in `LiveObjectsHelper` for better processing of state operation messages.
	- Improved initialization of `LiveCounter`, `LiveMap`, and `LiveObject` with regional timeserials.

- **Bug Fixes**
	- Updated tests to ensure correct handling of `STATE` and `STATE_SYNC` messages, improving reliability.

- **Documentation**
	- Improved clarity and maintainability of the test suite by modularizing the test logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->