### PR TITLE
Add `Message.connectionKey` to typings

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2411,6 +2411,10 @@ export interface Message {
    * update or delete operation.
    */
   operation?: Operation;
+  /**
+   * Allows a REST client to publish a message on behalf of a Realtime client. If you set this to the {@link Connection.key | private connection key} of a Realtime connection when publishing a message using a {@link RestClient}, the message will be published on behalf of that Realtime client. This property is only populated by a client performing a publish, and will never be populated on an inbound message.
+   */
+  connectionKey?: string;
 }
 
 /**
@@ -2471,7 +2475,8 @@ export type MessageAction =
 /**
  * A message received from Ably.
  */
-export type InboundMessage = Message & Required<Pick<Message, 'id' | 'timestamp' | 'serial' | 'action'>>;
+export type InboundMessage = Omit<Message, 'connectionKey'> &
+  Required<Pick<Message, 'id' | 'timestamp' | 'serial' | 'action'>>;
 
 /**
  * Static utilities related to messages.

--- a/test/browser/modular.test.js
+++ b/test/browser/modular.test.js
@@ -34,14 +34,6 @@ function registerAblyModularTests(Helper) {
       });
     };
 
-    async function monitorConnectionThenCloseAndFinish(helper, action, realtime, states) {
-      try {
-        await helper.monitorConnectionAsync(action, realtime, states);
-      } finally {
-        await helper.closeAndFinishAsync(realtime);
-      }
-    }
-
     before(function (done) {
       const helper = Helper.forHook(this);
       helper.setupApp(done);
@@ -204,25 +196,21 @@ function registerAblyModularTests(Helper) {
             this.test.helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
           );
 
-          await monitorConnectionThenCloseAndFinish(
-            helper,
-            async () => {
-              const channel = client.channels.get('channel');
-              await channel.attach();
+          await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+            const channel = client.channels.get('channel');
+            await channel.attach();
 
-              const recievedMessagePromise = new Promise((resolve) => {
-                channel.subscribe((message) => {
-                  resolve(message);
-                });
+            const recievedMessagePromise = new Promise((resolve) => {
+              channel.subscribe((message) => {
+                resolve(message);
               });
+            });
 
-              await channel.publish({ data: { foo: 'bar' } });
+            await channel.publish({ data: { foo: 'bar' } });
 
-              const receivedMessage = await recievedMessagePromise;
-              expect(receivedMessage.data).to.eql({ foo: 'bar' });
-            },
-            client,
-          );
+            const receivedMessage = await recievedMessagePromise;
+            expect(receivedMessage.data).to.eql({ foo: 'bar' });
+          }, client);
         });
 
         /** @nospec */
@@ -508,48 +496,42 @@ function registerAblyModularTests(Helper) {
 
           const rxClient = new BaseRealtime({ ...clientOptions, plugins: { WebSocketTransport, FetchRequest } });
 
-          await monitorConnectionThenCloseAndFinish(
-            helper,
-            async () => {
-              const rxChannel = rxClient.channels.get('channel');
-              await rxChannel.attach();
+          await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+            const rxChannel = rxClient.channels.get('channel');
+            await rxChannel.attach();
 
-              const rxMessagePromise = new Promise((resolve, _) => rxChannel.subscribe((message) => resolve(message)));
+            const rxMessagePromise = new Promise((resolve, _) => rxChannel.subscribe((message) => resolve(message)));
 
-              const encryptionChannelOptions = { cipher: { key } };
+            const encryptionChannelOptions = { cipher: { key } };
 
-              const txMessage = { name: 'message', data: 'data' };
-              const txClient = new clientClassConfig.clientClass({
-                ...clientOptions,
-                plugins: {
-                  ...clientClassConfig.additionalPlugins,
-                  FetchRequest,
-                  Crypto,
-                },
-              });
+            const txMessage = { name: 'message', data: 'data' };
+            const txClient = new clientClassConfig.clientClass({
+              ...clientOptions,
+              plugins: {
+                ...clientClassConfig.additionalPlugins,
+                FetchRequest,
+                Crypto,
+              },
+            });
 
-              await (
-                clientClassConfig.isRealtime ? monitorConnectionThenCloseAndFinish : async (helper, op) => await op()
-              )(
-                helper,
-                async () => {
-                  const txChannel = txClient.channels.get('channel', encryptionChannelOptions);
-                  await txChannel.publish(txMessage);
+            await (
+              clientClassConfig.isRealtime
+                ? (op, realtime) => helper.monitorConnectionThenCloseAndFinishAsync(op, realtime)
+                : async (op) => await op()
+            )(async () => {
+              const txChannel = txClient.channels.get('channel', encryptionChannelOptions);
+              await txChannel.publish(txMessage);
 
-                  const rxMessage = await rxMessagePromise;
+              const rxMessage = await rxMessagePromise;
 
-                  // Verify that the message was published with encryption
-                  expect(rxMessage.encoding).to.equal('utf-8/cipher+aes-256-cbc');
+              // Verify that the message was published with encryption
+              expect(rxMessage.encoding).to.equal('utf-8/cipher+aes-256-cbc');
 
-                  // Verify that the message was correctly encrypted
-                  const rxMessageDecrypted = await decodeEncryptedMessage(rxMessage, encryptionChannelOptions);
-                  helper.testMessageEquality(rxMessageDecrypted, txMessage);
-                },
-                txClient,
-              );
-            },
-            rxClient,
-          );
+              // Verify that the message was correctly encrypted
+              const rxMessageDecrypted = await decodeEncryptedMessage(rxMessage, encryptionChannelOptions);
+              helper.testMessageEquality(rxMessageDecrypted, txMessage);
+            }, txClient);
+          }, rxClient);
         }
 
         async function testIsAbleToDecryptHistoryMessages(helper, clientClassConfig) {
@@ -564,25 +546,25 @@ function registerAblyModularTests(Helper) {
             },
           });
 
