### PR TITLE
Fix failing of non-sent queued messages

### DIFF
--- a/src/common/lib/transport/protocol.ts
+++ b/src/common/lib/transport/protocol.ts
@@ -45,7 +45,7 @@ class Protocol extends EventEmitter {
 
   onAck(serial: number, count: number): void {
     Logger.logAction(this.logger, Logger.LOG_MICRO, 'Protocol.onAck()', 'serial = ' + serial + '; count = ' + count);
-    this.messageQueue.completeMessages(serial, count);
+    this.messageQueue.completeMessages({ serial, count });
   }
 
   onNack(serial: number, count: number, err: ErrorInfo): void {
@@ -58,7 +58,7 @@ class Protocol extends EventEmitter {
     if (!err) {
       err = new ErrorInfo('Unable to send message; channel not responding', 50001, 500);
     }
-    this.messageQueue.completeMessages(serial, count, err);
+    this.messageQueue.completeMessages({ serial, count }, err);
   }
 
   onceIdle(listener: ErrCallback): void {

--- a/test/common/modules/private_api_recorder.js
+++ b/test/common/modules/private_api_recorder.js
@@ -103,6 +103,7 @@ define(['test/support/output_directory_paths'], function (outputDirectoryPaths) 
     'read.connectionManager.connectionId',
     'read.connectionManager.connectionStateTtl',
     'read.connectionManager.domains',
+    'read.connectionManager.queuedMessages',
     'read.connectionManager.msgSerial',
     'read.connectionManager.options',
     'read.connectionManager.options.timeouts.httpMaxRetryDuration',


### PR DESCRIPTION
Non-sent queued messages were not being failed when the connection entered the `SUSPENDED` / `FAILED` / `CLOSED` states.

The existing logic relied on the queued messages having a `msgSerial`, but they don't get a `msgSerial` until the first time we send the message on the transport.

Resolves #2115.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to complete either a specific range of messages or all pending messages in the queue.

* **Bug Fixes**
  * Idle state now emitted only after processing and when the queue is empty.
  * Callbacks invoked after messages are removed to ensure correct ordering.
  * Improved completion/nack handling distinguishing queued vs sent messages.

* **Tests**
  * Expanded and renamed tests covering suspends/failures/closures for sent and queued messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->