### PR TITLE
[PUB-2558] Surface `connectionId` of a client who submitted a LiveObject operation in subscribe callbacks

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2738,6 +2738,8 @@ export declare interface LiveObjectUpdate {
   update: any;
   /** The client ID of the client that published this update. */
   clientId?: string;
+  /** The connection ID of the client that published this update. */
+  connectionId?: string;
 }
 
 /**

--- a/src/plugins/objects/livecounter.ts
+++ b/src/plugins/objects/livecounter.ts
@@ -292,6 +292,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
     // otherwise it is a diff between previous value and new value from object state.
     const update = this._updateFromDataDiff(previousDataRef, this._dataRef);
     update.clientId = objectMessage.clientId;
+    update.connectionId = objectMessage.connectionId;
     return update;
   }
 
@@ -324,7 +325,11 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
     this._dataRef.data += objectOperation.counter?.count ?? 0; // RTLC6d1
     this._createOperationIsMerged = true; // RTLC6d2
 
-    return { update: { amount: objectOperation.counter?.count ?? 0 }, clientId: msg.clientId };
+    return {
+      update: { amount: objectOperation.counter?.count ?? 0 },
+      clientId: msg.clientId,
+      connectionId: msg.connectionId,
+    };
   }
 
   private _throwNoPayloadError(op: ObjectOperation<ObjectData>): void {
@@ -357,6 +362,6 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
 
   private _applyCounterInc(op: ObjectsCounterOp, msg: ObjectMessage): LiveCounterUpdate {
     this._dataRef.data += op.amount;
-    return { update: { amount: op.amount }, clientId: msg.clientId };
+    return { update: { amount: op.amount }, clientId: msg.clientId, connectionId: msg.connectionId };
   }
 }

--- a/src/plugins/objects/livemap.ts
+++ b/src/plugins/objects/livemap.ts
@@ -515,6 +515,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
     // otherwise it is a diff between previous value and new value from object state.
     const update = this._updateFromDataDiff(previousDataRef, this._dataRef);
     update.clientId = objectMessage.clientId;
+    update.connectionId = objectMessage.connectionId;
     return update;
   }
 
@@ -602,10 +603,10 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
     if (this._client.Utils.isNil(objectOperation.map)) {
       // if a map object is missing for the MAP_CREATE op, the initial value is implicitly an empty map.
       // in this case there is nothing to merge into the current map, so we can just end processing the op.
-      return { update: {}, clientId: msg.clientId };
+      return { update: {}, clientId: msg.clientId, connectionId: msg.connectionId };
     }
 
-    const aggregatedUpdate: LiveMapUpdate<T> = { update: {}, clientId: msg.clientId };
+    const aggregatedUpdate: LiveMapUpdate<T> = { update: {}, clientId: msg.clientId, connectionId: msg.connectionId };
     // RTLM6d1
     // in order to apply MAP_CREATE op for an existing map, we should merge their underlying entries keys.
     // we can do this by iterating over entries from MAP_CREATE op and apply changes on per-key basis as if we had MAP_SET, MAP_REMOVE operations.
@@ -730,7 +731,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
       this._dataRef.data.set(op.key, newEntry);
     }
 
-    const update: LiveMapUpdate<T> = { update: {}, clientId: msg.clientId };
+    const update: LiveMapUpdate<T> = { update: {}, clientId: msg.clientId, connectionId: msg.connectionId };
     const typedKey: keyof T & string = op.key;
     update.update[typedKey] = 'updated';
 
@@ -787,7 +788,7 @@ export class LiveMap<T extends API.LiveMapType> extends LiveObject<LiveMapData, 
       this._dataRef.data.set(op.key, newEntry);
     }
 
-    const update: LiveMapUpdate<T> = { update: {}, clientId: msg.clientId };
+    const update: LiveMapUpdate<T> = { update: {}, clientId: msg.clientId, connectionId: msg.connectionId };
     const typedKey: keyof T & string = op.key;
     update.update[typedKey] = 'removed';
 

--- a/src/plugins/objects/liveobject.ts
+++ b/src/plugins/objects/liveobject.ts
@@ -14,6 +14,7 @@ export interface LiveObjectData {
 export interface LiveObjectUpdate {
   update: any;
   clientId?: string;
+  connectionId?: string;
 }
 
 export interface LiveObjectUpdateNoop {
@@ -167,6 +168,7 @@ export abstract class LiveObject<
     }
     const update = this.clearData();
     update.clientId = objectMessage.clientId;
+    update.connectionId = objectMessage.connectionId;
     this._lifecycleEvents.emit(LiveObjectLifecycleEvent.deleted);
 
     return update;

--- a/test/common/modules/objects_helper.js
+++ b/test/common/modules/objects_helper.js
@@ -241,7 +241,7 @@ define(['ably', 'shared_helper', 'objects'], function (Ably, Helper, ObjectsPlug
     }
 
     objectOperationMessage(opts) {
-      const { channelName, serial, serialTimestamp, siteCode, state, clientId } = opts;
+      const { channelName, serial, serialTimestamp, siteCode, state, clientId, connectionId } = opts;
 
       state?.forEach((objectMessage, i) => {
         objectMessage.serial = serial;
@@ -254,6 +254,7 @@ define(['ably', 'shared_helper', 'objects'], function (Ably, Helper, ObjectsPlug
         action: 19, // OBJECT
         channel: channelName,
         channelSerial: serial,
+        connectionId,
         state: state ?? [],
       };
     }


### PR DESCRIPTION
Based on the similar implementation for `clientId` from https://github.com/ably/ably-js/pull/2072

Resolves [PUB-2558](https://ably.atlassian.net/browse/PUB-2558)

[PUB-2558]: https://ably.atlassian.net/browse/PUB-2558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Subscription updates for LiveObject, LiveMap, and LiveCounter now include an optional connectionId alongside clientId so apps can identify the originating connection.
  - Public types updated to expose connectionId in update payloads; backward compatible.

- Tests
  - Updated tests to assert presence and correctness of connectionId in subscription updates and operation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->