### PR TITLE
test: fix test app setup logging to report correct endpoint

### DIFF
--- a/test/common/modules/testapp_module.js
+++ b/test/common/modules/testapp_module.js
@@ -38,8 +38,8 @@ define(['test/common/modules/testapp_manager', 'globals'], function (testAppMana
           console.info(
             'Test App ' +
               configuredTestApp().appId +
-              ' in environment ' +
-              (ablyGlobals.environment || 'production') +
+              ' at endpoint ' +
+              (ablyGlobals.endpoint || 'production:main') +
               ' has been set up',
           );
           done();


### PR DESCRIPTION
Previously reported 'environment production' which was incorrect after switching from environment to endpoint property. Now correctly shows the actual endpoint being used (e.g. 'nonprod:sandbox').

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Setup log now reports the active endpoint instead of the environment for clearer diagnostics.
  * Default target updated from “production” to “production:main” to reflect updated deployment naming.

* **Style**
  * Log phrasing changed from “in environment” to “at endpoint” to align terminology and improve clarity.

* **Notes**
  * No functional or control-flow changes; behavior and public interfaces are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->