### PR TITLE
Release 2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.10.1](https://github.com/ably/ably-js/tree/2.10.1) (2025-07-16)
+
+- Fix minimization issue with Next.js 15.4+ canary builds [\#2057](https://github.com/ably/ably-js/pull/2057)
+
 ## [2.10.0](https://github.com/ably/ably-js/tree/2.10.0) (2025-06-25)
 
 - Add `Channels.all` to type declarations [\#2040](https://github.com/ably/ably-js/pull/2040)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.10.0';
+export const version = '2.10.1';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a minimization issue affecting Next.js 15.4+ canary builds.

* **Chores**
  * Updated version to 2.10.1 in documentation and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->