### PR TITLE
chore: 2.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.13.0](https://github.com/ably/ably-js/tree/2.13.0) (2025-09-18)
+
+- Introduce version 4 of the Ably protocol [#2076](https://github.com/ably/ably-js/pull/2076)
+- Changes to the structure of the experimental annotations and message fields [#2076](https://github.com/ably/ably-js/pull/2076)
+  - A new field `Message.annotations` to store annotation information for the message.
+  - `Message.version` is now an object, containing information about the latest message version.
+  - `Message.createdAt` has been removed, its purpose is now served by `Message.timestamp`.
+  - Per the above, `Message.timestamp` now refers to when a message was first created on the server. For the latest updated at time, see `Message.version.timestamp`.
+  - `Message.operation` has been removed. Its fields are now in `Message.version.*`
+  - `Message.summary` has been moved to `Message.annotations.summary`
+
 ## [2.12.0](https://github.com/ably/ably-js/tree/2.12.0) (2025-08-22)
 
 - Add `clientId` of the client who submitted the operation to the `LiveObjectUpdate` in subscription callbacks [\#2072](https://github.com/ably/ably-js/pull/2072)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This contains only the most important and/or user-facing changes; for a full cha
 
 ## [2.13.0](https://github.com/ably/ably-js/tree/2.13.0) (2025-09-18)
 
+- Surface the `connectionId` of the client that submitted a `LiveObject` operation in subscribe callbacks [#2084](https://github.com/ably/ably-js/pull/2084)
 - Introduce version 4 of the Ably protocol [#2076](https://github.com/ably/ably-js/pull/2076)
 - Changes to the structure of the experimental annotations and message fields [#2076](https://github.com/ably/ably-js/pull/2076)
   - A new field `Message.annotations` to store annotation information for the message.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.12.0';
+export const version = '2.13.0';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
This change includes the documentation and version changes for release 2.13.0.

Note that there are breaking changes in experimental APIs - but as these are only used by the Chat SDK and not yet advertised publicly, this constitutes a minor version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added CHANGELOG for 2.13.0 documenting Ably protocol v4 and messaging schema updates.
  - Introduced Message.annotations and moved summary to annotations.summary.
  - Message.version is now an object; Message.createdAt and Message.operation removed; Message.timestamp now denotes original server creation time (latest update time in version.timestamp).

- New Features
  - LiveObject subscribe callbacks now surface the submitting client's connectionId.

- Chores
  - Bumped package/version identifiers to 2.13.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->