### PR TITLE
Update `Message` to support `updateSerial`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2356,9 +2356,9 @@ export interface Message {
    */
   updatedAt?: number;
   /**
-   * If a `deletion` operation was applied to this message, this will be the timestamp the deletion occurred.
+   * The serial of the operation that updated this message.
    */
-  deletedAt?: number;
+  updateSerial?: string;
   /**
    * If this message resulted from an operation, this will contain the operation details.
    */

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -341,7 +341,7 @@ class Message {
   refSerial?: string;
   refType?: string;
   updatedAt?: number;
-  deletedAt?: number;
+  updateSerial?: string;
   operation?: API.Operation;
 
   /**
@@ -378,7 +378,7 @@ class Message {
       refSerial: this.refSerial,
       refType: this.refType,
       updatedAt: this.updatedAt,
-      deletedAt: this.deletedAt,
+      updateSerial: this.updateSerial,
       operation: this.operation,
       encoding,
       data,
@@ -407,7 +407,7 @@ class Message {
     if (this.refSerial) result += '; refSerial=' + this.refSerial;
     if (this.refType) result += '; refType=' + this.refType;
     if (this.updatedAt) result += '; updatedAt=' + this.updatedAt;
-    if (this.deletedAt) result += '; deletedAt=' + this.deletedAt;
+    if (this.updateSerial) result += '; updateSerial=' + this.updateSerial;
     if (this.operation) result += '; operation=' + JSON.stringify(this.operation);
     result += ']';
     return result;


### PR DESCRIPTION
To handle ordering of operation messages, we have added an `updateSerial` field to the `Message` type. 
We will now use this new field and `updatedAt` to define the global and total order of operations (updates/deletes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `updateSerial` in the Message interface.
	- Removed the `deletedAt` property.

- **Documentation**
	- Updated serialization methods to reflect changes in message state representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->