### PR TITLE
Support RTP17g1: presence auto re-enter with a different connId 

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2284,7 +2284,6 @@ export declare interface Channels<T> {
    * This experimental method allows you to create custom realtime data feeds by selectively subscribing
    * to receive only part of the data from the channel.
    * See the [announcement post](https://pages.ably.com/subscription-filters-preview) for more information.
-   *
    * @param name - The channel name.
    * @param deriveOptions - A {@link DeriveOptions} object.
    * @param channelOptions - A {@link ChannelOptions} object.

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -441,9 +441,8 @@ class RealtimePresence extends EventEmitter {
       // RTP17g1: suppress id if the connId has changed
       const id = (entry.connectionId === connId) ? entry.id : undefined;
       this._enterOrUpdateClient(id, entry.clientId, entry.data, 'enter').catch((err) => {
-        const msg = 'Presence auto-re-enter failed: ' + err.toString();
-        const wrappedErr = new ErrorInfo(msg, 91004, 400);
-        Logger.logAction(this.logger, Logger.LOG_ERROR, 'RealtimePresence._ensureMyMembersPresent()', msg);
+        const wrappedErr = new ErrorInfo('Presence auto re-enter failed', 91004, 400, err);
+        Logger.logAction(this.logger, Logger.LOG_ERROR, 'RealtimePresence._ensureMyMembersPresent()', 'Presence auto re-enter failed; reason = ' + Utils.inspectError(err));
         const change = new ChannelStateChange(this.channel.state, this.channel.state, true, false, wrappedErr);
         this.channel.emit('update', change);
       });

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -439,10 +439,15 @@ class RealtimePresence extends EventEmitter {
       // RTP17g: Send ENTER containing the member id, clientId and data
       // attributes.
       // RTP17g1: suppress id if the connId has changed
-      const id = (entry.connectionId === connId) ? entry.id : undefined;
+      const id = entry.connectionId === connId ? entry.id : undefined;
       this._enterOrUpdateClient(id, entry.clientId, entry.data, 'enter').catch((err) => {
         const wrappedErr = new ErrorInfo('Presence auto re-enter failed', 91004, 400, err);
-        Logger.logAction(this.logger, Logger.LOG_ERROR, 'RealtimePresence._ensureMyMembersPresent()', 'Presence auto re-enter failed; reason = ' + Utils.inspectError(err));
+        Logger.logAction(
+          this.logger,
+          Logger.LOG_ERROR,
+          'RealtimePresence._ensureMyMembersPresent()',
+          'Presence auto re-enter failed; reason = ' + Utils.inspectError(err),
+        );
         const change = new ChannelStateChange(this.channel.state, this.channel.state, true, false, wrappedErr);
         this.channel.emit('update', change);
       });

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -425,16 +425,8 @@ class RealtimePresence extends EventEmitter {
   }
 
   _ensureMyMembersPresent(): void {
-    const myMembers = this._myMembers,
-      reenterCb = (err?: ErrorInfo | null) => {
-        if (err) {
-          const msg = 'Presence auto-re-enter failed: ' + err.toString();
-          const wrappedErr = new ErrorInfo(msg, 91004, 400);
-          Logger.logAction(this.logger, Logger.LOG_ERROR, 'RealtimePresence._ensureMyMembersPresent()', msg);
-          const change = new ChannelStateChange(this.channel.state, this.channel.state, true, false, wrappedErr);
-          this.channel.emit('update', change);
-        }
-      };
+    const myMembers = this._myMembers;
+    const connId = this.channel.connectionManager.connectionId;
 
     for (const memberKey in myMembers.map) {
       const entry = myMembers.map[memberKey];
@@ -446,7 +438,15 @@ class RealtimePresence extends EventEmitter {
       );
       // RTP17g: Send ENTER containing the member id, clientId and data
       // attributes.
-      Utils.whenPromiseSettles(this._enterOrUpdateClient(entry.id, entry.clientId, entry.data, 'enter'), reenterCb);
+      // RTP17g1: suppress id if the connId has changed
+      const id = (entry.connectionId === connId) ? entry.id : undefined;
+      this._enterOrUpdateClient(id, entry.clientId, entry.data, 'enter').catch((err) => {
+        const msg = 'Presence auto-re-enter failed: ' + err.toString();
+        const wrappedErr = new ErrorInfo(msg, 91004, 400);
+        Logger.logAction(this.logger, Logger.LOG_ERROR, 'RealtimePresence._ensureMyMembersPresent()', msg);
+        const change = new ChannelStateChange(this.channel.state, this.channel.state, true, false, wrappedErr);
+        this.channel.emit('update', change);
+      });
     }
   }
 

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -257,7 +257,7 @@ define([
 
     becomeSuspended(realtime, cb) {
       const helper = this.addingHelperFunction('becomeSuspended');
-      helper._becomeSuspended(realtime, cb);
+      return helper._becomeSuspended(realtime, cb);
     }
 
     _becomeSuspended(realtime, cb) {
@@ -268,10 +268,13 @@ define([
         self.recordPrivateApi('call.connectionManager.notifyState');
         realtime.connection.connectionManager.notifyState({ state: 'suspended' });
       });
-      if (cb)
+      if (cb) {
         realtime.connection.once('suspended', function () {
           cb();
         });
+      } else {
+        return realtime.connection.once('suspended');
+      }
     }
 
     callbackOnClose(realtime, callback) {

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async, chai) {
-  const { expect, assert }  = chai;
+  const { expect, assert } = chai;
   var createPM = Ably.protocolMessageFromDeserialized;
   var PresenceMessage = Ably.Realtime.PresenceMessage;
 
@@ -1636,7 +1636,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       await realtime.connection.once('connected');
       await channel.attach();
       // presence.get will wait for a sync if needed
-      await channel.presence.get()
+      await channel.presence.get();
 
       const pOnPresence = channel.presence.subscriptions.once('enter');
       await channel.presence.enterClient('one', 'onedata');
@@ -1711,14 +1711,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     it('presence_auto_reenter_different_connid', async function () {
       const helper = this.test.helper;
       const channelName = 'presence_auto_reenter_different_connid';
-      const realtime = helper.AblyRealtime({transportParams: {remainPresentFor: 5000}});
+      const realtime = helper.AblyRealtime({ transportParams: { remainPresentFor: 5000 } });
       const channel = realtime.channels.get(channelName);
 
       await realtime.connection.once('connected');
       const firstConnId = realtime.connection.id;
       await channel.attach();
       // presence.get will wait for a sync if needed
-      await channel.presence.get()
+      await channel.presence.get();
 
       const pOnPresence = channel.presence.subscriptions.once('enter');
       await channel.presence.enterClient('one', 'onedata');


### PR DESCRIPTION
see https://github.com/ably/specification/pull/215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced member re-entry logic in real-time presence management.
  - Added a new test case for handling presence re-entry with different connection IDs.

- **Bug Fixes**
  - Improved error handling during member re-entry to prevent outdated member IDs.

- **Tests**
  - Refactored test cases to utilize `async/await` for better readability and maintainability.
  - Introduced new test scenarios to validate presence behavior under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->