### PR TITLE
[AIT-45] Fix using CompactedValue incorrectly resolves all primitives to `string`

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2447,13 +2447,13 @@ export type CompactedValue<T extends Value> =
         : [T] extends [LiveCounter | undefined]
           ? number | undefined
           : // Binary types (converted to base64 strings)
-            [T] extends [Buffer]
+            [T] extends [ArrayBuffer]
             ? string
-            : [T] extends [Buffer | undefined]
+            : [T] extends [ArrayBuffer | undefined]
               ? string | undefined
-              : [T] extends [ArrayBuffer]
+              : [T] extends [ArrayBufferView]
                 ? string
-                : [T] extends [ArrayBuffer | undefined]
+                : [T] extends [ArrayBufferView | undefined]
                   ? string | undefined
                   : // Other primitive types
                     [T] extends [Primitive]


### PR DESCRIPTION
`Buffer` type is not defined in browser environments, and instead is resolved to `any`. This caused the conditional type `CompactedValue` to resolve `any` type to `string` apart from LiveObject types. One possible way to fix this is to use `ArrayBufferView` in the conditional type instead - it will cover Node's `Buffer` because `Buffer` extends `Uint8Array`, which is an `ArrayBufferView`. And `ArrayBufferView` is a JavaScript type so it works in both environments.

Resolves [AIT-45](https://ably.atlassian.net/browse/AIT-45)

[AIT-45]: https://ably.atlassian.net/browse/AIT-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Type System Updates**
  * Updated binary data type handling in CompactedValue to support ArrayBuffer and ArrayBufferView types for improved cross-platform compatibility
  * Binary payloads now properly serialize as base64-encoded strings when compacted

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->