### PR TITLE
Release 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.10.0](https://github.com/ably/ably-js/tree/2.10.0) (2025-06-25)
+
+- Add `Channels.all` to type declarations [\#2040](https://github.com/ably/ably-js/pull/2040)
+- Add `ClientOptions.endpoint` parameter and deprecate the `environment`, `restHost` and `realtimeHost` client options. See [platform customization](https://ably.com/docs/platform-customization#request-a-custom-environment) documentation for guidance on using the new `endpoint` parameter [\#1973](https://github.com/ably/ably-js/pull/1973)
+
 ## [2.9.0](https://github.com/ably/ably-js/tree/2.9.0) (2025-05-08)
 
 **Introducing Ably LiveObjects**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.9.0';
+export const version = '2.10.0';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
Will wait for https://github.com/ably/ably-js/pull/2049 before merging this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog with details for version 2.10.0, highlighting new features and deprecations, and referencing documentation for platform customization.
- **Chores**
  - Bumped the package version to 2.10.0.
  - Updated the reported version in the React Hooks package to 2.10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->