### PR TITLE
[PUB-2015] Surface `clientId` who submitted a LiveObject operation in subscribe callbacks

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2736,6 +2736,8 @@ export declare interface LiveObjectUpdate {
    * Holds an update object which describe changes applied to the object.
    */
   update: any;
+  /** The client ID of the client that published this update. */
+  clientId?: string;
 }
 
 /**

--- a/src/plugins/objects/liveobject.ts
+++ b/src/plugins/objects/liveobject.ts
@@ -13,6 +13,7 @@ export interface LiveObjectData {
 
 export interface LiveObjectUpdate {
   update: any;
+  clientId?: string;
 }
 
 export interface LiveObjectUpdateNoop {
@@ -165,6 +166,7 @@ export abstract class LiveObject<
       this._tombstonedAt = Date.now(); // best-effort estimate since no timestamp provided by the server
     }
     const update = this.clearData();
+    update.clientId = objectMessage.clientId;
     this._lifecycleEvents.emit(LiveObjectLifecycleEvent.deleted);
 
     return update;
@@ -255,5 +257,8 @@ export abstract class LiveObject<
    * This saves us from needing to merge the initial value with operations applied to
    * the object every time the object is read.
    */
-  protected abstract _mergeInitialDataFromCreateOperation(objectOperation: ObjectOperation<ObjectData>): TUpdate;
+  protected abstract _mergeInitialDataFromCreateOperation(
+    objectOperation: ObjectOperation<ObjectData>,
+    msg: ObjectMessage,
+  ): TUpdate;
 }

