### PR TITLE
Test that we can decrypt history messages

### DIFF
--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -483,6 +483,15 @@ define([
     dumpPrivateApiUsage() {
       privateApiRecorder.dump();
     }
+
+    async waitFor(condition, remaining) {
+      const success = await condition();
+      if (success || remaining <= 0) {
+        return success;
+      }
+      await this.setTimeoutAsync(100);
+      return this.waitFor(condition, remaining - 100);
+    }
   }
 
   SharedHelper.testOnAllTransports.skip = function (thisInDescribe, name, testFn) {

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -774,6 +774,31 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /**
+     * @spec RSL5a
+     */
+    it('encrypted history', async function () {
+      if (!Crypto) {
+        done(new Error('Encryption not supported'));
+        return;
+      }
+
+      const helper = this.test.helper,
+        rest = helper.AblyRest(),
+        channelName = 'encrypted_history',
+        messageText = 'Test message';
+
+      const key = await Crypto.generateRandomKey();
+      const channel = rest.channels.get(channelName, { cipher: { key: key } });
+      await channel.publish('event0', messageText);
+      let items;
+      await helper.waitFor(async () => {
+        items = (await channel.history()).items;
+        return items.length > 0;
+      }, 10_000);
+      expect(items[0].data).to.equal(messageText);
+    });
+
+    /**
      * Connect twice to the service, using different cipher keys.
      * Publish an encrypted message on that channel using
      * the default cipher params and verify that the decrypt failure


### PR DESCRIPTION
**Note: This PR is based on top of #1935; please review that one first.**

This was previously untested.

The new test in `crypto.test.js` is taken from a test Simon added in #1923, but I wanted to separate this test from all the other work that’s being done in that PR. I’ve also copied this new test to create a similar test for the modular variant of the library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new asynchronous method for waiting on conditions in tests, enhancing testing capabilities.
	- Added functionality to verify the decryption of messages from encrypted channel history.

- **Tests**
	- Expanded test coverage with new cases for checking encrypted message retrieval and history validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->