### PR TITLE
Split `PathObject/Instance.compact()` into `compact()` and `compactJson()`

### DIFF
--- a/src/plugins/objects/batchcontext.ts
+++ b/src/plugins/objects/batchcontext.ts
@@ -1,5 +1,13 @@
 import type BaseClient from 'common/lib/client/baseclient';
-import type { AnyBatchContext, BatchContext, CompactedValue, Instance, Primitive, Value } from '../../../ably';
+import type {
+  AnyBatchContext,
+  BatchContext,
+  CompactedJsonValue,
+  CompactedValue,
+  Instance,
+  Primitive,
+  Value,
+} from '../../../ably';
 import { DefaultInstance } from './instance';
 import { LiveCounter } from './livecounter';
 import { LiveMap } from './livemap';
@@ -37,6 +45,12 @@ export class DefaultBatchContext implements AnyBatchContext {
     this._realtimeObject.throwIfInvalidAccessApiConfiguration();
     this._throwIfClosed();
     return this._instance.compact();
+  }
+
+  compactJson<T extends Value = Value>(): CompactedJsonValue<T> | undefined {
+    this._realtimeObject.throwIfInvalidAccessApiConfiguration();
+    this._throwIfClosed();
+    return this._instance.compactJson();
   }
 
   get id(): string | undefined {

--- a/src/plugins/objects/instance.ts
+++ b/src/plugins/objects/instance.ts
@@ -3,6 +3,7 @@ import type {
   AnyInstance,
   BatchContext,
   BatchFunction,
+  CompactedJsonValue,
   CompactedValue,
   EventCallback,
   Instance,
@@ -42,18 +43,39 @@ export class DefaultInstance<T extends Value> implements AnyInstance<T> {
     return this._value.getObjectId();
   }
 
+  /**
+   * Returns an in-memory JavaScript object representation of this instance.
+   * Buffers are returned as-is.
+   * For primitive types, this is an alias for calling value().
+   *
+   * Use compactJson() for a JSON-serializable representation.
+   */
   compact<U extends Value = Value>(): CompactedValue<U> | undefined {
     if (this._value instanceof LiveMap) {
       return this._value.compact() as CompactedValue<U>;
     }
 
+    return this.value() as CompactedValue<U>;
+  }
+
+  /**
+   * Returns a JSON-serializable representation of this instance.
+   * Buffers are converted to base64 strings.
+   *
+   * Use compact() for an in-memory representation.
+   */
+  compactJson<U extends Value = Value>(): CompactedJsonValue<U> | undefined {
+    if (this._value instanceof LiveMap) {
+      return this._value.compactJson() as CompactedJsonValue<U>;
+    }
+
     const value = this.value();
 
     if (this._client.Platform.BufferUtils.isBuffer(value)) {
-      return this._client.Platform.BufferUtils.base64Encode(value) as CompactedValue<U>;
+      return this._client.Platform.BufferUtils.base64Encode(value) as CompactedJsonValue<U>;
     }
 
-    return value as CompactedValue<U>;
+    return value as CompactedJsonValue<U>;
   }
 
   get<U extends Value = Value>(key: string): Instance<U> | undefined {

--- a/test/realtime/objects.test.js
+++ b/test/realtime/objects.test.js
@@ -4090,6 +4090,10 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             // Next operations should not throw and silently handle non-existent path
             expect(nonExistentPathObj.compact(), 'Check PathObject.compact() for non-existent path returns undefined')
               .to.be.undefined;
+            expect(
+              nonExistentPathObj.compactJson(),
+              'Check PathObject.compactJson() for non-existent path returns undefined',
+            ).to.be.undefined;
             expect(nonExistentPathObj.value(), 'Check PathObject.value() for non-existent path returns undefined').to.be
               .undefined;
             expect(nonExistentPathObj.instance(), 'Check PathObject.instance() for non-existent path returns undefined')
@@ -4141,6 +4145,10 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             // Next operations should not throw and silently handle incorrect path
             expect(wrongTypePathObj.compact(), 'Check PathObject.compact() for non-collection path returns undefined')
               .to.be.undefined;
+            expect(
+              wrongTypePathObj.compactJson(),
+              'Check PathObject.compactJson() for non-collection path returns undefined',
+            ).to.be.undefined;
             expect(wrongTypePathObj.value(), 'Check PathObject.value() for non-collection path returns undefined').to.be
               .undefined;
             expect(wrongTypePathObj.instance(), 'Check PathObject.instance() for non-collection path returns undefined')
@@ -4969,7 +4977,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
         },
 
         {
-          description: 'PathObject.compact() returns correct representation for primitive values',
+          description: 'PathObject.compact() returns value as is for primitive values',
           action: async (ctx) => {
             const { entryPathObject, entryInstance, helper } = ctx;
 
@@ -4996,12 +5004,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             primitiveKeyData.forEach((keyData) => {
               const pathObj = entryPathObject.get(keyData.key);
               const compactValue = pathObj.compact();
-              // expect buffer values to be base64-encoded strings
-              helper.recordPrivateApi('call.BufferUtils.isBuffer');
-              helper.recordPrivateApi('call.BufferUtils.base64Encode');
-              const expectedValue = BufferUtils.isBuffer(pathObj.value())
-                ? BufferUtils.base64Encode(pathObj.value())
-                : pathObj.value();
+              const expectedValue = pathObj.value();
 
               expect(compactValue).to.deep.equal(
                 expectedValue,
@@ -5026,13 +5029,14 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
         },
 
         {
-          description: 'PathObject.compact() returns plain object for LiveMap objects',
+          description: 'PathObject.compact() returns plain object for LiveMap objects with buffers as-is',
           action: async (ctx) => {
             const { entryInstance, entryPathObject, helper } = ctx;
 
             // Create nested structure with different value types
             const keysUpdatedPromise = Promise.all([waitForMapKeyUpdate(entryInstance, 'nestedMap')]);
             helper.recordPrivateApi('call.BufferUtils.utf8Encode');
+            const bufferValue = BufferUtils.utf8Encode('value');
             await entryPathObject.set(
               'nestedMap',
               LiveMap.create({
@@ -5042,14 +5046,12 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                 counterKey: LiveCounter.create(99),
                 array: [1, 2, 3],
                 obj: { nested: 'value' },
-                buffer: BufferUtils.utf8Encode('value'),
+                buffer: bufferValue,
               }),
             );
             await keysUpdatedPromise;
 
             const compactValue = entryPathObject.get('nestedMap').compact();
-            helper.recordPrivateApi('call.BufferUtils.utf8Encode');
-            helper.recordPrivateApi('call.BufferUtils.base64Encode');
             const expected = {
               stringKey: 'stringValue',
               numberKey: 123,
@@ -5057,7 +5059,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
               counterKey: 99,
               array: [1, 2, 3],
               obj: { nested: 'value' },
-              buffer: BufferUtils.base64Encode(BufferUtils.utf8Encode('value')),
+              buffer: bufferValue,
             };
 
             expect(compactValue).to.deep.equal(expected, 'Check compact object has expected value');
@@ -5107,7 +5109,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const { objectsHelper, channelName, entryInstance, entryPathObject } = ctx;
 
             // Create a structure with cyclic references using REST API (realtime does not allow referencing objects by id):
-            // root -> map1 -> map2 -> map1 (back reference)
+            // root -> map1 -> map2 -> map1 pointer (back reference)
 
             const { objectId: map1Id } = await objectsHelper.operationRequest(
               channelName,
@@ -5167,6 +5169,211 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
               compactEntry.map1,
               'Check cyclic reference returns the same memoized result object',
             );
+          },
+        },
+
+        {
+          description: 'PathObject.compactJson() returns JSON-encodable value for primitive values',
+          action: async (ctx) => {
+            const { entryPathObject, entryInstance, helper } = ctx;
+
+            const keysUpdatedPromise = Promise.all(
+              primitiveKeyData.map((x) => waitForMapKeyUpdate(entryInstance, x.key)),
+            );
+            await Promise.all(
+              primitiveKeyData.map(async (keyData) => {
+                let value;
+                if (keyData.data.bytes != null) {
+                  helper.recordPrivateApi('call.BufferUtils.base64Decode');
+                  value = BufferUtils.base64Decode(keyData.data.bytes);
+                } else if (keyData.data.json != null) {
+                  value = JSON.parse(keyData.data.json);
+                } else {
+                  value = keyData.data.number ?? keyData.data.string ?? keyData.data.boolean;
+                }
+
+                await entryPathObject.set(keyData.key, value);
+              }),
+            );
+            await keysUpdatedPromise;
+
+            primitiveKeyData.forEach((keyData) => {
+              const pathObj = entryPathObject.get(keyData.key);
+              const compactJsonValue = pathObj.compactJson();
+              // expect buffer values to be base64-encoded strings
+              helper.recordPrivateApi('call.BufferUtils.isBuffer');
+              helper.recordPrivateApi('call.BufferUtils.base64Encode');
+              const expectedValue = BufferUtils.isBuffer(pathObj.value())
+                ? BufferUtils.base64Encode(pathObj.value())
+                : pathObj.value();
+
+              expect(compactJsonValue).to.deep.equal(
+                expectedValue,
+                `Check PathObject.compactJson() returns correct value for primitive "${keyData.key}"`,
+              );
+            });
+          },
+        },
+
+        {
+          description: 'PathObject.compactJson() returns number for LiveCounter objects',
+          action: async (ctx) => {
+            const { entryInstance, entryPathObject } = ctx;
+
+            const keyUpdatedPromise = waitForMapKeyUpdate(entryInstance, 'counter');
+            await entryPathObject.set('counter', LiveCounter.create(42));
+            await keyUpdatedPromise;
+
+            const compactJsonValue = entryPathObject.get('counter').compactJson();
+            expect(compactJsonValue).to.equal(42, 'Check PathObject.compactJson() returns number for LiveCounter');
+          },
+        },
+
+        {
+          description: 'PathObject.compactJson() returns plain object for LiveMap with base64-encoded buffers',
+          action: async (ctx) => {
+            const { entryInstance, entryPathObject, helper } = ctx;
+
+            // Create nested structure with different value types
+            const keysUpdatedPromise = Promise.all([waitForMapKeyUpdate(entryInstance, 'nestedMap')]);
+            helper.recordPrivateApi('call.BufferUtils.utf8Encode');
+            await entryPathObject.set(
+              'nestedMap',
+              LiveMap.create({
+                stringKey: 'stringValue',
+                numberKey: 123,
+                booleanKey: true,
+                counterKey: LiveCounter.create(99),
+                array: [1, 2, 3],
+                obj: { nested: 'value' },
+                buffer: BufferUtils.utf8Encode('value'),
+              }),
+            );
+            await keysUpdatedPromise;
+
+            const compactJsonValue = entryPathObject.get('nestedMap').compactJson();
+            helper.recordPrivateApi('call.BufferUtils.utf8Encode');
+            helper.recordPrivateApi('call.BufferUtils.base64Encode');
+            const expected = {
+              stringKey: 'stringValue',
+              numberKey: 123,
+              booleanKey: true,
+              counterKey: 99,
+              array: [1, 2, 3],
+              obj: { nested: 'value' },
+              buffer: BufferUtils.base64Encode(BufferUtils.utf8Encode('value')),
+            };
+
+            expect(compactJsonValue).to.deep.equal(expected, 'Check compact object has expected value');
+          },
+        },
+
+        {
+          description: 'PathObject.compactJson() handles complex nested structures',
+          action: async (ctx) => {
+            const { entryInstance, entryPathObject } = ctx;
+
+            const keyUpdatedPromise = waitForMapKeyUpdate(entryInstance, 'complex');
+            await entryPathObject.set(
+              'complex',
+              LiveMap.create({
+                level1: LiveMap.create({
+                  level2: LiveMap.create({
+                    counter: LiveCounter.create(10),
+                    primitive: 'deep value',
+                  }),
+                  directCounter: LiveCounter.create(20),
+                }),
+                topLevelCounter: LiveCounter.create(30),
+              }),
+            );
+            await keyUpdatedPromise;
+
+            const compactJsonValue = entryPathObject.get('complex').compactJson();
+            const expected = {
+              level1: {
+                level2: {
+                  counter: 10,
+                  primitive: 'deep value',
+                },
+                directCounter: 20,
+              },
+              topLevelCounter: 30,
+            };
+
+            expect(compactJsonValue).to.deep.equal(expected, 'Check complex nested structure is compacted correctly');
+          },
+        },
+
+        {
+          description: 'PathObject.compactJson() handles cyclic references with objectId',
+          action: async (ctx) => {
+            const { objectsHelper, channelName, entryInstance, entryPathObject } = ctx;
+
+            // Create a structure with cyclic references using REST API (realtime does not allow referencing objects by id):
+            // root -> map1 -> map2 -> map1BackRef = { objectId: map1Id }
+
+            const { objectId: map1Id } = await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapCreateRestOp({ data: { foo: { string: 'bar' } } }),
+            );
+            const { objectId: map2Id } = await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapCreateRestOp({ data: { baz: { number: 42 } } }),
+            );
+
+            // Set up the cyclic references
+            let keyUpdatedPromise = waitForMapKeyUpdate(entryInstance, 'map1');
+            await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapSetRestOp({
+                objectId: 'root',
+                key: 'map1',
+                value: { objectId: map1Id },
+              }),
+            );
+            await keyUpdatedPromise;
+
+            keyUpdatedPromise = waitForMapKeyUpdate(entryInstance.get('map1'), 'map2');
+            await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapSetRestOp({
+                objectId: map1Id,
+                key: 'map2',
+                value: { objectId: map2Id },
+              }),
+            );
+            await keyUpdatedPromise;
+
+            keyUpdatedPromise = waitForMapKeyUpdate(entryInstance.get('map1').get('map2'), 'map1BackRef');
+            await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapSetRestOp({
+                objectId: map2Id,
+                key: 'map1BackRef',
+                value: { objectId: map1Id },
+              }),
+            );
+            await keyUpdatedPromise;
+
+            // Test that compactJson() handles cyclic references by returning objectId
+            const compactJsonEntry = entryPathObject.compactJson();
+
+            expect(compactJsonEntry).to.exist;
+            expect(compactJsonEntry.map1).to.exist;
+            expect(compactJsonEntry.map1.foo).to.equal('bar', 'Check primitive value is preserved');
+            expect(compactJsonEntry.map1.map2).to.exist;
+            expect(compactJsonEntry.map1.map2.baz).to.equal(42, 'Check nested primitive value is preserved');
+            expect(compactJsonEntry.map1.map2.map1BackRef).to.exist;
+
+            // The back reference should be { objectId: string } instead of in-memory pointer
+            expect(compactJsonEntry.map1.map2.map1BackRef).to.deep.equal(
+              { objectId: map1Id },
+              'Check cyclic reference returns objectId structure for JSON serialization',
+            );
+
+            // Verify the result can be JSON stringified (no circular reference error)
+            expect(() => JSON.stringify(compactJsonEntry)).to.not.throw();
           },
         },
 
@@ -5992,7 +6199,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
         },
 
         {
-          description: 'DefaultInstance.compact() returns correct representation for primitive values',
+          description: 'DefaultInstance.compact() returns value as is for primitive values',
           action: async (ctx) => {
             const { entryInstance, entryPathObject, helper } = ctx;
 
@@ -6019,12 +6226,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             primitiveKeyData.forEach((keyData) => {
               const instance = entryInstance.get(keyData.key);
               const compactValue = instance.compact();
-              // expect buffer values to be base64-encoded strings
-              helper.recordPrivateApi('call.BufferUtils.isBuffer');
-              helper.recordPrivateApi('call.BufferUtils.base64Encode');
-              const expectedValue = BufferUtils.isBuffer(instance.value())
-                ? BufferUtils.base64Encode(instance.value())
-                : instance.value();
+              const expectedValue = instance.value();
 
               expect(compactValue).to.deep.equal(
                 expectedValue,
@@ -6049,13 +6251,14 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
         },
 
         {
-          description: 'DefaultInstance.compact() returns plain object for LiveMap objects',
+          description: 'DefaultInstance.compact() returns plain object for LiveMap objects with buffers as-is',
           action: async (ctx) => {
             const { entryInstance, entryPathObject, helper } = ctx;
 
             // Create nested structure with different value types
             const keysUpdatedPromise = Promise.all([waitForMapKeyUpdate(entryInstance, 'nestedMap')]);
             helper.recordPrivateApi('call.BufferUtils.utf8Encode');
+            const bufferValue = BufferUtils.utf8Encode('value');
             await entryPathObject.set(
               'nestedMap',
               LiveMap.create({
@@ -6065,14 +6268,12 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
                 counterKey: LiveCounter.create(111),
                 array: [1, 2, 3],
                 obj: { nested: 'value' },
-                buffer: BufferUtils.utf8Encode('value'),
+                buffer: bufferValue,
               }),
             );
             await keysUpdatedPromise;
 
             const compactValue = entryInstance.get('nestedMap').compact();
-            helper.recordPrivateApi('call.BufferUtils.utf8Encode');
-            helper.recordPrivateApi('call.BufferUtils.base64Encode');
             const expected = {
               stringKey: 'stringValue',
               numberKey: 456,
@@ -6080,7 +6281,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
               counterKey: 111,
               array: [1, 2, 3],
               obj: { nested: 'value' },
-              buffer: BufferUtils.base64Encode(BufferUtils.utf8Encode('value')),
+              buffer: bufferValue,
             };
 
             expect(compactValue).to.deep.equal(expected, 'Check compact object has expected value');
@@ -6161,7 +6362,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
             const { objectsHelper, channelName, entryInstance } = ctx;
 
             // Create a structure with cyclic references using REST API (realtime does not allow referencing objects by id):
-            // root -> map1 -> map2 -> map1 (back reference)
+            // root -> map1 -> map2 -> map1 pointer (back reference)
 
             const { objectId: map1Id } = await objectsHelper.operationRequest(
               channelName,
@@ -6221,6 +6422,248 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
               compactEntry.map1,
               'Check cyclic reference returns the same memoized result object',
             );
+          },
+        },
+
+        {
+          description: 'DefaultInstance.compactJson() returns JSON-encodable value for primitive values',
+          action: async (ctx) => {
+            const { entryInstance, entryPathObject, helper } = ctx;
+
+            const keysUpdatedPromise = Promise.all(
+              primitiveKeyData.map((x) => waitForMapKeyUpdate(entryInstance, x.key)),
+            );
+            await Promise.all(
+              primitiveKeyData.map(async (keyData) => {
+                let value;
+                if (keyData.data.bytes != null) {
+                  helper.recordPrivateApi('call.BufferUtils.base64Decode');
+                  value = BufferUtils.base64Decode(keyData.data.bytes);
+                } else if (keyData.data.json != null) {
+                  value = JSON.parse(keyData.data.json);
+                } else {
+                  value = keyData.data.number ?? keyData.data.string ?? keyData.data.boolean;
+                }
+
+                await entryPathObject.set(keyData.key, value);
+              }),
+            );
+            await keysUpdatedPromise;
+
+            primitiveKeyData.forEach((keyData) => {
+              const instance = entryInstance.get(keyData.key);
+              const compactJsonValue = instance.compactJson();
+              // expect buffer values to be base64-encoded strings
+              helper.recordPrivateApi('call.BufferUtils.isBuffer');
+              helper.recordPrivateApi('call.BufferUtils.base64Encode');
+              const expectedValue = BufferUtils.isBuffer(instance.value())
+                ? BufferUtils.base64Encode(instance.value())
+                : instance.value();
+
+              expect(compactJsonValue).to.deep.equal(
+                expectedValue,
+                `Check DefaultInstance.compactJson() returns correct value for primitive "${keyData.key}"`,
+              );
+            });
+          },
+        },
+
+        {
+          description: 'DefaultInstance.compactJson() returns number for LiveCounter objects',
+          action: async (ctx) => {
+            const { entryInstance, entryPathObject } = ctx;
+
+            const keyUpdatedPromise = waitForMapKeyUpdate(entryInstance, 'counter');
+            await entryPathObject.set('counter', LiveCounter.create(42));
+            await keyUpdatedPromise;
+
+            const compactJsonValue = entryInstance.get('counter').compactJson();
+            expect(compactJsonValue).to.equal(42, 'Check DefaultInstance.compactJson() returns number for LiveCounter');
+          },
+        },
+
+        {
+          description: 'DefaultInstance.compactJson() returns plain object for LiveMap with base64-encoded buffers',
+          action: async (ctx) => {
+            const { entryInstance, entryPathObject, helper } = ctx;
+
+            // Create nested structure with different value types
+            const keysUpdatedPromise = Promise.all([waitForMapKeyUpdate(entryInstance, 'nestedMapInstance')]);
+            helper.recordPrivateApi('call.BufferUtils.utf8Encode');
+            await entryPathObject.set(
+              'nestedMapInstance',
+              LiveMap.create({
+                stringKey: 'stringValue',
+                numberKey: 456,
+                booleanKey: false,
+                counterKey: LiveCounter.create(111),
+                array: [1, 2, 3],
+                obj: { nested: 'value' },
+                buffer: BufferUtils.utf8Encode('value'),
+              }),
+            );
+            await keysUpdatedPromise;
+
+            const compactJsonValue = entryInstance.get('nestedMapInstance').compactJson();
+            helper.recordPrivateApi('call.BufferUtils.utf8Encode');
+            helper.recordPrivateApi('call.BufferUtils.base64Encode');
+            const expected = {
+              stringKey: 'stringValue',
+              numberKey: 456,
+              booleanKey: false,
+              counterKey: 111,
+              array: [1, 2, 3],
+              obj: { nested: 'value' },
+              buffer: BufferUtils.base64Encode(BufferUtils.utf8Encode('value')),
+            };
+
+            expect(compactJsonValue).to.deep.equal(expected, 'Check compact object has expected value');
+          },
+        },
+
+        {
+          description: 'DefaultInstance.compactJson() handles complex nested structures',
+          action: async (ctx) => {
+            const { entryInstance, entryPathObject } = ctx;
+
+            const keyUpdatedPromise = waitForMapKeyUpdate(entryInstance, 'complex');
+            await entryPathObject.set(
+              'complex',
+              LiveMap.create({
+                level1: LiveMap.create({
+                  level2: LiveMap.create({
+                    counter: LiveCounter.create(100),
+                    primitive: 'instance deep value',
+                  }),
+                  directCounter: LiveCounter.create(200),
+                }),
+                topLevelCounter: LiveCounter.create(300),
+              }),
+            );
+            await keyUpdatedPromise;
+
+            const compactJsonValue = entryInstance.get('complex').compactJson();
+            const expected = {
+              level1: {
+                level2: {
+                  counter: 100,
+                  primitive: 'instance deep value',
+                },
+                directCounter: 200,
+              },
+              topLevelCounter: 300,
+            };
+
+            expect(compactJsonValue).to.deep.equal(expected, 'Check complex nested structure is compacted correctly');
+          },
+        },
+
+        {
+          description: 'DefaultInstance.compactJson() and PathObject.compactJson() return equivalent results',
+          action: async (ctx) => {
+            const { entryInstance, entryPathObject, helper } = ctx;
+
+            const keyUpdatedPromise = waitForMapKeyUpdate(entryInstance, 'comparison');
+            helper.recordPrivateApi('call.BufferUtils.utf8Encode');
+            await entryPathObject.set(
+              'comparison',
+              LiveMap.create({
+                counter: LiveCounter.create(50),
+                nested: LiveMap.create({
+                  value: 'test',
+                  innerCounter: LiveCounter.create(25),
+                }),
+                primitive: 'comparison test',
+                buffer: BufferUtils.utf8Encode('value'),
+              }),
+            );
+            await keyUpdatedPromise;
+
+            const pathCompactJson = entryPathObject.get('comparison').compactJson();
+            const instanceCompactJson = entryInstance.get('comparison').compactJson();
+
+            expect(pathCompactJson).to.deep.equal(
+              instanceCompactJson,
+              'Check PathObject.compactJson() and DefaultInstance.compactJson() return equivalent results',
+            );
+          },
+        },
+
+        {
+          description: 'DefaultInstance.compactJson() handles cyclic references with objectId',
+          action: async (ctx) => {
+            const { objectsHelper, channelName, entryInstance } = ctx;
+
+            // Create a structure with cyclic references using REST API (realtime does not allow referencing objects by id):
+            // root -> map1 -> map2 -> map1BackRef = { objectId: map1Id }
+
+            const { objectId: map1Id } = await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapCreateRestOp({ data: { foo: { string: 'bar' } } }),
+            );
+            const { objectId: map2Id } = await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapCreateRestOp({ data: { baz: { number: 42 } } }),
+            );
+
+            // Set up the cyclic references
+            let keyUpdatedPromise = waitForMapKeyUpdate(entryInstance, 'map1Instance');
+            await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapSetRestOp({
+                objectId: 'root',
+                key: 'map1Instance',
+                value: { objectId: map1Id },
+              }),
+            );
+            await keyUpdatedPromise;
+
+            keyUpdatedPromise = waitForMapKeyUpdate(entryInstance.get('map1Instance'), 'map2Instance');
+            await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapSetRestOp({
+                objectId: map1Id,
+                key: 'map2Instance',
+                value: { objectId: map2Id },
+              }),
+            );
+            await keyUpdatedPromise;
+
+            keyUpdatedPromise = waitForMapKeyUpdate(
+              entryInstance.get('map1Instance').get('map2Instance'),
+              'map1BackRefInstance',
+            );
+            await objectsHelper.operationRequest(
+              channelName,
+              objectsHelper.mapSetRestOp({
+                objectId: map2Id,
+                key: 'map1BackRefInstance',
+                value: { objectId: map1Id },
+              }),
+            );
+            await keyUpdatedPromise;
+
+            // Test that compactJson() handles cyclic references with objectId structure
+            const compactJsonEntry = entryInstance.compactJson();
+
+            expect(compactJsonEntry).to.exist;
+            expect(compactJsonEntry.map1Instance).to.exist;
+            expect(compactJsonEntry.map1Instance.foo).to.equal('bar', 'Check primitive value is preserved');
+            expect(compactJsonEntry.map1Instance.map2Instance).to.exist;
+            expect(compactJsonEntry.map1Instance.map2Instance.baz).to.equal(
+              42,
+              'Check nested primitive value is preserved',
+            );
+            expect(compactJsonEntry.map1Instance.map2Instance.map1BackRefInstance).to.exist;
+
+            // The back reference should be { objectId: string } instead of in-memory pointer
+            expect(compactJsonEntry.map1Instance.map2Instance.map1BackRefInstance).to.deep.equal(
+              { objectId: map1Id },
+              'Check cyclic reference returns objectId structure for JSON serialization',
+            );
+
+            // Verify the result can be JSON stringified (no circular reference error)
+            expect(() => JSON.stringify(compactJsonEntry)).to.not.throw();
           },
         },
 
