### PR TITLE
Fix internal `PushChannelSubscription.channel` should be non-optional

### DIFF
--- a/src/common/lib/types/pushchannelsubscription.ts
+++ b/src/common/lib/types/pushchannelsubscription.ts
@@ -2,14 +2,17 @@ import { MsgPack } from 'common/types/msgpack';
 import * as Utils from '../util/utils';
 
 type PushChannelSubscriptionObject = {
-  channel?: string;
+  channel: string;
   deviceId?: string;
   clientId?: string;
 };
 
 class PushChannelSubscription {
-  channel?: string;
+  /** PCS4, the channel name associated with this subscription */
+  channel!: string;
+  /** PCS2, optional, populated for subscriptions made for a specific device registration */
   deviceId?: string;
+  /** PCS3, optional, populated for subscriptions made for a specific clientId */
   clientId?: string;
 
   /**


### PR DESCRIPTION
PushChannelSubscription.channel is defined in the spec PCS4[1] as a non-optional field, and it is currently non-optional in the public API. This commit brings the internal type in line with the public API.

[1] https://sdk.ably.com/builds/ably/specification/main/features/#PCS4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced descriptions for push channel subscription properties to clarify their roles.

- **Refactor**
  - Made the channel name a required field in push channel subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->