### PR TITLE
updateMessage and deleteMessage: remove Message response

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2838,18 +2838,18 @@ export declare interface Channel {
    * @param message - A {@link Message} object containing a populated `serial` field and the fields to update.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the update operation.
    * @param params - Optional parameters sent as part of the query string.
-   * @returns A promise which, upon success, will be fulfilled with a {@link Message} object containing the updated message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @returns A promise which on success will be fulfilled, and on failure, rejected with an {@link ErrorInfo} object which explains the error.
    */
-  updateMessage(message: Message, operation?: MessageOperation, params?: Record<string, any>): Promise<Message>;
+  updateMessage(message: Message, operation?: MessageOperation, params?: Record<string, any>): Promise<void>;
   /**
    * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible. Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged (meaning that if you for example want the `MESSAGE_DELETE` to have an empty data, you should explicitly set the `data` to an empty object).
    *
    * @param message - A {@link Message} object containing a populated `serial` field.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the delete operation.
    * @param params - Optional parameters sent as part of the query string.
-   * @returns A promise which, upon success, will be fulfilled with a {@link Message} object containing the deleted message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @returns A promise which on success will be fulfilled, and on failure, rejected with an {@link ErrorInfo} object which explains the error.
    */
-  deleteMessage(message: Message, operation?: MessageOperation, params?: Record<string, any>): Promise<Message>;
+  deleteMessage(message: Message, operation?: MessageOperation, params?: Record<string, any>): Promise<void>;
   /**
    * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations.
    *
@@ -3086,18 +3086,18 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    * @param message - A {@link Message} object containing a populated `serial` field and the fields to update.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the update operation.
    * @param params - Optional parameters sent as part of the query string.
-   * @returns A promise which, upon success, will be fulfilled with a {@link Message} object containing the updated message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @returns A promise which on success will be fulfilled, and on failure, rejected with an {@link ErrorInfo} object which explains the error.
    */
-  updateMessage(message: Message, operation?: MessageOperation, params?: Record<string, any>): Promise<Message>;
+  updateMessage(message: Message, operation?: MessageOperation, params?: Record<string, any>): Promise<void>;
   /**
    * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible. Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged (meaning that if you for example want the `MESSAGE_DELETE` to have an empty data, you should explicitly set the `data` to an empty object).
    *
    * @param message - A {@link Message} object containing a populated `serial` field.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the delete operation.
    * @param params - Optional parameters sent as part of the query string.
-   * @returns A promise which, upon success, will be fulfilled with a {@link Message} object containing the deleted message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @returns A promise which on success will be fulfilled, and on failure, rejected with an {@link ErrorInfo} object which explains the error.
    */
-  deleteMessage(message: Message, operation?: MessageOperation, params?: Record<string, any>): Promise<Message>;
+  deleteMessage(message: Message, operation?: MessageOperation, params?: Record<string, any>): Promise<void>;
   /**
    * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations.
    *

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -1023,21 +1023,13 @@ class RealtimeChannel extends EventEmitter {
     return restMixin.getMessage(this, serialOrMessage);
   }
 
-  async updateMessage(
-    message: Message,
-    operation?: API.MessageOperation,
-    params?: Record<string, any>,
-  ): Promise<Message> {
+  async updateMessage(message: Message, operation?: API.MessageOperation, params?: Record<string, any>): Promise<void> {
     Logger.logAction(this.logger, Logger.LOG_MICRO, 'RealtimeChannel.updateMessage()', 'channel = ' + this.name);
     const restMixin = this.client.rest.channelMixin;
     return restMixin.updateDeleteMessage(this, { isDelete: false }, message, operation, params);
   }
 
-  async deleteMessage(
-    message: Message,
-    operation?: API.MessageOperation,
-    params?: Record<string, any>,
-  ): Promise<Message> {
+  async deleteMessage(message: Message, operation?: API.MessageOperation, params?: Record<string, any>): Promise<void> {
     Logger.logAction(this.logger, Logger.LOG_MICRO, 'RealtimeChannel.deleteMessage()', 'channel = ' + this.name);
     const restMixin = this.client.rest.channelMixin;
     return restMixin.updateDeleteMessage(this, { isDelete: true }, message, operation, params);

--- a/src/common/lib/client/restchannel.ts
+++ b/src/common/lib/client/restchannel.ts
@@ -156,20 +156,12 @@ class RestChannel {
     return this.client.rest.channelMixin.getMessage(this, serialOrMessage);
   }
 
-  async updateMessage(
-    message: Message,
-    operation?: API.MessageOperation,
-    params?: Record<string, any>,
-  ): Promise<Message> {
+  async updateMessage(message: Message, operation?: API.MessageOperation, params?: Record<string, any>): Promise<void> {
     Logger.logAction(this.logger, Logger.LOG_MICRO, 'RestChannel.updateMessage()', 'channel = ' + this.name);
     return this.client.rest.channelMixin.updateDeleteMessage(this, { isDelete: false }, message, operation, params);
   }
 
-  async deleteMessage(
-    message: Message,
-    operation?: API.MessageOperation,
-    params?: Record<string, any>,
-  ): Promise<Message> {
+  async deleteMessage(message: Message, operation?: API.MessageOperation, params?: Record<string, any>): Promise<void> {
     Logger.logAction(this.logger, Logger.LOG_MICRO, 'RestChannel.deleteMessage()', 'channel = ' + this.name);
     return this.client.rest.channelMixin.updateDeleteMessage(this, { isDelete: true }, message, operation, params);
   }

--- a/src/common/lib/client/restchannelmixin.ts
+++ b/src/common/lib/client/restchannelmixin.ts
@@ -105,7 +105,7 @@ export class RestChannelMixin {
     message: Message,
     operation?: API.MessageOperation,
     params?: Record<string, any>,
-  ): Promise<Message> {
+  ): Promise<void> {
     if (!message.serial) {
       throw new ErrorInfo(
         'This message lacks a serial and cannot be updated. Make sure you have enabled "Message annotations, updates, and deletes" in channel settings on your dashboard.',
@@ -137,7 +137,7 @@ export class RestChannelMixin {
 
     const method = opts.isDelete ? Resource.post : Resource.patch;
     const pathSuffix = opts.isDelete ? '/delete' : '';
-    const { body, unpacked } = await method<WireMessage>(
+    await method<WireMessage>(
       client,
       this.basePath(channel) + '/messages/' + encodeURIComponent(message.serial) + pathSuffix,
       requestBody,
@@ -146,9 +146,6 @@ export class RestChannelMixin {
       null,
       true,
     );
-
-    const decoded = unpacked ? body! : Utils.decodeBody<WireMessage>(body, client._MsgPack, format);
-    return _fromEncoded(decoded, channel);
   }
 
   static getMessageVersions(

--- a/test/rest/updates-deletes.test.js
+++ b/test/rest/updates-deletes.test.js
@@ -118,9 +118,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         metadata: { reason: 'testing' },
       };
 
-      const updatedMessage = await channel.updateMessage(updateMessage, operation);
-      expect(updatedMessage.serial).to.equal(originalMessage.serial);
-      expect(updatedMessage.data).to.deep.equal({ value: 'updated with metadata' });
+      await channel.updateMessage(updateMessage, operation);
 
       // Wait for the update to be the latest message
       let latestMessage;
@@ -173,9 +171,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
       const deletion = Object.assign({}, originalMessage, { data: {} });
 
-      const deletedMessage = await channel.deleteMessage(deletion, operation);
-      expect(deletedMessage.serial).to.equal(originalMessage.serial);
-      expect(deletedMessage.action).to.equal('message.delete');
+      await channel.deleteMessage(deletion, operation);
 
       // Wait for the delete to be the latest message
       let latestMessage;


### PR DESCRIPTION
As agreed before the preview release. I am going to add a new publishResponse type, but it won't be a Message, so until we do that, I'm removing the Message response so we don't release a version of ably-js which has a return type that anyone might try and come to rely on.

spec pr: https://github.com/ably/specification/pull/403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Message update and delete operations no longer return the message object; they now return void. Callers must fetch the message separately if needed.

* **Tests**
  * Tests updated to await operations without capturing a return value and verify results by retrieving the message afterward.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->