### PR TITLE
Remove deferral of Objects `SYNCED` events, and add sync event tests

### DIFF
--- a/src/plugins/objects/objects.ts
+++ b/src/plugins/objects/objects.ts
@@ -268,11 +268,7 @@ export class Objects {
     );
 
     // RTO4a
-    if (hasObjects || this._state == ObjectsState.initialized) {
-      // should always start a new sync sequence if we're in the initialized state, no matter the HAS_OBJECTS flag value.
-      // this guarantees we emit both "syncing" -> "synced" events in that order.
-      this._startNewSync();
-    }
+    this._startNewSync();
 
     // RTO4b
     if (!hasObjects) {

--- a/test/realtime/objects.test.js
+++ b/test/realtime/objects.test.js
@@ -5548,12 +5548,17 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
         },
 
         {
-          description: 'ATTACHED with HAS_OBJECTS false once SYNCED should not provoke further events',
+          description: 'ATTACHED with HAS_OBJECTS false once SYNCED emits SYNCING and then SYNCED',
           channelEvents: [
             { type: 'attached', hasObjects: false },
             { type: 'attached', hasObjects: false },
           ],
-          expectedSyncEvents: ['syncing', 'synced'],
+          expectedSyncEvents: [
+            'syncing',
+            'synced', // The initial SYNCED
+            'syncing',
+            'synced', // From the subsequent ATTACHED
+          ],
         },
 
         {


### PR DESCRIPTION
This does the following:

- removes the deferral of `SYNCED` events to the next event loop cycle (see commit message)
- adds tests for the `SYNCING` and `SYNCED` events based on the currently-implemented behaviour; will use this as a basis for https://github.com/ably/ably-liveobjects-swift-plugin/issues/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved object synchronization efficiency by streamlining internal state management, eliminating deferred event signaling in favor of immediate execution for enhanced responsiveness.

* **Tests**
  * Added comprehensive test suite for object synchronization events, validating sequences across multiple channel attachment scenarios and edge cases to ensure reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->