### PR TITLE
Don't use server side knowledge regarding timeserials / site codes in client side LiveObjects implementation

### DIFF
--- a/src/plugins/objects/defaults.ts
+++ b/src/plugins/objects/defaults.ts
@@ -2,7 +2,7 @@ export const DEFAULTS = {
   gcInterval: 1000 * 60 * 5, // 5 minutes
   /**
    * Must be > 2 minutes to ensure we keep tombstones long enough to avoid the possibility of receiving an operation
-   * with an earlier origin timeserial that would not have been applied if the tombstone still existed.
+   * with an earlier serial that would not have been applied if the tombstone still existed.
    *
    * Applies both for map entries tombstones and object tombstones.
    */

--- a/src/plugins/objects/livecounter.ts
+++ b/src/plugins/objects/livecounter.ts
@@ -168,20 +168,20 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
       );
     }
 
-    const opOriginTimeserial = msg.serial!;
+    const opSerial = msg.serial!;
     const opSiteCode = msg.siteCode!;
-    if (!this._canApplyOperation(opOriginTimeserial, opSiteCode)) {
+    if (!this._canApplyOperation(opSerial, opSiteCode)) {
       this._client.Logger.logAction(
         this._client.logger,
         this._client.Logger.LOG_MICRO,
         'LiveCounter.applyOperation()',
-        `skipping ${op.action} op: op timeserial ${opOriginTimeserial.toString()} <= site timeserial ${this._siteTimeserials[opSiteCode]?.toString()}; objectId=${this.getObjectId()}`,
+        `skipping ${op.action} op: op serial ${opSerial.toString()} <= site serial ${this._siteTimeserials[opSiteCode]?.toString()}; objectId=${this.getObjectId()}`,
       );
       return;
     }
-    // should update stored site timeserial immediately. doesn't matter if we successfully apply the op,
+    // should update stored site serial immediately. doesn't matter if we successfully apply the op,
     // as it's important to mark that the op was processed by the object
-    this._siteTimeserials[opSiteCode] = opOriginTimeserial;
+    this._siteTimeserials[opSiteCode] = opSerial;
 
     if (this.isTombstoned()) {
       // this object is tombstoned so the operation cannot be applied
@@ -250,8 +250,8 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
       }
     }
 
