### PR TITLE
fix: use device auth for web push deregistration

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2641,7 +2641,7 @@ export declare interface Push {
    *
    * @param deregisterCallback - A function passed to override the default implementation to deregister the local device for push activation.
    */
-  deactivate(deregisterCallback: DeregisterCallback): Promise<void>;
+  deactivate(deregisterCallback?: DeregisterCallback): Promise<void>;
 }
 
 /**

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -266,14 +266,19 @@ export class ActivationStateMachine {
 
       if (rest.options.headers) this.client.Utils.mixin(headers, rest.options.headers);
 
-      this.client.Utils.mixin(headers, this.client.push._getPushAuthHeaders());
-
       const authDetails = this.client.device.getAuthDetails(this.client, headers, params);
 
       if (rest.options.pushFullWait) this.client.Utils.mixin(params, { fullWait: 'true' });
 
       try {
-        await this.client.rest.Resource.delete(rest, '/push/deviceRegistrations', authDetails.headers, authDetails.params, format, true);
+        await this.client.rest.Resource.delete(
+          rest,
+          '/push/deviceRegistrations',
+          authDetails.headers,
+          authDetails.params,
+          format,
+          true,
+        );
         this.handleEvent(new Deregistered());
       } catch (err) {
         this.handleEvent(new DeregistrationFailed(err as ErrorInfo));

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -266,10 +266,14 @@ export class ActivationStateMachine {
 
       if (rest.options.headers) this.client.Utils.mixin(headers, rest.options.headers);
 
+      this.client.Utils.mixin(headers, this.client.push._getPushAuthHeaders());
+
+      const authDetails = this.client.device.getAuthDetails(this.client, headers, params);
+
       if (rest.options.pushFullWait) this.client.Utils.mixin(params, { fullWait: 'true' });
 
       try {
-        await this.client.rest.Resource.delete(rest, '/push/deviceRegistrations', headers, params, format, true);
+        await this.client.rest.Resource.delete(rest, '/push/deviceRegistrations', authDetails.headers, authDetails.params, format, true);
         this.handleEvent(new Deregistered());
       } catch (err) {
         this.handleEvent(new DeregistrationFailed(err as ErrorInfo));


### PR DESCRIPTION
resolves #1999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The push notification deactivation method can now be used without specifying a callback, providing more flexibility for users.

- **Bug Fixes**
	- Improved authentication handling during push notification deregistration for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->