### PR TITLE
Fix web FetchRequest does not respect `disableConnectivityCheck` client option

### DIFF
--- a/src/platform/web/lib/http/http.ts
+++ b/src/platform/web/lib/http/http.ts
@@ -117,18 +117,25 @@ const Http = class {
       this.Request = async (method, uri, headers, params, body) => {
         return fetchRequestImplementation(method, client ?? null, uri, headers, params, body);
       };
-      this.checkConnectivity = async function () {
-        Logger.logAction(
-          this.logger,
-          Logger.LOG_MICRO,
-          '(Fetch)Http.checkConnectivity()',
-          'Sending; ' + connectivityCheckUrl,
-        );
-        const requestResult = await this.doUri(HttpMethods.Get, connectivityCheckUrl, null, null, null);
-        const result = !requestResult.error && (requestResult.body as string)?.replace(/\n/, '') == 'yes';
-        Logger.logAction(this.logger, Logger.LOG_MICRO, '(Fetch)Http.checkConnectivity()', 'Result: ' + result);
-        return result;
-      };
+
+      if (client?.options.disableConnectivityCheck) {
+        this.checkConnectivity = async function () {
+          return true;
+        };
+      } else {
+        this.checkConnectivity = async function () {
+          Logger.logAction(
+            this.logger,
+            Logger.LOG_MICRO,
+            '(Fetch)Http.checkConnectivity()',
+            'Sending; ' + connectivityCheckUrl,
+          );
+          const requestResult = await this.doUri(HttpMethods.Get, connectivityCheckUrl, null, null, null);
+          const result = !requestResult.error && (requestResult.body as string)?.replace(/\n/, '') == 'yes';
+          Logger.logAction(this.logger, Logger.LOG_MICRO, '(Fetch)Http.checkConnectivity()', 'Result: ' + result);
+          return result;
+        };
+      }
     } else {
       this.Request = async () => {
         const error = hasImplementation


### PR DESCRIPTION
See internal [slack thread ](https://ably-real-time.slack.com/archives/CURL4U2FP/p1732272196982359?thread_ts=1731587842.925669&cid=CURL4U2FP)for more context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced connectivity check functionality, allowing for immediate success when the `disableConnectivityCheck` option is enabled.
  
- **Bug Fixes**
	- Improved error handling for unsupported HTTP transports.

- **Tests**
	- Expanded test coverage for browser connectivity scenarios, including new cases for disabled fetch and XHR request implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->