### PR TITLE
[ECO-5184] feat: update channel hooks implementation

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -893,6 +893,13 @@ export interface ChannelOptions {
    * An array of {@link ChannelMode} objects.
    */
   modes?: ChannelMode[];
+  /**
+   *  A boolean which determines whether calling subscribe
+   *  on a channel or presence object should trigger an implicit attach. Defaults to `true`
+   *
+   *  Note: this option is for realtime client libraries only
+   */
+  attachOnSubscribe?: boolean;
 }
 
 /**

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -433,7 +433,12 @@ class RealtimeChannel extends EventEmitter {
       this.subscriptions.on(event, listener);
     }
 
-    return this.attach();
+    // (RTL7g)
+    if (this.channelOptions.attachOnSubscribe !== false) {
+      return this.attach();
+    } else {
+      return null;
+    }
   }
 
   unsubscribe(...args: unknown[] /* [event], listener */): void {

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -454,7 +454,11 @@ class RealtimePresence extends EventEmitter {
     }
 
     this.subscriptions.on(event, listener);
-    await channel.attach();
+
+    // (RTP6d)
+    if (channel.channelOptions.attachOnSubscribe !== false) {
+      await channel.attach();
+    }
   }
 
   unsubscribe(..._args: unknown[] /* [event], listener */): void {

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -14,12 +14,18 @@ export type ChannelParameters = string | ChannelNameAndOptions;
 
 export const version = '2.6.1';
 
-export function channelOptionsWithAgent(options?: Ably.ChannelOptions) {
+/**
+ * channel options for react-hooks
+ */
+export function channelOptionsForReactHooks(options?: Ably.ChannelOptions): Ably.ChannelOptions {
   return {
     ...options,
     params: {
       ...options?.params,
       agent: `react-hooks/${version}`,
     },
+    // we explicitly attach channels in React hooks (useChannel, usePresence, usePresenceListener)
+    // to avoid situations where implicit attachment could cause errors (when connection state is failed or disconnected)
+    attachOnSubscribe: false,
   };
 }

--- a/src/platform/react-hooks/src/ChannelProvider.tsx
+++ b/src/platform/react-hooks/src/ChannelProvider.tsx
@@ -1,7 +1,7 @@
 import React, { useLayoutEffect, useMemo } from 'react';
 import * as Ably from 'ably';
 import { type AblyContextValue, AblyContext } from './AblyContext.js';
-import { channelOptionsWithAgent } from './AblyReactHooks.js';
+import { channelOptionsForReactHooks } from './AblyReactHooks.js';
 
 interface ChannelProviderProps {
   ablyId?: string;
@@ -45,7 +45,7 @@ export const ChannelProvider = ({
   }, [derived, client, channel, channelName, _channelNameToChannelContext, ablyId, context]);
 
   useLayoutEffect(() => {
-    channel.setOptions(channelOptionsWithAgent(options));
+    channel.setOptions(channelOptionsForReactHooks(options));
   }, [channel, options]);
 
   return <AblyContext.Provider value={value}>{children}</AblyContext.Provider>;

--- a/src/platform/react-hooks/src/fakes/ably.ts
+++ b/src/platform/react-hooks/src/fakes/ably.ts
@@ -163,6 +163,10 @@ export class ClientSingleChannelConnection extends EventEmitter {
   public async setOptions() {
     // do nothing
   }
+
+  public async attach() {
+    // do nothing
+  }
 }
 
 export class ClientSingleDerivedChannelConnection extends EventEmitter {
@@ -198,6 +202,10 @@ export class ClientSingleDerivedChannelConnection extends EventEmitter {
 
   public async publish() {
     throw Error('no publish for derived channel');
+  }
+
+  public async attach() {
+    // do nothing
   }
 }
 
@@ -346,6 +354,10 @@ export class Channel {
   }
 
   public async setOptions() {
+    // do nothing
+  }
+
+  public async attach() {
     // do nothing
   }
 }

--- a/src/platform/react-hooks/src/hooks/constants.ts
+++ b/src/platform/react-hooks/src/hooks/constants.ts
@@ -1,0 +1,4 @@
+import type * as Ably from 'ably';
+
+export const INACTIVE_CONNECTION_STATES: Ably.ConnectionState[] = ['suspended', 'closing', 'closed', 'failed'];
+export const INACTIVE_CHANNEL_STATES: Ably.ChannelState[] = ['failed', 'suspended', 'detaching'];

--- a/src/platform/react-hooks/src/hooks/useChannel.ts
+++ b/src/platform/react-hooks/src/hooks/useChannel.ts
@@ -4,6 +4,7 @@ import { ChannelParameters } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly.js';
 import { useStateErrors } from './useStateErrors.js';
 import { useChannelInstance } from './useChannelInstance.js';
+import { useChannelAttach } from './useChannelAttach.js';
 
 export type AblyMessageCallback = Ably.messageCallback<Ably.Message>;
 
@@ -81,6 +82,8 @@ export function useChannel(
       !skip && subscribeArgs && handleChannelUnmount(channel, ...subscribeArgs);
     };
   }, [channelEvent, channel, skip]);
+
+  useChannelAttach(channel, channelHookOptions.ablyId, skip);
 
   return { channel, publish, ably, connectionError, channelError };
 }

