### PR TITLE
[PUB-1672] Refactor encoding/decoding for `ObjectMessage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Ably Chat Header](/images/JavaScriptSDK-github.png)
 [![npm version](https://img.shields.io/npm/v/ably.svg?style=flat)](https://img.shields.io/npm/v/ably.svg?style=flat)
 [![License](https://badgen.net/github/license/ably/ably-js)](https://github.com/ably/ably-js/blob/main/LICENSE)
+
 ---
 
 # Ably Pub/Sub JavaScript SDK
@@ -13,8 +14,8 @@ Ably LiveObjects is also available as a Pub/Sub JavaScript SDK plugin. You can u
 
 Find out more:
 
-* [Ably Pub/Sub docs](https://ably.com/docs/basics)
-* [Ably Pub/Sub Examples](https://ably.com/examples?product=pubsub)
+- [Ably Pub/Sub docs](https://ably.com/docs/basics)
+- [Ably Pub/Sub Examples](https://ably.com/examples?product=pubsub)
 
 ---
 
@@ -34,13 +35,13 @@ Ably aims to support a wide range of platforms and all current browser versions,
 
 The following platforms are supported:
 
-| Platform | Support |
-|----------|---------|
-| JavaScript | ES2017 |
-| Node.js | See `engines` in [package.json](https://github.com/ably/ably-js/blob/main/package.json). |
-| React | >=16.8.x |
-| TypeScript | Type definitions are included in the package. |
-| Web Workers | Browser bundle and [modular](#modular-variant) support. |
+| Platform    | Support                                                                                  |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| JavaScript  | ES2017                                                                                   |
+| Node.js     | See `engines` in [package.json](https://github.com/ably/ably-js/blob/main/package.json). |
+| React       | >=16.8.x                                                                                 |
+| TypeScript  | Type definitions are included in the package.                                            |
+| Web Workers | Browser bundle and [modular](#modular-variant) support.                                  |
 
 > [!NOTE]
 > Versions 1.2.x of the SDK support Internet Explorer >=9 and other older browsers, as well as Node.js >=8.17.
@@ -178,7 +179,7 @@ To ensure compatibility, add the following to your `manifest.json`:
 ```json
 {
   // ...
-  "minimum_chrome_version": "116",
+  "minimum_chrome_version": "116"
   // ...
 }
 ```

--- a/src/common/lib/types/protocolmessage.ts
+++ b/src/common/lib/types/protocolmessage.ts
@@ -68,10 +68,10 @@ export function fromDeserialized(
     );
   }
 
-  let state: ObjectsPlugin.ObjectMessage[] | undefined;
+  let state: ObjectsPlugin.WireObjectMessage[] | undefined;
   if (objectsPlugin && deserialized.state) {
-    state = objectsPlugin.ObjectMessage.fromValuesArray(
-      deserialized.state as ObjectsPlugin.ObjectMessage[],
+    state = objectsPlugin.WireObjectMessage.fromValuesArray(
+      deserialized.state as ObjectsPlugin.WireObjectMessage[],
       Utils,
       MessageEncoding,
     );
@@ -128,7 +128,7 @@ export function stringify(
   }
   if (msg.state && objectsPlugin) {
     result +=
-      '; state=' + toStringArray(objectsPlugin.ObjectMessage.fromValuesArray(msg.state, Utils, MessageEncoding));
+      '; state=' + toStringArray(objectsPlugin.WireObjectMessage.fromValuesArray(msg.state, Utils, MessageEncoding));
   }
   if (msg.error) result += '; error=' + ErrorInfo.fromValues(msg.error).toString();
   if (msg.auth && msg.auth.accessToken) result += '; token=' + msg.auth.accessToken;
@@ -169,7 +169,7 @@ class ProtocolMessage {
   /**
    * This will be undefined if we skipped decoding this property due to user not requesting Objects functionality — see {@link fromDeserialized}
    */
-  state?: ObjectsPlugin.ObjectMessage[]; // TR4r
+  state?: ObjectsPlugin.WireObjectMessage[]; // TR4r
   auth?: unknown;
   connectionDetails?: Record<string, unknown>;
   params?: Record<string, string>;

--- a/src/plugins/objects/index.ts
+++ b/src/plugins/objects/index.ts
@@ -1,9 +1,10 @@
-import { ObjectMessage } from './objectmessage';
+import { ObjectMessage, WireObjectMessage } from './objectmessage';
 import { Objects } from './objects';
 
-export { Objects, ObjectMessage };
+export { Objects, ObjectMessage, WireObjectMessage };
 
 export default {
   Objects,
   ObjectMessage,
+  WireObjectMessage,
 };

--- a/src/plugins/objects/liveobject.ts
+++ b/src/plugins/objects/liveobject.ts
@@ -1,6 +1,6 @@
 import type BaseClient from 'common/lib/client/baseclient';
 import type EventEmitter from 'common/lib/util/eventemitter';
-import { ObjectMessage, ObjectOperation, ObjectState } from './objectmessage';
+import { ObjectData, ObjectMessage, ObjectOperation, ObjectState } from './objectmessage';
 import { Objects } from './objects';
 
 export enum LiveObjectSubscriptionEvent {
@@ -219,7 +219,7 @@ export abstract class LiveObject<
    *
    * @internal
    */
-  abstract applyOperation(op: ObjectOperation, msg: ObjectMessage): void;
+  abstract applyOperation(op: ObjectOperation<ObjectData>, msg: ObjectMessage): void;
   /**
    * Overrides internal data for this LiveObject with data from the given object state.
    * Provided object state should hold a valid data for current LiveObject, e.g. counter data for LiveCounter, map data for LiveMap.
@@ -232,7 +232,7 @@ export abstract class LiveObject<
    *
    * @internal
    */
-  abstract overrideWithObjectState(objectState: ObjectState): TUpdate | LiveObjectUpdateNoop;
+  abstract overrideWithObjectState(objectState: ObjectState<ObjectData>): TUpdate | LiveObjectUpdateNoop;
   /**
    * @internal
    */
@@ -253,5 +253,5 @@ export abstract class LiveObject<
    * This saves us from needing to merge the initial value with operations applied to
    * the object every time the object is read.
    */
-  protected abstract _mergeInitialDataFromCreateOperation(objectOperation: ObjectOperation): TUpdate;
+  protected abstract _mergeInitialDataFromCreateOperation(objectOperation: ObjectOperation<ObjectData>): TUpdate;
 }

--- a/src/plugins/objects/objects.ts
+++ b/src/plugins/objects/objects.ts
@@ -305,9 +305,9 @@ export class Objects {
   async publish(objectMessages: ObjectMessage[]): Promise<void> {
     this._channel.throwIfUnpublishableState();
 
-    objectMessages.forEach((x) => ObjectMessage.encode(x, this._client));
+    const encodedMsgs = objectMessages.map((x) => x.encode(this._client));
     const maxMessageSize = this._client.options.maxMessageSize;
-    const size = objectMessages.reduce((acc, msg) => acc + msg.getMessageSize(), 0);
+    const size = encodedMsgs.reduce((acc, msg) => acc + msg.getMessageSize(), 0);
     if (size > maxMessageSize) {
       throw new this._client.ErrorInfo(
         `Maximum size of object messages that can be published at once exceeded (was ${size} bytes; limit is ${maxMessageSize} bytes)`,
@@ -316,7 +316,7 @@ export class Objects {
       );
     }
 
-    return this._channel.sendState(objectMessages);
+    return this._channel.sendState(encodedMsgs);
   }
 
   /**

--- a/src/plugins/objects/syncobjectsdatapool.ts
+++ b/src/plugins/objects/syncobjectsdatapool.ts
@@ -1,10 +1,10 @@
 import type BaseClient from 'common/lib/client/baseclient';
 import type RealtimeChannel from 'common/lib/client/realtimechannel';
-import { ObjectMessage, ObjectState } from './objectmessage';
+import { ObjectData, ObjectMessage, ObjectState } from './objectmessage';
 import { Objects } from './objects';
 
 export interface LiveObjectDataEntry {
-  objectState: ObjectState;
+  objectState: ObjectState<ObjectData>;
   objectType: 'LiveMap' | 'LiveCounter';
 }
 
@@ -78,7 +78,7 @@ export class SyncObjectsDataPool {
     }
   }
 
-  private _createLiveCounterDataEntry(objectState: ObjectState): LiveCounterDataEntry {
+  private _createLiveCounterDataEntry(objectState: ObjectState<ObjectData>): LiveCounterDataEntry {
     const newEntry: LiveCounterDataEntry = {
       objectState,
       objectType: 'LiveCounter',
@@ -87,7 +87,7 @@ export class SyncObjectsDataPool {
     return newEntry;
   }
 
-  private _createLiveMapDataEntry(objectState: ObjectState): LiveMapDataEntry {
+  private _createLiveMapDataEntry(objectState: ObjectState<ObjectData>): LiveMapDataEntry {
     const newEntry: LiveMapDataEntry = {
       objectState,
       objectType: 'LiveMap',

--- a/test/realtime/objects.test.js
+++ b/test/realtime/objects.test.js
@@ -4721,90 +4721,75 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
           },
           {
             description: 'map create op with object payload',
-            message: objectMessageFromValues(
-              {
-                operation: {
-                  action: 0,
-                  objectId: 'object-id',
-                  map: {
-                    semantics: 0,
-                    entries: { 'key-1': { tombstone: false, data: { objectId: 'another-object-id' } } },
-                  },
+            message: objectMessageFromValues({
+              operation: {
+                action: 0,
+                objectId: 'object-id',
+                map: {
+                  semantics: 0,
+                  entries: { 'key-1': { tombstone: false, data: { objectId: 'another-object-id' } } },
                 },
               },
-              MessageEncoding,
-            ),
+            }),
             expected: Utils.dataSizeBytes('key-1'),
           },
           {
             description: 'map create op with string payload',
-            message: objectMessageFromValues(
-              {
-                operation: {
-                  action: 0,
-                  objectId: 'object-id',
-                  map: { semantics: 0, entries: { 'key-1': { tombstone: false, data: { string: 'a string' } } } },
-                },
+            message: objectMessageFromValues({
+              operation: {
+                action: 0,
+                objectId: 'object-id',
+                map: { semantics: 0, entries: { 'key-1': { tombstone: false, data: { string: 'a string' } } } },
               },
-              MessageEncoding,
-            ),
+            }),
             expected: Utils.dataSizeBytes('key-1') + Utils.dataSizeBytes('a string'),
           },
           {
             description: 'map create op with bytes payload',
-            message: objectMessageFromValues(
-              {
-                operation: {
-                  action: 0,
-                  objectId: 'object-id',
-                  map: {
-                    semantics: 0,
-                    entries: { 'key-1': { tombstone: false, data: { bytes: BufferUtils.utf8Encode('my-value') } } },
-                  },
+            message: objectMessageFromValues({
+              operation: {
+                action: 0,
+                objectId: 'object-id',
+                map: {
+                  semantics: 0,
+                  entries: { 'key-1': { tombstone: false, data: { bytes: BufferUtils.utf8Encode('my-value') } } },
                 },
               },
-              MessageEncoding,
-            ),
+            }),
             expected: Utils.dataSizeBytes('key-1') + Utils.dataSizeBytes(BufferUtils.utf8Encode('my-value')),
           },
           {
             description: 'map create op with boolean payload',
-            message: objectMessageFromValues(
-              {
-                operation: {
-                  action: 0,
-                  objectId: 'object-id',
-                  map: {
-                    semantics: 0,
-                    entries: {
-                      'key-1': { tombstone: false, data: { boolean: true } },
-                      'key-2': { tombstone: false, data: { boolean: false } },
-                    },
+            message: objectMessageFromValues({
+              operation: {
+                action: 0,
+                objectId: 'object-id',
+                map: {
+                  semantics: 0,
+                  entries: {
+                    'key-1': { tombstone: false, data: { boolean: true } },
+                    'key-2': { tombstone: false, data: { boolean: false } },
                   },
                 },
               },
-              MessageEncoding,
-            ),
+            }),
             expected: Utils.dataSizeBytes('key-1') + Utils.dataSizeBytes('key-2') + 2,
           },
           {
             description: 'map create op with double payload',
-            message: objectMessageFromValues(
-              {
-                operation: {
-                  action: 0,
-                  objectId: 'object-id',
-                  map: {
-                    semantics: 0,
-                    entries: {
-                      'key-1': { tombstone: false, data: { number: 123.456 } },
-                      'key-2': { tombstone: false, data: { number: 0 } },
-                    },
+            message: objectMessageFromValues({
+              operation: {
+                action: 0,
+                objectId: 'object-id',
+                map: {
+                  semantics: 0,
+                  entries: {
+                    'key-1': { tombstone: false, data: { number: 123.456 } },
+                    'key-2': { tombstone: false, data: { number: 0 } },
                   },
                 },
               },
-              MessageEncoding,
-            ),
+            }),
             expected: Utils.dataSizeBytes('key-1') + Utils.dataSizeBytes('key-2') + 16,
           },
           {
@@ -4944,12 +4929,12 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
         forScenarios(this, objectMessageSizeScenarios, function (helper, scenario) {
           const client = RealtimeWithObjects(helper, { autoConnect: false });
           helper.recordPrivateApi('call.ObjectMessage.encode');
-          ObjectsPlugin.ObjectMessage.encode(scenario.message, client);
+          const encodedMessage = scenario.message.encode(client);
           helper.recordPrivateApi('call.BufferUtils.utf8Encode'); // was called by a scenario to create buffers
           helper.recordPrivateApi('call.ObjectMessage.fromValues'); // was called by a scenario to create an ObjectMessage instance
           helper.recordPrivateApi('call.Utils.dataSizeBytes'); // was called by a scenario to calculated the expected byte size
           helper.recordPrivateApi('call.ObjectMessage.getMessageSize');
-          expect(scenario.message.getMessageSize()).to.equal(scenario.expected);
+          expect(encodedMessage.getMessageSize()).to.equal(scenario.expected);
         });
       });
     });


### PR DESCRIPTION
Use `WireObjectMessage` to represent the message received from the server which can be decoded into an `ObjectMessage`. `ObjectMessage` can then be encoded into a `WireObjectMessage`.
This matches the style used for messages/presencemessages/annotationmessages which was introduced in https://github.com/ably/ably-js/pull/1941 (see [Simon's comment](https://github.com/ably/ably-js/pull/1941#issuecomment-2580956182) to see changes in the PR, as it bugged out and "Files changed" doesn't work for some reason)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved support for wire-format object messages, enabling more robust encoding and decoding of data exchanged with the server.

* **Refactor**
  * Enhanced type safety and clarity by introducing generic typing for object operations, states, and map entries.
  * Separated raw (wire-format) and decoded object message representations for clearer data handling.
  * Updated internal message handling to use encoded wire-format messages for transmission.
  * Streamlined message encoding and decoding processes, including base64 handling for JSON protocol.

* **Style**
  * Refined type annotations across various components for improved code maintainability and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->