### PR TITLE
Fix `Message.createdAt` docstring typo

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3203,7 +3203,7 @@ export interface Message {
   refType?: string;
   /**
    * The timestamp of the very first version of a given message (will differ from
-   * createdAt only if the message has been updated or deleted).
+   * `timestamp` only if the message has been updated or deleted).
    */
   createdAt?: number;
   /**


### PR DESCRIPTION
Should've been `timestamp` according to spec docstring https://sdk.ably.com/builds/ably/specification/main/api-docstrings/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the description of message timestamps in the documentation for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->