-    // object's site timeserials are still updated even if it is tombstoned, so always use the site timeserials received from the op.
-    // should default to empty map if site timeserials do not exist on the object state, so that any future operation may be applied to this object.
+    // object's site serials are still updated even if it is tombstoned, so always use the site serials received from the operation.
+    // should default to empty map if site serials do not exist on the object state, so that any future operation may be applied to this object.
     this._siteTimeserials = objectState.siteTimeserials ?? {};
 
     if (this.isTombstoned()) {

--- a/src/plugins/objects/objectmessage.ts
+++ b/src/plugins/objects/objectmessage.ts
@@ -54,10 +54,10 @@ export interface MapEntry {
   /** Indicates whether the map entry has been removed. */
   tombstone?: boolean;
   /**
-   * The *origin* timeserial of the last operation that was applied to the map entry.
+   * The {@link ObjectMessage.serial} value of the last operation that was applied to the map entry.
    *
    * It is optional in a MAP_CREATE operation and might be missing, in which case the client should use a nullish value for it
-   * and treat it as the "earliest possible" timeserial for comparison purposes.
+   * and treat it as the "earliest possible" serial for comparison purposes.
    */
   timeserial?: string;
   /** The data that represents the value of the map entry. */
@@ -118,7 +118,7 @@ export interface ObjectOperation {
 export interface ObjectState {
   /** The identifier of the object. */
   objectId: string;
-  /** A vector of origin timeserials keyed by site code of the last operation that was applied to this object. */
+  /** A map of serials keyed by a {@link ObjectMessage.siteCode}, representing the last operations applied to this object */
   siteTimeserials: Record<string, string>;
   /** True if the object has been tombstoned. */
   tombstone: boolean;
@@ -162,9 +162,9 @@ export class ObjectMessage {
    * Mutually exclusive with the `operation` field. This field is only set on object messages if the `action` field of the `ProtocolMessage` encapsulating it is `OBJECT_SYNC`.
    */
   object?: ObjectState;
-  /** Timeserial format. Contains the origin timeserial for this object message. */
+  /** An opaque string that uniquely identifies this object message. */
   serial?: string;
-  /** Site code corresponding to this message's timeserial */
+  /** An opaque string used as a key to update the map of serial values on an object. */
   siteCode?: string;
 
   constructor(

--- a/src/plugins/objects/objects.ts
+++ b/src/plugins/objects/objects.ts
@@ -114,16 +114,16 @@ export class Objects {
 
     await this.publish([msg]);
 
-    // we may have already received the CREATE operation at this point, as it could arrive before the ACK for our publish message.
-    // this means the object might already exist in the local pool, having been added during the usual CREATE operation process.
+    // we may have already received the MAP_CREATE operation at this point, as it could arrive before the ACK for our publish message.
+    // this means the object might already exist in the local pool, having been added during the usual MAP_CREATE operation process.
     // here we check if the object is present, and return it if found; otherwise, create a new object on the client side.
     if (this._objectsPool.get(objectId)) {
       return this._objectsPool.get(objectId) as LiveMap<T>;
     }
 
-    // we haven't received the CREATE operation yet, so we can create a new map object using the locally constructed object operation.
-    // we don't know the timeserials for map entries, so we assign an "earliest possible" timeserial to each entry, so that any subsequent operation can be applied to them.
-    // we mark the CREATE operation as merged for the object, guaranteeing its idempotency and preventing it from being applied again when the operation arrives.
+    // we haven't received the MAP_CREATE operation yet, so we can create a new map object using the locally constructed object operation.
+    // we don't know the serials for map entries, so we assign an "earliest possible" serial to each entry, so that any subsequent operation can be applied to them.
+    // we mark the MAP_CREATE operation as merged for the object, guaranteeing its idempotency and preventing it from being applied again when the operation arrives.
     const map = LiveMap.fromObjectOperation<T>(this, msg.operation!);
     this._objectsPool.set(objectId, map);
 
@@ -146,15 +146,15 @@ export class Objects {
 
     await this.publish([msg]);
 
-    // we may have already received the CREATE operation at this point, as it could arrive before the ACK for our publish message.
-    // this means the object might already exist in the local pool, having been added during the usual CREATE operation process.
+    // we may have already received the COUNTER_CREATE operation at this point, as it could arrive before the ACK for our publish message.
+    // this means the object might already exist in the local pool, having been added during the usual COUNTER_CREATE operation process.
     // here we check if the object is present, and return it if found; otherwise, create a new object on the client side.
     if (this._objectsPool.get(objectId)) {
       return this._objectsPool.get(objectId) as LiveCounter;
     }
 
-    // we haven't received the CREATE operation yet, so we can create a new counter object using the locally constructed object operation.
-    // we mark the CREATE operation as merged for the object, guaranteeing its idempotency. this ensures we don't double count the initial counter value when the operation arrives.
+    // we haven't received the COUNTER_CREATE operation yet, so we can create a new counter object using the locally constructed object operation.
+    // we mark the COUNTER_CREATE operation as merged for the object, guaranteeing its idempotency. this ensures we don't double count the initial counter value when the operation arrives.
     const counter = LiveCounter.fromObjectOperation(this, msg.operation!);
     this._objectsPool.set(objectId, counter);
 


### PR DESCRIPTION
See the relevant discussion in the spec PR [1]

[1] https://github.com/ably/specification/pull/279#discussion_r2003000877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified terminology for operation tracking across object handling components, replacing "timeserial" with "serial" for improved clarity in variable names and comments.

- **Documentation**
  - Updated descriptive texts and comments to ensure consistent and clear communication regarding operational processes and object properties.

These enhancements improve internal communication clarity without affecting any outward functionality or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->