### PR TITLE
[PUB-1235] Add enumeration API to `LiveMap` and `BatchContextLiveMap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,17 @@ root.get('bar');
 // get a number of key/value pairs in a map with .size
 root.size();
 
+// iterate over keys/values in a map
+for (const [key, value] of root.entries()) {
+  /**/
+}
+for (const key of root.keys()) {
+  /**/
+}
+for (const value of root.values()) {
+  /**/
+}
+
 // set keys on a map with .set
 // different data types are supported
 await root.set('foo', 'Alice');

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2315,6 +2315,21 @@ export declare interface LiveMap<T extends LiveMapType> extends LiveObject<LiveM
   size(): number;
 
   /**
+   * Returns an iterable of key/value pairs for every entry in the map.
+   */
+  entries<TKey extends keyof T & string>(): IterableIterator<[TKey, T[TKey]]>;
+
+  /**
+   * Returns an iterable of keys in the map.
+   */
+  keys<TKey extends keyof T & string>(): IterableIterator<TKey>;
+
+  /**
+   * Returns an iterable of values in the map.
+   */
+  values<TKey extends keyof T & string>(): IterableIterator<T[TKey]>;
+
+  /**
    * Sends an operation to the Ably system to set a key on this `LiveMap` object to a specified value.
    *
    * This does not modify the underlying data of this object. Instead, the change is applied when

--- a/src/plugins/liveobjects/batchcontextlivemap.ts
+++ b/src/plugins/liveobjects/batchcontextlivemap.ts
@@ -28,6 +28,24 @@ export class BatchContextLiveMap<T extends API.LiveMapType> {
     return this._map.size();
   }
 
+  *entries<TKey extends keyof T & string>(): IterableIterator<[TKey, T[TKey]]> {
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
+    this._batchContext.throwIfClosed();
+    yield* this._map.entries();
+  }
+
+  *keys<TKey extends keyof T & string>(): IterableIterator<TKey> {
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
+    this._batchContext.throwIfClosed();
+    yield* this._map.keys();
+  }
+
+  *values<TKey extends keyof T & string>(): IterableIterator<T[TKey]> {
+    this._liveObjects.throwIfInvalidAccessApiConfiguration();
+    this._batchContext.throwIfClosed();
+    yield* this._map.values();
+  }
+
   set<TKey extends keyof T & string>(key: TKey, value: T[TKey]): void {
     this._liveObjects.throwIfInvalidWriteApiConfiguration();
     this._batchContext.throwIfClosed();

--- a/test/realtime/live_objects.test.js
+++ b/test/realtime/live_objects.test.js
@@ -3373,14 +3373,18 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
               savedCtxMap = ctxRoot.get('map');
             });
 
-            expect(() => savedCtx.getRoot()).to.throw('Batch is closed');
-            expect(() => savedCtxCounter.value()).to.throw('Batch is closed');
-            expect(() => savedCtxCounter.increment()).to.throw('Batch is closed');
-            expect(() => savedCtxCounter.decrement()).to.throw('Batch is closed');
-            expect(() => savedCtxMap.get()).to.throw('Batch is closed');
-            expect(() => savedCtxMap.size()).to.throw('Batch is closed');
-            expect(() => savedCtxMap.set()).to.throw('Batch is closed');
-            expect(() => savedCtxMap.remove()).to.throw('Batch is closed');
+            expectAccessBatchApiToThrow({
+              ctx: savedCtx,
+              map: savedCtxMap,
+              counter: savedCtxCounter,
+              errorMsg: 'Batch is closed',
+            });
+            expectWriteBatchApiToThrow({
+              ctx: savedCtx,
+              map: savedCtxMap,
+              counter: savedCtxCounter,
+              errorMsg: 'Batch is closed',
+            });
           },
         },
 
@@ -3418,14 +3422,18 @@ define(['ably', 'shared_helper', 'chai', 'live_objects', 'live_objects_helper'],
             }
 
             expect(caughtError, 'Check batch call failed with an error').to.exist;
-            expect(() => savedCtx.getRoot()).to.throw('Batch is closed');
-            expect(() => savedCtxCounter.value()).to.throw('Batch is closed');
-            expect(() => savedCtxCounter.increment()).to.throw('Batch is closed');
-            expect(() => savedCtxCounter.decrement()).to.throw('Batch is closed');
-            expect(() => savedCtxMap.get()).to.throw('Batch is closed');
-            expect(() => savedCtxMap.size()).to.throw('Batch is closed');
-            expect(() => savedCtxMap.set()).to.throw('Batch is closed');
-            expect(() => savedCtxMap.remove()).to.throw('Batch is closed');
+            expectAccessBatchApiToThrow({
+              ctx: savedCtx,
+              map: savedCtxMap,
+              counter: savedCtxCounter,
+              errorMsg: 'Batch is closed',
+            });
+            expectWriteBatchApiToThrow({
+              ctx: savedCtx,
+              map: savedCtxMap,
+              counter: savedCtxCounter,
+              errorMsg: 'Batch is closed',
+            });
           },
         },
       ];


### PR DESCRIPTION
Adds javascript Map's equivalents .keys(), .values(), .entries() to LiveMap and BatchContextLiveMap.

Resolves [PUB-1235](https://ably.atlassian.net/browse/PUB-1235)

[PUB-1235]: https://ably.atlassian.net/browse/PUB-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added iteration support for LiveMap objects, enabling retrieval of entries, keys, and values.
  - Enhanced batch context operations for more consistent access to map data.

- **Documentation**
  - Updated examples in the documentation to show how to iterate over LiveMap collections, improving user guidance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->