### PR TITLE
ci: bump ubuntu version for test-browser workflow

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-browser:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes browser CI currently failing with:
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the browser testing workflow to use the latest Ubuntu 22.04 environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->