--- a/src/platform/react-hooks/src/hooks/useChannelAttach.test.tsx
+++ b/src/platform/react-hooks/src/hooks/useChannelAttach.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChannelAttach } from './useChannelAttach.js';
+
+interface LocalTestContext {
+  useChannelAttach: typeof useChannelAttach;
+}
+
+describe('useChannelAttach', () => {
+  const fakeAblyClientRef: any = {};
+
+  beforeEach<LocalTestContext>(async (context) => {
+    vi.doMock('./useConnectionStateListener.js', () => ({
+      useConnectionStateListener: vi.fn(),
+    }));
+
+    vi.doMock('./useAbly.js', () => ({
+      useAbly: () => fakeAblyClientRef.current,
+    }));
+
+    context.useChannelAttach = (await import('./useChannelAttach.js')).useChannelAttach;
+    fakeAblyClientRef.current = { connection: { state: 'initialized' } };
+  });
+
+  it<LocalTestContext>('should call attach on render', ({ useChannelAttach }) => {
+    const channel = { attach: vi.fn(() => Promise.resolve()) };
+    const { result } = renderHook(() => useChannelAttach(channel, undefined, false));
+
+    expect(result.current.connectionState).toBe('initialized');
+    expect(channel.attach).toHaveBeenCalled();
+  });
+
+  it<LocalTestContext>('should not call attach when skipped', ({ useChannelAttach }) => {
+    const channel = { attach: vi.fn(() => Promise.resolve()) };
+    const { result } = renderHook(() => useChannelAttach(channel, undefined, true));
+
+    expect(result.current.connectionState).toBe('initialized');
+    expect(channel.attach).not.toHaveBeenCalled();
+  });
+
+  it<LocalTestContext>('should not call attach when in failed state', ({ useChannelAttach }) => {
+    fakeAblyClientRef.current = { connection: { state: 'failed' } };
+    const channel = { attach: vi.fn(() => Promise.resolve()) };
+    const { result } = renderHook(() => useChannelAttach(channel, undefined, false));
+
+    expect(result.current.connectionState).toBe('failed');
+    expect(channel.attach).not.toHaveBeenCalled();
+  });
+
+  it<LocalTestContext>('should call attach when go back to the connected state', async ({ useChannelAttach }) => {
+    fakeAblyClientRef.current = { connection: { state: 'suspended' } };
+    const channel = { attach: vi.fn(() => Promise.resolve()) };
+    const { result, rerender } = renderHook(() => useChannelAttach(channel, undefined, false));
+
+    expect(result.current.connectionState).toBe('suspended');
+    expect(channel.attach).not.toHaveBeenCalled();
+
+    fakeAblyClientRef.current = { connection: { state: 'connected' } };
+    rerender();
+
+    expect(result.current.connectionState).toBe('connected');
+    expect(channel.attach).toHaveBeenCalled();
+  });
+});

--- a/src/platform/react-hooks/src/hooks/useChannelAttach.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelAttach.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useConnectionStateListener } from './useConnectionStateListener.js';
 import { useAbly } from './useAbly.js';
 import { INACTIVE_CONNECTION_STATES } from './constants.js';
+import { logError } from '../utils.js';
 
 interface ChannelAttachResult {
   connectionState: Ably.ConnectionState;
@@ -35,7 +36,7 @@ export function useChannelAttach(
       channel.attach().catch((reason) => {
         // we use a fire-and-forget approach for attaching, but calling detach during the attaching process or while
         // suspending can cause errors that will be automatically resolved
-        console.log(reason);
+        logError(ably, reason.toString());
       });
     }
   }, [shouldAttachToTheChannel, channel]);

