### PR TITLE
Add ANNOTATION_* channel modes to ResolvedChannelMode types

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -902,7 +902,7 @@ declare namespace ResolvedChannelModes {
    */
   type PUBLISH = 'publish';
   /**
-   * The client can subscribe to messages.
+   * The client will receive messages.
    */
   type SUBSCRIBE = 'subscribe';
   /**
@@ -910,9 +910,17 @@ declare namespace ResolvedChannelModes {
    */
   type PRESENCE = 'presence';
   /**
-   * The client can receive presence messages.
+   * The client will receive presence messages.
    */
   type PRESENCE_SUBSCRIBE = 'presence_subscribe';
+  /**
+   * The client can publish annotations
+   */
+  type ANNOTATION_PUBLISH = 'annotation_publish';
+  /**
+   * The client will receive annotations
+   */
+  type ANNOTATION_SUBSCRIBE = 'annotation_subscribe';
 }
 
 /**
@@ -926,7 +934,9 @@ export type ResolvedChannelMode =
   | ResolvedChannelModes.PUBLISH
   | ResolvedChannelModes.SUBSCRIBE
   | ResolvedChannelModes.PRESENCE
-  | ResolvedChannelModes.PRESENCE_SUBSCRIBE;
+  | ResolvedChannelModes.PRESENCE_SUBSCRIBE
+  | ResolvedChannelModes.ANNOTATION_PUBLISH
+  | ResolvedChannelModes.ANNOTATION_SUBSCRIBE;
 
 /**
  * Passes additional properties to a {@link Channel} or {@link RealtimeChannel} object, such as encryption, {@link ChannelMode} and channel parameters.


### PR DESCRIPTION
This was missed in 7d989577aeeea4675b943d50a0a63d6fc0d0c10a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for annotation publishing and subscribing modes, allowing clients to publish and receive annotations on channels.

- **Documentation**
  - Improved descriptions for channel subscription modes to clarify when clients will receive messages or presence updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->