### PR TITLE
Change `Instance.id()` to `Instance.id` getter property to better align with other public interfaces

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2798,7 +2798,7 @@ interface BatchContextBase {
    *
    * @experimental
    */
-  id(): string | undefined;
+  readonly id: string | undefined;
 }
 
 /**
@@ -3372,7 +3372,7 @@ interface InstanceBase<T extends Value> {
    *
    * @experimental
    */
-  id(): string | undefined;
+  readonly id: string | undefined;
 
   /**
    * Registers a listener that is called each time this instance is updated.

--- a/src/plugins/objects/batchcontext.ts
+++ b/src/plugins/objects/batchcontext.ts
@@ -39,10 +39,10 @@ export class DefaultBatchContext implements AnyBatchContext {
     return this._instance.compact();
   }
 
-  id(): string | undefined {
+  get id(): string | undefined {
     this._realtimeObject.throwIfInvalidAccessApiConfiguration();
     this._throwIfClosed();
-    return this._instance.id();
+    return this._instance.id;
   }
 
   *entries<T extends Record<string, Value>>(): IterableIterator<[keyof T, BatchContext<T[keyof T]>]> {
@@ -81,7 +81,7 @@ export class DefaultBatchContext implements AnyBatchContext {
       throw new this._client.ErrorInfo('Cannot set a key on a non-LiveMap instance', 92007, 400);
     }
     this._rootContext.queueMessages(async () =>
-      LiveMap.createMapSetMessage(this._realtimeObject, this._instance.id()!, key, value),
+      LiveMap.createMapSetMessage(this._realtimeObject, this._instance.id!, key, value),
     );
   }
 
@@ -92,7 +92,7 @@ export class DefaultBatchContext implements AnyBatchContext {
       throw new this._client.ErrorInfo('Cannot remove a key from a non-LiveMap instance', 92007, 400);
     }
     this._rootContext.queueMessages(async () => [
-      LiveMap.createMapRemoveMessage(this._realtimeObject, this._instance.id()!, key),
+      LiveMap.createMapRemoveMessage(this._realtimeObject, this._instance.id!, key),
     ]);
   }
 
@@ -103,7 +103,7 @@ export class DefaultBatchContext implements AnyBatchContext {
       throw new this._client.ErrorInfo('Cannot increment a non-LiveCounter instance', 92007, 400);
     }
     this._rootContext.queueMessages(async () => [
-      LiveCounter.createCounterIncMessage(this._realtimeObject, this._instance.id()!, amount ?? 1),
+      LiveCounter.createCounterIncMessage(this._realtimeObject, this._instance.id!, amount ?? 1),
     ]);
   }
 

--- a/src/plugins/objects/instance.ts
+++ b/src/plugins/objects/instance.ts
@@ -34,7 +34,7 @@ export class DefaultInstance<T extends Value> implements AnyInstance<T> {
     this._client = this._realtimeObject.getClient();
   }
 
-  id(): string | undefined {
+  get id(): string | undefined {
     if (!(this._value instanceof LiveObject)) {
       // no id exists for non-LiveObject types
       return undefined;

--- a/src/plugins/objects/rootbatchcontext.ts
+++ b/src/plugins/objects/rootbatchcontext.ts
@@ -51,7 +51,7 @@ export class RootBatchContext extends DefaultBatchContext {
 
   /** @internal */
   wrapInstance(instance: Instance<Value>): DefaultBatchContext {
-    const objectId = instance.id();
+    const objectId = instance.id;
     if (objectId) {
       // memoize liveobject instances by their object ids
       if (this._wrappedInstances.has(objectId)) {

--- a/test/realtime/objects.test.js
+++ b/test/realtime/objects.test.js
@@ -297,7 +297,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
           await channel.attach();
           const entryPathObject = await channel.object.get();
 
-          expect(entryPathObject.instance().id()).to.equal('root', 'root object should have an object id "root"');
+          expect(entryPathObject.instance().id).to.equal('root', 'root object should have an object id "root"');
         }, client);
       });
 
@@ -2110,8 +2110,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             });
             await objectsCreatedPromise;
 