-          await (clientClassConfig.isRealtime ? monitorConnectionThenCloseAndFinish : async (helper, op) => await op())(
-            helper,
-            async () => {
-              const channelName = 'encrypted_history',
-                messageText = 'Test message';
+          await (
+            clientClassConfig.isRealtime
+              ? (op, realtime) => helper.monitorConnectionThenCloseAndFinishAsync(op, realtime)
+              : async (op) => await op()
+          )(async () => {
+            const channelName = 'encrypted_history',
+              messageText = 'Test message';
 
-              const key = await generateRandomKey();
+            const key = await generateRandomKey();
 
-              const channel = client.channels.get(channelName, { cipher: { key: key } });
-              await channel.publish('event0', messageText);
-              let items;
-              await helper.waitFor(async () => {
-                items = (await channel.history()).items;
-                return items.length > 0;
-              }, 10_000);
-              expect(items[0].data).to.equal(messageText);
-            },
-            client,
-          );
+            const channel = client.channels.get(channelName, { cipher: { key: key } });
+            await channel.publish('event0', messageText);
+            let items;
+            await helper.waitFor(async () => {
+              items = (await channel.history()).items;
+              return items.length > 0;
+            }, 10_000);
+            expect(items[0].data).to.equal(messageText);
+          }, client);
         }
 
         for (const clientClassConfig of [
@@ -679,13 +661,9 @@ function registerAblyModularTests(Helper) {
                 }),
               );
 
-              await monitorConnectionThenCloseAndFinish(
-                helper,
-                async () => {
-                  await testRealtimeUsesFormat(client, 'json');
-                },
-                client,
-              );
+              await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+                await testRealtimeUsesFormat(client, 'json');
+              }, client);
             });
           });
         });
@@ -723,13 +701,9 @@ function registerAblyModularTests(Helper) {
                 }),
               );
 
-              await monitorConnectionThenCloseAndFinish(
-                helper,
-                async () => {
-                  await testRealtimeUsesFormat(client, 'msgpack');
-                },
-                client,
-              );
+              await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+                await testRealtimeUsesFormat(client, 'msgpack');
+              }, client);
             });
           });
         });
@@ -743,15 +717,11 @@ function registerAblyModularTests(Helper) {
           const helper = this.test.helper;
           const client = new BaseRealtime(helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }));
 
-          await monitorConnectionThenCloseAndFinish(
-            helper,
-            async () => {
-              const channel = client.channels.get('channel');
+          await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+            const channel = client.channels.get('channel');
 
-              expect(() => channel.presence).to.throw('RealtimePresence plugin not provided');
-            },
-            client,
-          );
+            expect(() => channel.presence).to.throw('RealtimePresence plugin not provided');
+          }, client);
         });
 
         /** @nospec */
@@ -761,43 +731,35 @@ function registerAblyModularTests(Helper) {
             helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
           );
 
