### PR TITLE
fix: minimization issue with Next.js 15+

### DIFF
--- a/src/platform/web/lib/http/request/xhrrequest.ts
+++ b/src/platform/web/lib/http/request/xhrrequest.ts
@@ -183,7 +183,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
       Logger.logAction(this.logger, Logger.LOG_ERROR, 'Request.on' + errorEvent.type + '()', errorMessage);
       this.complete(new PartialErrorInfo(errorMessage, code, statusCode));
     };
-    xhr.onerror = function (errorEvent) {
+    xhr.onerror = (errorEvent) => {
       errorHandler(errorEvent, 'XHR error occurred', null, 400);
     };
     xhr.onabort = (errorEvent) => {
@@ -193,7 +193,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
         errorHandler(errorEvent, 'Request cancelled', null, 400);
       }
     };
-    xhr.ontimeout = function (errorEvent) {
+    xhr.ontimeout = (errorEvent) => {
       errorHandler(errorEvent, 'Request timed out', null, 408);
     };
 
@@ -306,7 +306,7 @@ class XHRRequest extends EventEmitter implements IXHRRequest {
       });
     };
 
-    xhr.onreadystatechange = function () {
+    xhr.onreadystatechange = () => {
       const readyState = xhr.readyState;
       if (readyState < 3) return;
       if (xhr.status !== 0) {


### PR DESCRIPTION
Related to https://github.com/ably/ably-js/issues/2057

SWC that Next.js uses for minimization, inlines functions inside `XHRRequest` class, that results in losing `this` context and broken code.

Unfortunately there is no easy way to fix this on the Next.js 15+ side:

> Starting with v15, minification cannot be customized using `next.config.js`. 

This PR fixes a single immediate issue. Another problem with other minimizers may appear soon. I’ll create a RFC with code practices we should adopt to avoid this in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the handling of HTTP request state changes for better consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->