### PR TITLE
CHORE: Add release information for v.2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.7.0](https://github.com/ably/ably-js/tree/2.7.0) (2025-01-13)
+
+- Removed an incorrect channel mode `ATTACH_RESUME` from the `ChannelModes` enum.
+- Deprecates the `UNSET` type from `MESSAGE_ACTIONS` enum, all messages will always have their `action` set.
+- Deprecates `ANNOTATION_CREATE` and `ANNOTATION_DELETE` from the `MESSAGE_ACTIONS` enum.
+- Adds support for upcoming message summaries with the new `MESSAGE_SUMMARY` message action type.
+- Multiple improvements to type definitions and message handling.
+
 ## [2.6.0](https://github.com/ably/ably-js/tree/2.6.0) (2024-12-10)
 
 - Removed a build check that prevented referencing branch builds in `package.json`. It is now possible to point npm at specific branches of ably-js.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.6.0';
+export const version = '2.7.0';
 
 export function channelOptionsWithAgent(options?: Ably.ChannelOptions) {
   return {


### PR DESCRIPTION
- Update CHANGELOG
- Update Ably package version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
	- Released version 2.7.0 of the library
- **Enum Changes**
	- Removed `ATTACH_RESUME` channel mode
	- Deprecated `UNSET`, `ANNOTATION_CREATE`, and `ANNOTATION_DELETE` message actions
	- Added new `MESSAGE_SUMMARY` message action type
- **Improvements**
	- Enhanced type definitions and message handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->