### PR TITLE
Update expected error code in a test

### DIFF
--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -31,9 +31,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
             var realtime = helper.AblyRealtime({ key: 'this.is:wrong', transports: transports });
             realtime.connection.on('failed', function (connectionStateChange) {
               try {
-                expect(realtime.connection.errorReason.code).to.equal(40400, 'wrong error reason code on connection.');
+                expect(realtime.connection.errorReason.code).to.equal(40101, 'wrong error reason code on connection.');
                 expect(connectionStateChange.reason.code).to.equal(
-                  40400,
+                  40101,
                   'wrong error reason code on connectionStateChange',
                 );
                 expect(connectionStateChange.reason).to.deep.equal(


### PR DESCRIPTION
Realtime is now returning 40101 (invalid credentials) when unable to extract an app ID from the key. The Realtime team have confirmed ([internal Slack thread](https://ably-real-time.slack.com/archives/CURL4U2FP/p1733479167314059?thread_ts=1733420816.469159&cid=CURL4U2FP)) that this new behaviour is correct and that the test should be updated.