### PR TITLE
[PUB-1529] Update bitwise value for `HAS_STATE` flag

### DIFF
--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -50,6 +50,7 @@ const flags: { [key: string]: number } = {
   RESUMED: 1 << 2,
   TRANSIENT: 1 << 4,
   ATTACH_RESUME: 1 << 5,
+  HAS_STATE: 1 << 7,
   /* Channel mode flags */
   PRESENCE: 1 << 16,
   PUBLISH: 1 << 17,
@@ -57,7 +58,6 @@ const flags: { [key: string]: number } = {
   PRESENCE_SUBSCRIBE: 1 << 19,
   OBJECT_SUBSCRIBE: 1 << 24,
   OBJECT_PUBLISH: 1 << 25,
-  HAS_STATE: 1 << 26,
 };
 const flagNames = Object.keys(flags);
 flags.MODE_ALL =


### PR DESCRIPTION
`HAS_STATE` flag was to moved to attach flags in https://github.com/ably/realtime/pull/7230

Resolves [PUB-1529](https://ably.atlassian.net/browse/PUB-1529)

[PUB-1529]: https://ably.atlassian.net/browse/PUB-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced internal message flag management to improve system consistency and maintainability, paving the way for smoother future enhancements without impacting the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->