### PR TITLE
Fix LiveObjects tests

### DIFF
--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1882,7 +1882,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           transport.send = function (msg) {
             if (msg.action === 10) {
               try {
-                expect(msg.channelSerial).to.equal('channelSerial2');
+                expect(msg.channelSerial).to.equal('channelSerial');
                 resolve();
               } catch (error) {
                 reject(error);

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -4246,7 +4246,7 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
           const root = await liveObjects.getRoot();
 
           const data = new Array(100).fill('a').join('');
-          const error = await expectRejectedWith(
+          const error = await expectToThrowAsync(
             async () => root.set('key', data),
             'Maximum size of state messages that can be published at once exceeded',
           );


### PR DESCRIPTION
channelSerial test should have always expected `channelSerial` value, but was wrongly set to `channelSerial2` in https://github.com/ably/ably-js/pull/1961 (I was testing things locally and pushed the wrong value).

live_objects connectionDetails.maxMessageSize test wrongly used obsolete `expectRejectedWith` function due to PR merge order.