### PR TITLE
chore: add auto-release script

### DIFF
--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -1,10 +1,7 @@
 name: Publish to CDN
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release tag'
-        required: true
+  release:
+    types: [published]
 
 jobs:
   publish:
@@ -16,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.version }}
+          ref: ${{ github.ref }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -28,4 +25,4 @@ jobs:
         with:
           node-version: 20.x
       - run: npm ci
-      - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.event.inputs.version }}
+      - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release packages
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'write'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.10.0'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm ci
+          npm run build
+          npm publish --provenance --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,10 @@
 4. Run `npm version <VERSION_NUMBER> --no-git-tag-version` with the new version and add the changes to the git index
 5. Update the version number to the new version in `src/platform/react-hooks/src/AblyReactHooks.ts`
 6. Create a PR for the release branch
-7. Once the release PR is landed to the `main` branch, checkout the `main` branch locally (remember to pull the remote changes) and run `npm run build`
-8. Run `git tag <VERSION_NUMBER>` with the new version and push the tag to GitHub with `git push <REMOTE> <VERSION_NUMBER>` (usually `git push origin <VERSION_NUMBER>`)
-9. Run `npm publish .` (should require OTP) - publishes to NPM
-10. Run the GitHub action "Publish to CDN" with the new tag name
-11. Visit https://github.com/ably/ably-js/tags and create a GitHub release based on the new tag (for release notes, you generally can just copy the notes you added to the CHANGELOG)
-12. Update the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/)) with these changes (again, you can just copy the notes you added to the CHANGELOG)
+7. Once all tests are passing, land the release branch into `main`.
+8. Create a GitHub release with the appropriate tag. For release notes, you generally can just copy the notes you added to the CHANGELOG.
+9. Verify that the Release and CDN publish actions have run successfully.
+10. Update the [Ably Changelog](https://changelog.ably.com/) (via [headwayapp](https://headwayapp.co/)) with these changes (again, you can just copy the notes you added to the CHANGELOG)
 
 ## Building the library
 


### PR DESCRIPTION
This change introduces an auto release script for actions, the same as we run for chat-js. It runs automatically upon release creation and publishes with provenance to npm. Similarly, the CDN publish script has been updated to invoke automatically.

This allows us to release automatically when new versions are tagged, including with provenance which provides guarantees as to the authenticity of the package.