-          await monitorConnectionThenCloseAndFinish(
-            helper,
-            async () => {
-              const rxChannel = rxClient.channels.get('channel');
+          await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+            const rxChannel = rxClient.channels.get('channel');
 
-              await rxChannel.attach();
+            await rxChannel.attach();
 
-              const receivedMessagePromise = new Promise((resolve) => rxChannel.subscribe(resolve));
+            const receivedMessagePromise = new Promise((resolve) => rxChannel.subscribe(resolve));
 
-              const txClient = new BaseRealtime(
-                this.test.helper.ablyClientOptions({
-                  clientId: Helper.randomString(),
-                  plugins: {
-                    WebSocketTransport,
-                    FetchRequest,
-                    RealtimePresence,
-                  },
-                }),
-              );
-
-              await monitorConnectionThenCloseAndFinish(
-                helper,
-                async () => {
-                  const txChannel = txClient.channels.get('channel');
-
-                  await txChannel.publish('message', 'body');
-                  await txChannel.presence.enter();
-
-                  // The idea being here that in order for receivedMessagePromise to resolve, rxClient must have first processed the PRESENCE ProtocolMessage that resulted from txChannel.presence.enter()
-
-                  await receivedMessagePromise;
+            const txClient = new BaseRealtime(
+              this.test.helper.ablyClientOptions({
+                clientId: Helper.randomString(),
+                plugins: {
+                  WebSocketTransport,
+                  FetchRequest,
+                  RealtimePresence,
                 },
-                txClient,
-              );
-            },
-            rxClient,
-          );
+              }),
+            );
+
+            await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+              const txChannel = txClient.channels.get('channel');
+
+              await txChannel.publish('message', 'body');
+              await txChannel.presence.enter();
+
+              // The idea being here that in order for receivedMessagePromise to resolve, rxClient must have first processed the PRESENCE ProtocolMessage that resulted from txChannel.presence.enter()
+
+              await receivedMessagePromise;
+            }, txClient);
+          }, rxClient);
         });
       });
 
@@ -821,41 +783,33 @@ function registerAblyModularTests(Helper) {
           );
           const rxChannel = rxClient.channels.get('channel');
 
-          await monitorConnectionThenCloseAndFinish(
-            helper,
-            async () => {
-              const txClientId = Helper.randomString();
-              const txClient = new BaseRealtime(
-                this.test.helper.ablyClientOptions({
-                  clientId: txClientId,
-                  plugins: {
-                    WebSocketTransport,
-                    FetchRequest,
-                    RealtimePresence,
-                  },
-                }),
-              );
-
-              await monitorConnectionThenCloseAndFinish(
-                helper,
-                async () => {
-                  const txChannel = txClient.channels.get('channel');
-
-                  let resolveRxPresenceMessagePromise;
-                  const rxPresenceMessagePromise = new Promise((resolve, reject) => {
-                    resolveRxPresenceMessagePromise = resolve;
-                  });
-                  await rxChannel.presence.subscribe('enter', resolveRxPresenceMessagePromise);
-                  await txChannel.presence.enter();
-
-                  const rxPresenceMessage = await rxPresenceMessagePromise;
-                  expect(rxPresenceMessage.clientId).to.equal(txClientId);
+          await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+            const txClientId = Helper.randomString();
+            const txClient = new BaseRealtime(
+              this.test.helper.ablyClientOptions({
+                clientId: txClientId,
+                plugins: {
+                  WebSocketTransport,
+                  FetchRequest,
+                  RealtimePresence,
                 },
-                txClient,
-              );
-            },
-            rxClient,
-          );
+              }),
+            );
+
+            await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+              const txChannel = txClient.channels.get('channel');
+
+              let resolveRxPresenceMessagePromise;
+              const rxPresenceMessagePromise = new Promise((resolve, reject) => {
+                resolveRxPresenceMessagePromise = resolve;
+              });
+              await rxChannel.presence.subscribe('enter', resolveRxPresenceMessagePromise);
+              await txChannel.presence.enter();
+
+              const rxPresenceMessage = await rxPresenceMessagePromise;
+              expect(rxPresenceMessage.clientId).to.equal(txClientId);
+            }, txClient);
+          }, rxClient);
         });
       });
     });
@@ -949,26 +903,22 @@ function registerAblyModularTests(Helper) {
                 }),
               );
 
