### PR TITLE
Release v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.12.0](https://github.com/ably/ably-js/tree/2.12.0) (2025-08-22)
+
+- Add `clientId` of the client who submitted the operation to the `LiveObjectUpdate` in subscription callbacks [\#2072](https://github.com/ably/ably-js/pull/2072)
+
 ## [2.11.1](https://github.com/ably/ably-js/tree/2.11.1) (2025-08-21)
 
 - Fix race for browsers that throttle timeouts in background tabs [\#2070](https://github.com/ably/ably-js/pull/2070)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.11.1';
+export const version = '2.12.0';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
Release PR for https://github.com/ably/ably-js/pull/2072, will merge after CI has passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription callbacks now include the clientId of the client who submitted the operation in LiveObjectUpdate.

* **Documentation**
  * Changelog updated with a new 2.12.0 entry describing this change.

* **Chores**
  * Package version updated to 2.12.0 and internal version identifiers adjusted accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->