### PR TITLE
test/browser/connection: fix hmac extraction

### DIFF
--- a/test/browser/connection.test.js
+++ b/test/browser/connection.test.js
@@ -216,15 +216,12 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
       // strip instanceID and handleID from connectionKey */
       function connectionHmac(key) {
         /* connectionKey has the form <instanceID>!<hmac>-<handleID> */
-
-        /* remove the handleID from the end of key */
-        let k = key.split('-')[0];
-
-        /* skip the server instanceID if present, as reconnects may be routed to different frontends */
-        if (k.includes('!')) {
-          k = k.split('!')[1];
+        let end = key.lastIndexOf('-');
+        if (end < 0) {
+          end = key.length;
         }
-        return k;
+        const start = key.indexOf('!');
+        return key.substring(start + 1, end);
       }
 
       /* uses internal realtime knowledge of the format of the connection key to


### PR DESCRIPTION
Relax the connectionKey hmac extraction and account for the possibilities of multiple - characters.

RAR-655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved connection key processing logic in the connection handling mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->