### PR TITLE
fix(typings): allow generic `Error` in authCallback callback

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -650,7 +650,7 @@ export interface AuthOptions {
      * @param tokenRequestOrDetails - A valid `TokenRequest`, `TokenDetails` or Ably JWT to be used for authentication.
      */
     callback: (
-      error: ErrorInfo | string | null,
+      error: Error | string | null,
       tokenRequestOrDetails: TokenDetails | TokenRequest | string | null,
     ) => void,
   ): void;

--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -400,7 +400,7 @@ class Auth {
     let tokenRequestCallback: (
         data: API.TokenParams,
         callback: (
-          error: API.ErrorInfo | RequestResultError | string | null,
+          error: API.ErrorInfo | Error | RequestResultError | string | null,
           tokenRequestOrDetails: API.TokenDetails | API.TokenRequest | string | null,
           contentType?: string,
         ) => void,


### PR DESCRIPTION
We shouldn't be expecting users to construct their own `ErrorInfo` here when their auth callback fails, since they won't know what `code` to use. ISTM the typings here were written to conform to the internal `tokenRequestCallback` variable? The code seems to treat the error opaquely so just changing to `Error` should be safe. NB: not a breaking change since I've maintained the `string` option and `ErrorInfo` inherits from `Error`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling to accept standard Error objects in callbacks, reducing edge-case failures during token requests and authorization flows.
  * Enhanced robustness of error propagation in auth-related callbacks, preventing unexpected crashes and improving reliability.

* **Refactor**
  * Aligned callback error types across authentication flows for greater consistency and compatibility with common error objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->