### PR TITLE
Add a deprecation warning `environment`, `restHost` and `realtimeHost` client options

### DIFF
--- a/src/common/lib/util/defaults.ts
+++ b/src/common/lib/util/defaults.ts
@@ -274,9 +274,20 @@ export function normaliseOptions(
   MsgPack: MsgPack | null,
   logger: Logger | null, // should only be omitted by tests
 ): NormalisedClientOptions {
-  checkIfClientOptionsAreValid(options);
-
   const loggerToUse = logger ?? Logger.defaultLogger;
+
+  // Deprecated options
+  if (options.environment) {
+    loggerToUse.deprecated('The `environment` client option', 'Use the `endpoint` client option instead.');
+  }
+  if (options.restHost) {
+    loggerToUse.deprecated('The `restHost` client option', 'Use the `endpoint` client option instead.');
+  }
+  if (options.realtimeHost) {
+    loggerToUse.deprecated('The `realtimeHost` client option', 'Use the `endpoint` client option instead.');
+  }
+
+  checkIfClientOptionsAreValid(options);
 
   if (typeof options.recover === 'function' && options.closeOnUnload === true) {
     Logger.logAction(


### PR DESCRIPTION
These client options have been deprecated in https://github.com/ably/ably-js/pull/1973 if favor of the new `ClientOptions.endpoint` parameter. They were marked as deprecated only in the type declaration file, meaning that non-TypeScript users wouldn't see the deprecation warning. This PR adds an explicit deprecation warning log message when using these deprecated client options.

Even though the mentioned PR added the function to check that the valid combination of `endpoint`, `environment`, `restHost` and `realtimeHost` options is used, it only informs the user about invalid combinations of options, and does not specify that old options are now deprecated: https://github.com/ably/ably-js/blob/6f2b7e654921dbda08e178939b1bfd230fd78d4a/src/common/lib/util/defaults.ts#L250-L270

The log message added in this PR is consistent with how we handled deprecated options when going from v1 to v2 ably-js release. For example, see https://github.com/ably/ably-js/pull/1681.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of deprecated options by ensuring deprecation warnings are logged before validating configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->