### PR TITLE
Add clipped field to annotation summary types

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3147,6 +3147,9 @@ export interface SummaryClientIdList {
   /** A list of the clientIds of all clients who have published an annotation with this name (or
    * type, depending on context). */
   clientIds: string[];
+  /** Whether the list of clientIds has been clipped due to exceeding the maximum number of
+   * clients. */
+  clipped?: boolean;
 }
 
 /** The per-name value for the multiple.v1 aggregation method. */
@@ -3160,6 +3163,11 @@ export interface SummaryClientIdCounts {
   /** The sum of the counts from all unidentified clients who have published an annotation with this
    * name, and so who are not included in the clientIds list */
   totalUnidentified: number;
+  /** Whether the list of clientIds has been clipped due to exceeding the maximum number of
+   * clients. */
+  clipped?: boolean;
+  /** The total number of distinct clientIds in the map (equal to length of map if clipped is false). */
+  totalClientIds: number;
 }
 
 /** The summary entry for aggregated annotations that use the total.v1

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3128,7 +3128,7 @@ export interface SummaryDistinctValues {
 
 /** The summary entry for aggregated annotations that use the unique.v1
  * aggregation method. */
-interface SummaryUniqueValues {
+export interface SummaryUniqueValues {
   [key: string]: SummaryClientIdList;
 }
 
@@ -3149,7 +3149,7 @@ export interface SummaryClientIdList {
   clientIds: string[];
   /** Whether the list of clientIds has been clipped due to exceeding the maximum number of
    * clients. */
-  clipped?: boolean;
+  clipped: boolean;
 }
 
 /** The per-name value for the multiple.v1 aggregation method. */
@@ -3165,7 +3165,7 @@ export interface SummaryClientIdCounts {
   totalUnidentified: number;
   /** Whether the list of clientIds has been clipped due to exceeding the maximum number of
    * clients. */
-  clipped?: boolean;
+  clipped: boolean;
   /** The total number of distinct clientIds in the map (equal to length of map if clipped is false). */
   totalClientIds: number;
 }

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -6,7 +6,7 @@ import { gzip } from 'zlib';
 import Table from 'cli-table';
 
 // The maximum size we allow for a minimal useful Realtime bundle (i.e. one that can subscribe to a channel)
-const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 103, gzip: 31 };
+const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 104, gzip: 32 };
 
 const baseClientNames = ['BaseRest', 'BaseRealtime'];
 

--- a/src/common/lib/types/message.ts
+++ b/src/common/lib/types/message.ts
@@ -133,6 +133,24 @@ class Message extends BaseMessage {
       // TM8a
       this.annotations.summary = {};
     }
+    if (this.annotations && this.annotations.summary) {
+      // Ensure clipped field is set to false where not explicitly provided
+      for (const [type, summaryEntry] of Object.entries(this.annotations.summary)) {
+        if (type.endsWith(':distinct.v1') || type.endsWith(':unique.v1') || type.endsWith(':multiple.v1')) {
+          for (const [, entry] of Object.entries(summaryEntry)) {
+            // TM7c1c, TM7d1c
+            if (!entry.clipped) {
+              entry.clipped = false;
+            }
+          }
+        } else if (type.endsWith(':flag.v1')) {
+          // TM7c1c
+          if (!(summaryEntry as API.SummaryClientIdList).clipped) {
+            (summaryEntry as API.SummaryClientIdList).clipped = false;
+          }
+        }
+      }
+    }
   }
 
   async encode(options: CipherOptions): Promise<WireMessage> {

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -1411,6 +1411,110 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           summary: {},
         });
       });
