### PR TITLE
[DTP-1121] Set `channel.properties.channelSerial` when receiving `STATE` messages

### DIFF
--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -516,7 +516,8 @@ class RealtimeChannel extends EventEmitter {
     if (
       message.action === actions.ATTACHED ||
       message.action === actions.MESSAGE ||
-      message.action === actions.PRESENCE
+      message.action === actions.PRESENCE ||
+      message.action === actions.STATE
     ) {
       // RTL15b
       this.setChannelSerial(message.channelSerial);


### PR DESCRIPTION
Also adds tests for [RTL4c1](https://sdk.ably.com/builds/ably/specification/main/features/#RTL4c1) and [RTL15b](https://sdk.ably.com/builds/ably/specification/main/features/#RTL15b).

Resolves [DTP-1121](https://ably.atlassian.net/browse/DTP-1121)

[DTP-1121]: https://ably.atlassian.net/browse/DTP-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message processing capabilities in the realtime channel
	- Improved handling of state messages

- **Tests**
	- Added tests to verify channel serial updates during message processing
	- Validated channel serial setting for different protocol message types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->