-            const mapId = entryInstance.get('map').id();
-            const counterId = entryInstance.get('counter').id();
+            const mapId = entryInstance.get('map').id;
+            const counterId = entryInstance.get('counter').id;
 
             const mapSubPromise = new Promise((resolve, reject) =>
               entryInstance.get('map').subscribe((event) => {
@@ -4846,7 +4846,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                 expect(event.message.operation).to.deep.include(
                   {
                     action: 'map.set',
-                    objectId: entryPathObject.get('map').instance().id(),
+                    objectId: entryPathObject.get('map').instance().id,
                   },
                   'Check event message operation',
                 );
@@ -5185,7 +5185,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
 
       const instanceScenarios = [
         {
-          description: 'DefaultInstance.id() returns object ID of the underlying LiveObject',
+          description: 'DefaultInstance.id returns object ID of the underlying LiveObject',
           action: async (ctx) => {
             const { objectsHelper, channelName, entryInstance } = ctx;
 
@@ -5208,8 +5208,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const map = entryInstance.get('map');
             const counter = entryInstance.get('counter');
 
-            expect(map.id()).to.equal(mapId, 'Check DefaultInstance.id() for map matches expected value');
-            expect(counter.id()).to.equal(counterId, 'Check DefaultInstance.id() for counter matches expected value');
+            expect(map.id).to.equal(mapId, 'Check DefaultInstance.id for map matches expected value');
+            expect(counter.id).to.equal(counterId, 'Check DefaultInstance.id for counter matches expected value');
           },
         },
 
@@ -5492,10 +5492,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const primitiveInstance = mapInstance.get('foo');
 
             // next methods silently handle incorrect underlying type
-            expect(
-              primitiveInstance.id(),
-              'Check DefaultInstance.id() for wrong underlying object type returns undefined',
-            ).to.be.undefined;
+            expect(primitiveInstance.id, 'Check DefaultInstance.id for wrong underlying object type returns undefined')
+              .to.be.undefined;
             expect(
               primitiveInstance.get('foo'),
               'Check DefaultInstance.get() for wrong underlying object type returns undefined',
@@ -5776,7 +5774,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                 try {
                   expect(event.object, 'Check event object exists').to.exist;
                   expectInstanceOf(event.object, 'DefaultInstance', 'Check event object is DefaultInstance');
-                  expect(event.object.id()).to.equal('root', 'Check event object has correct object ID');
+                  expect(event.object.id).to.equal('root', 'Check event object has correct object ID');
                   expect(event.object).to.equal(entryInstance, 'Check event object is the same instance');
                   resolve();
                 } catch (error) {
@@ -5840,8 +5838,8 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                 expect(event.message, 'Check event message exists').to.exist;
                 expect(event.message.operation).to.deep.include(
                   events.length === 0
-                    ? { action: 'map.set', objectId: map.id(), mapOp: { key: 'foo', data: { value: 'bar' } } }
-                    : { action: 'map.remove', objectId: map.id(), mapOp: { key: 'foo' } },
+                    ? { action: 'map.set', objectId: map.id, mapOp: { key: 'foo', data: { value: 'bar' } } }
+                    : { action: 'map.remove', objectId: map.id, mapOp: { key: 'foo' } },
                   'Check event message operation',
                 );
                 events.push(event);
@@ -5883,7 +5881,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                 expect(event.message.operation).to.deep.include(
                   {
                     action: 'counter.inc',
-                    objectId: counter.id(),
+                    objectId: counter.id,
                     counterOp: { amount: events.length === 0 ? 1 : -2 },
                   },
                   'Check event message operation',
@@ -6291,7 +6289,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                   expect(event?.message?.operation).to.deep.include(
                     {
                       action: 'counter.inc',
-                      objectId: counter.id(),
+                      objectId: counter.id,
                       counterOp: { amount: 1 },
                     },
                     'Check counter subscription callback is called with an expected event message for COUNTER_INC operation',
@@ -6332,7 +6330,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                   expect(event?.message?.operation).to.deep.include(
                     {
                       action: 'counter.inc',
-                      objectId: counter.id(),
+                      objectId: counter.id,
                       counterOp: { amount: expectedInc },
                     },
                     `Check counter subscription callback is called with an expected event message operation for ${currentUpdateIndex + 1} times`,
@@ -6376,7 +6374,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                   expect(event?.message?.operation).to.deep.include(
                     {
                       action: 'map.set',
-                      objectId: map.id(),
+                      objectId: map.id,
                       mapOp: { key: 'stringKey', data: { value: 'stringValue' } },
                     },
                     'Check map subscription callback is called with an expected event message for MAP_SET operation',
@@ -6412,7 +6410,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
               map.subscribe((event) => {
                 try {
                   expect(event?.message?.operation).to.deep.include(
-                    { action: 'map.remove', objectId: map.id(), mapOp: { key: 'stringKey' } },
+                    { action: 'map.remove', objectId: map.id, mapOp: { key: 'stringKey' } },
                     'Check map subscription callback is called with an expected event message for MAP_REMOVE operation',
                   );
                   resolve();
@@ -7128,7 +7126,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
         expect(() => ctx.get()).to.throw(errorMsg);
         expect(() => ctx.value()).to.throw(errorMsg);
         expect(() => ctx.compact()).to.throw(errorMsg);
-        expect(() => ctx.id()).to.throw(errorMsg);
+        expect(() => ctx.id).to.throw(errorMsg);
         expect(() => [...ctx.entries()]).to.throw(errorMsg);
         expect(() => [...ctx.keys()]).to.throw(errorMsg);
         expect(() => [...ctx.values()]).to.throw(errorMsg);


### PR DESCRIPTION
Types like `Connection` and `LocalDevice` which represent some class with behavior still expose a unique identifier as property rather than a method. This commit align our LiveObjects API to this convention.

Prompted by a review comment: https://github.com/ably/ably-js/pull/2124#discussion_r2602582243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The public `id()` method has been replaced by a readonly `id` property on BatchContext and Instance objects. Update call sites to use property access (e.g., `instance.id`).

* **Tests**
  * Test suites updated to reflect property-based id access and corresponding expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->