### PR TITLE
Use endpoint as default connection option (ADR-119)

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -391,6 +391,11 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
   echoMessages?: boolean;
 
   /**
+   * Set a routing policy or FQDN to connect to Ably. See [platform customization](https://ably.com/docs/platform-customization).
+   */
+  endpoint?: string;
+
+  /**
    * Enables a [custom environment](https://ably.com/docs/platform-customization) to be used with the Ably service.
    */
   environment?: string;

--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -13,6 +13,7 @@ import { ModularPlugins } from '../client/modularplugins';
 let agent = 'ably-js/' + version;
 
 type CompleteDefaults = IDefaults & {
+  ENDPOINT: string;
   ENVIRONMENT: string;
   REST_HOST: string;
   REALTIME_HOST: string;
@@ -40,7 +41,7 @@ type CompleteDefaults = IDefaults & {
   getHost(options: ClientOptions, host?: string | null, ws?: boolean): string;
   getPort(options: ClientOptions, tls?: boolean): number | undefined;
   getHttpScheme(options: ClientOptions): string;
-  environmentFallbackHosts(environment: string): string[];
+  getEndpointFallbackHosts(endpoint: string): string[];
   getFallbackHosts(options: NormalisedClientOptions): string[];
   getHosts(options: NormalisedClientOptions, ws?: boolean): string[];
   checkHost(host: string): void;
@@ -57,15 +58,16 @@ type CompleteDefaults = IDefaults & {
 };
 
 const Defaults = {
+  ENDPOINT: 'main',
   ENVIRONMENT: '',
   REST_HOST: 'rest.ably.io',
   REALTIME_HOST: 'realtime.ably.io',
   FALLBACK_HOSTS: [
-    'A.ably-realtime.com',
-    'B.ably-realtime.com',
-    'C.ably-realtime.com',
-    'D.ably-realtime.com',
-    'E.ably-realtime.com',
+    'main.a.fallback.ably-realtime.com',
+    'main.b.fallback.ably-realtime.com',
+    'main.c.fallback.ably-realtime.com',
+    'main.d.fallback.ably-realtime.com',
+    'main.e.fallback.ably-realtime.com',
   ],
   PORT: 80,
   TLS_PORT: 443,
@@ -94,7 +96,7 @@ const Defaults = {
   getHost,
   getPort,
   getHttpScheme,
-  environmentFallbackHosts,
+  getEndpointFallbackHosts,
   getFallbackHosts,
   getHosts,
   checkHost,
@@ -119,15 +121,30 @@ export function getHttpScheme(options: ClientOptions): string {
   return options.tls ? 'https://' : 'http://';
 }
 
-// construct environment fallback hosts as per RSC15i
-export function environmentFallbackHosts(environment: string): string[] {
-  return [
-    environment + '-a-fallback.ably-realtime.com',
-    environment + '-b-fallback.ably-realtime.com',
-    environment + '-c-fallback.ably-realtime.com',
-    environment + '-d-fallback.ably-realtime.com',
-    environment + '-e-fallback.ably-realtime.com',
-  ];
+export function getEndpointHostname(endpoint: string): string {
+  if (endpoint.includes('.') || endpoint.includes('::') || endpoint.includes('localhost')) {
+    return endpoint;
+  }
+
+  if (endpoint.startsWith('nonprod:')) {
+    const root = endpoint.replace('nonprod:', '');
+    return `${root}.realtime.ably-nonprod.net`;
+  }
+
+  return `${endpoint}.realtime.ably.net`;
+}
+
+export function getEndpointFallbackHosts(endpoint: string): string[] {
+  if (endpoint.startsWith('nonprod:')) {
+    const root = endpoint.replace('nonprod:', '');
+    return endpointFallbacks(root, 'ably-realtime-nonprod.com');
+  }
+
+  return endpointFallbacks(endpoint, 'ably-realtime.com');
+}
+
+export function endpointFallbacks(root: string, domain: string): string[] {
+  return ['a', 'b', 'c', 'd', 'e'].map((id) => `${root}.${id}.fallback.${domain}`);
 }
 
 export function getFallbackHosts(options: NormalisedClientOptions): string[] {
@@ -150,26 +167,6 @@ function checkHost(host: string): void {
   if (!host.length) {
     throw new ErrorInfo('host must not be zero-length', 40000, 400);
   }
-}
-
-function getRealtimeHost(options: ClientOptions, production: boolean, environment: string, logger: Logger): string {
-  if (options.realtimeHost) return options.realtimeHost;
-  /* prefer setting realtimeHost to restHost as a custom restHost typically indicates
-   * a development environment is being used that can't be inferred by the library */
-  if (options.restHost) {
-    Logger.logAction(
-      logger,
-      Logger.LOG_MINOR,
-      'Defaults.normaliseOptions',
-      'restHost is set to "' +
-        options.restHost +
-        '" but realtimeHost is not set, so setting realtimeHost to "' +
-        options.restHost +
-        '" too. If this is not what you want, please set realtimeHost explicitly.',
-    );
-    return options.restHost;
-  }
-  return production ? Defaults.REALTIME_HOST : environment + '-' + Defaults.REALTIME_HOST;
 }
 
 function getTimeouts(options: ClientOptions) {
@@ -262,16 +259,15 @@ export function normaliseOptions(
 
   if (!('queueMessages' in options)) options.queueMessages = true;
 
-  /* infer hosts and fallbacks based on the configured environment */
-  const environment = (options.environment && String(options.environment).toLowerCase()) || Defaults.ENVIRONMENT;
-  const production = !environment || environment === 'production';
+  /* infer hosts and fallbacks based on the specified endpoint */
+  const endpoint = options.endpoint || options.environment || Defaults.ENDPOINT;
 
   if (!options.fallbackHosts && !options.restHost && !options.realtimeHost && !options.port && !options.tlsPort) {
-    options.fallbackHosts = production ? Defaults.FALLBACK_HOSTS : environmentFallbackHosts(environment);
+    options.fallbackHosts = getEndpointFallbackHosts(endpoint);
   }
 
-  const restHost = options.restHost || (production ? Defaults.REST_HOST : environment + '-' + Defaults.REST_HOST);
-  const realtimeHost = getRealtimeHost(options, production, environment, loggerToUse);
+  const restHost = options.restHost || getEndpointHostname(endpoint);
+  const realtimeHost = options.realtimeHost || getEndpointHostname(endpoint);
 
   (options.fallbackHosts || []).concat(restHost, realtimeHost).forEach(checkHost);
 

--- a/test/common/globals/environment.js
+++ b/test/common/globals/environment.js
@@ -3,7 +3,7 @@
 define(function (require) {
   var defaultLogLevel = 4,
     environment = isBrowser ? window.__env__ || {} : process.env,
-    ablyEnvironment = environment.ABLY_ENV || 'sandbox',
+    ablyEnvironment = environment.ABLY_ENV || 'nonprod:sandbox',
     realtimeHost = environment.ABLY_REALTIME_HOST,
     restHost = environment.ABLY_REST_HOST,
     port = environment.ABLY_PORT || 80,

--- a/test/common/modules/testapp_manager.js
+++ b/test/common/modules/testapp_manager.js
@@ -3,7 +3,7 @@
 
 /* testapp module is responsible for setting up and tearing down apps in the test environment */
 define(['globals', 'ably'], function (ablyGlobals, ably) {
-  var restHost = ablyGlobals.restHost || prefixDomainWithEnvironment('rest.ably.io', ablyGlobals.environment),
+  var restHost = ablyGlobals.restHost || setHostname(ablyGlobals.environment),
     port = ablyGlobals.tls ? ablyGlobals.tlsPort : ablyGlobals.port,
     scheme = ablyGlobals.tls ? 'https' : 'http';
 
@@ -23,12 +23,12 @@ define(['globals', 'ably'], function (ablyGlobals, ably) {
     }
   }
 
-  function prefixDomainWithEnvironment(domain, environment) {
-    if (environment.toLowerCase() === 'production') {
-      return domain;
-    } else {
-      return environment + '-' + domain;
+  function setHostname(endpoint) {
+    if (endpoint.startsWith('nonprod:')) {
+      return `${endpoint.replace('nonprod:', '')}.realtime.ably-nonprod.net`;
     }
+
+    return `${endpoint}.realtime.ably.net`;
   }
 
   function toBase64(helper, str) {

--- a/test/package/browser/template/playwright/index.tsx
+++ b/test/package/browser/template/playwright/index.tsx
@@ -9,7 +9,7 @@ beforeMount(async ({ App }) => {
 
   const client = new Ably.Realtime({
     key,
-    environment: 'sandbox',
+    environment: 'nonprod:sandbox',
   });
 
   return (

--- a/test/package/browser/template/src/index-default.ts
+++ b/test/package/browser/template/src/index-default.ts
@@ -9,7 +9,7 @@ async function attachChannel(channel: Ably.RealtimeChannel) {
 globalThis.testAblyPackage = async function () {
   const key = await createSandboxAblyAPIKey();
 
-  const realtime = new Ably.Realtime({ key, environment: 'sandbox' });
+  const realtime = new Ably.Realtime({ key, environment: 'nonprod:sandbox' });
 
   const channel = realtime.channels.get('channel');
   await attachChannel(channel);

--- a/test/package/browser/template/src/index-modular.ts
+++ b/test/package/browser/template/src/index-modular.ts
@@ -18,7 +18,11 @@ async function checkStandaloneFunction() {
 globalThis.testAblyPackage = async function () {
   const key = await createSandboxAblyAPIKey();
 
-  const realtime = new BaseRealtime({ key, environment: 'sandbox', plugins: { WebSocketTransport, FetchRequest } });
+  const realtime = new BaseRealtime({
+    key,
+    environment: 'nonprod:sandbox',
+    plugins: { WebSocketTransport, FetchRequest },
+  });
 
   const channel = realtime.channels.get('channel');
   await attachChannel(channel);

--- a/test/package/browser/template/src/sandbox.ts
+++ b/test/package/browser/template/src/sandbox.ts
@@ -1,7 +1,7 @@
 import testAppSetup from '../../../../common/ably-common/test-resources/test-app-setup.json';
 
 export async function createSandboxAblyAPIKey() {
-  const response = await fetch('https://sandbox-rest.ably.io/apps', {
+  const response = await fetch('https://sandbox.realtime.ably-nonprod.net/apps', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(testAppSetup.post_apps),

--- a/test/realtime/connectivity.test.js
+++ b/test/realtime/connectivity.test.js
@@ -136,7 +136,7 @@ define(['ably', 'shared_helper', 'chai'], function (Ably, Helper, chai) {
       it('succeeds with plain url', function (done) {
         const helper = this.test.helper;
         Helper.whenPromiseSettles(
-          helper.AblyRealtime(options(helper, 'sandbox-rest.ably.io/time')).http.checkConnectivity(),
+          helper.AblyRealtime(options(helper, 'sandbox.realtime.ably-nonprod.net/time')).http.checkConnectivity(),
           function (err, res) {
             try {
               expect(

--- a/test/rest/defaults.test.js
+++ b/test/rest/defaults.test.js
@@ -24,8 +24,8 @@ define(['ably', 'chai'], function (Ably, chai) {
       helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions({}, null, null);
 
-      expect(normalisedOptions.restHost).to.equal('rest.ably.io');
-      expect(normalisedOptions.realtimeHost).to.equal('realtime.ably.io');
+      expect(normalisedOptions.restHost).to.equal('main.realtime.ably.net');
+      expect(normalisedOptions.realtimeHost).to.equal('main.realtime.ably.net');
       expect(normalisedOptions.port).to.equal(80);
       expect(normalisedOptions.tlsPort).to.equal(443);
       expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.FALLBACK_HOSTS.sort());
@@ -35,8 +35,10 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(Defaults.getHosts(normalisedOptions).length).to.equal(4);
       expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
       helper.recordPrivateApi('call.Defaults.getHost');
-      expect(Defaults.getHost(normalisedOptions, 'rest.ably.io', false)).to.deep.equal('rest.ably.io');
-      expect(Defaults.getHost(normalisedOptions, 'rest.ably.io', true)).to.equal('realtime.ably.io');
+      expect(Defaults.getHost(normalisedOptions, 'main.realtime.ably.net', false)).to.deep.equal(
+        'main.realtime.ably.net',
+      );
+      expect(Defaults.getHost(normalisedOptions, 'main.realtime.ably.net', true)).to.equal('main.realtime.ably.net');
 
       helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
@@ -65,8 +67,8 @@ define(['ably', 'chai'], function (Ably, chai) {
       helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions({ environment: 'production' }, null, null);
 
-      expect(normalisedOptions.restHost).to.equal('rest.ably.io');
-      expect(normalisedOptions.realtimeHost).to.equal('realtime.ably.io');
+      expect(normalisedOptions.restHost).to.equal('main.realtime.ably.net');
+      expect(normalisedOptions.realtimeHost).to.equal('main.realtime.ably.net');
       expect(normalisedOptions.port).to.equal(80);
       expect(normalisedOptions.tlsPort).to.equal(443);
       expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.FALLBACK_HOSTS.sort());
@@ -76,8 +78,12 @@ define(['ably', 'chai'], function (Ably, chai) {
       expect(Defaults.getHosts(normalisedOptions).length).to.deep.equal(4);
       expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
       helper.recordPrivateApi('call.Defaults.getHost');
-      expect(Defaults.getHost(normalisedOptions, 'rest.ably.io', false)).to.deep.equal('rest.ably.io');
-      expect(Defaults.getHost(normalisedOptions, 'rest.ably.io', true)).to.deep.equal('realtime.ably.io');
+      expect(Defaults.getHost(normalisedOptions, 'main.realtime.ably.net', false)).to.deep.equal(
+        'main.realtime.ably.net',
+      );
+      expect(Defaults.getHost(normalisedOptions, 'main.realtime.ably.net', true)).to.deep.equal(
+        'main.realtime.ably.net',
+      );
 
       helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(443);
@@ -101,22 +107,26 @@ define(['ably', 'chai'], function (Ably, chai) {
       const helper = this.test.helper;
 
       helper.recordPrivateApi('call.Defaults.normaliseOptions');
-      var normalisedOptions = Defaults.normaliseOptions({ environment: 'sandbox' }, null, null);
+      var normalisedOptions = Defaults.normaliseOptions({ environment: 'nonprod:sandbox' }, null, null);
 
-      expect(normalisedOptions.restHost).to.equal('sandbox-rest.ably.io');
-      expect(normalisedOptions.realtimeHost).to.equal('sandbox-realtime.ably.io');
+      expect(normalisedOptions.restHost).to.equal('sandbox.realtime.ably-nonprod.net');
+      expect(normalisedOptions.realtimeHost).to.equal('sandbox.realtime.ably-nonprod.net');
       expect(normalisedOptions.port).to.equal(80);
       expect(normalisedOptions.tlsPort).to.equal(443);
-      expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.environmentFallbackHosts('sandbox').sort());
+      expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(
+        Defaults.getEndpointFallbackHosts('nonprod:sandbox').sort(),
+      );
       expect(normalisedOptions.tls).to.equal(true);
 
       helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions).length).to.deep.equal(4);
       expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
       helper.recordPrivateApi('call.Defaults.getHost');
-      expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', false)).to.deep.equal('sandbox-rest.ably.io');
-      expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', true)).to.deep.equal(
-        'sandbox-realtime.ably.io',
+      expect(Defaults.getHost(normalisedOptions, 'sandbox.realtime.ably-nonprod.net', false)).to.deep.equal(
+        'sandbox.realtime.ably-nonprod.net',
+      );
+      expect(Defaults.getHost(normalisedOptions, 'sandbox.realtime.ably-nonprod.net', true)).to.deep.equal(
+        'sandbox.realtime.ably-nonprod.net',
       );
 
       helper.recordPrivateApi('call.Defaults.getPort');
@@ -147,8 +157,8 @@ define(['ably', 'chai'], function (Ably, chai) {
         null,
       );
 
-      expect(normalisedOptions.restHost).to.equal('local-rest.ably.io');
-      expect(normalisedOptions.realtimeHost).to.equal('local-realtime.ably.io');
+      expect(normalisedOptions.restHost).to.equal('local.realtime.ably.net');
+      expect(normalisedOptions.realtimeHost).to.equal('local.realtime.ably.net');
       expect(normalisedOptions.port).to.equal(8080);
       expect(normalisedOptions.tlsPort).to.equal(8081);
       expect(normalisedOptions.fallbackHosts).to.equal(undefined);
@@ -157,8 +167,12 @@ define(['ably', 'chai'], function (Ably, chai) {
       helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions)).to.deep.equal([normalisedOptions.restHost]);
       helper.recordPrivateApi('call.Defaults.getHost');
-      expect(Defaults.getHost(normalisedOptions, 'local-rest.ably.io', false)).to.deep.equal('local-rest.ably.io');
-      expect(Defaults.getHost(normalisedOptions, 'local-rest.ably.io', true)).to.deep.equal('local-realtime.ably.io');
+      expect(Defaults.getHost(normalisedOptions, 'local.realtime.ably.net', false)).to.deep.equal(
+        'local.realtime.ably.net',
+      );
+      expect(Defaults.getHost(normalisedOptions, 'local.realtime.ably.net', true)).to.deep.equal(
+        'local.realtime.ably.net',
+      );
 
       helper.recordPrivateApi('call.Defaults.getPort');
       expect(Defaults.getPort(normalisedOptions)).to.equal(8081);
@@ -255,24 +269,28 @@ define(['ably', 'chai'], function (Ably, chai) {
       const helper = this.test.helper;
 
       helper.recordPrivateApi('write.Defaults.ENVIRONMENT');
-      Defaults.ENVIRONMENT = 'sandbox';
+      Defaults.ENVIRONMENT = 'nonprod:sandbox';
       helper.recordPrivateApi('call.Defaults.normaliseOptions');
       var normalisedOptions = Defaults.normaliseOptions({}, null, null);
 
-      expect(normalisedOptions.restHost).to.equal('sandbox-rest.ably.io');
-      expect(normalisedOptions.realtimeHost).to.equal('sandbox-realtime.ably.io');
+      expect(normalisedOptions.restHost).to.equal('sandbox.realtime.ably-nonprod.net');
+      expect(normalisedOptions.realtimeHost).to.equal('sandbox.realtime.ably-nonprod.net');
       expect(normalisedOptions.port).to.equal(80);
       expect(normalisedOptions.tlsPort).to.equal(443);
-      expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(Defaults.environmentFallbackHosts('sandbox').sort());
+      expect(normalisedOptions.fallbackHosts.sort()).to.deep.equal(
+        Defaults.getEndpointFallbackHosts('nonprod:sandbox').sort(),
+      );
       expect(normalisedOptions.tls).to.equal(true);
 
       helper.recordPrivateApi('call.Defaults.getHosts');
       expect(Defaults.getHosts(normalisedOptions).length).to.equal(4);
       expect(Defaults.getHosts(normalisedOptions)[0]).to.deep.equal(normalisedOptions.restHost);
       helper.recordPrivateApi('call.Defaults.getHost');
-      expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', false)).to.deep.equal('sandbox-rest.ably.io');
-      expect(Defaults.getHost(normalisedOptions, 'sandbox-rest.ably.io', true)).to.deep.equal(
-        'sandbox-realtime.ably.io',
+      expect(Defaults.getHost(normalisedOptions, 'sandbox.realtime.ably-nonprod.net', false)).to.deep.equal(
+        'sandbox.realtime.ably-nonprod.net',
+      );
+      expect(Defaults.getHost(normalisedOptions, 'sandbox.realtime.ably-nonprod.net', true)).to.deep.equal(
+        'sandbox.realtime.ably-nonprod.net',
       );
 
       helper.recordPrivateApi('call.Defaults.getPort');


### PR DESCRIPTION
This implements ADR-119[1], which specifies the client connection options to update requests to the endpoints implemented as part of ADR-042[2].

The endpoint may be one of the following:

* a routing policy name (such as `main`)
* a nonprod routing policy name (such as `nonprod:sandbox`)
* a FQDN such as `foo.example.com`

The endpoint option is not valid with any of `environment`, `restHost` or `realtimeHost`, but we still intend to support the legacy options.

If the client has been configured to use any of these legacy options, then they should continue to work in the same way, using the same primary and fallback hostnames.

If the client has not been explicitly configured, then the hostnames will change to the new `ably.net` domain when the package is upgraded.

## Notes on implementation

As per previous guidance, I have _not_ updated tests to use the endpoint client option, but since the hostnames are changing, then the assertions and default environment must be updated (from `sandbox` to `nonprod:sandbox`).

I have not added any explicit tests for the endpoint client option, but I can do this if we think it's necessary, although using `environment` is essentially the same as using `endpoint`.

See related Go (merged), Ruby and Python PRs:

* https://github.com/ably/ably-go/pull/679
* https://github.com/ably/ably-ruby/pull/441
* https://github.com/ably/ably-python/pull/590

[1] https://ably.atlassian.net/wiki/spaces/ENG/pages/3428810778/ADR-119+ClientOptions+for+new+DNS+structure
[2] https://ably.atlassian.net/wiki/spaces/ENG/pages/1791754276/ADR-042+DNS+Restructure