### PR TITLE
Make `DETACHING` channels become `DETACHED` when connection becomes `SUSPENDED`

### DIFF
--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -171,7 +171,7 @@ class Channels extends EventEmitter {
   /* Connection interruptions (ie when the connection will no longer queue
    * events) imply connection state changes for any channel which is either
    * attached, pending, or will attempt to become attached in the future */
-  propogateConnectionInterruption(connectionState: string, reason: ErrorInfo) {
+  propagateConnectionInterruption(connectionState: string, reason: ErrorInfo) {
     const connectionStateToChannelState: Record<string, API.ChannelState> = {
       closing: 'detached',
       closed: 'detached',

--- a/src/common/lib/client/baserealtime.ts
+++ b/src/common/lib/client/baserealtime.ts
@@ -172,19 +172,40 @@ class Channels extends EventEmitter {
    * events) imply connection state changes for any channel which is either
    * attached, pending, or will attempt to become attached in the future */
   propagateConnectionInterruption(connectionState: string, reason: ErrorInfo) {
-    const connectionStateToChannelState: Record<string, API.ChannelState> = {
-      closing: 'detached',
-      closed: 'detached',
-      failed: 'failed',
-      suspended: 'suspended',
-    };
-    const fromChannelStates = ['attaching', 'attached', 'detaching', 'suspended'];
-    const toChannelState = connectionStateToChannelState[connectionState];
-
     for (const channelId in this.all) {
       const channel = this.all[channelId];
-      if (fromChannelStates.includes(channel.state)) {
-        channel.notifyState(toChannelState, reason);
+
+      let toChannelState: API.ChannelState | null = null;
+      let channelErrorReason: ErrorInfo | null = reason;
+
+      switch (connectionState) {
+        case 'failed':
+          if (['attaching', 'attached', 'detaching'].includes(channel.state)) {
+            // RTL3a, RTL3g
+            toChannelState = 'failed';
+          }
+          break;
+        case 'closed':
+          if (['attaching', 'attached', 'detaching'].includes(channel.state)) {
+            // RTL3b, RTL3h
+            toChannelState = 'detached';
+          }
+          break;
+        case 'suspended':
+          if (['attaching', 'attached'].includes(channel.state)) {
+            // RTL3c
+            toChannelState = 'suspended';
+          } else if (channel.state === 'detaching') {
+            // RTL3h
+            toChannelState = 'detached';
+            // Don't propagate the error
+            channelErrorReason = null;
+          }
+          break;
+      }
+
+      if (toChannelState !== null) {
+        channel.notifyState(toChannelState, channelErrorReason);
       }
     }
   }

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1303,7 +1303,7 @@ class ConnectionManager extends EventEmitter {
     if (this.state.sendEvents) {
       this.sendQueuedMessages();
     } else if (!this.state.queueEvents) {
-      this.realtime.channels.propogateConnectionInterruption(state, change.reason);
+      this.realtime.channels.propagateConnectionInterruption(state, change.reason);
       this.failQueuedMessages(change.reason as ErrorInfo); // RTN7c
     }
   }

--- a/test/realtime/auth.test.js
+++ b/test/realtime/auth.test.js
@@ -768,7 +768,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /**
-     * Check state change reason is propogated during a disconnect
+     * Check state change reason is propagated during a disconnect
      * (when connecting with a token that expires while connected)
      *
      * @spec RSA4b1

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -1258,7 +1258,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
             realtime.options.timeouts.realtimeRequestTimeout = 100;
             channel.once(function (stateChange) {
               expect(stateChange.current).to.equal('attaching', 'Channel reattach attempt happens immediately');
-              expect(stateChange.reason.code).to.equal(50000, 'check error is propogated in the reason');
+              expect(stateChange.reason.code).to.equal(50000, 'check error is propagated in the reason');
               cb();
             });
             helper.recordPrivateApi('call.connectionManager.activeProtocol.getTransport');
@@ -1326,7 +1326,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         };
         Helper.whenPromiseSettles(channel.attach(), function (err) {
           try {
-            expect(err.code).to.equal(50000, 'check error is propogated to the attach callback');
+            expect(err.code).to.equal(50000, 'check error is propagated to the attach callback');
             expect(channel.state).to.equal('suspended', 'check channel goes into suspended');
             helper.closeAndFinish(done, realtime);
           } catch (err) {
@@ -1356,7 +1356,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
           channel.on('failed', function (stateChange) {
             try {
-              expect(stateChange.reason.code).to.equal(50000, 'check error is propogated');
+              expect(stateChange.reason.code).to.equal(50000, 'check error is propagated');
               helper.closeAndFinish(done, realtime);
             } catch (err) {
               helper.closeAndFinish(done, realtime, err);
@@ -1406,7 +1406,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               expect(stateChange.current).to.equal('attached', 'check current');
               expect(stateChange.previous).to.equal('attached', 'check previous');
               expect(stateChange.resumed).to.equal(false, 'check resumed');
-              expect(stateChange.reason.code).to.equal(50000, 'check error propogated');
+              expect(stateChange.reason.code).to.equal(50000, 'check error propagated');
               expect(channel.state).to.equal('attached', 'check channel still attached');
               cb();
             });

--- a/test/realtime/resume.test.js
+++ b/test/realtime/resume.test.js
@@ -448,7 +448,7 @@ define(['shared_helper', 'async', 'chai'], function (Helper, async, chai) {
               function (cb) {
                 connection.once('failed', function (stateChange) {
                   try {
-                    expect(stateChange.reason.code).to.equal(40101, 'check correct code propogated');
+                    expect(stateChange.reason.code).to.equal(40101, 'check correct code propagated');
                   } catch (err) {
                     cb(err);
                     return;


### PR DESCRIPTION
Implements the changes of [`34e53e5`](https://github.com/ably/specification/pull/318/commits/34e53e54fd4fad9380a86cd52089506b3de6a568) from https://github.com/ably/specification/pull/318.