### PR TITLE
[PUB-1030] LiveObjects behavior under different channel states

### DIFF
--- a/src/plugins/liveobjects/batchcontext.ts
+++ b/src/plugins/liveobjects/batchcontext.ts
@@ -24,7 +24,7 @@ export class BatchContext {
   }
 
   getRoot<T extends API.LiveMapType = API.DefaultRoot>(): BatchContextLiveMap<T> {
-    this._liveObjects.throwIfMissingStateSubscribeMode();
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
     this.throwIfClosed();
     return this.getWrappedObject(ROOT_OBJECT_ID) as BatchContextLiveMap<T>;
   }

--- a/src/plugins/liveobjects/batchcontextlivecounter.ts
+++ b/src/plugins/liveobjects/batchcontextlivecounter.ts
@@ -15,20 +15,20 @@ export class BatchContextLiveCounter {
   }
 
   value(): number {
-    this._liveObjects.throwIfMissingStateSubscribeMode();
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
     this._batchContext.throwIfClosed();
     return this._counter.value();
   }
 
   increment(amount: number): void {
-    this._liveObjects.throwIfMissingStatePublishMode();
+    this._liveObjects.throwIfInvalidWriteApiConfiguration();
     this._batchContext.throwIfClosed();
     const stateMessage = LiveCounter.createCounterIncMessage(this._liveObjects, this._counter.getObjectId(), amount);
     this._batchContext.queueStateMessage(stateMessage);
   }
 
   decrement(amount: number): void {
-    this._liveObjects.throwIfMissingStatePublishMode();
+    this._liveObjects.throwIfInvalidWriteApiConfiguration();
     this._batchContext.throwIfClosed();
     // do an explicit type safety check here before negating the amount value,
     // so we don't unintentionally change the type sent by a user

--- a/src/plugins/liveobjects/batchcontextlivemap.ts
+++ b/src/plugins/liveobjects/batchcontextlivemap.ts
@@ -12,7 +12,7 @@ export class BatchContextLiveMap<T extends API.LiveMapType> {
   ) {}
 
   get<TKey extends keyof T & string>(key: TKey): T[TKey] | undefined {
-    this._liveObjects.throwIfMissingStateSubscribeMode();
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
     this._batchContext.throwIfClosed();
     const value = this._map.get(key);
     if (value instanceof LiveObject) {
@@ -23,20 +23,20 @@ export class BatchContextLiveMap<T extends API.LiveMapType> {
   }
 
   size(): number {
-    this._liveObjects.throwIfMissingStateSubscribeMode();
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
     this._batchContext.throwIfClosed();
     return this._map.size();
   }
 
   set<TKey extends keyof T & string>(key: TKey, value: T[TKey]): void {
-    this._liveObjects.throwIfMissingStatePublishMode();
+    this._liveObjects.throwIfInvalidWriteApiConfiguration();
     this._batchContext.throwIfClosed();
     const stateMessage = LiveMap.createMapSetMessage(this._liveObjects, this._map.getObjectId(), key, value);
     this._batchContext.queueStateMessage(stateMessage);
   }
 
   remove<TKey extends keyof T & string>(key: TKey): void {
-    this._liveObjects.throwIfMissingStatePublishMode();
+    this._liveObjects.throwIfInvalidWriteApiConfiguration();
     this._batchContext.throwIfClosed();
     const stateMessage = LiveMap.createMapRemoveMessage(this._liveObjects, this._map.getObjectId(), key);
     this._batchContext.queueStateMessage(stateMessage);

--- a/src/plugins/liveobjects/livecounter.ts
+++ b/src/plugins/liveobjects/livecounter.ts
@@ -123,7 +123,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
   }
 
   value(): number {
-    this._liveObjects.throwIfMissingStateSubscribeMode();
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
     return this._dataRef.data;
   }
 
@@ -137,7 +137,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
    * @returns A promise which resolves upon receiving the ACK message for the published operation message.
    */
   async increment(amount: number): Promise<void> {
-    this._liveObjects.throwIfMissingStatePublishMode();
+    this._liveObjects.throwIfInvalidWriteApiConfiguration();
     const stateMessage = LiveCounter.createCounterIncMessage(this._liveObjects, this.getObjectId(), amount);
     return this._liveObjects.publish([stateMessage]);
   }
@@ -146,7 +146,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
    * An alias for calling {@link LiveCounter.increment | LiveCounter.increment(-amount)}
    */
   async decrement(amount: number): Promise<void> {
-    this._liveObjects.throwIfMissingStatePublishMode();
+    this._liveObjects.throwIfInvalidWriteApiConfiguration();
     // do an explicit type safety check here before negating the amount value,
     // so we don't unintentionally change the type sent by a user
     if (typeof amount !== 'number' || !isFinite(amount)) {

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -266,7 +266,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
    */
   // force the key to be of type string as we only allow strings as key in a map
   get<TKey extends keyof T & string>(key: TKey): T[TKey] | undefined {
-    this._liveObjects.throwIfMissingStateSubscribeMode();
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
 
     if (this.isTombstoned()) {
       return undefined as T[TKey];
@@ -305,7 +305,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
   }
 
   size(): number {
-    this._liveObjects.throwIfMissingStateSubscribeMode();
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
 
     let size = 0;
     for (const value of this._dataRef.data.values()) {
@@ -341,7 +341,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
    * @returns A promise which resolves upon receiving the ACK message for the published operation message.
    */
   async set<TKey extends keyof T & string>(key: TKey, value: T[TKey]): Promise<void> {
-    this._liveObjects.throwIfMissingStatePublishMode();
+    this._liveObjects.throwIfInvalidWriteApiConfiguration();
     const stateMessage = LiveMap.createMapSetMessage(this._liveObjects, this.getObjectId(), key, value);
     return this._liveObjects.publish([stateMessage]);
   }
@@ -356,7 +356,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
    * @returns A promise which resolves upon receiving the ACK message for the published operation message.
    */
   async remove<TKey extends keyof T & string>(key: TKey): Promise<void> {
-    this._liveObjects.throwIfMissingStatePublishMode();
+    this._liveObjects.throwIfInvalidWriteApiConfiguration();
     const stateMessage = LiveMap.createMapRemoveMessage(this._liveObjects, this.getObjectId(), key);
     return this._liveObjects.publish([stateMessage]);
   }

--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -77,7 +77,7 @@ export abstract class LiveObject<
   }
 
   subscribe(listener: (update: TUpdate) => void): SubscribeResponse {
-    this._liveObjects.throwIfMissingStateSubscribeMode();
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
 
     this._subscriptions.on(LiveObjectSubscriptionEvent.updated, listener);
 
@@ -89,7 +89,7 @@ export abstract class LiveObject<
   }
 
   unsubscribe(listener: (update: TUpdate) => void): void {
-    // can allow calling this public method without checking for state modes on the channel as the result of this method is not dependant on them
+    // this public API method can be called without specific configuration, so checking for invalid settings is unnecessary.
 
     // current implementation of the EventEmitter will remove all listeners if .off is called without arguments or with nullish arguments.
     // or when called with just an event argument, it will remove all listeners for the event.
@@ -102,12 +102,12 @@ export abstract class LiveObject<
   }
 
   unsubscribeAll(): void {
-    // can allow calling this public method without checking for state modes on the channel as the result of this method is not dependant on them
+    // this public API method can be called without specific configuration, so checking for invalid settings is unnecessary.
     this._subscriptions.off(LiveObjectSubscriptionEvent.updated);
   }
 
   on(event: LiveObjectLifecycleEvent, callback: LiveObjectLifecycleEventCallback): OnLiveObjectLifecycleEventResponse {
-    // we don't require any specific channel mode to be set to call this public method
+    // this public API method can be called without specific configuration, so checking for invalid settings is unnecessary.
     this._lifecycleEvents.on(event, callback);
 
     const off = () => {
@@ -118,7 +118,7 @@ export abstract class LiveObject<
   }
 
   off(event: LiveObjectLifecycleEvent, callback: LiveObjectLifecycleEventCallback): void {
-    // we don't require any specific channel mode to be set to call this public method
+    // this public API method can be called without specific configuration, so checking for invalid settings is unnecessary.
 
     // prevent accidentally calling .off without any arguments on an EventEmitter and removing all callbacks
     if (this._client.Utils.isNil(event) && this._client.Utils.isNil(callback)) {
@@ -129,7 +129,7 @@ export abstract class LiveObject<
   }
 
   offAll(): void {
-    // we don't require any specific channel mode to be set to call this public method
+    // this public API method can be called without specific configuration, so checking for invalid settings is unnecessary.
     this._lifecycleEvents.off();
   }
 


### PR DESCRIPTION
When the channel is `SUSPENDED`

- The local copy of the last known LiveObjects state is maintained, ensuring that the API for accessing objects continues to function and returns the latest known data.
- The getRoot() function will return the last known root object.
- Write API functions will throw an error, as the channel is in an invalid state (i.e., messages cannot be sent or queued while suspended).

When the channel is `DETACHED` or `FAILED`

- The local LiveObjects state copy is cleared (LiveObjects data update events are not emitted in this case (e.g., counter increments, map key set/delete), as the current state of LiveObjects data is unknown)
- All access and write API functions, including getRoot(), will throw an error indicating that the channel is in an invalid state.

Resolves [PUB-1030](https://ably.atlassian.net/browse/)

[PUB-1030]: https://ably.atlassian.net/browse/PUB-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