--- a/src/plugins/objects/objects.ts
+++ b/src/plugins/objects/objects.ts
@@ -133,7 +133,7 @@ export class Objects {
     // we haven't received the MAP_CREATE operation yet, so we can create a new map object using the locally constructed object operation.
     // we don't know the serials for map entries, so we assign an "earliest possible" serial to each entry, so that any subsequent operation can be applied to them.
     // we mark the MAP_CREATE operation as merged for the object, guaranteeing its idempotency and preventing it from being applied again when the operation arrives.
-    const map = LiveMap.fromObjectOperation<T>(this, msg.operation!);
+    const map = LiveMap.fromObjectOperation<T>(this, msg);
     this._objectsPool.set(objectId, map);
 
     return map;
@@ -164,7 +164,7 @@ export class Objects {
 
     // we haven't received the COUNTER_CREATE operation yet, so we can create a new counter object using the locally constructed object operation.
     // we mark the COUNTER_CREATE operation as merged for the object, guaranteeing its idempotency. this ensures we don't double count the initial counter value when the operation arrives.
-    const counter = LiveCounter.fromObjectOperation(this, msg.operation!);
+    const counter = LiveCounter.fromObjectOperation(this, msg);
     this._objectsPool.set(objectId, counter);
 
     return counter;

--- a/test/common/modules/objects_helper.js
+++ b/test/common/modules/objects_helper.js
@@ -241,12 +241,13 @@ define(['ably', 'shared_helper', 'objects'], function (Ably, Helper, ObjectsPlug
     }
 
     objectOperationMessage(opts) {
-      const { channelName, serial, serialTimestamp, siteCode, state } = opts;
+      const { channelName, serial, serialTimestamp, siteCode, state, clientId } = opts;
 
       state?.forEach((objectMessage, i) => {
         objectMessage.serial = serial;
         objectMessage.serialTimestamp = serialTimestamp;
         objectMessage.siteCode = siteCode;
+        objectMessage.clientId = clientId;
       });
 
       return {

--- a/test/realtime/objects.test.js
+++ b/test/realtime/objects.test.js
@@ -899,8 +899,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const counterSubPromise = new Promise((resolve, reject) =>
               root.get('counter').subscribe((update) => {
                 try {
-                  expect(update).to.deep.equal(
-                    { update: { amount: -1 } },
+                  expect(update?.update).to.deep.equal(
+                    { amount: -1 },
                     'Check counter subscription callback is called with an expected update object after OBJECT_SYNC sequence with "tombstone=true"',
                   );
                   resolve();
@@ -2087,8 +2087,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const mapSubPromise = new Promise((resolve, reject) =>
               root.get('map').subscribe((update) => {
                 try {
-                  expect(update).to.deep.equal(
-                    { update: { foo: 'removed', baz: 'removed' } },
+                  expect(update?.update).to.deep.equal(
+                    { foo: 'removed', baz: 'removed' },
                     'Check map subscription callback is called with an expected update object after OBJECT_DELETE operation',
                   );
                   resolve();
@@ -2100,8 +2100,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const counterSubPromise = new Promise((resolve, reject) =>
               root.get('counter').subscribe((update) => {
                 try {
-                  expect(update).to.deep.equal(
-                    { update: { amount: -1 } },
+                  expect(update?.update).to.deep.equal(
+                    { amount: -1 },
                     'Check counter subscription callback is called with an expected update object after OBJECT_DELETE operation',
                   );
                   resolve();
@@ -3993,8 +3993,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const subscriptionPromise = new Promise((resolve, reject) =>
               counter.subscribe((update) => {
                 try {
-                  expect(update).to.deep.equal(
-                    { update: { amount: 1 } },
+                  expect(update?.update).to.deep.equal(
+                    { amount: 1 },
                     'Check counter subscription callback is called with an expected update object for COUNTER_INC operation',
                   );
                   resolve();
@@ -4030,8 +4030,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
               counter.subscribe((update) => {
                 try {
                   const expectedInc = expectedCounterIncrements[currentUpdateIndex];
-                  expect(update).to.deep.equal(
-                    { update: { amount: expectedInc } },
+                  expect(update?.update).to.deep.equal(
+                    { amount: expectedInc },
                     `Check counter subscription callback is called with an expected update object for ${currentUpdateIndex + 1} times`,
                   );
 
@@ -4070,8 +4070,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const subscriptionPromise = new Promise((resolve, reject) =>
               map.subscribe((update) => {
                 try {
-                  expect(update).to.deep.equal(
-                    { update: { stringKey: 'updated' } },
+                  expect(update?.update).to.deep.equal(
+                    { stringKey: 'updated' },
                     'Check map subscription callback is called with an expected update object for MAP_SET operation',
                   );
                   resolve();
@@ -4104,8 +4104,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const subscriptionPromise = new Promise((resolve, reject) =>
               map.subscribe((update) => {
                 try {
-                  expect(update).to.deep.equal(
-                    { update: { stringKey: 'removed' } },
+                  expect(update?.update).to.deep.equal(
+                    { stringKey: 'removed' },
                     'Check map subscription callback is called with an expected update object for MAP_REMOVE operation',
                   );
                   resolve();
@@ -4129,24 +4129,156 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
 
         {
           allTransportsAndProtocols: true,
+          description: 'subscription update object contains the clientId of the client who made the update',
+          action: async (ctx) => {
+            const { root, objectsHelper, channel, channelName, sampleMapKey, sampleCounterKey, helper } = ctx;
+            const publishClientId = 'publish-clientId';
+            const publishClient = RealtimeWithObjects(helper, { clientId: publishClientId });
+
+            const createCheckUpdateClientIdPromise = (subscribeFn, msg) => {
+              return new Promise((resolve, reject) =>
+                subscribeFn((update) => {
+                  try {
+                    expect(update.clientId).to.equal(publishClientId, msg);
+                    resolve();
+                  } catch (error) {
+                    reject(error);
+                  }
+                }),
+              );
+            };
+
+            // check clientId is surfaced for mutation ops
+            const mutationOpsPromises = Promise.all([
+              createCheckUpdateClientIdPromise(
+                (cb) => root.get(sampleCounterKey).subscribe(cb),
+                'Check counter subscription callback has clientId for COUNTER_INC operation',
+              ),
+              createCheckUpdateClientIdPromise(
+                (cb) =>
+                  root.get(sampleMapKey).subscribe((update) => {
+                    if (update.update.foo === 'updated') {
+                      cb(update);
+                    }
+                  }),
+                'Check map subscription callback has clientId for MAP_SET operation',
+              ),
+              createCheckUpdateClientIdPromise(
+                (cb) =>
+                  root.get(sampleMapKey).subscribe((update) => {
+                    if (update.update.foo === 'removed') {
+                      cb(update);
+                    }
+                  }),
+                'Check map subscription callback has clientId for MAP_REMOVE operation',
+              ),
+            ]);
+
+            await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+              const publishChannel = publishClient.channels.get(channelName, channelOptionsWithObjects());
+              await publishChannel.attach();
+              const publishRoot = await publishChannel.objects.getRoot();
+
+              await publishRoot.get(sampleCounterKey).increment(1);
+              await publishRoot.get(sampleMapKey).set('foo', 'bar');
+              await publishRoot.get(sampleMapKey).remove('foo');
+            }, publishClient);
+
+            await mutationOpsPromises;
+
+            // check clientId is surfaced for create ops.
+            // first need to create non-initialized objects first and then publish create op for them
+            const objectsCreatedPromise = Promise.all([
+              waitForMapKeyUpdate(root, 'nonInitializedCounter'),
+              waitForMapKeyUpdate(root, 'nonInitializedMap'),
+            ]);
+
+            const fakeCounterObjectId = objectsHelper.fakeCounterObjectId();
+            const fakeMapObjectId = objectsHelper.fakeMapObjectId();
+
+            await objectsHelper.processObjectOperationMessageOnChannel({
+              channel,
+              serial: lexicoTimeserial('aaa', 0, 0),
+              siteCode: 'aaa',
+              state: [
+                objectsHelper.mapSetOp({
+                  objectId: 'root',
+                  key: 'nonInitializedCounter',
+                  data: { objectId: fakeCounterObjectId },
+                }),
+              ],
+            });
+            await objectsHelper.processObjectOperationMessageOnChannel({
+              channel,
+              serial: lexicoTimeserial('aaa', 1, 0),
+              siteCode: 'aaa',
+              state: [
+                objectsHelper.mapSetOp({
+                  objectId: 'root',
+                  key: 'nonInitializedMap',
+                  data: { objectId: fakeMapObjectId },
+                }),
+              ],
+            });
+
+            await objectsCreatedPromise;
+
+            const createOpsPromises = Promise.all([
+              createCheckUpdateClientIdPromise(
+                (cb) => root.get('nonInitializedCounter').subscribe(cb),
+                'Check counter subscription callback has clientId for COUNTER_CREATE operation',
+              ),
+              createCheckUpdateClientIdPromise(
+                (cb) => root.get('nonInitializedMap').subscribe(cb),
+                'Check map subscription callback has clientId for MAP_CREATE operation',
+              ),
+            ]);
+
+            // and now post create operations which will trigger subscription callbacks
+            await objectsHelper.processObjectOperationMessageOnChannel({
+              channel,
+              serial: lexicoTimeserial('aaa', 1, 1),
+              siteCode: 'aaa',
+              clientId: publishClientId,
+              state: [objectsHelper.counterCreateOp({ objectId: fakeCounterObjectId, count: 1 })],
+            });
+            await objectsHelper.processObjectOperationMessageOnChannel({
+              channel,
+              serial: lexicoTimeserial('aaa', 1, 1),
+              siteCode: 'aaa',
+              clientId: publishClientId,
+              state: [
+                objectsHelper.mapCreateOp({
+                  objectId: fakeMapObjectId,
+                  entries: { foo: { timeserial: lexicoTimeserial('aaa', 1, 1), data: { string: 'bar' } } },
+                }),
+              ],
+            });
+
+            await createOpsPromises;
+          },
+        },
+
+        {
+          allTransportsAndProtocols: true,
           description: 'can subscribe to multiple incoming operations on a LiveMap',
           action: async (ctx) => {
             const { root, objectsHelper, channelName, sampleMapKey, sampleMapObjectId } = ctx;
 
             const map = root.get(sampleMapKey);
             const expectedMapUpdates = [
-              { update: { foo: 'updated' } },
-              { update: { bar: 'updated' } },
-              { update: { foo: 'removed' } },
-              { update: { baz: 'updated' } },
-              { update: { bar: 'removed' } },
+              { foo: 'updated' },
+              { bar: 'updated' },
+              { foo: 'removed' },
+              { baz: 'updated' },
+              { bar: 'removed' },
             ];
             let currentUpdateIndex = 0;
 
             const subscriptionPromise = new Promise((resolve, reject) =>
               map.subscribe((update) => {
                 try {
-                  expect(update).to.deep.equal(
+                  expect(update?.update).to.deep.equal(
                     expectedMapUpdates[currentUpdateIndex],
                     `Check map subscription callback is called with an expected update object for ${currentUpdateIndex + 1} times`,
                   );
@@ -4507,6 +4639,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             sampleMapObjectId,
             sampleCounterKey,
             sampleCounterObjectId,
+            helper,
           });
         }, client);
       });


### PR DESCRIPTION
Resolves [PUB-2015](https://ably.atlassian.net/browse/PUB-2015)

[PUB-2015]: https://ably.atlassian.net/browse/PUB-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription updates for live objects, maps, and counters now include an optional clientId identifying the client that made the change; initial create updates carry clientId when applicable.

* **Refactor**
  * Object handlers now receive full message context so clientId is consistently propagated through create and mutation flows.

* **Tests**
  * End-to-end tests added/updated to verify subscription updates include the publishing client’s clientId for create and mutation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->