### PR TITLE
build: dont check submodules to build module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,7 +73,7 @@ module.exports = function (grunt) {
     });
   });
 
-  grunt.registerTask('build', ['checkGitSubmodules', 'webpack:all', 'build:browser', 'build:node', 'build:push']);
+  grunt.registerTask('build', ['webpack:all', 'build:browser', 'build:node', 'build:push']);
 
   grunt.registerTask('all', ['build', 'requirejs']);
 


### PR DESCRIPTION
The only git submodule we need is ably-common, and this is only used as part of testing to create test apps. We don't use it when building (despite it being a build check).

This check during build prevents other SDKs from depending on a branch of ably-js, as it doesn't have the submodules, and can't init them.

This change therefore removes the submodules check when building the library, allowing SDKs to depend on branch versions, if they want to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the build process by removing the prerequisite check for Git submodules, streamlining the build registration.
  
This change enhances the overall efficiency of the build process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->