+
+      /**
+       * @spec TM7c1c
+       * @spec TM7d1c
+       */
+      it('should ensure clipped field is set to false where not explicitly provided', async function () {
+        const values = {
+          annotations: {
+            summary: {
+              // all unset, expecting false
+              'reactions:distinct.v1': {
+                foo: { total: 1, clientIds: ['client1'] },
+                bar: { total: 1, clientIds: ['client2'] },
+              },
+              'reactions:unique.v1': {
+                foo: { total: 1, clientIds: ['client2'] },
+                bar: { total: 1, clientIds: ['client3'] },
+              },
+              'reactions:multiple.v1': {
+                foo: { total: 1, clientIds: ['client3'] },
+                bar: { total: 1, clientIds: ['client3'] },
+              },
+              'reactions:flag.v1': { total: 1, clientIds: ['client4'] },
+
+              // some set to true
+              'votes:distinct.v1': {
+                foo: { total: 1, clientIds: ['client1'], clipped: true },
+                bar: { total: 1, clientIds: ['client2'] },
+              },
+              'votes:unique.v1': {
+                foo: { total: 1, clientIds: ['client2'] },
+                bar: { total: 1, clientIds: ['client3'], clipped: true },
+              },
+              'votes:multiple.v1': {
+                foo: { total: 1, clientIds: ['client3'], clipped: true },
+                bar: { total: 1, clientIds: ['client3'] },
+              },
+              'votes:flag.v1': { total: 1, clientIds: ['client4'], clipped: true },
+            },
+          },
+        };
+
+        const message = await Message.fromEncoded(values);
+
+        // Check reactions types (all should have clipped=false when not provided)
+        expect(message.annotations.summary['reactions:distinct.v1']['foo'].clipped).to.equal(
+          false,
+          'reactions:distinct.v1 foo should have clipped=false',
+        );
+        expect(message.annotations.summary['reactions:distinct.v1']['bar'].clipped).to.equal(
+          false,
+          'reactions:distinct.v1 bar should have clipped=false',
+        );
+        expect(message.annotations.summary['reactions:unique.v1']['foo'].clipped).to.equal(
+          false,
+          'reactions:unique.v1 foo should have clipped=false',
+        );
+        expect(message.annotations.summary['reactions:unique.v1']['bar'].clipped).to.equal(
+          false,
+          'reactions:unique.v1 bar should have clipped=false',
+        );
+        expect(message.annotations.summary['reactions:multiple.v1']['foo'].clipped).to.equal(
+          false,
+          'reactions:multiple.v1 foo should have clipped=false',
+        );
+        expect(message.annotations.summary['reactions:multiple.v1']['bar'].clipped).to.equal(
+          false,
+          'reactions:multiple.v1 bar should have clipped=false',
+        );
+        expect(message.annotations.summary['reactions:flag.v1'].clipped).to.equal(
+          false,
+          'reactions:flag.v1 should have clipped=false',
+        );
+
+        // Check votes types (should preserve true values and set false for unset ones)
+        expect(message.annotations.summary['votes:distinct.v1']['foo'].clipped).to.equal(
+          true,
+          'votes:distinct.v1 foo should remain clipped=true',
+        );
+        expect(message.annotations.summary['votes:distinct.v1']['bar'].clipped).to.equal(
+          false,
+          'votes:distinct.v1 bar should have clipped=false',
+        );
+        expect(message.annotations.summary['votes:unique.v1']['foo'].clipped).to.equal(
+          false,
+          'votes:unique.v1 foo should have clipped=false',
+        );
+        expect(message.annotations.summary['votes:unique.v1']['bar'].clipped).to.equal(
+          true,
+          'votes:unique.v1 bar should remain clipped=true',
+        );
+        expect(message.annotations.summary['votes:multiple.v1']['foo'].clipped).to.equal(
+          true,
+          'votes:multiple.v1 foo should remain clipped=true',
+        );
+        expect(message.annotations.summary['votes:multiple.v1']['bar'].clipped).to.equal(
+          false,
+          'votes:multiple.v1 bar should have clipped=false',
+        );
+        expect(message.annotations.summary['votes:flag.v1'].clipped).to.equal(
+          true,
+          'votes:flag.v1 should remain clipped=true',
+        );
+      });
     });
 
     /**


### PR DESCRIPTION
Add `clipped` and `totalClientIds` fields to summary types. https://ably.atlassian.net/browse/CHA-1100

https://ably.atlassian.net/browse/CHA-1178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Summaries now include explicit clipping indicators and a total distinct-client count so truncated results are clearly reported.

- **Behavior**
  - Summary entries default clipping indicators to false when omitted, ensuring consistent summary output for reactions and votes.

- **Documentation**
  - Field descriptions clarified to explain clipping semantics and total distinct clientIds.

- **Tests**
  - Added unit tests verifying clipped defaults and preservation of explicit clipped values.

- **Chores**
  - Relaxed minimal Realtime bundle size thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->