### PR TITLE
chore: add release information for 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
-## [2.6.0](https://github.com/ably/ably-js/tree/2.6.0) (2024-12-09)
+## [2.6.0](https://github.com/ably/ably-js/tree/2.6.0) (2024-12-10)
 
 - Removed a build check that prevented referencing branch builds in `package.json`. It is now possible to point npm at specific branches of ably-js.
 - Presence will now only emit a `LEAVE` event if a member was present in the presence set to begin with.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.6.0](https://github.com/ably/ably-js/tree/2.6.0) (2024-12-09)
+
+- Removed a build check that prevented referencing branch builds in `package.json`. It is now possible to point npm at specific branches of ably-js.
+- Presence will now only emit a `LEAVE` event if a member was present in the presence set to begin with.
+- The experimental attributes on the `Message` type to support edits and deletes have been updated and renamed.
+
 ## [2.5.0](https://github.com/ably/ably-js/tree/2.5.0) (2024-11-06)
 
 With this release, ably-js will now expose the new `Message` attributes needed to support upcoming features,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.5.0';
+export const version = '2.6.0';
 
 export function channelOptionsWithAgent(options?: Ably.ChannelOptions) {
   return {


### PR DESCRIPTION
This change adds the README and other updates for 2.6.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated presence functionality to emit a `LEAVE` event only if a member was previously present.
	- Introduced experimental attributes on the `Message` type for edits and deletes.

- **Bug Fixes**
	- Removed a build check allowing npm to reference specific branches in the `ably-js` repository.

- **Version Updates**
	- Incremented version number from `2.5.0` to `2.6.0` across relevant files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->