### PR TITLE
[PUB-1634] push: get local channel subscriptions

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3180,6 +3180,13 @@ export declare interface LocalDevice {
    * A unique device identity token that the device uses to authenticate itself with Ably.
    */
   deviceIdentityToken?: string;
+
+  /**
+   * Retrieves push subscriptions active for the local device.
+   *
+   * @returns a {@link PaginatedResult} object containing an array of {@link PushChannelSubscription} objects for each push channel subscription active for the local device.
+   */
+  listSubscriptions(): Promise<PaginatedResult<PushChannelSubscription>>;
 }
 
 /**

--- a/src/common/lib/client/rest.ts
+++ b/src/common/lib/client/rest.ts
@@ -17,6 +17,7 @@ import { useTokenAuth } from './auth';
 import { RestChannelMixin } from './restchannelmixin';
 import { RestPresenceMixin } from './restpresencemixin';
 import DeviceDetails from '../types/devicedetails';
+import PushChannelSubscription from '../types/pushchannelsubscription';
 
 type BatchResult<T> = API.BatchResult<T>;
 
@@ -44,7 +45,9 @@ export class Rest {
 
   // exposed for plugins but shouldn't be bundled with minimal realtime
   Resource = Resource;
+  PaginatedResource = PaginatedResource;
   DeviceDetails = DeviceDetails;
+  PushChannelSubscription = PushChannelSubscription;
 
   constructor(client: BaseClient) {
     this.client = client;

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -4,8 +4,10 @@ import { ulid } from 'ulid';
 import type { ErrCallback, StandardCallback } from 'common/types/utils';
 import type ErrorInfo from 'common/lib/types/errorinfo';
 import DeviceDetails, { DevicePlatform, DevicePushDetails } from 'common/lib/types/devicedetails';
+import type PushChannelSubscription from 'common/lib/types/pushchannelsubscription';
 import { getW3CPushDeviceDetails } from './getW3CDeviceDetails';
 import type BaseClient from 'common/lib/client/baseclient';
+import type { PaginatedResult } from 'common/lib/client/paginatedresource';
 
 const persistKeys = {
   deviceId: 'ably.push.deviceId',
@@ -55,6 +57,40 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
       const device = new LocalDevice(rest);
       device.loadPersisted();
       return device;
+    }
+
+    async listSubscriptions(): Promise<PaginatedResult<PushChannelSubscription>> {
+      const Platform = this.rest.Platform;
+      if (!Platform.Config.push) {
+        throw new this.rest.ErrorInfo('Push activation is not available on this platform', 40000, 400);
+      }
+
+      if (!this.id) {
+        throw new this.rest.ErrorInfo('Device not activated', 40000, 400);
+      }
+
+      const client = this.rest,
+        format = client.options.useBinaryProtocol ? client.Utils.Format.msgpack : client.Utils.Format.json,
+        envelope = client.http.supportsLinkHeaders ? undefined : format,
+        headers = client.Defaults.defaultGetHeaders(client.options, { format });
+
+      client.Utils.mixin(headers, client.options.headers);
+
+      const authDetails = this.getAuthDetails(client, headers, {});
+
+      return new client.rest.PaginatedResource(
+        client,
+        '/push/channelSubscriptions',
+        authDetails.headers,
+        envelope,
+        async function (body, headers, unpacked) {
+          return client.rest.PushChannelSubscription.fromResponseBody(
+            body as Record<string, unknown>[],
+            client._MsgPack,
+            unpacked ? undefined : format,
+          );
+        },
+      ).get({ deviceId: this.id });
     }
 
     loadPersisted() {


### PR DESCRIPTION
- adds `Rest.device.channelSubscriptions` method which uses device auth to get channel subscriptions only for the local device.

NB: the newly added test currently fails with: `action not permitted` and will not pass until https://github.com/ably/realtime/pull/7314 is deployed in sandbox.

resolves #2003 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a method to allow users to list all push channel subscriptions currently active for their device.

- **Tests**
  - Introduced a new test to verify that device push channel subscriptions can be listed and validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->