### PR TITLE
[PUB-1666] Remove `ObjectValue`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2374,9 +2374,9 @@ declare global {
 
 /**
  * Represents the type of data stored in a {@link LiveMap}.
- * It maps string keys to scalar values ({@link ObjectValue}), or other {@link LiveObject | LiveObjects}.
+ * It maps string keys to primitive values ({@link PrimitiveObjectValue}), or other {@link LiveObject | LiveObjects}.
  */
-export type LiveMapType = { [key: string]: ObjectValue | LiveMap<LiveMapType> | LiveCounter | undefined };
+export type LiveMapType = { [key: string]: PrimitiveObjectValue | LiveMap<LiveMapType> | LiveCounter | undefined };
 
 /**
  * The default type for the `root` object for Objects on a channel, based on the globally defined {@link AblyObjectsTypes} interface.
@@ -2502,7 +2502,7 @@ export declare interface BatchContextLiveCounter {
  * Conflicts in a LiveMap are automatically resolved with last-write-wins (LWW) semantics,
  * meaning that if two clients update the same key in the map, the update with the most recent timestamp wins.
  *
- * Keys must be strings. Values can be another {@link LiveObject}, or a primitive type, such as a string, number, boolean, or binary data (see {@link ObjectValue}).
+ * Keys must be strings. Values can be another {@link LiveObject}, or a primitive type, such as a string, number, boolean, or binary data (see {@link PrimitiveObjectValue}).
  */
 export declare interface LiveMap<T extends LiveMapType> extends LiveObject<LiveMapUpdate<T>> {
   /**
@@ -2589,7 +2589,7 @@ export declare interface LiveMapUpdate<T extends LiveMapType> extends LiveObject
  *
  * For binary data, the resulting type depends on the platform (`Buffer` in Node.js, `ArrayBuffer` elsewhere).
  */
-export type ObjectValue = string | number | boolean | Buffer | ArrayBuffer;
+export type PrimitiveObjectValue = string | number | boolean | Buffer | ArrayBuffer;
 
 /**
  * The `LiveCounter` class represents a counter that can be incremented or decremented and is synchronized across clients in realtime.

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -949,6 +949,10 @@ class ConnectionManager extends EventEmitter {
     this.clearSessionRecoverData();
   }
 
+  getActiveTransportFormat(): Utils.Format | undefined {
+    return this.activeProtocol?.getTransport().format;
+  }
+
   /*********************
    * state management
    *********************/

--- a/test/common/modules/private_api_recorder.js
+++ b/test/common/modules/private_api_recorder.js
@@ -112,6 +112,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'read.realtime.options.maxMessageSize',
     'read.realtime.options.realtimeHost',
     'read.realtime.options.token',
+    'read.realtime.options.useBinaryProtocol',
     'read.rest._currentFallback',
     'read.rest._currentFallback.host',
     'read.rest._currentFallback.validUntil',


### PR DESCRIPTION
Leaf values for objects are now stored in type keys on ObjectData object
instead of a single `value` key with a union type.

The new approach caused an issue with comet transports (only
implemented in ably-js) as comet transports do not support msgpack
protocol. We can't rely on the usual `client.options.useBinaryProtocol`
option to identify the protocol used, as comet transport changes the
selected protocol in its implementation. Instead we get the current
active transport object and its format.

Resolves [PUB-1666](https://ably.atlassian.net/browse/PUB-1666)

[PUB-1666]: https://ably.atlassian.net/browse/PUB-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal map values to use explicit typed fields (`string`, `number`, `boolean`, `bytes`) instead of a generic value field.
  - Enhanced type safety and consistency in handling primitive values within live objects.
  - Refined encoding and decoding processes to support distinct typed data and adapt to multiple wire formats.
  - Improved dynamic protocol format detection for message decoding to ensure compatibility with various transport protocols.
  - Standardized type naming to `PrimitiveObjectValue` for clarity and consistency.
  - Added method to retrieve the current transport format from the connection manager.

- **Tests**
  - Revised tests to adopt the new typed data format, ensuring alignment with the updated value representation and decoding logic.

- **Chores**
  - Added a new private API identifier to the tracked list during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->