### PR TITLE
Readme tweak: re-add CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ The JavaScript SDK is available as an [NPM module](https://www.npmjs.com/package
 npm install ably
 ```
 
-Run the following to instantiate a client:
+You can also source it directly in your HTML. (This url will point to the latest version of v2 of the SDK, the current major version, avoiding breaking changes per semver)
 
-```javascript
-import * as Ably from 'ably';
-const realtime = new Ably.Realtime({ key: apiKey });
+```html
+<script src="https://cdn.ably.com/lib/ably.min-2.js"></script>
 ```
 
 ## Usage
@@ -72,6 +71,7 @@ The following code connects to Ably's realtime messaging service, subscribes to 
 
 ```javascript
 // Initialize Ably Realtime client
+// (for the REST client use new Ably.Rest({...}) instead)
 const realtimeClient = new Ably.Realtime({ key: 'your-ably-api-key', clientId: 'me' });
 
 // Wait for connection to be established


### PR DESCRIPTION
I don't know why this was removed. This seem quite important. Plenty of people still just write scripts and pull in the hosted lib. (And LLMs are still recommending the v1 cdn url, because they can't see the v2 one!).

Also remove redundant usage line, and add note about how to instantiate the rest client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced import-based JavaScript SDK initialization examples with an HTML CDN example for v2.
  * Added guidance showing REST client usage with an Ably.Rest(...) note and inline comment in the JS snippet to clarify the REST alternative.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->