### PR TITLE
[DTP-948] Surface errors when user has not attached to a channel with state modes

### DIFF
--- a/src/plugins/liveobjects/batchcontext.ts
+++ b/src/plugins/liveobjects/batchcontext.ts
@@ -24,6 +24,7 @@ export class BatchContext {
   }
 
   getRoot<T extends API.LiveMapType = API.DefaultRoot>(): BatchContextLiveMap<T> {
+    this._liveObjects.throwIfMissingStateSubscribeMode();
     this.throwIfClosed();
     return this.getWrappedObject(ROOT_OBJECT_ID) as BatchContextLiveMap<T>;
   }

--- a/src/plugins/liveobjects/batchcontextlivecounter.ts
+++ b/src/plugins/liveobjects/batchcontextlivecounter.ts
@@ -15,17 +15,20 @@ export class BatchContextLiveCounter {
   }
 
   value(): number {
+    this._liveObjects.throwIfMissingStateSubscribeMode();
     this._batchContext.throwIfClosed();
     return this._counter.value();
   }
 
   increment(amount: number): void {
+    this._liveObjects.throwIfMissingStatePublishMode();
     this._batchContext.throwIfClosed();
     const stateMessage = LiveCounter.createCounterIncMessage(this._liveObjects, this._counter.getObjectId(), amount);
     this._batchContext.queueStateMessage(stateMessage);
   }
 
   decrement(amount: number): void {
+    this._liveObjects.throwIfMissingStatePublishMode();
     this._batchContext.throwIfClosed();
     // do an explicit type safety check here before negating the amount value,
     // so we don't unintentionally change the type sent by a user

--- a/src/plugins/liveobjects/batchcontextlivemap.ts
+++ b/src/plugins/liveobjects/batchcontextlivemap.ts
@@ -12,6 +12,7 @@ export class BatchContextLiveMap<T extends API.LiveMapType> {
   ) {}
 
   get<TKey extends keyof T & string>(key: TKey): T[TKey] | undefined {
+    this._liveObjects.throwIfMissingStateSubscribeMode();
     this._batchContext.throwIfClosed();
     const value = this._map.get(key);
     if (value instanceof LiveObject) {
@@ -22,17 +23,20 @@ export class BatchContextLiveMap<T extends API.LiveMapType> {
   }
 
   size(): number {
+    this._liveObjects.throwIfMissingStateSubscribeMode();
     this._batchContext.throwIfClosed();
     return this._map.size();
   }
 
   set<TKey extends keyof T & string>(key: TKey, value: T[TKey]): void {
+    this._liveObjects.throwIfMissingStatePublishMode();
     this._batchContext.throwIfClosed();
     const stateMessage = LiveMap.createMapSetMessage(this._liveObjects, this._map.getObjectId(), key, value);
     this._batchContext.queueStateMessage(stateMessage);
   }
 
   remove<TKey extends keyof T & string>(key: TKey): void {
+    this._liveObjects.throwIfMissingStatePublishMode();
     this._batchContext.throwIfClosed();
     const stateMessage = LiveMap.createMapRemoveMessage(this._liveObjects, this._map.getObjectId(), key);
     this._batchContext.queueStateMessage(stateMessage);

--- a/src/plugins/liveobjects/livecounter.ts
+++ b/src/plugins/liveobjects/livecounter.ts
@@ -123,6 +123,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
   }
 
   value(): number {
+    this._liveObjects.throwIfMissingStateSubscribeMode();
     return this._dataRef.data;
   }
 
@@ -136,6 +137,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
    * @returns A promise which resolves upon receiving the ACK message for the published operation message.
    */
   async increment(amount: number): Promise<void> {
+    this._liveObjects.throwIfMissingStatePublishMode();
     const stateMessage = LiveCounter.createCounterIncMessage(this._liveObjects, this.getObjectId(), amount);
     return this._liveObjects.publish([stateMessage]);
   }
@@ -144,6 +146,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
    * Alias for calling {@link LiveCounter.increment | LiveCounter.increment(-amount)}
    */
   async decrement(amount: number): Promise<void> {
+    this._liveObjects.throwIfMissingStatePublishMode();
     // do an explicit type safety check here before negating the amount value,
     // so we don't unintentionally change the type sent by a user
     if (typeof amount !== 'number' || !isFinite(amount)) {

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -266,6 +266,8 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
    */
   // force the key to be of type string as we only allow strings as key in a map
   get<TKey extends keyof T & string>(key: TKey): T[TKey] | undefined {
+    this._liveObjects.throwIfMissingStateSubscribeMode();
+
     if (this.isTombstoned()) {
       return undefined as T[TKey];
     }
@@ -303,6 +305,8 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
   }
 
   size(): number {
+    this._liveObjects.throwIfMissingStateSubscribeMode();
+
     let size = 0;
     for (const value of this._dataRef.data.values()) {
       if (value.tombstone === true) {
@@ -337,6 +341,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
    * @returns A promise which resolves upon receiving the ACK message for the published operation message.
    */
   async set<TKey extends keyof T & string>(key: TKey, value: T[TKey]): Promise<void> {
+    this._liveObjects.throwIfMissingStatePublishMode();
     const stateMessage = LiveMap.createMapSetMessage(this._liveObjects, this.getObjectId(), key, value);
     return this._liveObjects.publish([stateMessage]);
   }
@@ -351,6 +356,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
    * @returns A promise which resolves upon receiving the ACK message for the published operation message.
    */
   async remove<TKey extends keyof T & string>(key: TKey): Promise<void> {
+    this._liveObjects.throwIfMissingStatePublishMode();
     const stateMessage = LiveMap.createMapRemoveMessage(this._liveObjects, this.getObjectId(), key);
     return this._liveObjects.publish([stateMessage]);
   }

--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -65,6 +65,8 @@ export abstract class LiveObject<
   }
 
   subscribe(listener: (update: TUpdate) => void): SubscribeResponse {
+    this._liveObjects.throwIfMissingStateSubscribeMode();
+
     this._eventEmitter.on(LiveObjectEvents.Updated, listener);
 
     const unsubscribe = () => {
@@ -75,6 +77,8 @@ export abstract class LiveObject<
   }
 
   unsubscribe(listener: (update: TUpdate) => void): void {
+    // can allow calling this public method without checking for state modes on the channel as the result of this method is not dependant on them
+
     // current implementation of the EventEmitter will remove all listeners if .off is called without arguments or with nullish arguments.
     // or when called with just an event argument, it will remove all listeners for the event.
     // thus we need to check that listener does actually exist before calling .off.
@@ -86,6 +90,7 @@ export abstract class LiveObject<
   }
 
   unsubscribeAll(): void {
+    // can allow calling this public method without checking for state modes on the channel as the result of this method is not dependant on them
     this._eventEmitter.off(LiveObjectEvents.Updated);
   }
 

--- a/test/common/modules/private_api_recorder.js
+++ b/test/common/modules/private_api_recorder.js
@@ -141,6 +141,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'write.auth.key',
     'write.auth.tokenDetails.token',
     'write.channel._lastPayload',
+    'write.channel.channelOptions.modes',
     'write.channel.state',
     'write.connectionManager.connectionDetails.maxMessageSize',
     'write.connectionManager.connectionId',

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -57,7 +57,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
     return `${paddedTimestamp}-${paddedCounter}@${seriesId}` + (paddedIndex ? `:${paddedIndex}` : '');
   }
 
-  async function expectRejectedWith(fn, errorStr) {
+  async function expectToThrowAsync(fn, errorStr) {
     let verifiedError = false;
     try {
       await fn();
@@ -2123,51 +2123,51 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
             const counter = root.get('counter');
 
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(null),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(Number.NaN),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(Number.POSITIVE_INFINITY),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(Number.NEGATIVE_INFINITY),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment('foo'),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(BigInt(1)),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(true),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(Symbol()),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment({}),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment([]),
               'Counter value increment should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.increment(counter),
               'Counter value increment should be a valid number',
             );
@@ -2225,51 +2225,51 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
             const counter = root.get('counter');
 
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(null),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(Number.NaN),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(Number.POSITIVE_INFINITY),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(Number.NEGATIVE_INFINITY),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement('foo'),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(BigInt(1)),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(true),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(Symbol()),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement({}),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement([]),
               'Counter value decrement should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => counter.decrement(counter),
               'Counter value decrement should be a valid number',
             );
@@ -2351,22 +2351,22 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
             const map = root.get('map');
 
-            await expectRejectedWith(async () => map.set(), 'Map key should be string');
-            await expectRejectedWith(async () => map.set(null), 'Map key should be string');
-            await expectRejectedWith(async () => map.set(1), 'Map key should be string');
-            await expectRejectedWith(async () => map.set(BigInt(1)), 'Map key should be string');
-            await expectRejectedWith(async () => map.set(true), 'Map key should be string');
-            await expectRejectedWith(async () => map.set(Symbol()), 'Map key should be string');
-            await expectRejectedWith(async () => map.set({}), 'Map key should be string');
-            await expectRejectedWith(async () => map.set([]), 'Map key should be string');
-            await expectRejectedWith(async () => map.set(map), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set(), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set(null), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set(1), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set(BigInt(1)), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set(true), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set(Symbol()), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set({}), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set([]), 'Map key should be string');
+            await expectToThrowAsync(async () => map.set(map), 'Map key should be string');
 
-            await expectRejectedWith(async () => map.set('key'), 'Map value data type is unsupported');
-            await expectRejectedWith(async () => map.set('key', null), 'Map value data type is unsupported');
-            await expectRejectedWith(async () => map.set('key', BigInt(1)), 'Map value data type is unsupported');
-            await expectRejectedWith(async () => map.set('key', Symbol()), 'Map value data type is unsupported');
-            await expectRejectedWith(async () => map.set('key', {}), 'Map value data type is unsupported');
-            await expectRejectedWith(async () => map.set('key', []), 'Map value data type is unsupported');
+            await expectToThrowAsync(async () => map.set('key'), 'Map value data type is unsupported');
+            await expectToThrowAsync(async () => map.set('key', null), 'Map value data type is unsupported');
+            await expectToThrowAsync(async () => map.set('key', BigInt(1)), 'Map value data type is unsupported');
+            await expectToThrowAsync(async () => map.set('key', Symbol()), 'Map value data type is unsupported');
+            await expectToThrowAsync(async () => map.set('key', {}), 'Map value data type is unsupported');
+            await expectToThrowAsync(async () => map.set('key', []), 'Map value data type is unsupported');
           },
         },
 
@@ -2414,15 +2414,15 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
             const map = root.get('map');
 
-            await expectRejectedWith(async () => map.remove(), 'Map key should be string');
-            await expectRejectedWith(async () => map.remove(null), 'Map key should be string');
-            await expectRejectedWith(async () => map.remove(1), 'Map key should be string');
-            await expectRejectedWith(async () => map.remove(BigInt(1)), 'Map key should be string');
-            await expectRejectedWith(async () => map.remove(true), 'Map key should be string');
-            await expectRejectedWith(async () => map.remove(Symbol()), 'Map key should be string');
-            await expectRejectedWith(async () => map.remove({}), 'Map key should be string');
-            await expectRejectedWith(async () => map.remove([]), 'Map key should be string');
-            await expectRejectedWith(async () => map.remove(map), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove(), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove(null), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove(1), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove(BigInt(1)), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove(true), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove(Symbol()), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove({}), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove([]), 'Map key should be string');
+            await expectToThrowAsync(async () => map.remove(map), 'Map key should be string');
           },
         },
 
@@ -2552,47 +2552,47 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
           action: async (ctx) => {
             const { root, liveObjects } = ctx;
 
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter(null),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter(Number.NaN),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter(Number.POSITIVE_INFINITY),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter(Number.NEGATIVE_INFINITY),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter('foo'),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter(BigInt(1)),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter(true),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter(Symbol()),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter({}),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter([]),
               'Counter value should be a valid number',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createCounter(root),
               'Counter value should be a valid number',
             );
@@ -2805,49 +2805,49 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
           action: async (ctx) => {
             const { root, liveObjects } = ctx;
 
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap(null),
               'Map entries should be a key/value object',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap('foo'),
               'Map entries should be a key/value object',
             );
-            await expectRejectedWith(async () => liveObjects.createMap(1), 'Map entries should be a key/value object');
-            await expectRejectedWith(
+            await expectToThrowAsync(async () => liveObjects.createMap(1), 'Map entries should be a key/value object');
+            await expectToThrowAsync(
               async () => liveObjects.createMap(BigInt(1)),
               'Map entries should be a key/value object',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap(true),
               'Map entries should be a key/value object',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap(Symbol()),
               'Map entries should be a key/value object',
             );
 
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap({ key: undefined }),
               'Map value data type is unsupported',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap({ key: null }),
               'Map value data type is unsupported',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap({ key: BigInt(1) }),
               'Map value data type is unsupported',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap({ key: Symbol() }),
               'Map value data type is unsupported',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap({ key: {} }),
               'Map value data type is unsupported',
             );
-            await expectRejectedWith(
+            await expectToThrowAsync(
               async () => liveObjects.createMap({ key: [] }),
               'Map value data type is unsupported',
             );
@@ -3813,6 +3813,157 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
           helper.recordPrivateApi('write.LiveObjects._DEFAULTS.gcGracePeriod');
           LiveObjectsPlugin.LiveObjects._DEFAULTS.gcGracePeriod = gcGracePeriodOriginal;
         }
+      });
+
+      const expectToThrowMissingStateMode = async ({ liveObjects, map, counter }) => {
+        await expectToThrowAsync(
+          async () => liveObjects.getRoot(),
+          '"state_subscribe" channel mode must be set for this operation',
+        );
+        await expectToThrowAsync(
+          async () => liveObjects.batch(),
+          '"state_publish" channel mode must be set for this operation',
+        );
+        await expectToThrowAsync(
+          async () => liveObjects.createMap(),
+          '"state_publish" channel mode must be set for this operation',
+        );
+        await expectToThrowAsync(
+          async () => liveObjects.createCounter(),
+          '"state_publish" channel mode must be set for this operation',
+        );
+
+        expect(() => counter.value()).to.throw('"state_subscribe" channel mode must be set for this operation');
+        await expectToThrowAsync(
+          async () => counter.increment(),
+          '"state_publish" channel mode must be set for this operation',
+        );
+        await expectToThrowAsync(
+          async () => counter.decrement(),
+          '"state_publish" channel mode must be set for this operation',
+        );
+
+        expect(() => map.get()).to.throw('"state_subscribe" channel mode must be set for this operation');
+        expect(() => map.size()).to.throw('"state_subscribe" channel mode must be set for this operation');
+        await expectToThrowAsync(async () => map.set(), '"state_publish" channel mode must be set for this operation');
+        await expectToThrowAsync(
+          async () => map.remove(),
+          '"state_publish" channel mode must be set for this operation',
+        );
+
+        for (const obj of [map, counter]) {
+          expect(() => obj.subscribe()).to.throw('"state_subscribe" channel mode must be set for this operation');
+          expect(() => obj.unsubscribe(() => {})).not.to.throw(
+            '"state_subscribe" channel mode must be set for this operation',
+          ); // note: this should not throw
+          expect(() => obj.unsubscribe(() => {})).not.to.throw(
+            '"state_publish" channel mode must be set for this operation',
+          ); // note: this should not throw
+          expect(() => obj.unsubscribeAll()).not.to.throw(
+            '"state_subscribe" channel mode must be set for this operation',
+          ); // note: this should not throw
+          expect(() => obj.unsubscribeAll()).not.to.throw(
+            '"state_publish" channel mode must be set for this operation',
+          ); // note: this should not throw
+        }
+      };
+
+      const expectToThrowMissingStateModeInBatchContext = ({ ctx, map, counter }) => {
+        expect(() => ctx.getRoot()).to.throw('"state_subscribe" channel mode must be set for this operation');
+
+        expect(() => counter.value()).to.throw('"state_subscribe" channel mode must be set for this operation');
+        expect(() => counter.increment()).to.throw('"state_publish" channel mode must be set for this operation');
+        expect(() => counter.decrement()).to.throw('"state_publish" channel mode must be set for this operation');
+
+        expect(() => map.get()).to.throw('"state_subscribe" channel mode must be set for this operation');
+        expect(() => map.size()).to.throw('"state_subscribe" channel mode must be set for this operation');
+        expect(() => map.set()).to.throw('"state_publish" channel mode must be set for this operation');
+        expect(() => map.remove()).to.throw('"state_publish" channel mode must be set for this operation');
+      };
+
+      const missingChannelModesScenarios = [
+        {
+          description: 'public API throws missing state modes error when attached without correct state modes',
+          action: async (ctx) => {
+            const { liveObjects, channel, map, counter } = ctx;
+
+            // obtain batch context with valid modes first
+            await liveObjects.batch((ctx) => {
+              const map = ctx.getRoot().get('map');
+              const counter = ctx.getRoot().get('counter');
+              // now simulate missing modes
+              channel.modes = [];
+              expectToThrowMissingStateModeInBatchContext({ ctx, map, counter });
+            });
+            await expectToThrowMissingStateMode({ liveObjects, map, counter });
+          },
+        },
+
+        {
+          description:
+            'public API throws missing state modes error when not yet attached but client options are missing correct modes',
+          action: async (ctx) => {
+            const { liveObjects, channel, map, counter, helper } = ctx;
+
+            // obtain batch context with valid modes first
+            await liveObjects.batch((ctx) => {
+              const map = ctx.getRoot().get('map');
+              const counter = ctx.getRoot().get('counter');
+              // now simulate a situation where we're not yet attached/modes are not received on ATTACHED event
+              channel.modes = undefined;
+              helper.recordPrivateApi('write.channel.channelOptions.modes');
+              channel.channelOptions.modes = [];
+
+              expectToThrowMissingStateModeInBatchContext({ ctx, map, counter });
+            });
+            await expectToThrowMissingStateMode({ liveObjects, map, counter });
+          },
+        },
+      ];
+
+      /** @nospec */
+      forScenarios(missingChannelModesScenarios, async function (helper, scenario) {
+        const liveObjectsHelper = new LiveObjectsHelper(helper);
+        const client = RealtimeWithLiveObjects(helper);
+
+        await helper.monitorConnectionThenCloseAndFinish(async () => {
+          const channelName = scenario.description;
+          // attach with correct channel modes so we can create liveobjects on the root for testing.
+          // each scenario will modify the underlying modes array to test specific behavior
+          const channel = client.channels.get(channelName, channelOptionsWithLiveObjects());
+          const liveObjects = channel.liveObjects;
+
+          await channel.attach();
+          const root = await liveObjects.getRoot();
+
+          let mapSet = false;
+          let counterSet = false;
+          const rootReadyPromise = new Promise((resolve) => {
+            const { unsubscribe } = root.subscribe(({ update }) => {
+              if (update.map) {
+                mapSet = true;
+              }
+              if (update.counter) {
+                counterSet = true;
+              }
+
+              if (mapSet && counterSet) {
+                unsubscribe();
+                resolve();
+              }
+            });
+          });
+
+          const map = await liveObjects.createMap();
+          const counter = await liveObjects.createCounter();
+
+          await root.set('map', map);
+          await root.set('counter', counter);
+
+          await rootReadyPromise;
+
+          await scenario.action({ liveObjects, liveObjectsHelper, channelName, channel, root, map, counter, helper });
+        }, client);
       });
     });
 


### PR DESCRIPTION
- `state_subscribe` mode is required for access/subscribe API
- `state_publish` mode is required for create/edit API

I think the existing subscribe mode checks are still needed in case the modes are updated via setOptions

Channel modes can change post channel attachment (if user calls `channel.setOptions`) at which point user may have already obtained a `root` and other live object instances. This means that every public live objects API method needs to check for the required modes set on a channel separately.

Resolves [DTP-948](https://ably.atlassian.net/browse/DTP-948)

[DTP-948]: https://ably.atlassian.net/browse/DTP-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added state mode validation checks to LiveObjects, LiveMap, LiveCounter, and related classes.
	- Enhanced error handling for operations in different channel modes.

- **Bug Fixes**
	- Improved robustness of state management in live object operations.
	- Added precondition checks to prevent unauthorized state transitions.

- **Tests**
	- Updated test suite to cover new state mode validation scenarios.
	- Introduced new test functions for checking missing state modes.

- **Chores**
	- Added private API identifier for channel mode tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->