### PR TITLE
[PUB-1837] Use server-provided timestamp to sweep old tombstones

### DIFF
--- a/src/plugins/objects/objectmessage.ts
+++ b/src/plugins/objects/objectmessage.ts
@@ -99,6 +99,8 @@ export interface ObjectsMapEntry<TData> {
    * and treat it as the "earliest possible" serial for comparison purposes.
    */
   timeserial?: string; // OME2b
+  /** A timestamp from the {@link timeserial} field. Only present if {@link tombstone} is `true` */
+  serialTimestamp?: number; // OME2d
   /** The data that represents the value of the map entry. */
   data?: TData; // OME2c
 }
@@ -344,6 +346,7 @@ function copyMsg(
     connectionId: msg.connectionId,
     timestamp: msg.timestamp,
     serial: msg.serial,
+    serialTimestamp: msg.serialTimestamp,
     siteCode: msg.siteCode,
   };
 
@@ -385,6 +388,8 @@ export class ObjectMessage {
   object?: ObjectState<ObjectData>; // OM2g
   /** An opaque string that uniquely identifies this object message. */
   serial?: string; // OM2h
+  /** A timestamp from the {@link serial} field. */
+  serialTimestamp?: number; // OM2j
   /** An opaque string used as a key to update the map of serial values on an object. */
   siteCode?: string; // OM2i
 
@@ -479,6 +484,8 @@ export class WireObjectMessage {
   object?: ObjectState<WireObjectData>; // OM2g
   /** An opaque string that uniquely identifies this object message. */
   serial?: string; // OM2h
+  /** A timestamp from the {@link serial} field. */
+  serialTimestamp?: number; // OM2j
   /** An opaque string used as a key to update the map of serial values on an object. */
   siteCode?: string; // OM2i
 

--- a/src/plugins/objects/objects.ts
+++ b/src/plugins/objects/objects.ts
@@ -393,7 +393,7 @@ export class Objects {
 
       // RTO5c1a
       if (existingObject) {
-        const update = existingObject.overrideWithObjectState(entry.objectState); // RTO5c1a1
+        const update = existingObject.overrideWithObjectState(entry.objectMessage); // RTO5c1a1
         // store updates to call subscription callbacks for all of them once the sync sequence is completed.
         // this will ensure that clients get notified about the changes only once everything has been applied.
         existingObjectUpdates.push({ object: existingObject, update });
@@ -406,11 +406,11 @@ export class Objects {
       const objectType = entry.objectType;
       switch (objectType) {
         case 'LiveCounter':
-          newObject = LiveCounter.fromObjectState(this, entry.objectState); // RTO5c1b1a
+          newObject = LiveCounter.fromObjectState(this, entry.objectMessage); // RTO5c1b1a
           break;
 
         case 'LiveMap':
-          newObject = LiveMap.fromObjectState(this, entry.objectState); // RTO5c1b1b
+          newObject = LiveMap.fromObjectState(this, entry.objectMessage); // RTO5c1b1b
           break;
 
         default:

--- a/src/plugins/objects/syncobjectsdatapool.ts
+++ b/src/plugins/objects/syncobjectsdatapool.ts
@@ -1,10 +1,10 @@
 import type BaseClient from 'common/lib/client/baseclient';
 import type RealtimeChannel from 'common/lib/client/realtimechannel';
-import { ObjectData, ObjectMessage, ObjectState } from './objectmessage';
+import { ObjectMessage } from './objectmessage';
 import { Objects } from './objects';
 
 export interface LiveObjectDataEntry {
-  objectState: ObjectState<ObjectData>;
+  objectMessage: ObjectMessage;
   objectType: 'LiveMap' | 'LiveCounter';
 }
 
@@ -64,9 +64,9 @@ export class SyncObjectsDataPool {
       const objectState = objectMessage.object;
 
       if (objectState.counter) {
-        this._pool.set(objectState.objectId, this._createLiveCounterDataEntry(objectState));
+        this._pool.set(objectState.objectId, this._createLiveCounterDataEntry(objectMessage));
       } else if (objectState.map) {
-        this._pool.set(objectState.objectId, this._createLiveMapDataEntry(objectState));
+        this._pool.set(objectState.objectId, this._createLiveMapDataEntry(objectMessage));
       } else {
         this._client.Logger.logAction(
           this._client.logger,
@@ -78,18 +78,18 @@ export class SyncObjectsDataPool {
     }
   }
 
-  private _createLiveCounterDataEntry(objectState: ObjectState<ObjectData>): LiveCounterDataEntry {
+  private _createLiveCounterDataEntry(objectMessage: ObjectMessage): LiveCounterDataEntry {
     const newEntry: LiveCounterDataEntry = {
-      objectState,
+      objectMessage,
       objectType: 'LiveCounter',
     };
 
     return newEntry;
   }
 
-  private _createLiveMapDataEntry(objectState: ObjectState<ObjectData>): LiveMapDataEntry {
+  private _createLiveMapDataEntry(objectMessage: ObjectMessage): LiveMapDataEntry {
     const newEntry: LiveMapDataEntry = {
-      objectState,
+      objectMessage,
       objectType: 'LiveMap',
     };
 

--- a/test/common/modules/objects_helper.js
+++ b/test/common/modules/objects_helper.js
@@ -237,10 +237,11 @@ define(['ably', 'shared_helper', 'objects'], function (Ably, Helper, ObjectsPlug
     }
 
     objectOperationMessage(opts) {
-      const { channelName, serial, siteCode, state } = opts;
+      const { channelName, serial, serialTimestamp, siteCode, state } = opts;
 
       state?.forEach((objectMessage, i) => {
         objectMessage.serial = serial;
+        objectMessage.serialTimestamp = serialTimestamp;
         objectMessage.siteCode = siteCode;
       });
 
@@ -253,7 +254,11 @@ define(['ably', 'shared_helper', 'objects'], function (Ably, Helper, ObjectsPlug
     }
 
     objectStateMessage(opts) {
-      const { channelName, syncSerial, state } = opts;
+      const { channelName, syncSerial, state, serialTimestamp } = opts;
+
+      state?.forEach((objectMessage, i) => {
+        objectMessage.serialTimestamp = serialTimestamp;
+      });
 
       return {
         action: 20, // OBJECT_SYNC

--- a/test/common/modules/private_api_recorder.js
+++ b/test/common/modules/private_api_recorder.js
@@ -16,6 +16,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'call.EventEmitter.emit',
     'call.LiveObject.getObjectId',
     'call.LiveObject.isTombstoned',
+    'call.LiveObject.tombstonedAt',
     'call.Objects._objectsPool._onGCInterval',
     'call.Objects._objectsPool.get',
     'call.Message.decode',


### PR DESCRIPTION
Use `serialTimestamp` field from ObjectMessage to know when a tombstone was created for an object or a map entry.

Resolves [PUB-1837](https://ably.atlassian.net/browse/PUB-1837)

[PUB-1837]: https://ably.atlassian.net/browse/PUB-1837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking and exposing tombstone timestamps when objects or map entries are deleted, using server-provided timestamps when available.

* **Bug Fixes**
  * Improved error handling for missing object state in messages.

* **Tests**
  * Introduced new test cases to verify correct assignment of tombstone timestamps during object and map entry deletions.

* **Chores**
  * Updated method signatures and internal structures to consistently use object messages and propagate tombstone timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->