### PR TITLE
Fix named exports not working for plugins in Node.js ESM

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -127,6 +127,7 @@ module.exports = function (grunt) {
 
     Promise.all([
       esbuild.build(esbuildConfig.pushPluginConfig),
+      esbuild.build(esbuildConfig.pushPluginEsmConfig),
       esbuild.build(esbuildConfig.pushPluginCdnConfig),
       esbuild.build(esbuildConfig.minifiedPushPluginCdnConfig),
     ])
@@ -143,6 +144,7 @@ module.exports = function (grunt) {
 
     Promise.all([
       esbuild.build(esbuildConfig.objectsPluginConfig),
+      esbuild.build(esbuildConfig.objectsPluginEsmConfig),
       esbuild.build(esbuildConfig.objectsPluginCdnConfig),
       esbuild.build(esbuildConfig.minifiedObjectsPluginCdnConfig),
     ])

--- a/grunt/esbuild/build.js
+++ b/grunt/esbuild/build.js
@@ -62,6 +62,15 @@ const pushPluginConfig = {
   external: ['ulid'],
 };
 
+const pushPluginEsmConfig = {
+  ...createBaseConfig(),
+  format: 'esm',
+  plugins: [],
+  entryPoints: ['src/plugins/push/index.ts'],
+  outfile: 'build/push.mjs',
+  external: ['ulid'],
+};
+
 const pushPluginCdnConfig = {
   ...createBaseConfig(),
   entryPoints: ['src/plugins/push/index.ts'],
@@ -82,6 +91,15 @@ const objectsPluginConfig = {
   entryPoints: ['src/plugins/objects/index.ts'],
   plugins: [umdWrapper.default({ libraryName: 'AblyObjectsPlugin', amdNamedModule: false })],
   outfile: 'build/objects.js',
+  external: ['dequal'],
+};
+
+const objectsPluginEsmConfig = {
+  ...createBaseConfig(),
+  format: 'esm',
+  plugins: [],
+  entryPoints: ['src/plugins/objects/index.ts'],
+  outfile: 'build/objects.mjs',
   external: ['dequal'],
 };
 
@@ -106,9 +124,11 @@ module.exports = {
   modularConfig,
   nodeConfig,
   pushPluginConfig,
+  pushPluginEsmConfig,
   pushPluginCdnConfig,
   minifiedPushPluginCdnConfig,
   objectsPluginConfig,
+  objectsPluginEsmConfig,
   objectsPluginCdnConfig,
   minifiedObjectsPluginCdnConfig,
 };

--- a/objects.d.ts
+++ b/objects.d.ts
@@ -25,4 +25,4 @@ import { BaseRealtime } from './modular';
  */
 declare const Objects: any;
 
-export = Objects;
+export default Objects;

--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
     },
     "./push": {
       "types": "./push.d.ts",
-      "import": "./build/push.js"
+      "import": "./build/push.mjs",
+      "require": "./build/push.js"
     },
     "./objects": {
       "types": "./objects.d.ts",
-      "import": "./build/objects.js"
+      "import": "./build/objects.mjs",
+      "require": "./build/objects.js"
     }
   },
   "files": [

--- a/push.d.ts
+++ b/push.d.ts
@@ -25,4 +25,4 @@ import { BaseRest, BaseRealtime, Rest } from './modular';
  */
 declare const Push: any;
 
-export = Push;
+export default Push;


### PR DESCRIPTION
The issue occurs in Node.js with ESM resolution because the plugin modules are built only as UMD. As a result, Node.js with ESM cannot determine that such a UMD module has named exports.

This PR introduces separate CJS and ESM builds for plugins to resolve the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ES module builds for push and objects plugins, enabling modern import syntax support alongside CommonJS.

* **Chores**
  * Updated package export configurations to support both CommonJS and ES module imports for improved module compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->