-              await monitorConnectionThenCloseAndFinish(
-                helper,
-                async () => {
-                  let firstTransportCandidate;
-                  const connectionManager = realtime.connection.connectionManager;
-                  const originalTryATransport = connectionManager.tryATransport;
-                  realtime.connection.connectionManager.tryATransport = (transportParams, candidate, callback) => {
-                    if (!firstTransportCandidate) {
-                      firstTransportCandidate = candidate;
-                    }
-                    originalTryATransport.bind(connectionManager)(transportParams, candidate, callback);
-                  };
+              await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+                let firstTransportCandidate;
+                const connectionManager = realtime.connection.connectionManager;
+                const originalTryATransport = connectionManager.tryATransport;
+                realtime.connection.connectionManager.tryATransport = (transportParams, candidate, callback) => {
+                  if (!firstTransportCandidate) {
+                    firstTransportCandidate = candidate;
+                  }
+                  originalTryATransport.bind(connectionManager)(transportParams, candidate, callback);
+                };
 
-                  realtime.connect();
+                realtime.connect();
 
-                  await realtime.connection.once('connected');
-                  expect(firstTransportCandidate).to.equal(scenario.transportName);
-                },
-                realtime,
-              );
+                await realtime.connection.once('connected');
+                expect(firstTransportCandidate).to.equal(scenario.transportName);
+              }, realtime);
             });
           });
         }
@@ -1008,21 +958,17 @@ function registerAblyModularTests(Helper) {
               helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
             );
 
-            await monitorConnectionThenCloseAndFinish(
-              helper,
-              async () => {
-                const channel = realtime.channels.get('channel');
-                await channel.attach();
+            await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+              const channel = realtime.channels.get('channel');
+              await channel.attach();
 
-                const subscribeReceivedMessagePromise = new Promise((resolve) => channel.subscribe(resolve));
+              const subscribeReceivedMessagePromise = new Promise((resolve) => channel.subscribe(resolve));
 
-                await channel.publish('message', 'body');
+              await channel.publish('message', 'body');
 
-                const subscribeReceivedMessage = await subscribeReceivedMessagePromise;
-                expect(subscribeReceivedMessage.data).to.equal('body');
-              },
-              realtime,
-            );
+              const subscribeReceivedMessage = await subscribeReceivedMessagePromise;
+              expect(subscribeReceivedMessage.data).to.equal('body');
+            }, realtime);
           });
 
           /** @nospec */
@@ -1032,23 +978,19 @@ function registerAblyModularTests(Helper) {
               helper.ablyClientOptions({ plugins: { WebSocketTransport, FetchRequest } }),
             );
 
-            await monitorConnectionThenCloseAndFinish(
-              helper,
-              async () => {
-                const channel = realtime.channels.get('channel');
+            await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+              const channel = realtime.channels.get('channel');
 
-                let thrownError = null;
-                try {
-                  await channel.subscribe({ clientId: 'someClientId' }, () => {});
-                } catch (error) {
-                  thrownError = error;
-                }
+              let thrownError = null;
+              try {
+                await channel.subscribe({ clientId: 'someClientId' }, () => {});
+              } catch (error) {
+                thrownError = error;
+              }
 
-                expect(thrownError).not.to.be.null;
-                expect(thrownError.message).to.equal('MessageInteractions plugin not provided');
-              },
-              realtime,
-            );
+              expect(thrownError).not.to.be.null;
+              expect(thrownError.message).to.equal('MessageInteractions plugin not provided');
+            }, realtime);
           });
         });
 
@@ -1069,56 +1011,52 @@ function registerAblyModularTests(Helper) {
               }),
             );
 
