### PR TITLE
Message: fix parent-populated version not being propagated to serial

### DIFF
--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -596,8 +596,7 @@ class RealtimeChannel extends EventEmitter {
 
         const encoded = message.messages!,
           firstMessage = encoded[0],
-          lastMessage = encoded[encoded.length - 1],
-          channelSerial = message.channelSerial;
+          lastMessage = encoded[encoded.length - 1];
 
         if (
           firstMessage.extras &&
@@ -636,13 +635,6 @@ class RealtimeChannel extends EventEmitter {
               default:
               // do nothing, continue decoding
             }
-          }
-        }
-
-        for (let i = 0; i < messages.length; i++) {
-          const msg = messages[i];
-          if (channelSerial && !msg.version) {
-            msg.version = channelSerial + ':' + i.toString().padStart(3, '0');
           }
         }
 


### PR DESCRIPTION
I intended to move the version propagation into populateFieldsFromParent in https://github.com/ably/ably-js/commit/494500fa54d49a46eec183239b96661adbc17199#diff-94e592083882d1fcef5156d5f972441c3932403b3f1fce9588802dac216e9142L662 , but apparently forgot. without the move it's done after the decode, which is too late for expandFields().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated message processing logic to handle version assignments more efficiently
	- Improved code readability in message field population method
	- Simplified message version tracking mechanism

The changes appear to be internal optimizations related to message handling and version management, which should not directly impact end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->