### PR TITLE
Make PathObjectSubscriptionRegister.subscribe options null check more robust

### DIFF
--- a/src/plugins/liveobjects/pathobjectsubscriptionregister.ts
+++ b/src/plugins/liveobjects/pathobjectsubscriptionregister.ts
@@ -57,7 +57,7 @@ export class PathObjectSubscriptionRegister {
     listener: EventCallback<PathObjectSubscriptionEvent>,
     options: PathObjectSubscriptionOptions,
   ): Subscription {
-    if (options != null && typeof options !== 'object') {
+    if (options == null || typeof options !== 'object') {
       throw new this._client.ErrorInfo('Subscription options must be an object', 40000, 400);
     }
 


### PR DESCRIPTION
Based on https://github.com/ably/ably-js/pull/2134#discussion_r2631871338