### PR TITLE
[DTP-1076, DTP-1077] Handle isolated create ops and site timeserials vector on the `StateObject`

### DIFF
--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -649,7 +649,7 @@ class RealtimeChannel extends EventEmitter {
           }
         }
 
-        this._liveObjects.handleStateMessages(stateMessages, message.channelSerial);
+        this._liveObjects.handleStateMessages(stateMessages);
 
         break;
       }

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -1,14 +1,13 @@
 import deepEqual from 'deep-equal';
 
-import type BaseClient from 'common/lib/client/baseclient';
 import { LiveObject, LiveObjectData, LiveObjectUpdate, LiveObjectUpdateNoop } from './liveobject';
 import { LiveObjects } from './liveobjects';
 import {
   MapSemantics,
-  StateMap,
   StateMapEntry,
   StateMapOp,
   StateMessage,
+  StateObject,
   StateOperation,
   StateOperationAction,
   StateValue,
@@ -50,11 +49,9 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
   constructor(
     liveObjects: LiveObjects,
     private _semantics: MapSemantics,
-    initialData?: LiveMapData | null,
-    objectId?: string,
-    siteTimeserials?: Record<string, Timeserial>,
+    objectId: string,
   ) {
-    super(liveObjects, initialData, objectId, siteTimeserials);
+    super(liveObjects, objectId);
   }
 
   /**
@@ -62,41 +59,20 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
    *
    * @internal
    */
-  static zeroValue(liveobjects: LiveObjects, objectId?: string, siteTimeserials?: Record<string, Timeserial>): LiveMap {
-    return new LiveMap(liveobjects, MapSemantics.LWW, null, objectId, siteTimeserials);
+  static zeroValue(liveobjects: LiveObjects, objectId: string): LiveMap {
+    return new LiveMap(liveobjects, MapSemantics.LWW, objectId);
   }
 
   /**
+   * Returns a {@link LiveMap} instance based on the provided state object.
+   * The provided state object must hold a valid map object data.
+   *
    * @internal
    */
-  static liveMapDataFromMapEntries(client: BaseClient, entries: Record<string, StateMapEntry>): LiveMapData {
-    const liveMapData: LiveMapData = {
-      data: new Map<string, MapEntry>(),
-    };
-
-    // need to iterate over entries manually to work around optional parameters from state object entries type
-    Object.entries(entries ?? {}).forEach(([key, entry]) => {
-      let liveData: StateData;
-      if (typeof entry.data.objectId !== 'undefined') {
-        liveData = { objectId: entry.data.objectId } as ObjectIdStateData;
-      } else {
-        liveData = { encoding: entry.data.encoding, value: entry.data.value } as ValueStateData;
-      }
-
-      const liveDataEntry: MapEntry = {
-        ...entry,
-        timeserial: entry.timeserial
-          ? DefaultTimeserial.calculateTimeserial(client, entry.timeserial)
-          : DefaultTimeserial.zeroValueTimeserial(client),
-        // true only if we received explicit true. otherwise always false
-        tombstone: entry.tombstone === true,
-        data: liveData,
-      };
-
-      liveMapData.data.set(key, liveDataEntry);
-    });
-
-    return liveMapData;
+  static fromStateObject(liveobjects: LiveObjects, stateObject: StateObject): LiveMap {
+    const obj = new LiveMap(liveobjects, stateObject.map?.semantics!, stateObject.objectId);
+    obj.overrideWithStateObject(stateObject);
+    return obj;
   }
 
   /**
@@ -170,7 +146,7 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
     let update: LiveMapUpdate | LiveObjectUpdateNoop;
     switch (op.action) {
       case StateOperationAction.MAP_CREATE:
-        update = this._applyMapCreate(op.map);
+        update = this._applyMapCreate(op);
         break;
 
       case StateOperationAction.MAP_SET:
@@ -204,14 +180,73 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
     this.notifyUpdated(update);
   }
 
+  /**
+   * @internal
+   */
+  overrideWithStateObject(stateObject: StateObject): LiveMapUpdate {
+    if (stateObject.objectId !== this.getObjectId()) {
+      throw new this._client.ErrorInfo(
+        `Invalid state object: state object objectId=${stateObject.objectId}; LiveMap objectId=${this.getObjectId()}`,
+        50000,
+        500,
+      );
+    }
+
+    if (stateObject.map?.semantics !== this._semantics) {
+      throw new this._client.ErrorInfo(
+        `Invalid state object: state object map semantics=${stateObject.map?.semantics}; LiveMap semantics=${this._semantics}`,
+        50000,
+        500,
+      );
+    }
+
+    if (!this._client.Utils.isNil(stateObject.createOp)) {
+      // it is expected that create operation can be missing in the state object, so only validate it when it exists
+      if (stateObject.createOp.objectId !== this.getObjectId()) {
+        throw new this._client.ErrorInfo(
+          `Invalid state object: state object createOp objectId=${stateObject.createOp?.objectId}; LiveMap objectId=${this.getObjectId()}`,
+          50000,
+          500,
+        );
+      }
+
+      if (stateObject.createOp.action !== StateOperationAction.MAP_CREATE) {
+        throw new this._client.ErrorInfo(
+          `Invalid state object: state object createOp action=${stateObject.createOp?.action}; LiveMap objectId=${this.getObjectId()}`,
+          50000,
+          500,
+        );
+      }
+
+      if (stateObject.createOp.map?.semantics !== this._semantics) {
+        throw new this._client.ErrorInfo(
+          `Invalid state object: state object createOp map semantics=${stateObject.createOp.map?.semantics}; LiveMap semantics=${this._semantics}`,
+          50000,
+          500,
+        );
+      }
+    }
+
+    const previousDataRef = this._dataRef;
+    // override all relevant data for this object with data from the state object
+    this._createOperationIsMerged = false;
+    this._dataRef = this._liveMapDataFromMapEntries(stateObject.map?.entries ?? {});
+    this._siteTimeserials = this._timeserialMapFromStringMap(stateObject.siteTimeserials);
+    if (!this._client.Utils.isNil(stateObject.createOp)) {
+      this._mergeInitialDataFromCreateOperation(stateObject.createOp);
+    }
+
+    return this._updateFromDataDiff(previousDataRef, this._dataRef);
+  }
+
   protected _getZeroValueData(): LiveMapData {
     return { data: new Map<string, MapEntry>() };
   }
 
-  protected _updateFromDataDiff(currentDataRef: LiveMapData, newDataRef: LiveMapData): LiveMapUpdate {
+  protected _updateFromDataDiff(prevDataRef: LiveMapData, newDataRef: LiveMapData): LiveMapUpdate {
     const update: LiveMapUpdate = { update: {} };
 
-    for (const [key, currentEntry] of currentDataRef.data.entries()) {
+    for (const [key, currentEntry] of prevDataRef.data.entries()) {
       // any non-tombstoned properties that exist on a current map, but not in the new data - got removed
       if (currentEntry.tombstone === false && !newDataRef.data.has(key)) {
         update.update[key] = 'removed';
@@ -219,7 +254,7 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
     }
 
     for (const [key, newEntry] of newDataRef.data.entries()) {
-      if (!currentDataRef.data.has(key)) {
+      if (!prevDataRef.data.has(key)) {
         // if property does not exist in the current map, but new data has it as a non-tombstoned property - got updated
         if (newEntry.tombstone === false) {
           update.update[key] = 'updated';
@@ -233,7 +268,7 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
       }
 
       // properties that exist both in current and new map data need to have their values compared to decide on the update type
-      const currentEntry = currentDataRef.data.get(key)!;
+      const currentEntry = prevDataRef.data.get(key)!;
 
       // compare tombstones first
       if (currentEntry.tombstone === true && newEntry.tombstone === false) {
@@ -262,33 +297,17 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
     return update;
   }
 
-  private _throwNoPayloadError(op: StateOperation): void {
-    throw new this._client.ErrorInfo(
-      `No payload found for ${op.action} op for LiveMap objectId=${this.getObjectId()}`,
-      50000,
-      500,
-    );
-  }
-
-  private _applyMapCreate(op: StateMap | undefined): LiveMapUpdate | LiveObjectUpdateNoop {
-    if (this._client.Utils.isNil(op)) {
+  protected _mergeInitialDataFromCreateOperation(stateOperation: StateOperation): LiveMapUpdate {
+    if (this._client.Utils.isNil(stateOperation.map)) {
       // if a map object is missing for the MAP_CREATE op, the initial value is implicitly an empty map.
       // in this case there is nothing to merge into the current map, so we can just end processing the op.
       return { update: {} };
     }
 
-    if (this._semantics !== op.semantics) {
-      throw new this._client.ErrorInfo(
-        `Cannot apply MAP_CREATE op on LiveMap objectId=${this.getObjectId()}; map's semantics=${this._semantics}, but op expected ${op.semantics}`,
-        50000,
-        500,
-      );
-    }
-
     const aggregatedUpdate: LiveMapUpdate | LiveObjectUpdateNoop = { update: {} };
     // in order to apply MAP_CREATE op for an existing map, we should merge their underlying entries keys.
     // we can do this by iterating over entries from MAP_CREATE op and apply changes on per-key basis as if we had MAP_SET, MAP_REMOVE operations.
-    Object.entries(op.entries ?? {}).forEach(([key, entry]) => {
+    Object.entries(stateOperation.map.entries ?? {}).forEach(([key, entry]) => {
       // for MAP_CREATE op we must use dedicated timeserial field available on an entry, instead of a timeserial on a message
       const opOriginTimeserial = entry.timeserial
         ? DefaultTimeserial.calculateTimeserial(this._client, entry.timeserial)
@@ -311,7 +330,42 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
       Object.assign(aggregatedUpdate.update, update.update);
     });
 
+    this._createOperationIsMerged = true;
+
     return aggregatedUpdate;
+  }
+
+  private _throwNoPayloadError(op: StateOperation): void {
+    throw new this._client.ErrorInfo(
+      `No payload found for ${op.action} op for LiveMap objectId=${this.getObjectId()}`,
+      50000,
+      500,
+    );
+  }
+
+  private _applyMapCreate(op: StateOperation): LiveMapUpdate | LiveObjectUpdateNoop {
+    if (this._createOperationIsMerged) {
+      // There can't be two different create operation for the same object id, because the object id
+      // fully encodes that operation. This means we can safely ignore any new incoming create operations
+      // if we already merged it once.
+      this._client.Logger.logAction(
+        this._client.logger,
+        this._client.Logger.LOG_MICRO,
+        'LiveMap._applyMapCreate()',
+        `skipping applying MAP_CREATE op on a map instance as it was already applied before; objectId=${this._objectId}`,
+      );
+      return { noop: true };
+    }
+
+    if (this._semantics !== op.map?.semantics) {
+      throw new this._client.ErrorInfo(
+        `Cannot apply MAP_CREATE op on LiveMap objectId=${this.getObjectId()}; map's semantics=${this._semantics}, but op expected ${op.map?.semantics}`,
+        50000,
+        500,
+      );
+    }
+
+    return this._mergeInitialDataFromCreateOperation(op);
   }
 
   private _applyMapSet(op: StateMapOp, opOriginTimeserial: Timeserial): LiveMapUpdate | LiveObjectUpdateNoop {
@@ -397,5 +451,35 @@ export class LiveMap extends LiveObject<LiveMapData, LiveMapUpdate> {
     }
 
     return { update: { [op.key]: 'removed' } };
+  }
+
+  private _liveMapDataFromMapEntries(entries: Record<string, StateMapEntry>): LiveMapData {
+    const liveMapData: LiveMapData = {
+      data: new Map<string, MapEntry>(),
+    };
+
+    // need to iterate over entries manually to work around optional parameters from state object entries type
+    Object.entries(entries ?? {}).forEach(([key, entry]) => {
+      let liveData: StateData;
+      if (typeof entry.data.objectId !== 'undefined') {
+        liveData = { objectId: entry.data.objectId } as ObjectIdStateData;
+      } else {
+        liveData = { encoding: entry.data.encoding, value: entry.data.value } as ValueStateData;
+      }
+
+      const liveDataEntry: MapEntry = {
+        ...entry,
+        timeserial: entry.timeserial
+          ? DefaultTimeserial.calculateTimeserial(this._client, entry.timeserial)
+          : DefaultTimeserial.zeroValueTimeserial(this._client),
+        // true only if we received explicit true. otherwise always false
+        tombstone: entry.tombstone === true,
+        data: liveData,
+      };
+
+      liveMapData.data.set(key, liveDataEntry);
+    });
+
+    return liveMapData;
   }
 }

--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -1,8 +1,8 @@
 import type BaseClient from 'common/lib/client/baseclient';
 import type EventEmitter from 'common/lib/util/eventemitter';
 import { LiveObjects } from './liveobjects';
-import { StateMessage, StateOperation } from './statemessage';
-import { Timeserial } from './timeserial';
+import { StateMessage, StateObject, StateOperation } from './statemessage';
+import { DefaultTimeserial, Timeserial } from './timeserial';
 
 enum LiveObjectEvents {
   Updated = 'Updated',
@@ -32,22 +32,26 @@ export abstract class LiveObject<
 > {
   protected _client: BaseClient;
   protected _eventEmitter: EventEmitter;
-  protected _dataRef: TData;
   protected _objectId: string;
+  /**
+   * Represents an aggregated value for an object, which combines the initial value for an object from the create operation,
+   * and all state operations applied to the object.
+   */
+  protected _dataRef: TData;
   protected _siteTimeserials: Record<string, Timeserial>;
+  protected _createOperationIsMerged: boolean;
 
-  constructor(
+  protected constructor(
     protected _liveObjects: LiveObjects,
-    initialData?: TData | null,
-    objectId?: string,
-    siteTimeserials?: Record<string, Timeserial>,
+    objectId: string,
   ) {
     this._client = this._liveObjects.getClient();
     this._eventEmitter = new this._client.EventEmitter(this._client.logger);
-    this._dataRef = initialData ?? this._getZeroValueData();
-    this._objectId = objectId ?? this._createObjectId();
+    this._dataRef = this._getZeroValueData();
+    this._createOperationIsMerged = false;
+    this._objectId = objectId;
     // use empty timeserials vector by default, so any future operation can be applied to this object
-    this._siteTimeserials = siteTimeserials ?? {};
+    this._siteTimeserials = {};
   }
 
   subscribe(listener: (update: TUpdate) => void): SubscribeResponse {
@@ -83,24 +87,8 @@ export abstract class LiveObject<
   }
 
   /**
-   * Sets a new data reference for the LiveObject and returns an update object that describes the changes applied based on the object's previous value.
+   * Emits the {@link LiveObjectEvents.Updated} event with provided update object if it isn't a noop.
    *
-   * @internal
-   */
-  setData(newDataRef: TData): TUpdate {
-    const update = this._updateFromDataDiff(this._dataRef, newDataRef);
-    this._dataRef = newDataRef;
-    return update;
-  }
-
-  /**
-   * @internal
-   */
-  setSiteTimeserials(siteTimeserials: Record<string, Timeserial>): void {
-    this._siteTimeserials = siteTimeserials;
-  }
-
-  /**
    * @internal
    */
   notifyUpdated(update: TUpdate | LiveObjectUpdateNoop): void {
@@ -123,18 +111,57 @@ export abstract class LiveObject<
     return !siteTimeserial || opOriginTimeserial.after(siteTimeserial);
   }
 
+  protected _timeserialMapFromStringMap(stringTimeserialsMap: Record<string, string>): Record<string, Timeserial> {
+    const objTimeserialsMap = Object.entries(stringTimeserialsMap).reduce(
+      (acc, v) => {
+        const [key, timeserialString] = v;
+        acc[key] = DefaultTimeserial.calculateTimeserial(this._client, timeserialString);
+        return acc;
+      },
+      {} as Record<string, Timeserial>,
+    );
+
+    return objTimeserialsMap;
+  }
+
   private _createObjectId(): string {
     // TODO: implement object id generation based on live object type and initial value
     return Math.random().toString().substring(2);
   }
 
   /**
+   * Apply state operation message on live object.
+   *
    * @internal
    */
   abstract applyOperation(op: StateOperation, msg: StateMessage): void;
+  /**
+   * Overrides internal data for live object with data from the given state object.
+   * Provided state object should hold a valid data for current live object, e.g. counter data for LiveCounter, map data for LiveMap.
+   *
+   * State objects are received during SYNC sequence, and SYNC sequence is a source of truth for the current state of the objects,
+   * so we can use the data received from the SYNC sequence directly and override any data values or site timeserials this live object has
+   * without the need to merge them.
+   *
+   * Returns an update object that describes the changes applied based on the object's previous value.
+   *
+   * @internal
+   */
+  abstract overrideWithStateObject(stateObject: StateObject): TUpdate;
   protected abstract _getZeroValueData(): TData;
   /**
    * Calculate the update object based on the current Live Object data and incoming new data.
    */
-  protected abstract _updateFromDataDiff(currentDataRef: TData, newDataRef: TData): TUpdate;
+  protected abstract _updateFromDataDiff(prevDataRef: TData, newDataRef: TData): TUpdate;
+  /**
+   * Merges the initial data from the create operation into the live object state.
+   *
+   * Client SDKs do not need to keep around the state operation that created the object,
+   * so we can merge the initial data the first time we receive it for the object,
+   * and work with aggregated value after that.
+   *
+   * This saves us from needing to merge the initial value with operations applied to
+   * the object every time the object is read.
+   */
+  protected abstract _mergeInitialDataFromCreateOperation(stateOperation: StateOperation): TUpdate;
 }

--- a/src/plugins/liveobjects/liveobjects.ts
+++ b/src/plugins/liveobjects/liveobjects.ts
@@ -8,15 +8,9 @@ import { LiveObject, LiveObjectUpdate } from './liveobject';
 import { LiveObjectsPool, ROOT_OBJECT_ID } from './liveobjectspool';
 import { StateMessage } from './statemessage';
 import { LiveCounterDataEntry, SyncLiveObjectsDataPool } from './syncliveobjectsdatapool';
-import { DefaultTimeserial, Timeserial } from './timeserial';
 
 enum LiveObjectsEvents {
   SyncCompleted = 'SyncCompleted',
-}
-
-export interface BufferedStateMessage {
-  stateMessage: StateMessage;
-  regionalTimeserial: Timeserial;
 }
 
 export class LiveObjects {
@@ -30,7 +24,7 @@ export class LiveObjects {
   private _syncInProgress: boolean;
   private _currentSyncId: string | undefined;
   private _currentSyncCursor: string | undefined;
-  private _bufferedStateOperations: BufferedStateMessage[];
+  private _bufferedStateOperations: StateMessage[];
 
   constructor(channel: RealtimeChannel) {
     this._channel = channel;
@@ -92,23 +86,17 @@ export class LiveObjects {
   /**
    * @internal
    */
-  handleStateMessages(stateMessages: StateMessage[], msgRegionalTimeserial: string | null | undefined): void {
-    const timeserial = DefaultTimeserial.calculateTimeserial(this._client, msgRegionalTimeserial);
-
+  handleStateMessages(stateMessages: StateMessage[]): void {
     if (this._syncInProgress) {
       // The client receives state messages in realtime over the channel concurrently with the SYNC sequence.
       // Some of the incoming state messages may have already been applied to the state objects described in
       // the SYNC sequence, but others may not; therefore we must buffer these messages so that we can apply
-      // them to the state objects once the SYNC is complete. To avoid double-counting, the buffered operations
-      // are applied according to the state object's regional timeserial, which reflects the regional timeserial
-      // of the state message that was last applied to that state object.
-      stateMessages.forEach((x) =>
-        this._bufferedStateOperations.push({ stateMessage: x, regionalTimeserial: timeserial }),
-      );
+      // them to the state objects once the SYNC is complete.
+      this._bufferedStateOperations.push(...stateMessages);
       return;
     }
 
-    this._liveObjectsPool.applyStateMessages(stateMessages, timeserial);
+    this._liveObjectsPool.applyStateMessages(stateMessages);
   }
 
   /**
@@ -164,8 +152,9 @@ export class LiveObjects {
 
   private _endSync(): void {
     this._applySync();
-    // should apply buffered state operations after we applied the SYNC data
-    this._liveObjectsPool.applyBufferedStateMessages(this._bufferedStateOperations);
+    // should apply buffered state operations after we applied the SYNC data.
+    // can use regular state messages application logic
+    this._liveObjectsPool.applyStateMessages(this._bufferedStateOperations);
 
     this._bufferedStateOperations = [];
     this._syncLiveObjectsDataPool.reset();
@@ -204,11 +193,13 @@ export class LiveObjects {
     for (const [objectId, entry] of this._syncLiveObjectsDataPool.entries()) {
       receivedObjectIds.add(objectId);
       const existingObject = this._liveObjectsPool.get(objectId);
-      const regionalTimeserialObj = DefaultTimeserial.calculateTimeserial(this._client, entry.regionalTimeserial);
 
       if (existingObject) {
+        // SYNC sequence is a source of truth for the current state of the objects,
+        // so we can use the data received from the SYNC sequence directly
+        // without the need to merge data values or site timeserials.
         const update = existingObject.setData(entry.objectData);
-        existingObject.setRegionalTimeserial(regionalTimeserialObj);
+        existingObject.setSiteTimeserials(entry.siteTimeserials);
         if (existingObject instanceof LiveCounter) {
           existingObject.setCreated((entry as LiveCounterDataEntry).created);
         }
@@ -223,11 +214,11 @@ export class LiveObjects {
       const objectType = entry.objectType;
       switch (objectType) {
         case 'LiveCounter':
-          newObject = new LiveCounter(this, entry.created, entry.objectData, objectId, regionalTimeserialObj);
+          newObject = new LiveCounter(this, entry.created, entry.objectData, objectId, entry.siteTimeserials);
           break;
 
         case 'LiveMap':
-          newObject = new LiveMap(this, entry.semantics, entry.objectData, objectId, regionalTimeserialObj);
+          newObject = new LiveMap(this, entry.semantics, entry.objectData, objectId, entry.siteTimeserials);
           break;
 
         default:

--- a/src/plugins/liveobjects/liveobjectspool.ts
+++ b/src/plugins/liveobjects/liveobjectspool.ts
@@ -3,7 +3,7 @@ import type RealtimeChannel from 'common/lib/client/realtimechannel';
 import { LiveCounter } from './livecounter';
 import { LiveMap } from './livemap';
 import { LiveObject } from './liveobject';
-import { BufferedStateMessage, LiveObjects } from './liveobjects';
+import { LiveObjects } from './liveobjects';
 import { ObjectId } from './objectid';
 import { MapSemantics, StateMessage, StateOperation, StateOperationAction } from './statemessage';
 import { DefaultTimeserial, Timeserial } from './timeserial';
@@ -52,24 +52,22 @@ export class LiveObjectsPool {
     }
 
     const parsedObjectId = ObjectId.fromString(this._client, objectId);
-    // use zero value timeserial, so any operation can be applied for this object
-    const regionalTimeserial = DefaultTimeserial.zeroValueTimeserial(this._client);
     let zeroValueObject: LiveObject;
     switch (parsedObjectId.type) {
       case 'map': {
-        zeroValueObject = LiveMap.zeroValue(this._liveObjects, objectId, regionalTimeserial);
+        zeroValueObject = LiveMap.zeroValue(this._liveObjects, objectId);
         break;
       }
 
       case 'counter':
-        zeroValueObject = LiveCounter.zeroValue(this._liveObjects, false, objectId, regionalTimeserial);
+        zeroValueObject = LiveCounter.zeroValue(this._liveObjects, false, objectId);
         break;
     }
 
     this.set(objectId, zeroValueObject);
   }
 
-  applyStateMessages(stateMessages: StateMessage[], regionalTimeserial: Timeserial): void {
+  applyStateMessages(stateMessages: StateMessage[]): void {
     for (const stateMessage of stateMessages) {
       if (!stateMessage.operation) {
         this._client.Logger.logAction(
@@ -81,6 +79,7 @@ export class LiveObjectsPool {
         continue;
       }
 
+      const opOriginTimeserial = DefaultTimeserial.calculateTimeserial(this._client, stateMessage.serial);
       const stateOperation = stateMessage.operation;
 
       switch (stateOperation.action) {
@@ -89,17 +88,17 @@ export class LiveObjectsPool {
           if (this.get(stateOperation.objectId)) {
             // object wich such id already exists (we may have created a zero-value object before, or this is a duplicate *_CREATE op),
             // so delegate application of the op to that object
-            this.get(stateOperation.objectId)!.applyOperation(stateOperation, stateMessage, regionalTimeserial);
+            this.get(stateOperation.objectId)!.applyOperation(stateOperation, stateMessage);
             break;
           }
 
           // otherwise we can create new objects in the pool
           if (stateOperation.action === StateOperationAction.MAP_CREATE) {
-            this._handleMapCreate(stateOperation, regionalTimeserial);
+            this._handleMapCreate(stateOperation, opOriginTimeserial);
           }
 
           if (stateOperation.action === StateOperationAction.COUNTER_CREATE) {
-            this._handleCounterCreate(stateOperation, regionalTimeserial);
+            this._handleCounterCreate(stateOperation, opOriginTimeserial);
           }
           break;
 
@@ -110,7 +109,7 @@ export class LiveObjectsPool {
           // we create a zero-value object for the provided object id, and apply operation for that zero-value object.
           // when we eventually receive a corresponding *_CREATE op for that object, its application will be handled by that zero-value object.
           this.createZeroValueObjectIfNotExists(stateOperation.objectId);
-          this.get(stateOperation.objectId)!.applyOperation(stateOperation, stateMessage, regionalTimeserial);
+          this.get(stateOperation.objectId)!.applyOperation(stateOperation, stateMessage);
           break;
 
         default:
@@ -124,49 +123,6 @@ export class LiveObjectsPool {
     }
   }
 
-  applyBufferedStateMessages(bufferedStateMessages: BufferedStateMessage[]): void {
-    // since we receive state operation messages concurrently with the SYNC sequence,
-    // we must determine which operation messages should be applied to the now local copy of the object pool, and the rest will be skipped.
-    // since messages are delivered in regional order to the client, we can inspect the regional timeserial
-    // of each state operation message to know whether it has reached a point in the message stream
-    // that is no longer included in the state object snapshot we received from SYNC sequence.
-    for (const { regionalTimeserial, stateMessage } of bufferedStateMessages) {
-      if (!stateMessage.operation) {
-        this._client.Logger.logAction(
-          this._client.logger,
-          this._client.Logger.LOG_MAJOR,
-          'LiveObjects.LiveObjectsPool.applyBufferedStateMessages()',
-          `state operation message is received without 'operation' field, skipping message; message id: ${stateMessage.id}, channel: ${this._channel.name}`,
-        );
-        continue;
-      }
-
-      const existingObject = this.get(stateMessage.operation.objectId);
-      if (!existingObject) {
-        // for object ids we haven't seen yet we can apply operation immediately
-        this.applyStateMessages([stateMessage], regionalTimeserial);
-        continue;
-      }
-
-      // otherwise we need to compare regional timeserials
-      if (
-        regionalTimeserial.before(existingObject.getRegionalTimeserial()) ||
-        regionalTimeserial.equal(existingObject.getRegionalTimeserial())
-      ) {
-        // the operation's regional timeserial <= the object's timeserial, ignore the operation.
-        this._client.Logger.logAction(
-          this._client.logger,
-          this._client.Logger.LOG_MICRO,
-          'LiveObjects.LiveObjectsPool.applyBufferedStateMessages()',
-          `skipping buffered state operation message: op regional timeserial ${regionalTimeserial.toString()} <= object regional timeserial ${existingObject.getRegionalTimeserial().toString()}; objectId=${stateMessage.operation.objectId}, message id: ${stateMessage.id}, channel: ${this._channel.name}`,
-        );
-        continue;
-      }
-
-      this.applyStateMessages([stateMessage], regionalTimeserial);
-    }
-  }
-
   private _getInitialPool(): Map<string, LiveObject> {
     const pool = new Map<string, LiveObject>();
     const root = LiveMap.zeroValue(this._liveObjects, ROOT_OBJECT_ID);
@@ -174,29 +130,37 @@ export class LiveObjectsPool {
     return pool;
   }
 
-  private _handleCounterCreate(stateOperation: StateOperation, opRegionalTimeserial: Timeserial): void {
+  private _handleCounterCreate(stateOperation: StateOperation, opOriginTimeserial: Timeserial): void {
+    // should use op's origin timeserial as the initial value for the object's site timeserials vector
+    const siteTimeserials = {
+      [opOriginTimeserial.siteCode]: opOriginTimeserial,
+    };
     let counter: LiveCounter;
     if (this._client.Utils.isNil(stateOperation.counter)) {
       // if a counter object is missing for the COUNTER_CREATE op, the initial value is implicitly a zero-value counter.
-      counter = LiveCounter.zeroValue(this._liveObjects, true, stateOperation.objectId, opRegionalTimeserial);
+      counter = LiveCounter.zeroValue(this._liveObjects, true, stateOperation.objectId, siteTimeserials);
     } else {
       counter = new LiveCounter(
         this._liveObjects,
         true,
         { data: stateOperation.counter.count ?? 0 },
         stateOperation.objectId,
-        opRegionalTimeserial,
+        siteTimeserials,
       );
     }
 
     this.set(stateOperation.objectId, counter);
   }
 
-  private _handleMapCreate(stateOperation: StateOperation, opRegionalTimeserial: Timeserial): void {
+  private _handleMapCreate(stateOperation: StateOperation, opOriginTimeserial: Timeserial): void {
+    // should use op's origin timeserial as the initial value for the object's site timeserials vector
+    const siteTimeserials = {
+      [opOriginTimeserial.siteCode]: opOriginTimeserial,
+    };
     let map: LiveMap;
     if (this._client.Utils.isNil(stateOperation.map)) {
       // if a map object is missing for the MAP_CREATE op, the initial value is implicitly a zero-value map.
-      map = LiveMap.zeroValue(this._liveObjects, stateOperation.objectId, opRegionalTimeserial);
+      map = LiveMap.zeroValue(this._liveObjects, stateOperation.objectId, siteTimeserials);
     } else {
       const objectData = LiveMap.liveMapDataFromMapEntries(this._client, stateOperation.map.entries ?? {});
       map = new LiveMap(
@@ -204,7 +168,7 @@ export class LiveObjectsPool {
         stateOperation.map.semantics ?? MapSemantics.LWW,
         objectData,
         stateOperation.objectId,
-        opRegionalTimeserial,
+        siteTimeserials,
       );
     }
 

--- a/src/plugins/liveobjects/statemessage.ts
+++ b/src/plugins/liveobjects/statemessage.ts
@@ -151,23 +151,23 @@ export class StateMessage {
     // TODO: decide how to handle individual errors from decoding values. currently we throw first ever error we get
 
     if (message.object?.map?.entries) {
-      await this._decodeMapEntries(message.object.map.entries, inputContext, decodeDataFn);
+      await StateMessage._decodeMapEntries(message.object.map.entries, inputContext, decodeDataFn);
     }
 
     if (message.object?.createOp?.map?.entries) {
-      await this._decodeMapEntries(message.object.createOp.map.entries, inputContext, decodeDataFn);
+      await StateMessage._decodeMapEntries(message.object.createOp.map.entries, inputContext, decodeDataFn);
     }
 
     if (message.object?.createOp?.mapOp?.data && 'value' in message.object.createOp.mapOp.data) {
-      await this._decodeStateData(message.object.createOp.mapOp.data, inputContext, decodeDataFn);
+      await StateMessage._decodeStateData(message.object.createOp.mapOp.data, inputContext, decodeDataFn);
     }
 
     if (message.operation?.map?.entries) {
-      await this._decodeMapEntries(message.operation.map.entries, inputContext, decodeDataFn);
+      await StateMessage._decodeMapEntries(message.operation.map.entries, inputContext, decodeDataFn);
     }
 
     if (message.operation?.mapOp?.data && 'value' in message.operation.mapOp.data) {
-      await this._decodeStateData(message.operation.mapOp.data, inputContext, decodeDataFn);
+      await StateMessage._decodeStateData(message.operation.mapOp.data, inputContext, decodeDataFn);
     }
   }
 
@@ -180,7 +180,7 @@ export class StateMessage {
     const result = new Array(count);
 
     for (let i = 0; i < count; i++) {
-      result[i] = this.fromValues(values[i] as Record<string, unknown>, platform);
+      result[i] = StateMessage.fromValues(values[i] as Record<string, unknown>, platform);
     }
 
     return result;
@@ -192,7 +192,7 @@ export class StateMessage {
     decodeDataFn: typeof decodeData,
   ): Promise<void> {
     for (const entry of Object.values(mapEntries)) {
-      await this._decodeStateData(entry.data, inputContext, decodeDataFn);
+      await StateMessage._decodeStateData(entry.data, inputContext, decodeDataFn);
     }
   }
 
@@ -221,13 +221,21 @@ export class StateMessage {
 
     if (stateOperationCopy.mapOp?.data && 'value' in stateOperationCopy.mapOp.data) {
       // use original "stateOperation" object when encoding values, so we have access to the original buffer values.
-      stateOperationCopy.mapOp.data = this._encodeStateData(platform, stateOperation.mapOp?.data!, withBase64Encoding);
+      stateOperationCopy.mapOp.data = StateMessage._encodeStateData(
+        platform,
+        stateOperation.mapOp?.data!,
+        withBase64Encoding,
+      );
     }
 
     if (stateOperationCopy.map?.entries) {
       Object.entries(stateOperationCopy.map.entries).forEach(([key, entry]) => {
         // use original "stateOperation" object when encoding values, so we have access to original buffer values.
-        entry.data = this._encodeStateData(platform, stateOperation?.map?.entries?.[key].data!, withBase64Encoding);
+        entry.data = StateMessage._encodeStateData(
+          platform,
+          stateOperation?.map?.entries?.[key].data!,
+          withBase64Encoding,
+        );
       });
     }
 
@@ -256,14 +264,23 @@ export class StateMessage {
 
     if (stateObjectCopy.createOp) {
       // use original "stateObject" object when encoding values, so we have access to original buffer values.
-      stateObjectCopy.createOp = this._encodeStateOperation(platform, stateObject.createOp!, withBase64Encoding);
+      stateObjectCopy.createOp = StateMessage._encodeStateOperation(
+        platform,
+        stateObject.createOp!,
+        withBase64Encoding,
+      );
     }
 
     return stateObjectCopy;
   }
 
   private static _encodeStateData(platform: typeof Platform, data: StateData, withBase64Encoding: boolean): StateData {
-    const { value, encoding } = this._encodeStateValue(platform, data?.value, data?.encoding, withBase64Encoding);
+    const { value, encoding } = StateMessage._encodeStateValue(
+      platform,
+      data?.value,
+      data?.encoding,
+      withBase64Encoding,
+    );
     return {
       ...data,
       value,

--- a/src/plugins/liveobjects/statemessage.ts
+++ b/src/plugins/liveobjects/statemessage.ts
@@ -164,8 +164,8 @@ export class StateMessage {
       }
     }
 
-    if (message.operation?.map) {
-      for (const entry of Object.values(message.operation.map)) {
+    if (message.operation?.map?.entries) {
+      for (const entry of Object.values(message.operation.map.entries)) {
         await decodeMapEntry(entry, inputContext, decodeDataFn);
       }
     }

--- a/src/plugins/liveobjects/statemessage.ts
+++ b/src/plugins/liveobjects/statemessage.ts
@@ -110,8 +110,8 @@ export interface StateOperation {
 export interface StateObject {
   /** The identifier of the state object. */
   objectId: string;
-  /** The *regional* timeserial of the last operation that was applied to this state object. */
-  regionalTimeserial: string;
+  /** A vector of origin timeserials keyed by site code of the last operation that was applied to this state object. */
+  siteTimeserials: Record<string, string>;
   /** The data that represents the state of the object if it is a Map object type. */
   map?: StateMap;
   /** The data that represents the state of the object if it is a Counter object type. */

--- a/src/plugins/liveobjects/syncliveobjectsdatapool.ts
+++ b/src/plugins/liveobjects/syncliveobjectsdatapool.ts
@@ -1,30 +1,24 @@
 import type BaseClient from 'common/lib/client/baseclient';
 import type RealtimeChannel from 'common/lib/client/realtimechannel';
-import { LiveCounterData } from './livecounter';
-import { LiveMap } from './livemap';
-import { LiveObjectData } from './liveobject';
 import { LiveObjects } from './liveobjects';
-import { MapSemantics, StateMessage, StateObject } from './statemessage';
-import { DefaultTimeserial, Timeserial } from './timeserial';
+import { StateMessage, StateObject } from './statemessage';
 
 export interface LiveObjectDataEntry {
-  objectData: LiveObjectData;
-  siteTimeserials: Record<string, Timeserial>;
+  stateObject: StateObject;
   objectType: 'LiveMap' | 'LiveCounter';
 }
 
 export interface LiveCounterDataEntry extends LiveObjectDataEntry {
-  created: boolean;
   objectType: 'LiveCounter';
 }
 
 export interface LiveMapDataEntry extends LiveObjectDataEntry {
   objectType: 'LiveMap';
-  semantics: MapSemantics;
 }
 
 export type AnyDataEntry = LiveCounterDataEntry | LiveMapDataEntry;
 
+// TODO: investigate if this class is still needed after changes with createOp. objects are now initialized from the stateObject and this class does minimal processing
 /**
  * @internal
  */
@@ -85,45 +79,20 @@ export class SyncLiveObjectsDataPool {
   }
 
   private _createLiveCounterDataEntry(stateObject: StateObject): LiveCounterDataEntry {
-    const counter = stateObject.counter!;
-
-    const objectData: LiveCounterData = {
-      data: counter.count ?? 0,
-    };
     const newEntry: LiveCounterDataEntry = {
-      objectData,
+      stateObject,
       objectType: 'LiveCounter',
-      siteTimeserials: this._timeserialMapFromStringMap(stateObject.siteTimeserials),
-      created: counter.created,
     };
 
     return newEntry;
   }
 
   private _createLiveMapDataEntry(stateObject: StateObject): LiveMapDataEntry {
-    const map = stateObject.map!;
-    const objectData = LiveMap.liveMapDataFromMapEntries(this._client, map.entries ?? {});
-
     const newEntry: LiveMapDataEntry = {
-      objectData,
+      stateObject,
       objectType: 'LiveMap',
-      siteTimeserials: this._timeserialMapFromStringMap(stateObject.siteTimeserials),
-      semantics: map.semantics ?? MapSemantics.LWW,
     };
 
     return newEntry;
-  }
-
-  private _timeserialMapFromStringMap(stringTimeserialsMap: Record<string, string>): Record<string, Timeserial> {
-    const objTimeserialsMap = Object.entries(stringTimeserialsMap).reduce(
-      (acc, v) => {
-        const [key, timeserialString] = v;
-        acc[key] = DefaultTimeserial.calculateTimeserial(this._client, timeserialString);
-        return acc;
-      },
-      {} as Record<string, Timeserial>,
-    );
-
-    return objTimeserialsMap;
   }
 }

--- a/src/plugins/liveobjects/timeserial.ts
+++ b/src/plugins/liveobjects/timeserial.ts
@@ -10,6 +10,11 @@ export interface Timeserial {
   readonly seriesId: string;
 
   /**
+   * The site code of the timeserial.
+   */
+  readonly siteCode: string;
+
+  /**
    * The timestamp of the timeserial.
    */
   readonly timestamp: number;
@@ -40,6 +45,7 @@ export interface Timeserial {
  */
 export class DefaultTimeserial implements Timeserial {
   public readonly seriesId: string;
+  public readonly siteCode: string;
   public readonly timestamp: number;
   public readonly counter: number;
   public readonly index?: number;
@@ -55,6 +61,8 @@ export class DefaultTimeserial implements Timeserial {
     this.timestamp = timestamp;
     this.counter = counter;
     this.index = index;
+    // TODO: will be removed once https://ably.atlassian.net/browse/DTP-1078 is implemented on the realtime
+    this.siteCode = this.seriesId.slice(0, 3); // site code is stored in the first 3 letters of the epoch, which is stored in the series id field
   }
 
   /**

--- a/test/common/modules/live_objects_helper.js
+++ b/test/common/modules/live_objects_helper.js
@@ -101,11 +101,17 @@ define(['ably', 'shared_helper', 'live_objects'], function (Ably, Helper, LiveOb
           action: ACTIONS.MAP_CREATE,
           nonce: nonce(),
           objectId,
+          map: {
+            semantics: 0,
+          },
         },
       };
 
       if (entries) {
-        op.operation.map = { entries };
+        op.operation.map = {
+          ...op.operation.map,
+          entries,
+        };
       }
 
       return op;
@@ -175,30 +181,40 @@ define(['ably', 'shared_helper', 'live_objects'], function (Ably, Helper, LiveOb
     }
 
     mapObject(opts) {
-      const { objectId, siteTimeserials, entries } = opts;
+      const { objectId, siteTimeserials, initialEntries, materialisedEntries } = opts;
       const obj = {
         object: {
           objectId,
           siteTimeserials,
-          map: { entries },
+          map: {
+            semantics: 0,
+            entries: materialisedEntries,
+          },
         },
       };
+
+      if (initialEntries) {
+        obj.object.createOp = this.mapCreateOp({ objectId, entries: initialEntries }).operation;
+      }
 
       return obj;
     }
 
     counterObject(opts) {
-      const { objectId, siteTimeserials, count } = opts;
+      const { objectId, siteTimeserials, initialCount, materialisedCount } = opts;
       const obj = {
         object: {
           objectId,
           siteTimeserials,
           counter: {
-            created: true,
-            count,
+            count: materialisedCount,
           },
         },
       };
+
+      if (initialCount != null) {
+        obj.object.createOp = this.counterCreateOp({ objectId, count: initialCount }).operation;
+      }
 
       return obj;
     }

--- a/test/common/modules/live_objects_helper.js
+++ b/test/common/modules/live_objects_helper.js
@@ -175,11 +175,11 @@ define(['ably', 'shared_helper', 'live_objects'], function (Ably, Helper, LiveOb
     }
 
     mapObject(opts) {
-      const { objectId, regionalTimeserial, entries } = opts;
+      const { objectId, siteTimeserials, entries } = opts;
       const obj = {
         object: {
           objectId,
-          regionalTimeserial,
+          siteTimeserials,
           map: { entries },
         },
       };
@@ -188,11 +188,11 @@ define(['ably', 'shared_helper', 'live_objects'], function (Ably, Helper, LiveOb
     }
 
     counterObject(opts) {
-      const { objectId, regionalTimeserial, count } = opts;
+      const { objectId, siteTimeserials, count } = opts;
       const obj = {
         object: {
           objectId,
-          regionalTimeserial,
+          siteTimeserials,
           counter: {
             created: true,
             count,

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -30,6 +30,21 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
     expect(object.constructor.name).to.match(new RegExp(`_?${className}`), msg);
   }
 
+  function forScenarios(scenarios, testFn) {
+    // if there are scenarios marked as "only", run only them.
+    // otherwise go over every scenario
+    const onlyScenarios = scenarios.filter((x) => x.only === true);
+    const scenariosToRun = onlyScenarios.length > 0 ? onlyScenarios : scenarios;
+
+    for (const scenario of scenariosToRun) {
+      if (scenario.skip === true) {
+        continue;
+      }
+
+      testFn(scenario);
+    }
+  }
+
   describe('realtime/live_objects', function () {
     this.timeout(60 * 1000);
 
@@ -881,11 +896,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
       ];
 
-      for (const scenario of applyOperationsScenarios) {
-        if (scenario.skip === true) {
-          continue;
-        }
-
+      forScenarios(applyOperationsScenarios, (scenario) =>
         /** @nospec */
         it(`can apply ${scenario.description} state operation messages`, async function () {
           const helper = this.test.helper;
@@ -902,8 +913,8 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
             await scenario.action({ root, liveObjectsHelper, channelName });
           }, client);
-        });
-      }
+        }),
+      );
 
       const applyOperationsDuringSyncScenarios = [
         {
@@ -1206,11 +1217,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
       ];
 
-      for (const scenario of applyOperationsDuringSyncScenarios) {
-        if (scenario.skip === true) {
-          continue;
-        }
-
+      forScenarios(applyOperationsDuringSyncScenarios, (scenario) =>
         /** @nospec */
         it(scenario.description, async function () {
           const helper = this.test.helper;
@@ -1229,8 +1236,8 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
             await scenario.action({ root, liveObjectsHelper, channelName, channel });
           }, client);
-        });
-      }
+        }),
+      );
 
       const subscriptionCallbacksScenarios = [
         {
@@ -1699,11 +1706,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
       ];
 
-      for (const scenario of subscriptionCallbacksScenarios) {
-        if (scenario.skip === true) {
-          continue;
-        }
-
+      forScenarios(subscriptionCallbacksScenarios, (scenario) =>
         /** @nospec */
         it(scenario.description, async function () {
           const helper = this.test.helper;
@@ -1744,8 +1747,8 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
               sampleCounterObjectId,
             });
           }, client);
-        });
-      }
+        }),
+      );
     });
 
     /** @nospec */

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -293,7 +293,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
               liveObjectsHelper.mapObject({
                 objectId: 'root',
                 siteTimeserials: { '000': '000@0-0' },
-                entries: { key: { timeserial: '000@0-0', data: { value: 1 } } },
+                initialEntries: { key: { timeserial: '000@0-0', data: { value: 1 } } },
               }),
             ],
           });
@@ -1394,7 +1394,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
                     bbb: 'bbb@2-0',
                     ccc: 'ccc@5-0',
                   },
-                  entries: {
+                  materialisedEntries: {
                     foo1: { timeserial: 'bbb@0-0', data: { value: 'bar' } },
                     foo2: { timeserial: 'bbb@0-0', data: { value: 'bar' } },
                     foo3: { timeserial: 'ccc@5-0', data: { value: 'bar' } },
@@ -1410,13 +1410,13 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
                   siteTimeserials: {
                     bbb: 'bbb@1-0',
                   },
-                  count: 1,
+                  initialCount: 1,
                 }),
                 // add objects to the root so they're discoverable in the state tree
                 liveObjectsHelper.mapObject({
                   objectId: 'root',
                   siteTimeserials: { '000': '000@0-0' },
-                  entries: {
+                  initialEntries: {
                     map: { timeserial: '000@0-0', data: { objectId: mapId } },
                     counter: { timeserial: '000@0-0', data: { objectId: counterId } },
                   },

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -1351,7 +1351,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
               map.subscribe((update) => {
                 try {
                   expect(update).to.deep.equal(
-                    { update: { stringKey: 'deleted' } },
+                    { update: { stringKey: 'removed' } },
                     'Check map subscription callback is called with an expected update object for MAP_REMOVE operation',
                   );
                   resolve();
@@ -1382,9 +1382,9 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
             const expectedMapUpdates = [
               { update: { foo: 'updated' } },
               { update: { bar: 'updated' } },
-              { update: { foo: 'deleted' } },
+              { update: { foo: 'removed' } },
               { update: { baz: 'updated' } },
-              { update: { bar: 'deleted' } },
+              { update: { bar: 'removed' } },
             ];
             let currentUpdateIndex = 0;
 


### PR DESCRIPTION
Removes usage of `regionalTimeserial` and instead uses `siteTimeserials` from `StateObject` to decide which operations to apply (site code parsing will be removed from the SDK side once https://ably.atlassian.net/browse/DTP-1078 is completed on realtime).

Removed `created` flag from LiveCounter and uses new `createOp` field on `StateObject` to handle the initial value for live objects.

**The biggest difference** from the [realtime implementation](https://github.com/ably/realtime/blob/0ee47aecc895d542c2d382081ede20505b0c4daa/go/realtime/lib/state/liveobject/counter.go#L105-L115) here is that client SDK merges the initial value from the `createOp` field (once corresponding op is received via a SYNC sequence or as a separate message) into the data stored on the live object only once (and remembers that it was merged, functions similarly to how `created` worked for Counters), to avoid merging those values every time a live object is read by client (potentially saves a bunch of computation on merging big Map objects).

Resolves [DTP-1076](https://ably.atlassian.net/browse/DTP-1076), [DTP-1077](https://ably.atlassian.net/browse/DTP-1077)

[DTP-1076]: https://ably.atlassian.net/browse/DTP-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DTP-1077]: https://ably.atlassian.net/browse/DTP-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new methods for creating `LiveCounter` and `LiveMap` instances from state objects, enhancing state management.
	- Added a `siteCode` property to the `Timeserial` interface for improved site-specific tracking.
	- Added a new helper function for streamlined execution of test scenarios.

- **Bug Fixes**
	- Refined handling of state synchronization messages to ensure correct application of operations based on timeserial conditions.

- **Documentation**
	- Updated test descriptions for clarity regarding state management and operations.

- **Refactor**
	- Streamlined constructors and method signatures across various classes to simplify initialization and improve maintainability.
	- Simplified the handling of state messages and buffered operations in the `LiveObjects` class.
	- Enhanced the structure and readability of test scenarios related to state operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->