### PR TITLE
PublishOptions type issue fix

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2287,7 +2287,7 @@ export type PublishOptions = {
    * Support any publish options that may be added serverside without needing
    * typings changes.
    */
-  [k: string]: string | number | boolean;
+  [k: string]: string | number | boolean | undefined;
 };
 
 /**


### PR DESCRIPTION
When using Ably with TypeScript, I cannot build because I am told that quickAck cannot be undefined based on the definition below, yet quickAck has a `?` which I assume means it does allow  boolean or undefined as a value. This is an incompatible change introduced in https://github.com/ably/ably-js/commit/02de82b07f8985cd0c2fa776af24b4ce841bc266 and is breaking TypeScript builds.

![MO screenshot 2025-03-23 at 20 45 52](https://github.com/user-attachments/assets/e7781fb3-635f-49fb-a35c-8c6e77b9e051)
