### PR TITLE
[AIT-46] Fix type inference in LiveMap.create to catch type errors

### DIFF
--- a/objects.d.ts
+++ b/objects.d.ts
@@ -11,6 +11,20 @@ import { BaseRealtime } from './modular';
 /* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
 
 /**
+ * Blocks inferences to the contained type.
+ * Polyfill for TypeScript's `NoInfer` utility type introduced in TypeScript 5.4.
+ *
+ * This works by leveraging deferred conditional types - the compiler can't
+ * evaluate the conditional until it knows what T is, which prevents TypeScript
+ * from digging into the type to find inference candidates.
+ *
+ * See:
+ * - https://stackoverflow.com/questions/56687668
+ * - https://www.typescriptlang.org/docs/handbook/utility-types.html#noinfertype
+ */
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
+/**
  * Static utilities related to LiveMap instances.
  */
 export class LiveMap {
@@ -23,7 +37,9 @@ export class LiveMap {
    * @experimental
    */
   static create<T extends Record<string, Value>>(
-    initialEntries?: T,
+    // block TypeScript from inferring T from the initialEntries argument, so instead it is inferred
+    // from the contextual type in a LiveMap.set call
+    initialEntries?: NoInfer<T>,
   ): LiveMapType<T extends Record<string, Value> ? T : {}>;
 }
 


### PR DESCRIPTION
Previously, TypeScript would not catch type errors when creating LiveMap instances and assigning them to a collection via LiveMap.set with incorrect data structures. For example, passing `{ done: 1 }` (number) when the expected type for the object at path required `{ done: boolean }` would not produce a compilation error.

The issue was that TypeScript inferred the generic type parameter T from the `initialData` argument itself, rather than from the contextual type where the created object would be used. This meant TypeScript would infer T based on what was actually passed, effectively making any structure valid.

Fixed by wrapping the `initialData` parameter type with `NoInfer<T>`, which prevents TypeScript from inferring T from that parameter. Now T must be inferred from the calling context (e.g., the expected type in a LiveMap.set() call), ensuring that the data passed to .create() is validated against the expected type structure.

Resolves [AIT-46](https://ably.atlassian.net/browse/AIT-46)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference when initializing map-like data structures, reducing spurious type errors and providing more accurate compile-time validation for developers. This yields a smoother development experience and fewer manual type workarounds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[AIT-46]: https://ably.atlassian.net/browse/AIT-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