--- a/src/platform/react-hooks/src/hooks/useChannelAttach.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelAttach.ts
@@ -1,0 +1,46 @@
+import type * as Ably from 'ably';
+import { useEffect, useState } from 'react';
+import { useConnectionStateListener } from './useConnectionStateListener.js';
+import { useAbly } from './useAbly.js';
+import { INACTIVE_CONNECTION_STATES } from './constants.js';
+
+interface ChannelAttachResult {
+  connectionState: Ably.ConnectionState;
+}
+
+export function useChannelAttach(
+  channel: Ably.RealtimeChannel,
+  ablyId: string | undefined,
+  skip: boolean,
+): ChannelAttachResult {
+  const ably = useAbly(ablyId);
+
+  // we need to listen for the current connection state in order to react to it.
+  // for example, we should attach when first connected, re-enter when reconnected,
+  // and be able to prevent attaching when the connection is in an inactive state.
+  // all of that can be achieved by using the useConnectionStateListener hook.
+  const [connectionState, setConnectionState] = useState(ably.connection.state);
+  useConnectionStateListener((stateChange) => {
+    setConnectionState(stateChange.current);
+  }, ablyId);
+
+  if (ably.connection.state !== connectionState) {
+    setConnectionState(ably.connection.state);
+  }
+
+  const shouldAttachToTheChannel = !skip && !INACTIVE_CONNECTION_STATES.includes(connectionState);
+
+  useEffect(() => {
+    if (shouldAttachToTheChannel) {
+      channel.attach().catch((reason) => {
+        // we use a fire-and-forget approach for attaching, but calling detach during the attaching process or while
+        // suspending can cause errors that will be automatically resolved
+        console.log(reason);
+      });
+    }
+  }, [shouldAttachToTheChannel, channel]);
+
+  // we expose `connectionState` here for reuse in the usePresence hook, where we need to prevent
+  // entering and leaving presence in a similar manner
+  return { connectionState };
+}

--- a/src/platform/react-hooks/src/hooks/usePresenceListener.ts
+++ b/src/platform/react-hooks/src/hooks/usePresenceListener.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChannelParameters } from '../AblyReactHooks.js';
 import { useChannelInstance } from './useChannelInstance.js';
 import { useStateErrors } from './useStateErrors.js';
+import { useChannelAttach } from './useChannelAttach.js';
 
 interface PresenceMessage<T = any> extends Ably.PresenceMessage {
   data: T;
@@ -63,6 +64,8 @@ export function usePresenceListener<T = any>(
       onUnmount();
     };
   }, [skip, onMount, onUnmount]);
+
+  useChannelAttach(channel, params.ablyId, skip);
 
   return { presenceData, connectionError, channelError };
 }

--- a/src/platform/react-hooks/src/utils.ts
+++ b/src/platform/react-hooks/src/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * In rare cases when we need to access core logger to log error messages
+ *
+ * @param ablyClient ably core SDK client, it has any type because we access internal Logger class
+ * @param message message to log
+ */
+export const logError = (ablyClient: any, message: string) => {
+  try {
+    ablyClient.Logger.logAction(ablyClient.logger, ablyClient.Logger.LOG_ERROR, `[react-hooks] ${message}`);
+  } catch (error) {
+    // we don't want to fail on logger if something change
+    console.error(`Unable to access ably-js logger, while sending ${message}`);
+  }
+};


### PR DESCRIPTION
Because of implicit `attach()` hooks can produce additional errors e.g. when updating ably client

to avoid this situation, channels created inside `ChannelProvider` now use `attachOnSubscribe = false` flag and attach is happening explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added optional `attachOnSubscribe` configuration for more flexible channel subscription behavior.
	- Introduced constants for inactive connection and channel states.
	- Implemented `useChannelAttach` hook for managing channel attachment to the Ably Realtime service.
	- Added `attach` method to multiple classes for future functionality.

- **Refactor**
	- Centralized inactive connection and channel states in a constants module.
	- Updated channel and presence subscription logic to support new configuration options.
	- Renamed and clarified function signatures for better understanding.

- **Tests**
	- Added tests for the `useChannelAttach` hook to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->