### PR TITLE
[DTP-1096] Run LiveObjects tests using both `MsgPack` and `JSON` protocols, and on all transports

### DIFF
--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -342,35 +342,49 @@ define([
       );
     }
 
-    /* testFn is assumed to be a function of realtimeOptions that returns a mocha test */
-    static testOnAllTransports(thisInDescribe, name, testFn, skip) {
-      const helper = this.forTestDefinition(thisInDescribe, name).addingHelperFunction('testOnAllTransports');
-      var itFn = skip ? it.skip : it;
+    /* testFn is assumed to be a function of realtimeOptions and channelName that returns a mocha test */
+    static testOnAllTransportsAndProtocols(thisInDescribe, testName, testFn, skip, only) {
+      const helper = SharedHelper.forTestDefinition(thisInDescribe, testName).addingHelperFunction(
+        'testOnAllTransportsAndProtocols',
+      );
+      const itFn = skip ? it.skip : only ? it.only : it;
 
-      function createTest(options) {
+      function createTest(options, channelName) {
         return function (done) {
-          this.test.helper = this.test.helper.withParameterisedTestTitle(name);
-          return testFn(options).apply(this, [done]);
+          this.test.helper = this.test.helper.withParameterisedTestTitle(testName);
+          // we want to support both callback-based and async test functions here.
+          // for this we check the return type of the test function to see if it is a Promise.
+          // if it is, then the test function provided is an async one, and won't call done function on its own.
+          // instead we attach own .then and .catch callbacks for the promise here and call done when needed
+          const testFnReturn = testFn(options, channelName).apply(this, [done]);
+          if (testFnReturn instanceof Promise) {
+            testFnReturn.then(done).catch(done);
+          } else {
+            return testFnReturn;
+          }
         };
       }
 
-      let transports = helper.availableTransports;
+      const transports = helper.availableTransports;
       transports.forEach(function (transport) {
         itFn(
-          name + '_with_' + transport + '_binary_transport',
-          createTest({ transports: [transport], useBinaryProtocol: true }),
+          testName + ' with ' + transport + ' binary protocol',
+          createTest({ transports: [transport], useBinaryProtocol: true }, `${testName} ${transport} binary`),
         );
         itFn(
-          name + '_with_' + transport + '_text_transport',
-          createTest({ transports: [transport], useBinaryProtocol: false }),
+          testName + ' with ' + transport + ' text protocol',
+          createTest({ transports: [transport], useBinaryProtocol: false }, `${testName} ${transport} text`),
         );
       });
       /* Plus one for no transport specified (ie use websocket/base mechanism if
        * present).  (we explicitly specify all transports since node only does
        * websocket+nodecomet if comet is explicitly requested)
        * */
-      itFn(name + '_with_binary_transport', createTest({ transports, useBinaryProtocol: true }));
-      itFn(name + '_with_text_transport', createTest({ transports, useBinaryProtocol: false }));
+      itFn(
+        testName + ' with binary protocol',
+        createTest({ transports, useBinaryProtocol: true }, `${testName} binary`),
+      );
+      itFn(testName + ' with text protocol', createTest({ transports, useBinaryProtocol: false }, `${testName} text`));
     }
 
     static testOnJsonMsgpack(testName, testFn, skip, only) {
@@ -494,8 +508,12 @@ define([
     }
   }
 
-  SharedHelper.testOnAllTransports.skip = function (thisInDescribe, name, testFn) {
-    SharedHelper.testOnAllTransports(thisInDescribe, name, testFn, true);
+  SharedHelper.testOnAllTransportsAndProtocols.skip = function (thisInDescribe, testName, testFn) {
+    SharedHelper.testOnAllTransportsAndProtocols(thisInDescribe, testName, testFn, true);
+  };
+
+  SharedHelper.testOnAllTransportsAndProtocols.only = function (thisInDescribe, testName, testFn) {
+    SharedHelper.testOnAllTransportsAndProtocols(thisInDescribe, testName, testFn, false, true);
   };
 
   SharedHelper.testOnJsonMsgpack.skip = function (testName, testFn) {

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -373,17 +373,18 @@ define([
       itFn(name + '_with_text_transport', createTest({ transports, useBinaryProtocol: false }));
     }
 
-    static restTestOnJsonMsgpack(name, testFn, skip) {
-      var itFn = skip ? it.skip : it;
-      itFn(name + ' with binary protocol', async function () {
-        const helper = this.test.helper.withParameterisedTestTitle(name);
+    static testOnJsonMsgpack(testName, testFn, skip, only) {
+      const itFn = skip ? it.skip : only ? it.only : it;
 
-        await testFn(new clientModule.AblyRest(helper, { useBinaryProtocol: true }), name + '_binary', helper);
+      itFn(testName + ' with binary protocol', async function () {
+        const helper = this.test.helper.withParameterisedTestTitle(testName);
+        const channelName = testName + ' binary';
+        await testFn({ useBinaryProtocol: true }, channelName, helper);
       });
-      itFn(name + ' with text protocol', async function () {
-        const helper = this.test.helper.withParameterisedTestTitle(name);
-
-        await testFn(new clientModule.AblyRest(helper, { useBinaryProtocol: false }), name + '_text', helper);
+      itFn(testName + ' with text protocol', async function () {
+        const helper = this.test.helper.withParameterisedTestTitle(testName);
+        const channelName = testName + ' text';
+        await testFn({ useBinaryProtocol: false }, channelName, helper);
       });
     }
 
@@ -497,8 +498,12 @@ define([
     SharedHelper.testOnAllTransports(thisInDescribe, name, testFn, true);
   };
 
-  SharedHelper.restTestOnJsonMsgpack.skip = function (name, testFn) {
-    SharedHelper.restTestOnJsonMsgpack(name, testFn, true);
+  SharedHelper.testOnJsonMsgpack.skip = function (testName, testFn) {
+    SharedHelper.testOnJsonMsgpack(testName, testFn, true);
+  };
+
+  SharedHelper.testOnJsonMsgpack.only = function (testName, testFn) {
+    SharedHelper.testOnJsonMsgpack(testName, testFn, false, true);
   };
 
   return (module.exports = SharedHelper);

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -774,7 +774,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA4b1
      * @specpartial RSA4b - token expired
      */
-    Helper.testOnAllTransports(this, 'auth_token_expires', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'auth_token_expires', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           clientRealtime,
@@ -879,7 +879,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTN15a - attempt to reconnect and restore the connection state on token expire
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
-    Helper.testOnAllTransports(this, 'auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'auth_tokenDetails_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -928,7 +928,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RTN15a - attempt to reconnect and restore the connection state on token expire
      * @specpartial RSA10e - obtain new token from authcallback when previous expires
      */
-    Helper.testOnAllTransports(this, 'auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'auth_token_string_expiry_with_authcallback', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -975,7 +975,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA4a
      * @spec RSA4a2
      */
-    Helper.testOnAllTransports(this, 'auth_token_string_expiry_with_token', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'auth_token_string_expiry_with_token', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -1023,7 +1023,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RSA4a
      * @spec RSA4a2
      */
-    Helper.testOnAllTransports(this, 'auth_expired_token_string', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'auth_expired_token_string', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -1073,7 +1073,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTC8
      * @specskip
      */
-    Helper.testOnAllTransports.skip(this, 'reauth_authCallback', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols.skip(this, 'reauth_authCallback', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           realtime,
@@ -1586,7 +1586,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /** @nospec */
-    Helper.testOnAllTransports(this, 'authorize_immediately_after_init', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'authorize_immediately_after_init', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var realtime = helper.AblyRealtime({

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -170,7 +170,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTS3c
      * @spec RTL16
      */
-    Helper.testOnAllTransports(this, 'channelinit0', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'channelinit0', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -208,7 +208,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL4
      */
-    Helper.testOnAllTransports(this, 'channelattach0', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'channelattach0', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -235,7 +235,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL4
      */
-    Helper.testOnAllTransports(this, 'channelattach2', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'channelattach2', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -262,7 +262,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4
      * @spec RTL5
      */
-    Helper.testOnAllTransports(
+    Helper.testOnAllTransportsAndProtocols(
       this,
       'channelattach3',
       function (realtimeOpts) {
@@ -303,7 +303,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL4d
      */
-    Helper.testOnAllTransports(this, 'channelattachempty', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'channelattachempty', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -338,7 +338,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL4d
      */
-    Helper.testOnAllTransports(this, 'channelattachinvalid', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'channelattachinvalid', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -379,7 +379,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTL6
      */
-    Helper.testOnAllTransports(this, 'publish_no_attach', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'publish_no_attach', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -409,7 +409,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @specpartial RTL6b - callback which is called with an error
      */
-    Helper.testOnAllTransports(this, 'channelattach_publish_invalid', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'channelattach_publish_invalid', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -443,7 +443,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @nospec
      */
-    Helper.testOnAllTransports(this, 'channelattach_invalid_twice', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'channelattach_invalid_twice', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -538,7 +538,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4k1
      * @spec RTL4m
      */
-    Helper.testOnAllTransports(this, 'attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'attachWithChannelParamsBasicChannelsGet', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelParamsBasicChannelsGet';
@@ -601,7 +601,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4m
      * @spec RTL16
      */
-    Helper.testOnAllTransports(this, 'attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'attachWithChannelParamsBasicSetOptions', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelParamsBasicSetOptions';
@@ -656,7 +656,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL16
      * @spec RTL7c
      */
-    Helper.testOnAllTransports(this, 'subscribeAfterSetOptions', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'subscribeAfterSetOptions', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'subscribeAfterSetOptions';
@@ -732,7 +732,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /** @spec RTL16a */
-    Helper.testOnAllTransports(this, 'setOptionsCallbackBehaviour', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'setOptionsCallbackBehaviour', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'setOptionsCallbackBehaviour';
@@ -814,61 +814,65 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * Verify modes is ignored when params.modes is present
      * @nospec
      */
-    Helper.testOnAllTransports(this, 'attachWithChannelParamsModesAndChannelModes', function (realtimeOpts) {
-      return function (done) {
-        const helper = this.test.helper;
-        var testName = 'attachWithChannelParamsModesAndChannelModes';
-        try {
-          var realtime = helper.AblyRealtime(realtimeOpts);
-          realtime.connection.on('connected', function () {
-            var paramsModes = ['presence', 'subscribe'];
-            var params = {
-              modes: paramsModes.join(','),
-            };
-            var channelOptions = {
-              params: params,
-              modes: ['publish', 'presence_subscribe'],
-            };
-            var channel = realtime.channels.get(testName, channelOptions);
-            Helper.whenPromiseSettles(channel.attach(), function (err) {
-              if (err) {
-                helper.closeAndFinish(done, realtime, err);
-                return;
-              }
-              try {
-                helper.recordPrivateApi('read.channel.channelOptions');
-                expect(channel.channelOptions).to.deep.equal(channelOptions, 'Check requested channel options');
-                expect(channel.params).to.deep.equal(params, 'Check result params');
-                expect(channel.modes).to.deep.equal(paramsModes, 'Check result modes');
-              } catch (err) {
-                helper.closeAndFinish(done, realtime, err);
-                return;
-              }
+    Helper.testOnAllTransportsAndProtocols(
+      this,
+      'attachWithChannelParamsModesAndChannelModes',
+      function (realtimeOpts) {
+        return function (done) {
+          const helper = this.test.helper;
+          var testName = 'attachWithChannelParamsModesAndChannelModes';
+          try {
+            var realtime = helper.AblyRealtime(realtimeOpts);
+            realtime.connection.on('connected', function () {
+              var paramsModes = ['presence', 'subscribe'];
+              var params = {
+                modes: paramsModes.join(','),
+              };
+              var channelOptions = {
+                params: params,
+                modes: ['publish', 'presence_subscribe'],
+              };
+              var channel = realtime.channels.get(testName, channelOptions);
+              Helper.whenPromiseSettles(channel.attach(), function (err) {
+                if (err) {
+                  helper.closeAndFinish(done, realtime, err);
+                  return;
+                }
+                try {
+                  helper.recordPrivateApi('read.channel.channelOptions');
+                  expect(channel.channelOptions).to.deep.equal(channelOptions, 'Check requested channel options');
+                  expect(channel.params).to.deep.equal(params, 'Check result params');
+                  expect(channel.modes).to.deep.equal(paramsModes, 'Check result modes');
+                } catch (err) {
+                  helper.closeAndFinish(done, realtime, err);
+                  return;
+                }
 
-              var testRealtime = helper.AblyRealtime();
-              testRealtime.connection.on('connected', function () {
-                var testChannel = testRealtime.channels.get(testName);
-                async.series(
-                  [
-                    checkCanSubscribe(channel, testChannel),
-                    checkCanEnterPresence(channel),
-                    checkCantPublish(channel),
-                    checkCantPresenceSubscribe(channel, testChannel),
-                  ],
-                  function (err) {
-                    testRealtime.close();
-                    helper.closeAndFinish(done, realtime, err);
-                  },
-                );
+                var testRealtime = helper.AblyRealtime();
+                testRealtime.connection.on('connected', function () {
+                  var testChannel = testRealtime.channels.get(testName);
+                  async.series(
+                    [
+                      checkCanSubscribe(channel, testChannel),
+                      checkCanEnterPresence(channel),
+                      checkCantPublish(channel),
+                      checkCantPresenceSubscribe(channel, testChannel),
+                    ],
+                    function (err) {
+                      testRealtime.close();
+                      helper.closeAndFinish(done, realtime, err);
+                    },
+                  );
+                });
               });
             });
-          });
-          helper.monitorConnection(done, realtime);
-        } catch (err) {
-          helper.closeAndFinish(done, realtime, err);
-        }
-      };
-    });
+            helper.monitorConnection(done, realtime);
+          } catch (err) {
+            helper.closeAndFinish(done, realtime, err);
+          }
+        };
+      },
+    );
 
     /**
      * No spec items found for 'modes' property behavior (like preventing publish, entering presence, presence subscription)
@@ -877,7 +881,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4l
      * @spec RTL4m
      */
-    Helper.testOnAllTransports(this, 'attachWithChannelModes', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'attachWithChannelModes', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelModes';
@@ -937,7 +941,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL4l
      * @spec RTL4m
      */
-    Helper.testOnAllTransports(this, 'attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'attachWithChannelParamsDeltaAndModes', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var testName = 'attachWithChannelParamsDeltaAndModes';

--- a/test/realtime/crypto.test.js
+++ b/test/realtime/crypto.test.js
@@ -465,7 +465,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     }
 
     function single_send(done, helper, realtimeOpts, keyLength) {
-      // the _128 and _256 variants both call this so it makes more sense for this to be the parameterisedTestTitle instead of that set by testOnAllTransports
+      // the _128 and _256 variants both call this so it makes more sense for this to be the parameterisedTestTitle instead of that set by testOnAllTransportsAndProtocols
       helper = helper.withParameterisedTestTitle('single_send');
 
       if (!Crypto) {
@@ -513,14 +513,14 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     // Publish and subscribe, various transport, 128 and 256-bit
     /** @specpartial RSL5b - test aes 128 */
-    Helper.testOnAllTransports(this, 'single_send_128', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'single_send_128', function (realtimeOpts) {
       return function (done) {
         single_send(done, this.test.helper, realtimeOpts, 128);
       };
     });
 
     /** @specpartial RSL5b - test aes 256 */
-    Helper.testOnAllTransports(this, 'single_send_256', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'single_send_256', function (realtimeOpts) {
       return function (done) {
         single_send(done, this.test.helper, realtimeOpts, 256);
       };

--- a/test/realtime/failure.test.js
+++ b/test/realtime/failure.test.js
@@ -619,7 +619,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /** @specpartial RTN14d - last sentence: check that if we received a 5xx disconnected, when we try again we use a fallback host */
-    Helper.testOnAllTransports(this, 'try_fallback_hosts_on_placement_constraint', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'try_fallback_hosts_on_placement_constraint', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         /* Use the echoserver as a fallback host because it doesn't support

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -34,14 +34,29 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
     expect(object.constructor.name).to.match(new RegExp(`_?${className}`), msg);
   }
 
-  function forScenarios(scenarios, testFn) {
+  function forScenarios(thisInDescribe, scenarios, testFn) {
     for (const scenario of scenarios) {
-      const itFn = scenario.skip ? it.skip : scenario.only ? it.only : it;
+      if (scenario.allTransportsAndProtocols) {
+        Helper.testOnAllTransportsAndProtocols(
+          thisInDescribe,
+          scenario.description,
+          function (options, channelName) {
+            return async function () {
+              const helper = this.test.helper;
+              await testFn(helper, scenario, options, channelName);
+            };
+          },
+          scenario.skip,
+          scenario.only,
+        );
+      } else {
+        const itFn = scenario.skip ? it.skip : scenario.only ? it.only : it;
 
-      itFn(scenario.description, async function () {
-        const helper = this.test.helper;
-        await testFn(helper, scenario);
-      });
+        itFn(scenario.description, async function () {
+          const helper = this.test.helper;
+          await testFn(helper, scenario, {}, scenario.description);
+        });
+      }
     }
   }
 
@@ -404,175 +419,209 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
       });
 
       /** @nospec */
-      it('builds state object tree from STATE_SYNC sequence on channel attachment', async function () {
-        const helper = this.test.helper;
-        const client = RealtimeWithLiveObjects(helper);
+      Helper.testOnAllTransportsAndProtocols(
+        this,
+        'builds state object tree from STATE_SYNC sequence on channel attachment',
+        function (options, channelName) {
+          return async function () {
+            const helper = this.test.helper;
+            const client = RealtimeWithLiveObjects(helper, options);
 
-        await helper.monitorConnectionThenCloseAndFinish(async () => {
-          await waitFixtureChannelIsReady(client);
+            await helper.monitorConnectionThenCloseAndFinish(async () => {
+              await waitFixtureChannelIsReady(client);
 
-          const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
-          const liveObjects = channel.liveObjects;
+              const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
+              const liveObjects = channel.liveObjects;
 
-          await channel.attach();
-          const root = await liveObjects.getRoot();
+              await channel.attach();
+              const root = await liveObjects.getRoot();
 
-          const counterKeys = ['emptyCounter', 'initialValueCounter', 'referencedCounter'];
-          const mapKeys = ['emptyMap', 'referencedMap', 'valuesMap'];
-          const rootKeysCount = counterKeys.length + mapKeys.length;
+              const counterKeys = ['emptyCounter', 'initialValueCounter', 'referencedCounter'];
+              const mapKeys = ['emptyMap', 'referencedMap', 'valuesMap'];
+              const rootKeysCount = counterKeys.length + mapKeys.length;
 
-          expect(root, 'Check getRoot() is resolved when STATE_SYNC sequence ends').to.exist;
-          expect(root.size()).to.equal(rootKeysCount, 'Check root has correct number of keys');
+              expect(root, 'Check getRoot() is resolved when STATE_SYNC sequence ends').to.exist;
+              expect(root.size()).to.equal(rootKeysCount, 'Check root has correct number of keys');
 
-          counterKeys.forEach((key) => {
-            const counter = root.get(key);
-            expect(counter, `Check counter at key="${key}" in root exists`).to.exist;
-            expectInstanceOf(counter, 'LiveCounter', `Check counter at key="${key}" in root is of type LiveCounter`);
-          });
+              counterKeys.forEach((key) => {
+                const counter = root.get(key);
+                expect(counter, `Check counter at key="${key}" in root exists`).to.exist;
+                expectInstanceOf(
+                  counter,
+                  'LiveCounter',
+                  `Check counter at key="${key}" in root is of type LiveCounter`,
+                );
+              });
 
-          mapKeys.forEach((key) => {
-            const map = root.get(key);
-            expect(map, `Check map at key="${key}" in root exists`).to.exist;
-            expectInstanceOf(map, 'LiveMap', `Check map at key="${key}" in root is of type LiveMap`);
-          });
+              mapKeys.forEach((key) => {
+                const map = root.get(key);
+                expect(map, `Check map at key="${key}" in root exists`).to.exist;
+                expectInstanceOf(map, 'LiveMap', `Check map at key="${key}" in root is of type LiveMap`);
+              });
 
-          const valuesMap = root.get('valuesMap');
-          const valueMapKeys = [
-            'stringKey',
-            'emptyStringKey',
-            'bytesKey',
-            'emptyBytesKey',
-            'numberKey',
-            'zeroKey',
-            'trueKey',
-            'falseKey',
-            'mapKey',
-          ];
-          expect(valuesMap.size()).to.equal(valueMapKeys.length, 'Check nested map has correct number of keys');
-          valueMapKeys.forEach((key) => {
-            const value = valuesMap.get(key);
-            expect(value, `Check value at key="${key}" in nested map exists`).to.exist;
-          });
-        }, client);
-      });
-
-      /** @nospec */
-      it('LiveCounter is initialized with initial value from STATE_SYNC sequence', async function () {
-        const helper = this.test.helper;
-        const client = RealtimeWithLiveObjects(helper);
-
-        await helper.monitorConnectionThenCloseAndFinish(async () => {
-          await waitFixtureChannelIsReady(client);
-
-          const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
-          const liveObjects = channel.liveObjects;
-
-          await channel.attach();
-          const root = await liveObjects.getRoot();
-
-          const counters = [
-            { key: 'emptyCounter', value: 0 },
-            { key: 'initialValueCounter', value: 10 },
-            { key: 'referencedCounter', value: 20 },
-          ];
-
-          counters.forEach((x) => {
-            const counter = root.get(x.key);
-            expect(counter.value()).to.equal(x.value, `Check counter at key="${x.key}" in root has correct value`);
-          });
-        }, client);
-      });
+              const valuesMap = root.get('valuesMap');
+              const valueMapKeys = [
+                'stringKey',
+                'emptyStringKey',
+                'bytesKey',
+                'emptyBytesKey',
+                'numberKey',
+                'zeroKey',
+                'trueKey',
+                'falseKey',
+                'mapKey',
+              ];
+              expect(valuesMap.size()).to.equal(valueMapKeys.length, 'Check nested map has correct number of keys');
+              valueMapKeys.forEach((key) => {
+                const value = valuesMap.get(key);
+                expect(value, `Check value at key="${key}" in nested map exists`).to.exist;
+              });
+            }, client);
+          };
+        },
+      );
 
       /** @nospec */
-      it('LiveMap is initialized with initial value from STATE_SYNC sequence', async function () {
-        const helper = this.test.helper;
-        const client = RealtimeWithLiveObjects(helper);
+      Helper.testOnAllTransportsAndProtocols(
+        this,
+        'LiveCounter is initialized with initial value from STATE_SYNC sequence',
+        function (options, channelName) {
+          return async function () {
+            const helper = this.test.helper;
+            const client = RealtimeWithLiveObjects(helper, options);
 
-        await helper.monitorConnectionThenCloseAndFinish(async () => {
-          await waitFixtureChannelIsReady(client);
+            await helper.monitorConnectionThenCloseAndFinish(async () => {
+              await waitFixtureChannelIsReady(client);
 
-          const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
-          const liveObjects = channel.liveObjects;
+              const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
+              const liveObjects = channel.liveObjects;
 
-          await channel.attach();
-          const root = await liveObjects.getRoot();
+              await channel.attach();
+              const root = await liveObjects.getRoot();
 
-          const emptyMap = root.get('emptyMap');
-          expect(emptyMap.size()).to.equal(0, 'Check empty map in root has no keys');
+              const counters = [
+                { key: 'emptyCounter', value: 0 },
+                { key: 'initialValueCounter', value: 10 },
+                { key: 'referencedCounter', value: 20 },
+              ];
 
-          const referencedMap = root.get('referencedMap');
-          expect(referencedMap.size()).to.equal(1, 'Check referenced map in root has correct number of keys');
-
-          const counterFromReferencedMap = referencedMap.get('counterKey');
-          expect(counterFromReferencedMap.value()).to.equal(20, 'Check nested counter has correct value');
-
-          const valuesMap = root.get('valuesMap');
-          expect(valuesMap.size()).to.equal(9, 'Check values map in root has correct number of keys');
-
-          expect(valuesMap.get('stringKey')).to.equal('stringValue', 'Check values map has correct string value key');
-          expect(valuesMap.get('emptyStringKey')).to.equal('', 'Check values map has correct empty string value key');
-          helper.recordPrivateApi('call.BufferUtils.base64Decode');
-          helper.recordPrivateApi('call.BufferUtils.areBuffersEqual');
-          expect(
-            BufferUtils.areBuffersEqual(
-              valuesMap.get('bytesKey'),
-              BufferUtils.base64Decode('eyJwcm9kdWN0SWQiOiAiMDAxIiwgInByb2R1Y3ROYW1lIjogImNhciJ9'),
-            ),
-            'Check values map has correct bytes value key',
-          ).to.be.true;
-          helper.recordPrivateApi('call.BufferUtils.base64Decode');
-          helper.recordPrivateApi('call.BufferUtils.areBuffersEqual');
-          expect(
-            BufferUtils.areBuffersEqual(valuesMap.get('emptyBytesKey'), BufferUtils.base64Decode('')),
-            'Check values map has correct empty bytes value key',
-          ).to.be.true;
-          expect(valuesMap.get('numberKey')).to.equal(1, 'Check values map has correct number value key');
-          expect(valuesMap.get('zeroKey')).to.equal(0, 'Check values map has correct zero number value key');
-          expect(valuesMap.get('trueKey')).to.equal(true, `Check values map has correct 'true' value key`);
-          expect(valuesMap.get('falseKey')).to.equal(false, `Check values map has correct 'false' value key`);
-
-          const mapFromValuesMap = valuesMap.get('mapKey');
-          expect(mapFromValuesMap.size()).to.equal(1, 'Check nested map has correct number of keys');
-        }, client);
-      });
+              counters.forEach((x) => {
+                const counter = root.get(x.key);
+                expect(counter.value()).to.equal(x.value, `Check counter at key="${x.key}" in root has correct value`);
+              });
+            }, client);
+          };
+        },
+      );
 
       /** @nospec */
-      it('LiveMaps can reference the same object in their keys', async function () {
-        const helper = this.test.helper;
-        const client = RealtimeWithLiveObjects(helper);
+      Helper.testOnAllTransportsAndProtocols(
+        this,
+        'LiveMap is initialized with initial value from STATE_SYNC sequence',
+        function (options, channelName) {
+          return async function () {
+            const helper = this.test.helper;
+            const client = RealtimeWithLiveObjects(helper, options);
 
-        await helper.monitorConnectionThenCloseAndFinish(async () => {
-          await waitFixtureChannelIsReady(client);
+            await helper.monitorConnectionThenCloseAndFinish(async () => {
+              await waitFixtureChannelIsReady(client);
 
-          const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
-          const liveObjects = channel.liveObjects;
+              const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
+              const liveObjects = channel.liveObjects;
 
-          await channel.attach();
-          const root = await liveObjects.getRoot();
+              await channel.attach();
+              const root = await liveObjects.getRoot();
 
-          const referencedCounter = root.get('referencedCounter');
-          const referencedMap = root.get('referencedMap');
-          const valuesMap = root.get('valuesMap');
+              const emptyMap = root.get('emptyMap');
+              expect(emptyMap.size()).to.equal(0, 'Check empty map in root has no keys');
 
-          const counterFromReferencedMap = referencedMap.get('counterKey');
-          expect(counterFromReferencedMap, 'Check nested counter exists at a key in a map').to.exist;
-          expectInstanceOf(counterFromReferencedMap, 'LiveCounter', 'Check nested counter is of type LiveCounter');
-          expect(counterFromReferencedMap).to.equal(
-            referencedCounter,
-            'Check nested counter is the same object instance as counter on the root',
-          );
-          expect(counterFromReferencedMap.value()).to.equal(20, 'Check nested counter has correct value');
+              const referencedMap = root.get('referencedMap');
+              expect(referencedMap.size()).to.equal(1, 'Check referenced map in root has correct number of keys');
 
-          const mapFromValuesMap = valuesMap.get('mapKey');
-          expect(mapFromValuesMap, 'Check nested map exists at a key in a map').to.exist;
-          expectInstanceOf(mapFromValuesMap, 'LiveMap', 'Check nested map is of type LiveMap');
-          expect(mapFromValuesMap.size()).to.equal(1, 'Check nested map has correct number of keys');
-          expect(mapFromValuesMap).to.equal(
-            referencedMap,
-            'Check nested map is the same object instance as map on the root',
-          );
-        }, client);
-      });
+              const counterFromReferencedMap = referencedMap.get('counterKey');
+              expect(counterFromReferencedMap.value()).to.equal(20, 'Check nested counter has correct value');
+
+              const valuesMap = root.get('valuesMap');
+              expect(valuesMap.size()).to.equal(9, 'Check values map in root has correct number of keys');
+
+              expect(valuesMap.get('stringKey')).to.equal(
+                'stringValue',
+                'Check values map has correct string value key',
+              );
+              expect(valuesMap.get('emptyStringKey')).to.equal(
+                '',
+                'Check values map has correct empty string value key',
+              );
+              helper.recordPrivateApi('call.BufferUtils.base64Decode');
+              helper.recordPrivateApi('call.BufferUtils.areBuffersEqual');
+              expect(
+                BufferUtils.areBuffersEqual(
+                  valuesMap.get('bytesKey'),
+                  BufferUtils.base64Decode('eyJwcm9kdWN0SWQiOiAiMDAxIiwgInByb2R1Y3ROYW1lIjogImNhciJ9'),
+                ),
+                'Check values map has correct bytes value key',
+              ).to.be.true;
+              helper.recordPrivateApi('call.BufferUtils.base64Decode');
+              helper.recordPrivateApi('call.BufferUtils.areBuffersEqual');
+              expect(
+                BufferUtils.areBuffersEqual(valuesMap.get('emptyBytesKey'), BufferUtils.base64Decode('')),
+                'Check values map has correct empty bytes value key',
+              ).to.be.true;
+              expect(valuesMap.get('numberKey')).to.equal(1, 'Check values map has correct number value key');
+              expect(valuesMap.get('zeroKey')).to.equal(0, 'Check values map has correct zero number value key');
+              expect(valuesMap.get('trueKey')).to.equal(true, `Check values map has correct 'true' value key`);
+              expect(valuesMap.get('falseKey')).to.equal(false, `Check values map has correct 'false' value key`);
+
+              const mapFromValuesMap = valuesMap.get('mapKey');
+              expect(mapFromValuesMap.size()).to.equal(1, 'Check nested map has correct number of keys');
+            }, client);
+          };
+        },
+      );
+
+      /** @nospec */
+      Helper.testOnAllTransportsAndProtocols(
+        this,
+        'LiveMap can reference the same object in their keys',
+        function (options, channelName) {
+          return async function () {
+            const helper = this.test.helper;
+            const client = RealtimeWithLiveObjects(helper, options);
+
+            await helper.monitorConnectionThenCloseAndFinish(async () => {
+              await waitFixtureChannelIsReady(client);
+
+              const channel = client.channels.get(liveObjectsFixturesChannel, channelOptionsWithLiveObjects());
+              const liveObjects = channel.liveObjects;
+
+              await channel.attach();
+              const root = await liveObjects.getRoot();
+
+              const referencedCounter = root.get('referencedCounter');
+              const referencedMap = root.get('referencedMap');
+              const valuesMap = root.get('valuesMap');
+
+              const counterFromReferencedMap = referencedMap.get('counterKey');
+              expect(counterFromReferencedMap, 'Check nested counter exists at a key in a map').to.exist;
+              expectInstanceOf(counterFromReferencedMap, 'LiveCounter', 'Check nested counter is of type LiveCounter');
+              expect(counterFromReferencedMap).to.equal(
+                referencedCounter,
+                'Check nested counter is the same object instance as counter on the root',
+              );
+              expect(counterFromReferencedMap.value()).to.equal(20, 'Check nested counter has correct value');
+
+              const mapFromValuesMap = valuesMap.get('mapKey');
+              expect(mapFromValuesMap, 'Check nested map exists at a key in a map').to.exist;
+              expectInstanceOf(mapFromValuesMap, 'LiveMap', 'Check nested map is of type LiveMap');
+              expect(mapFromValuesMap.size()).to.equal(1, 'Check nested map has correct number of keys');
+              expect(mapFromValuesMap).to.equal(
+                referencedMap,
+                'Check nested map is the same object instance as map on the root',
+              );
+            }, client);
+          };
+        },
+      );
 
       const primitiveKeyData = [
         { key: 'stringKey', data: { value: 'stringValue' } },
@@ -663,6 +712,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'STATE_SYNC sequence with state object "tombstone" property deletes existing object',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, channel } = ctx;
@@ -712,6 +762,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description:
             'STATE_SYNC sequence with state object "tombstone" property triggers subscription callback for existing object',
           action: async (ctx) => {
@@ -769,6 +820,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
       const applyOperationsScenarios = [
         {
+          allTransportsAndProtocols: true,
           description: 'can apply MAP_CREATE with primitives state operation messages',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, helper } = ctx;
@@ -832,6 +884,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can apply MAP_CREATE with object ids state operation messages',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -989,6 +1042,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can apply MAP_SET with primitives state operation messages',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, helper } = ctx;
@@ -1037,6 +1091,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can apply MAP_SET with object ids state operation messages',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -1163,6 +1218,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can apply MAP_REMOVE state operation messages',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -1297,6 +1353,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can apply COUNTER_CREATE state operation messages',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -1419,6 +1476,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can apply COUNTER_INC state operation messages',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -2217,6 +2275,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
       const writeApiScenarios = [
         {
+          allTransportsAndProtocols: true,
           description: 'LiveCounter.increment sends COUNTER_INC operation',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -2326,6 +2385,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveCounter.decrement sends COUNTER_INC operation',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -2435,6 +2495,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveMap.set sends MAP_SET operation with primitive values',
           action: async (ctx) => {
             const { root, helper } = ctx;
@@ -2469,6 +2530,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveMap.set sends MAP_SET operation with reference to another LiveObject',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -2546,6 +2608,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveMap.remove sends MAP_REMOVE operation',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName } = ctx;
@@ -2608,6 +2671,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveObjects.createCounter sends COUNTER_CREATE operation',
           action: async (ctx) => {
             const { liveObjects } = ctx;
@@ -2629,6 +2693,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveCounter created with LiveObjects.createCounter can be assigned to the state tree',
           action: async (ctx) => {
             const { root, liveObjects } = ctx;
@@ -2671,6 +2736,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description:
             'LiveObjects.createCounter can return LiveCounter with initial value from applied CREATE operation',
           action: async (ctx) => {
@@ -2702,7 +2768,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
         {
           description:
-            'Initial value is not double counted for LiveCounter from LiveObjects.createCounter when CREATE op is received',
+            'initial value is not double counted for LiveCounter from LiveObjects.createCounter when CREATE op is received',
           action: async (ctx) => {
             const { liveObjects, liveObjectsHelper, helper, channel } = ctx;
 
@@ -2783,6 +2849,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveObjects.createMap sends MAP_CREATE operation with primitive values',
           action: async (ctx) => {
             const { liveObjects, helper } = ctx;
@@ -2836,6 +2903,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveObjects.createMap sends MAP_CREATE operation with reference to another LiveObject',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, liveObjects } = ctx;
@@ -2876,6 +2944,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveMap created with LiveObjects.createMap can be assigned to the state tree',
           action: async (ctx) => {
             const { root, liveObjects } = ctx;
@@ -2919,6 +2988,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'LiveObjects.createMap can return LiveMap with initial value from applied CREATE operation',
           action: async (ctx) => {
             const { liveObjects, liveObjectsHelper, helper, channel } = ctx;
@@ -2955,7 +3025,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
         {
           description:
-            'Initial value is not double counted for LiveMap from LiveObjects.createMap when CREATE op is received',
+            'initial value is not double counted for LiveMap from LiveObjects.createMap when CREATE op is received',
           action: async (ctx) => {
             const { liveObjects, liveObjectsHelper, helper, channel } = ctx;
 
@@ -3181,6 +3251,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'batch API scheduled operations are applied when batch callback is finished',
           action: async (ctx) => {
             const { root, liveObjects } = ctx;
@@ -3361,18 +3432,18 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
       /** @nospec */
       forScenarios(
+        this,
         [
           ...stateSyncSequenceScenarios,
           ...applyOperationsScenarios,
           ...applyOperationsDuringSyncScenarios,
           ...writeApiScenarios,
         ],
-        async function (helper, scenario) {
+        async function (helper, scenario, clientOptions, channelName) {
           const liveObjectsHelper = new LiveObjectsHelper(helper);
-          const client = RealtimeWithLiveObjects(helper);
+          const client = RealtimeWithLiveObjects(helper, clientOptions);
 
           await helper.monitorConnectionThenCloseAndFinish(async () => {
-            const channelName = scenario.description;
             const channel = client.channels.get(channelName, channelOptionsWithLiveObjects());
             const liveObjects = channel.liveObjects;
 
@@ -3386,6 +3457,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
 
       const subscriptionCallbacksScenarios = [
         {
+          allTransportsAndProtocols: true,
           description: 'can subscribe to the incoming COUNTER_INC operation on a LiveCounter',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, sampleCounterKey, sampleCounterObjectId } = ctx;
@@ -3418,6 +3490,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can subscribe to multiple incoming operations on a LiveCounter',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, sampleCounterKey, sampleCounterObjectId } = ctx;
@@ -3461,6 +3534,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can subscribe to the incoming MAP_SET operation on a LiveMap',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, sampleMapKey, sampleMapObjectId } = ctx;
@@ -3494,6 +3568,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can subscribe to the incoming MAP_REMOVE operation on a LiveMap',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, sampleMapKey, sampleMapObjectId } = ctx;
@@ -3526,6 +3601,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'can subscribe to multiple incoming operations on a LiveMap',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, sampleMapKey, sampleMapObjectId } = ctx;
@@ -3864,12 +3940,11 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
       ];
 
       /** @nospec */
-      forScenarios(subscriptionCallbacksScenarios, async function (helper, scenario) {
+      forScenarios(this, subscriptionCallbacksScenarios, async function (helper, scenario, clientOptions, channelName) {
         const liveObjectsHelper = new LiveObjectsHelper(helper);
-        const client = RealtimeWithLiveObjects(helper);
+        const client = RealtimeWithLiveObjects(helper, clientOptions);
 
         await helper.monitorConnectionThenCloseAndFinish(async () => {
-          const channelName = scenario.description;
           const channel = client.channels.get(channelName, channelOptionsWithLiveObjects());
           const liveObjects = channel.liveObjects;
 
@@ -3965,6 +4040,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         },
 
         {
+          allTransportsAndProtocols: true,
           description: 'tombstoned map entry is removed from the LiveMap after the GC grace period',
           action: async (ctx) => {
             const { root, liveObjectsHelper, channelName, helper, waitForGCCycles } = ctx;
@@ -4014,7 +4090,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
       ];
 
       /** @nospec */
-      forScenarios(tombstonesGCScenarios, async function (helper, scenario) {
+      forScenarios(this, tombstonesGCScenarios, async function (helper, scenario, clientOptions, channelName) {
         try {
           helper.recordPrivateApi('write.LiveObjects._DEFAULTS.gcInterval');
           LiveObjectsPlugin.LiveObjects._DEFAULTS.gcInterval = 500;
@@ -4022,10 +4098,9 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
           LiveObjectsPlugin.LiveObjects._DEFAULTS.gcGracePeriod = 250;
 
           const liveObjectsHelper = new LiveObjectsHelper(helper);
-          const client = RealtimeWithLiveObjects(helper);
+          const client = RealtimeWithLiveObjects(helper, clientOptions);
 
           await helper.monitorConnectionThenCloseAndFinish(async () => {
-            const channelName = scenario.description;
             const channel = client.channels.get(channelName, channelOptionsWithLiveObjects());
             const liveObjects = channel.liveObjects;
 
@@ -4179,12 +4254,11 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
       ];
 
       /** @nospec */
-      forScenarios(missingChannelModesScenarios, async function (helper, scenario) {
+      forScenarios(this, missingChannelModesScenarios, async function (helper, scenario, clientOptions, channelName) {
         const liveObjectsHelper = new LiveObjectsHelper(helper);
-        const client = RealtimeWithLiveObjects(helper);
+        const client = RealtimeWithLiveObjects(helper, clientOptions);
 
         await helper.monitorConnectionThenCloseAndFinish(async () => {
-          const channelName = scenario.description;
           // attach with correct channel modes so we can create liveobjects on the root for testing.
           // each scenario will modify the underlying modes array to test specific behavior
           const channel = client.channels.get(channelName, channelOptionsWithLiveObjects());
@@ -4467,7 +4541,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
         ];
 
         /** @nospec */
-        forScenarios(stateMessageSizeScenarios, function (helper, scenario) {
+        forScenarios(this, stateMessageSizeScenarios, function (helper, scenario) {
           helper.recordPrivateApi('call.StateMessage.encode');
           LiveObjectsPlugin.StateMessage.encode(scenario.message);
           helper.recordPrivateApi('call.BufferUtils.utf8Encode'); // was called by a scenario to create buffers

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -79,7 +79,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * Test publishes in quick succession (on successive ticks of the event loop)
      * @spec RTL6b
      */
-    Helper.testOnAllTransports(this, 'publishfast', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'publishfast', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         try {
@@ -146,7 +146,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL6c2
      * @specpartial RTL3d - test processing queued messages
      */
-    Helper.testOnAllTransports(this, 'publishQueued', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'publishQueued', function (realtimeOpts) {
       return function (done) {
         var helper = this.test.helper,
           txRealtime,
@@ -629,7 +629,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec RTL6
      * @spec RTL6b
      */
-    Helper.testOnAllTransports(this, 'publish', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'publish', function (realtimeOpts) {
       return function (done) {
         const helper = this.test.helper;
         var count = 10;

--- a/test/realtime/reauth.test.js
+++ b/test/realtime/reauth.test.js
@@ -178,7 +178,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     }
 
     function testCase(thisInDescribe, name, createSteps) {
-      Helper.testOnAllTransports(thisInDescribe, name, function (realtimeOpts) {
+      Helper.testOnAllTransportsAndProtocols(thisInDescribe, name, function (realtimeOpts) {
         return function (done) {
           const helper = this.test.helper;
           var _steps = createSteps(helper).slice();

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -140,7 +140,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Related to RTN15b, RTN15c.
      * @nospec
      */
-    Helper.testOnAllTransports(this, 'resume_inactive', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'resume_inactive', function (realtimeOpts) {
       return function (done) {
         resume_inactive(done, this.test.helper, 'resume_inactive' + String(Math.random()), {}, realtimeOpts);
       };
@@ -266,7 +266,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Related to RTN15b, RTN15c.
      * @nospec
      */
-    Helper.testOnAllTransports(this, 'resume_active', function (realtimeOpts) {
+    Helper.testOnAllTransportsAndProtocols(this, 'resume_active', function (realtimeOpts) {
       return function (done) {
         resume_active(done, this.test.helper, 'resume_active' + String(Math.random()), {}, realtimeOpts);
       };
@@ -276,7 +276,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Resume with loss of continuity
      * @spec RTN15c7
      */
-    Helper.testOnAllTransports(
+    Helper.testOnAllTransportsAndProtocols(
       this,
       'resume_lost_continuity',
       function (realtimeOpts) {
@@ -353,7 +353,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Resume with token error
      * @spec RTN15c5
      */
-    Helper.testOnAllTransports(
+    Helper.testOnAllTransportsAndProtocols(
       this,
       'resume_token_error',
       function (realtimeOpts) {
@@ -411,7 +411,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * Resume with fatal error
      * @spec RTN15c4
      */
-    Helper.testOnAllTransports(
+    Helper.testOnAllTransportsAndProtocols(
       this,
       'resume_fatal_error',
       function (realtimeOpts) {

--- a/test/rest/history.test.js
+++ b/test/rest/history.test.js
@@ -31,7 +31,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RSL2
      * @spec RSL2a
      */
-    Helper.restTestOnJsonMsgpack('history_simple', async function (rest, channelName, helper) {
+    Helper.testOnJsonMsgpack('history_simple', async function (options, channelName, helper) {
+      const rest = helper.AblyRest(options);
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -63,7 +64,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RSL2
      * @spec RSL2a
      */
-    Helper.restTestOnJsonMsgpack('history_multiple', async function (rest, channelName, helper) {
+    Helper.testOnJsonMsgpack('history_multiple', async function (options, channelName, helper) {
+      const rest = helper.AblyRest(options);
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -92,7 +94,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
      * @spec RSL2b2
      * @specpartial RSL2b3 - should also test maximum supported limit of 1000
      */
-    Helper.restTestOnJsonMsgpack('history_simple_paginated_b', async function (rest, channelName, helper) {
+    Helper.testOnJsonMsgpack('history_simple_paginated_b', async function (options, channelName, helper) {
+      const rest = helper.AblyRest(options);
       var testchannel = rest.channels.get('persisted:' + channelName);
 
       /* first, send a number of events to this channel */
@@ -259,7 +262,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     });
 
     /** @nospec */
-    Helper.restTestOnJsonMsgpack('history_encoding_errors', async function (rest, channelName) {
+    Helper.testOnJsonMsgpack('history_encoding_errors', async function (options, channelName, helper) {
+      const rest = helper.AblyRest(options);
       var testchannel = rest.channels.get('persisted:' + channelName);
       var badMessage = { name: 'jsonUtf8string', encoding: 'json/utf-8', data: '{"foo":"bar"}' };
       testchannel.publish(badMessage);
@@ -272,7 +276,8 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
     });
 
     /** @specpartial TG4 - in the context of RestChannel#history */
-    Helper.restTestOnJsonMsgpack('history_no_next_page', async function (rest, channelName) {
+    Helper.testOnJsonMsgpack('history_no_next_page', async function (options, channelName, helper) {
+      const rest = helper.AblyRest(options);
       const channel = rest.channels.get(channelName);
 
       const firstPage = await channel.history();

--- a/test/rest/request.test.js
+++ b/test/rest/request.test.js
@@ -28,7 +28,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSC7e - tests providing a version value in .request parameters
      * @specpartial CSV2c - tests version is provided in http requests
      */
-    Helper.restTestOnJsonMsgpack('request_version', function (rest, _, helper) {
+    Helper.testOnJsonMsgpack('request_version', function (options, _, helper) {
+      const rest = helper.AblyRest(options);
       const version = 150; // arbitrarily chosen
 
       async function testRequestHandler(_, __, headers) {
@@ -56,7 +57,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec HP5
      * @specpartial RSC19f - basic test for passing a http method, path and version parameters
      */
-    Helper.restTestOnJsonMsgpack('request_time', async function (rest) {
+    Helper.testOnJsonMsgpack('request_time', async function (options, _, helper) {
+      const rest = helper.AblyRest(options);
       const res = await rest.request('get', '/time', 3, null, null, null);
       expect(res.statusCode).to.equal(200, 'Check statusCode');
       expect(res.success).to.equal(true, 'Check success');
@@ -72,7 +74,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec HP6
      * @spec HP7
      */
-    Helper.restTestOnJsonMsgpack('request_404', async function (rest) {
+    Helper.testOnJsonMsgpack('request_404', async function (options, _, helper) {
+      const rest = helper.AblyRest(options);
       /* NB: can't just use /invalid or something as the CORS preflight will
        * fail. Need something superficially a valid path but where the actual
        * request fails */
@@ -110,7 +113,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial HP2 - tests overriden .next method only
      * @specpartial RSC19f - more tests with passing other methods, body and parameters
      */
-    Helper.restTestOnJsonMsgpack('request_post_get_messages', async function (rest, channelName) {
+    Helper.testOnJsonMsgpack('request_post_get_messages', async function (options, channelName, helper) {
+      const rest = helper.AblyRest(options);
       var channelPath = '/channels/' + channelName + '/messages',
         msgone = { name: 'faye', data: 'whittaker' },
         msgtwo = { name: 'martin', data: 'reed' };
@@ -155,7 +159,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @spec HP7
      * @specpartial RSC19f - more tests with POST method and passing body
      */
-    Helper.restTestOnJsonMsgpack('request_batch_api_success', async function (rest, name) {
+    Helper.testOnJsonMsgpack('request_batch_api_success', async function (options, name, helper) {
+      const rest = helper.AblyRest(options);
       var body = { channels: [name + '1', name + '2'], messages: { data: 'foo' } };
 
       const res = await rest.request('POST', '/messages', 2, {}, body, {});
@@ -186,7 +191,8 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      * @specpartial RSC19f - more tests with POST method and passing body
      * @specskip
      */
-    Helper.restTestOnJsonMsgpack.skip('request_batch_api_partial_success', async function (rest, name) {
+    Helper.testOnJsonMsgpack.skip('request_batch_api_partial_success', async function (options, name, helper) {
+      const rest = helper.AblyRest(options);
       var body = { channels: [name, '[invalid', ''], messages: { data: 'foo' } };
 
       var res = await rest.request('POST', '/messages', 2, {}, body, {});

--- a/test/rest/status.test.js
+++ b/test/rest/status.test.js
@@ -34,7 +34,8 @@ define(['shared_helper', 'chai'], function (Helper, chai) {
      * @spec CHM2e
      * @spec CHM2f
      */
-    Helper.restTestOnJsonMsgpack('status0', async function (rest) {
+    Helper.testOnJsonMsgpack('status0', async function (options, _, helper) {
+      const rest = helper.AblyRest(options);
       var channel = rest.channels.get('status0');
       var channelDetails = await channel.status();
       expect(channelDetails.channelId).to.equal('status0');


### PR DESCRIPTION
Only the tests that interact with the realtime server are marked to run with both `MsgPack` and `JSON` protocols. Tests that rely on private `channel.processMessage` calls to inject forged state messages are not included.

Resolves [DTP-1096](https://ably.atlassian.net/browse/DTP-1096)

[DTP-1096]: https://ably.atlassian.net/browse/DTP-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated test helper methods across multiple test files.
	- Renamed `restTestOnJsonMsgpack` to `testOnJsonMsgpack`.
	- Renamed `testOnAllTransports` to `testOnAllTransportsAndProtocols`.
	- Modified test function signatures to support more flexible testing options.
	- Added `only` and `skip` methods for more granular test control.

- **Tests**
	- Enhanced test suite for live objects, history, requests, and status functionality.
	- Improved protocol and scenario testing capabilities.
	- Expanded testing scope to include both transports and protocols across various test cases.
	- Updated tests to ensure compatibility with new method signatures and parameters.
	- Refined existing test structures and descriptions without introducing new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->