### PR TITLE
Remove Message.refSerial/refType (added prematurely, not used)

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3201,14 +3201,6 @@ export interface Message {
    */
   serial?: string;
   /**
-   * If this message references another, the serial of that message.
-   */
-  refSerial?: string;
-  /**
-   * If this message references another, the type of reference that is.
-   */
-  refType?: string;
-  /**
    * The timestamp of the very first version of a given message (will differ from
    * `timestamp` only if the message has been updated or deleted).
    */

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -105,8 +105,6 @@ class Message extends BaseMessage {
   connectionKey?: string;
   action?: API.MessageAction;
   serial?: string;
-  refSerial?: string;
-  refType?: string;
   createdAt?: number;
   version?: string;
   operation?: API.Operation;
@@ -150,8 +148,6 @@ export class WireMessage extends BaseMessage {
   connectionKey?: string;
   action?: number;
   serial?: string;
-  refSerial?: string;
-  refType?: string;
   createdAt?: number;
   version?: string;
   operation?: API.Operation;


### PR DESCRIPTION
https://github.com/ably/specification/pull/348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the optional fields for message references (`refSerial` and `refType`) from message-related types and classes. This simplifies the structure of messages in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->