-            await monitorConnectionThenCloseAndFinish(
-              helper,
-              async () => {
-                const channel = realtime.channels.get('channel');
+            await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+              const channel = realtime.channels.get('channel');
 
-                await channel.attach();
+              await channel.attach();
 
-                // Test `subscribe` with a filter: send two messages with different clientIds, and check that unfiltered subscription receives both messages but clientId-filtered subscription only receives the matching one.
-                const messageFilter = { clientId: 'someClientId' }; // note that `unsubscribe` compares filter by reference, I found that a bit surprising
+              // Test `subscribe` with a filter: send two messages with different clientIds, and check that unfiltered subscription receives both messages but clientId-filtered subscription only receives the matching one.
+              const messageFilter = { clientId: 'someClientId' }; // note that `unsubscribe` compares filter by reference, I found that a bit surprising
 
-                const filteredSubscriptionReceivedMessages = [];
-                channel.subscribe(messageFilter, (message) => {
-                  filteredSubscriptionReceivedMessages.push(message);
-                });
+              const filteredSubscriptionReceivedMessages = [];
+              channel.subscribe(messageFilter, (message) => {
+                filteredSubscriptionReceivedMessages.push(message);
+              });
 
-                const unfilteredSubscriptionReceivedFirstTwoMessagesPromise = new Promise((resolve) => {
-                  const receivedMessages = [];
-                  channel.subscribe(function listener(message) {
-                    receivedMessages.push(message);
-                    if (receivedMessages.length === 2) {
-                      channel.unsubscribe(listener);
-                      resolve();
-                    }
-                  });
-                });
-
-                await channel.publish(await decodeMessage({ clientId: 'someClientId' }));
-                await channel.publish(await decodeMessage({ clientId: 'someOtherClientId' }));
-                await unfilteredSubscriptionReceivedFirstTwoMessagesPromise;
-
-                expect(filteredSubscriptionReceivedMessages.length).to.equal(1);
-                expect(filteredSubscriptionReceivedMessages[0].clientId).to.equal('someClientId');
-
-                // Test `unsubscribe` with a filter: call `unsubscribe` with the clientId filter, publish a message matching the filter, check that only the unfiltered listener recieves it
-                channel.unsubscribe(messageFilter);
-
-                const unfilteredSubscriptionReceivedNextMessagePromise = new Promise((resolve) => {
-                  channel.subscribe(function listener() {
+              const unfilteredSubscriptionReceivedFirstTwoMessagesPromise = new Promise((resolve) => {
+                const receivedMessages = [];
+                channel.subscribe(function listener(message) {
+                  receivedMessages.push(message);
+                  if (receivedMessages.length === 2) {
                     channel.unsubscribe(listener);
                     resolve();
-                  });
+                  }
                 });
+              });
 
-                await channel.publish(await decodeMessage({ clientId: 'someClientId' }));
-                await unfilteredSubscriptionReceivedNextMessagePromise;
+              await channel.publish(await decodeMessage({ clientId: 'someClientId' }));
+              await channel.publish(await decodeMessage({ clientId: 'someOtherClientId' }));
+              await unfilteredSubscriptionReceivedFirstTwoMessagesPromise;
 
-                expect(filteredSubscriptionReceivedMessages.length).to./* (still) */ equal(1);
-              },
-              realtime,
-            );
+              expect(filteredSubscriptionReceivedMessages.length).to.equal(1);
+              expect(filteredSubscriptionReceivedMessages[0].clientId).to.equal('someClientId');
+
+              // Test `unsubscribe` with a filter: call `unsubscribe` with the clientId filter, publish a message matching the filter, check that only the unfiltered listener recieves it
+              channel.unsubscribe(messageFilter);
+
+              const unfilteredSubscriptionReceivedNextMessagePromise = new Promise((resolve) => {
+                channel.subscribe(function listener() {
+                  channel.unsubscribe(listener);
+                  resolve();
+                });
+              });
+
+              await channel.publish(await decodeMessage({ clientId: 'someClientId' }));
+              await unfilteredSubscriptionReceivedNextMessagePromise;
+
+              expect(filteredSubscriptionReceivedMessages.length).to./* (still) */ equal(1);
+            }, realtime);
           });
         });
       });

--- a/test/common/modules/shared_helper.js
+++ b/test/common/modules/shared_helper.js
@@ -492,6 +492,14 @@ define([
       await this.setTimeoutAsync(100);
       return this.waitFor(condition, remaining - 100);
     }
+
+    async monitorConnectionThenCloseAndFinishAsync(action, realtime, states) {
+      try {
+        await this.monitorConnectionAsync(action, realtime, states);
+      } finally {
+        await this.closeAndFinishAsync(realtime);
+      }
+    }
   }
 
   SharedHelper.testOnAllTransports.skip = function (thisInDescribe, name, testFn) {


### PR DESCRIPTION
And add a test for the functionality that this property enables, whilst I'm at it.

Docstring taken from https://github.com/ably/specification/pull/276.

Resolves #1977.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled messages to be published on behalf of an active real-time connection via a new `connectionKey` option, enhancing messaging flexibility.
  - Added a new test case to validate the functionality of publishing messages using the `connectionKey`.

- **Refactor**
  - Simplified connection monitoring and cleanup processes to improve overall stability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->