### PR TITLE
[DTP-986] Handle `StateObject.tombstone` and `OBJECT_DELETE` messages

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2103,12 +2103,12 @@ export type DefaultRoot =
  */
 export declare interface LiveMap<T extends LiveMapType> extends LiveObject<LiveMapUpdate> {
   /**
-   * Returns the value associated with a given key. Returns `undefined` if the key doesn't exist in a map.
+   * Returns the value associated with a given key. Returns `undefined` if the key doesn't exist in a map or if the associated {@link LiveObject} has been deleted.
    *
    * @param key - The key to retrieve the value for.
-   * @returns A {@link LiveObject}, a primitive type (string, number, boolean, or binary data) or `undefined` if the key doesn't exist in a map.
+   * @returns A {@link LiveObject}, a primitive type (string, number, boolean, or binary data) or `undefined` if the key doesn't exist in a map or the associated {@link LiveObject} has been deleted.
    */
-  get<TKey extends keyof T & string>(key: TKey): T[TKey];
+  get<TKey extends keyof T & string>(key: TKey): T[TKey] extends StateValue ? T[TKey] : T[TKey] | undefined;
 
   /**
    * Returns the number of key/value pairs in the map.

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2105,10 +2105,12 @@ export declare interface LiveMap<T extends LiveMapType> extends LiveObject<LiveM
   /**
    * Returns the value associated with a given key. Returns `undefined` if the key doesn't exist in a map or if the associated {@link LiveObject} has been deleted.
    *
+   * Always returns undefined if this map object is deleted.
+   *
    * @param key - The key to retrieve the value for.
-   * @returns A {@link LiveObject}, a primitive type (string, number, boolean, or binary data) or `undefined` if the key doesn't exist in a map or the associated {@link LiveObject} has been deleted.
+   * @returns A {@link LiveObject}, a primitive type (string, number, boolean, or binary data) or `undefined` if the key doesn't exist in a map or the associated {@link LiveObject} has been deleted. Always `undefined` if this map object is deleted.
    */
-  get<TKey extends keyof T & string>(key: TKey): T[TKey] extends StateValue ? T[TKey] : T[TKey] | undefined;
+  get<TKey extends keyof T & string>(key: TKey): T[TKey] | undefined;
 
   /**
    * Returns the number of key/value pairs in the map.

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -78,6 +78,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
   /**
    * Returns the value associated with the specified key in the underlying Map object.
    *
+   * - If this map object is tombstoned (deleted), `undefined` is returned.
    * - If no entry is associated with the specified key, `undefined` is returned.
    * - If map entry is tombstoned (deleted), `undefined` is returned.
    * - If the value associated with the provided key is an objectId string of another Live Object, a reference to that Live Object
@@ -85,7 +86,11 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
    * - If the value is not an objectId, then that value is returned.
    */
   // force the key to be of type string as we only allow strings as key in a map
-  get<TKey extends keyof T & string>(key: TKey): T[TKey] extends StateValue ? T[TKey] : T[TKey] | undefined {
+  get<TKey extends keyof T & string>(key: TKey): T[TKey] | undefined {
+    if (this.isTombstoned()) {
+      return undefined as T[TKey];
+    }
+
     const element = this._dataRef.data.get(key);
 
     if (element === undefined) {

--- a/src/plugins/liveobjects/liveobjects.ts
+++ b/src/plugins/liveobjects/liveobjects.ts
@@ -6,7 +6,7 @@ import { LiveCounter } from './livecounter';
 import { LiveMap } from './livemap';
 import { LiveObject, LiveObjectUpdate } from './liveobject';
 import { LiveObjectsPool, ROOT_OBJECT_ID } from './liveobjectspool';
-import { StateMessage } from './statemessage';
+import { StateMessage, StateOperationAction } from './statemessage';
 import { SyncLiveObjectsDataPool } from './syncliveobjectsdatapool';
 
 enum LiveObjectsEvents {
@@ -101,7 +101,7 @@ export class LiveObjects {
       return;
     }
 
-    this._liveObjectsPool.applyStateMessages(stateMessages);
+    this._applyStateMessages(stateMessages);
   }
 
   /**
@@ -159,7 +159,7 @@ export class LiveObjects {
     this._applySync();
     // should apply buffered state operations after we applied the SYNC data.
     // can use regular state messages application logic
-    this._liveObjectsPool.applyStateMessages(this._bufferedStateOperations);
+    this._applyStateMessages(this._bufferedStateOperations);
 
     this._bufferedStateOperations = [];
     this._syncLiveObjectsDataPool.reset();
@@ -231,5 +231,46 @@ export class LiveObjects {
 
     // call subscription callbacks for all updated existing objects
     existingObjectUpdates.forEach(({ object, update }) => object.notifyUpdated(update));
+  }
+
+  private _applyStateMessages(stateMessages: StateMessage[]): void {
+    for (const stateMessage of stateMessages) {
+      if (!stateMessage.operation) {
+        this._client.Logger.logAction(
+          this._client.logger,
+          this._client.Logger.LOG_MAJOR,
+          'LiveObjects._applyStateMessages()',
+          `state operation message is received without 'operation' field, skipping message; message id: ${stateMessage.id}, channel: ${this._channel.name}`,
+        );
+        continue;
+      }
+
+      const stateOperation = stateMessage.operation;
+
+      switch (stateOperation.action) {
+        case StateOperationAction.MAP_CREATE:
+        case StateOperationAction.COUNTER_CREATE:
+        case StateOperationAction.MAP_SET:
+        case StateOperationAction.MAP_REMOVE:
+        case StateOperationAction.COUNTER_INC:
+          // we can receive an op for an object id we don't have yet in the pool. instead of buffering such operations,
+          // we can create a zero-value object for the provided object id and apply the operation to that zero-value object.
+          // this also means that all objects are capable of applying the corresponding *_CREATE ops on themselves,
+          // since they need to be able to eventually initialize themselves from that *_CREATE op.
+          // so to simplify operations handling, we always try to create a zero-value object in the pool first,
+          // and then we can always apply the operation on the existing object in the pool.
+          this._liveObjectsPool.createZeroValueObjectIfNotExists(stateOperation.objectId);
+          this._liveObjectsPool.get(stateOperation.objectId)!.applyOperation(stateOperation, stateMessage);
+          break;
+
+        default:
+          this._client.Logger.logAction(
+            this._client.logger,
+            this._client.Logger.LOG_MAJOR,
+            'LiveObjects._applyStateMessages()',
+            `received unsupported action in state operation message: ${stateOperation.action}, skipping message; message id: ${stateMessage.id}, channel: ${this._channel.name}`,
+          );
+      }
+    }
   }
 }

--- a/src/plugins/liveobjects/liveobjects.ts
+++ b/src/plugins/liveobjects/liveobjects.ts
@@ -4,7 +4,7 @@ import type EventEmitter from 'common/lib/util/eventemitter';
 import type * as API from '../../../ably';
 import { LiveCounter } from './livecounter';
 import { LiveMap } from './livemap';
-import { LiveObject, LiveObjectUpdate } from './liveobject';
+import { LiveObject, LiveObjectUpdate, LiveObjectUpdateNoop } from './liveobject';
 import { LiveObjectsPool, ROOT_OBJECT_ID } from './liveobjectspool';
 import { StateMessage, StateOperationAction } from './statemessage';
 import { SyncLiveObjectsDataPool } from './syncliveobjectsdatapool';
@@ -193,7 +193,7 @@ export class LiveObjects {
     }
 
     const receivedObjectIds = new Set<string>();
-    const existingObjectUpdates: { object: LiveObject; update: LiveObjectUpdate }[] = [];
+    const existingObjectUpdates: { object: LiveObject; update: LiveObjectUpdate | LiveObjectUpdateNoop }[] = [];
 
     for (const [objectId, entry] of this._syncLiveObjectsDataPool.entries()) {
       receivedObjectIds.add(objectId);
@@ -253,6 +253,7 @@ export class LiveObjects {
         case StateOperationAction.MAP_SET:
         case StateOperationAction.MAP_REMOVE:
         case StateOperationAction.COUNTER_INC:
+        case StateOperationAction.OBJECT_DELETE:
           // we can receive an op for an object id we don't have yet in the pool. instead of buffering such operations,
           // we can create a zero-value object for the provided object id and apply the operation to that zero-value object.
           // this also means that all objects are capable of applying the corresponding *_CREATE ops on themselves,

--- a/src/plugins/liveobjects/liveobjectspool.ts
+++ b/src/plugins/liveobjects/liveobjectspool.ts
@@ -1,11 +1,9 @@
 import type BaseClient from 'common/lib/client/baseclient';
-import type RealtimeChannel from 'common/lib/client/realtimechannel';
 import { LiveCounter } from './livecounter';
 import { LiveMap } from './livemap';
 import { LiveObject } from './liveobject';
 import { LiveObjects } from './liveobjects';
 import { ObjectId } from './objectid';
-import { StateMessage, StateOperationAction } from './statemessage';
 
 export const ROOT_OBJECT_ID = 'root';
 
@@ -14,12 +12,10 @@ export const ROOT_OBJECT_ID = 'root';
  */
 export class LiveObjectsPool {
   private _client: BaseClient;
-  private _channel: RealtimeChannel;
   private _pool: Map<string, LiveObject>;
 
   constructor(private _liveObjects: LiveObjects) {
     this._client = this._liveObjects.getClient();
-    this._channel = this._liveObjects.getChannel();
     this._pool = this._getInitialPool();
   }
 
@@ -64,47 +60,6 @@ export class LiveObjectsPool {
     }
 
     this.set(objectId, zeroValueObject);
-  }
-
-  applyStateMessages(stateMessages: StateMessage[]): void {
-    for (const stateMessage of stateMessages) {
-      if (!stateMessage.operation) {
-        this._client.Logger.logAction(
-          this._client.logger,
-          this._client.Logger.LOG_MAJOR,
-          'LiveObjects.LiveObjectsPool.applyStateMessages()',
-          `state operation message is received without 'operation' field, skipping message; message id: ${stateMessage.id}, channel: ${this._channel.name}`,
-        );
-        continue;
-      }
-
-      const stateOperation = stateMessage.operation;
-
-      switch (stateOperation.action) {
-        case StateOperationAction.MAP_CREATE:
-        case StateOperationAction.COUNTER_CREATE:
-        case StateOperationAction.MAP_SET:
-        case StateOperationAction.MAP_REMOVE:
-        case StateOperationAction.COUNTER_INC:
-          // we can receive an op for an object id we don't have yet in the pool. instead of buffering such operations,
-          // we can create a zero-value object for the provided object id and apply the operation to that zero-value object.
-          // this also means that all objects are capable of applying the corresponding *_CREATE ops on themselves,
-          // since they need to be able to eventually initialize themselves from that *_CREATE op.
-          // so to simplify operations handling, we always try to create a zero-value object in the pool first,
-          // and then we can always apply the operation on the existing object in the pool.
-          this.createZeroValueObjectIfNotExists(stateOperation.objectId);
-          this.get(stateOperation.objectId)!.applyOperation(stateOperation, stateMessage);
-          break;
-
-        default:
-          this._client.Logger.logAction(
-            this._client.logger,
-            this._client.Logger.LOG_MAJOR,
-            'LiveObjects.LiveObjectsPool.applyStateMessages()',
-            `received unsupported action in state operation message: ${stateOperation.action}, skipping message; message id: ${stateMessage.id}, channel: ${this._channel.name}`,
-          );
-      }
-    }
   }
 
   private _getInitialPool(): Map<string, LiveObject> {

--- a/src/plugins/liveobjects/statemessage.ts
+++ b/src/plugins/liveobjects/statemessage.ts
@@ -8,6 +8,7 @@ export enum StateOperationAction {
   MAP_REMOVE = 2,
   COUNTER_CREATE = 3,
   COUNTER_INC = 4,
+  OBJECT_DELETE = 5,
 }
 
 export enum MapSemantics {
@@ -106,6 +107,8 @@ export interface StateObject {
   objectId: string;
   /** A vector of origin timeserials keyed by site code of the last operation that was applied to this state object. */
   siteTimeserials: Record<string, string>;
+  /** True if the object has been tombstoned. */
+  tombstone: boolean;
   /**
    * The operation that created the state object.
    *

--- a/test/common/modules/live_objects_helper.js
+++ b/test/common/modules/live_objects_helper.js
@@ -12,6 +12,7 @@ define(['ably', 'shared_helper', 'live_objects'], function (Ably, Helper, LiveOb
     MAP_REMOVE: 2,
     COUNTER_CREATE: 3,
     COUNTER_INC: 4,
+    OBJECT_DELETE: 5,
   };
 
   function nonce() {
@@ -180,12 +181,25 @@ define(['ably', 'shared_helper', 'live_objects'], function (Ably, Helper, LiveOb
       return op;
     }
 
+    objectDeleteOp(opts) {
+      const { objectId } = opts ?? {};
+      const op = {
+        operation: {
+          action: ACTIONS.OBJECT_DELETE,
+          objectId,
+        },
+      };
+
+      return op;
+    }
+
     mapObject(opts) {
-      const { objectId, siteTimeserials, initialEntries, materialisedEntries } = opts;
+      const { objectId, siteTimeserials, initialEntries, materialisedEntries, tombstone } = opts;
       const obj = {
         object: {
           objectId,
           siteTimeserials,
+          tombstone: tombstone === true,
           map: {
             semantics: 0,
             entries: materialisedEntries,
@@ -201,11 +215,12 @@ define(['ably', 'shared_helper', 'live_objects'], function (Ably, Helper, LiveOb
     }
 
     counterObject(opts) {
-      const { objectId, siteTimeserials, initialCount, materialisedCount } = opts;
+      const { objectId, siteTimeserials, initialCount, materialisedCount, tombstone } = opts;
       const obj = {
         object: {
           objectId,
           siteTimeserials,
+          tombstone: tombstone === true,
           counter: {
             count: materialisedCount,
           },

--- a/test/package/browser/template/src/ably.config.d.ts
+++ b/test/package/browser/template/src/ably.config.d.ts
@@ -5,13 +5,13 @@ type CustomRoot = {
   stringKey: string;
   booleanKey: boolean;
   couldBeUndefined?: string;
-  mapKey?: LiveMap<{
+  mapKey: LiveMap<{
     foo: 'bar';
     nestedMap?: LiveMap<{
       baz: 'qux';
     }>;
   }>;
-  counterKey?: LiveCounter;
+  counterKey: LiveCounter;
 };
 
 declare global {

--- a/test/package/browser/template/src/index-liveobjects.ts
+++ b/test/package/browser/template/src/index-liveobjects.ts
@@ -30,8 +30,10 @@ globalThis.testAblyPackage = async function () {
   const aBoolean: boolean = root.get('booleanKey');
   const couldBeUndefined: string | undefined = root.get('couldBeUndefined');
   // live objects on a root:
+  // LiveMap.get can still return undefined for LiveObject typed properties even if custom typings have them as non-optional.
+  // objects can be tombstoned and result in the undefined value
   const counter: Ably.LiveCounter | undefined = root.get('counterKey');
-  const map: LiveObjectsTypes['root']['mapKey'] = root.get('mapKey');
+  const map: LiveObjectsTypes['root']['mapKey'] | undefined = root.get('mapKey');
   // check string literal types works
   // need to use nullish coalescing as we didn't actually create any data on the root,
   // so the next calls would fail. we only need to check that TypeScript types work

--- a/test/package/browser/template/src/index-liveobjects.ts
+++ b/test/package/browser/template/src/index-liveobjects.ts
@@ -24,14 +24,14 @@ globalThis.testAblyPackage = async function () {
   const size: number = root.size();
 
   // check custom user provided typings via LiveObjectsTypes are working:
+  // any LiveMap.get() call can return undefined, as the LiveMap itself can be tombstoned (has empty state),
+  // or referenced object is tombstoned.
   // keys on a root:
-  const aNumber: number = root.get('numberKey');
-  const aString: string = root.get('stringKey');
-  const aBoolean: boolean = root.get('booleanKey');
-  const couldBeUndefined: string | undefined = root.get('couldBeUndefined');
+  const aNumber: number | undefined = root.get('numberKey');
+  const aString: string | undefined = root.get('stringKey');
+  const aBoolean: boolean | undefined = root.get('booleanKey');
+  const userProvidedUndefined: string | undefined = root.get('couldBeUndefined');
   // live objects on a root:
-  // LiveMap.get can still return undefined for LiveObject typed properties even if custom typings have them as non-optional.
-  // objects can be tombstoned and result in the undefined value
   const counter: Ably.LiveCounter | undefined = root.get('counterKey');
   const map: LiveObjectsTypes['root']['mapKey'] | undefined = root.get('mapKey');
   // check string literal types works
@@ -63,5 +63,5 @@ globalThis.testAblyPackage = async function () {
 
   // check can provide custom types for the getRoot method, ignoring global LiveObjectsTypes interface
   const explicitRoot: Ably.LiveMap<ExplicitRootType> = await liveObjects.getRoot<ExplicitRootType>();
-  const someOtherKey: string = explicitRoot.get('someOtherKey');
+  const someOtherKey: string | undefined = explicitRoot.get('someOtherKey');
 };


### PR DESCRIPTION
- Tombstoned objects clear their underlying data by setting it to a zero-value: 0 for a counter object, empty map for a map.
- No state operations can be applied on a tombstoned object.
- Tombstoned objects are not surfaced to the end users.
- When deleted, object triggers a subscription callback with cleared data.

Resolves [DTP-986](https://ably.atlassian.net/browse/DTP-986)

[DTP-986]: https://ably.atlassian.net/browse/DTP-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `OBJECT_DELETE` operation to enhance state management.
	- Added tombstone functionality to manage object deletion states.
	- Enhanced `LiveMap`, `LiveCounter`, and `LiveObject` classes to handle tombstoned states effectively.
	- Updated return types in `LiveMap` methods to include `undefined` for tombstoned entries.

- **Bug Fixes**
	- Improved error handling to prevent operations on tombstoned objects.

- **Documentation**
	- Updated method comments to clarify behavior regarding tombstoned objects.

- **Tests**
	- Added new test scenarios for handling object deletions and tombstoned states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->