### PR TITLE
chore: 2.14.0 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.14.0](https://github.com/ably/ably-js/tree/2.14.0) (2025-09-29)
+
+- Add `clipped` field to annotation summary types [#2078](https://github.com/ably/ably-js/pull/2078)
+
 ## [2.13.0](https://github.com/ably/ably-js/tree/2.13.0) (2025-09-18)
 
 - Surface the `connectionId` of the client that submitted a `LiveObject` operation in subscribe callbacks [#2084](https://github.com/ably/ably-js/pull/2084)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -12,7 +12,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.13.0';
+export const version = '2.14.0';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
Make a release to add the clipped summary field as it is required by chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new “clipped” field to annotation summary types.

- Documentation
  - Updated the changelog with release notes for version 2.14.0 (2025-09-29).

- Chores
  - Bumped the application version to 2.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->