### PR TITLE
Change `ObjectOperation.initialValue` to be a JSON encoded string

### DIFF
--- a/src/plugins/objects/objectid.ts
+++ b/src/plugins/objects/objectid.ts
@@ -1,6 +1,5 @@
 import type BaseClient from 'common/lib/client/baseclient';
 import type Platform from 'common/platform';
-import type { Bufferlike } from 'common/platform';
 
 export type LiveObjectType = 'map' | 'counter';
 
@@ -19,12 +18,12 @@ export class ObjectId {
   static fromInitialValue(
     platform: typeof Platform,
     objectType: LiveObjectType,
-    encodedInitialValue: Bufferlike,
+    initialValue: string,
     nonce: string,
     msTimestamp: number,
   ): ObjectId {
     const valueForHashBuffer = platform.BufferUtils.concat([
-      encodedInitialValue,
+      platform.BufferUtils.utf8Encode(initialValue),
       platform.BufferUtils.utf8Encode(':'),
       platform.BufferUtils.utf8Encode(nonce),
     ]);

--- a/test/realtime/objects.test.js
+++ b/test/realtime/objects.test.js
@@ -5078,10 +5078,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
           {
             description: 'initial value',
             message: objectMessageFromValues({
-              operation: {
-                initialValue: BufferUtils.utf8Encode('{"counter":{"count":1}}'),
-                initialValueEncoding: 'json',
-              },
+              operation: { initialValue: JSON.stringify({ counter: { count: 1 } }) },
             }),
             expected: 0,
           },


### PR DESCRIPTION
This updates ably-js SDK to use simpler `initialValue` API added to realtime in [1], based on the LiveObjects DR [2]

[1] https://github.com/ably/realtime/pull/7549
[2] https://ably.atlassian.net/wiki/x/GID-9Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initial values for counters and maps now use JSON string serialization instead of binary encoding.
  * Object identifiers and creation messages are generated from the JSON initial value.
  * Encoding APIs simplified and related method names clarified to reflect operation-based initial values.
* **Tests**
  * Updated tests to use JSON-string initial values and to match the new encoding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->