@@ -7126,6 +7569,7 @@ define(['ably', 'shared_helper', 'chai', 'objects', 'objects_helper'], function 
         expect(() => ctx.get()).to.throw(errorMsg);
         expect(() => ctx.value()).to.throw(errorMsg);
         expect(() => ctx.compact()).to.throw(errorMsg);
+        expect(() => ctx.compactJson()).to.throw(errorMsg);
         expect(() => ctx.id).to.throw(errorMsg);
         expect(() => [...ctx.entries()]).to.throw(errorMsg);
         expect(() => [...ctx.keys()]).to.throw(errorMsg);


### PR DESCRIPTION
Note: I have also decided to keep both `compact()` and `compactJson` methods for Primitive PathObject/Instance classes (as opposed to removing them and essentially throwing an error for them) even though in most cases it does the same as calling `value()` on a Primitive value. The reason is to remain consistent in the PathObject/Instance API, so if someone iterates over a list of entries in a map/list and calls compact on entries, they won't need to handle Primitive case any different than LiveCounter/LiveMap - there is really no need for this and would be a poor DX. So I just documented for primitive values that `compact` and `compactJson` is essentially an alias for calling `value` on the same primitive, the only difference is that `compactJson` will return base64 string for an underlying buffer value.

compact() now returns a memory-traversable object (binary is left as memory Buffers, cyclic references are in-memory pointers), and compactJson() returns a JSON-serializable object (binary is base64 strings, cyclic references are { objectId: string } references).

This change addresses inconsistencies in current compact() behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON-serializable export for live objects, including cycle-safe references and base64 encoding for binary data; available on path, batch, and instance surfaces.
  * Clarified in-memory vs JSON-serializable representations so users can choose the appropriate export.

* **Documentation**
  * Updated docs to describe JSON-safe output, cycle handling, and when to use each export.

* **Tests**
  * Expanded tests covering primitives, counters, maps, binary data, nesting, and cyclic references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->