### PR TITLE
Chore: Release version 2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.6.2](https://github.com/ably/ably-js/tree/2.6.2) (2025-01-14)
+
+- Minor bugfix for experimental message fields.
+
 ## [2.6.1](https://github.com/ably/ably-js/tree/2.6.1) (2025-01-13)
 
 - Removed an incorrect channel mode `ATTACH_RESUME` from the `ChannelModes` enum.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.6.1';
+export const version = '2.6.2';
 
 export function channelOptionsWithAgent(options?: Ably.ChannelOptions) {
   return {


### PR DESCRIPTION
## Summary

- **Version Update**
	- Released version 2.6.2
- **Bugfix**
	- Correctly returns serial from when receiving a `Message` over the wire protocol. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version to 2.6.2
	- Updated version references in changelog and react hooks
	- Minor documentation update for version tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->