### PR TITLE
[ECO-5672] fix: msgpack encode function

### DIFF
--- a/src/platform/web/lib/util/msgpack.ts
+++ b/src/platform/web/lib/util/msgpack.ts
@@ -25,101 +25,22 @@ function inspect(buffer: undefined | ArrayBuffer | DataView) {
 
 // Encode string as utf8 into dataview at offset
 function utf8Write(view: DataView, offset: number, string: string) {
-  for (let i = 0, l = string.length; i < l; i++) {
-    const codePoint = string.charCodeAt(i);
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(string);
 
-    // One byte of UTF-8
-    if (codePoint < 0x80) {
-      view.setUint8(offset++, ((codePoint >>> 0) & 0x7f) | 0x00);
-      continue;
-    }
-
-    // Two bytes of UTF-8
-    if (codePoint < 0x800) {
-      view.setUint8(offset++, ((codePoint >>> 6) & 0x1f) | 0xc0);
-      view.setUint8(offset++, ((codePoint >>> 0) & 0x3f) | 0x80);
-      continue;
-    }
-
-    // Three bytes of UTF-8.
-    if (codePoint < 0x10000) {
-      view.setUint8(offset++, ((codePoint >>> 12) & 0x0f) | 0xe0);
-      view.setUint8(offset++, ((codePoint >>> 6) & 0x3f) | 0x80);
-      view.setUint8(offset++, ((codePoint >>> 0) & 0x3f) | 0x80);
-      continue;
-    }
-
-    // Four bytes of UTF-8
-    if (codePoint < 0x110000) {
-      view.setUint8(offset++, ((codePoint >>> 18) & 0x07) | 0xf0);
-      view.setUint8(offset++, ((codePoint >>> 12) & 0x3f) | 0x80);
-      view.setUint8(offset++, ((codePoint >>> 6) & 0x3f) | 0x80);
-      view.setUint8(offset++, ((codePoint >>> 0) & 0x3f) | 0x80);
-      continue;
-    }
-    throw new Error('bad codepoint ' + codePoint);
+  for (let i = 0; i < encoded.length; i++) {
+    view.setUint8(offset + i, encoded[i]);
   }
 }
 
 function utf8Read(view: DataView, offset: number, length: number) {
-  let string = '';
-  for (let i = offset, end = offset + length; i < end; i++) {
-    const byte_ = view.getUint8(i);
-    // One byte character
-    if ((byte_ & 0x80) === 0x00) {
-      string += String.fromCharCode(byte_);
-      continue;
-    }
-    // Two byte character
-    if ((byte_ & 0xe0) === 0xc0) {
-      string += String.fromCharCode(((byte_ & 0x0f) << 6) | (view.getUint8(++i) & 0x3f));
-      continue;
-    }
-    // Three byte character
-    if ((byte_ & 0xf0) === 0xe0) {
-      string += String.fromCharCode(
-        ((byte_ & 0x0f) << 12) | ((view.getUint8(++i) & 0x3f) << 6) | ((view.getUint8(++i) & 0x3f) << 0),
-      );
-      continue;
-    }
-    // Four byte character
-    if ((byte_ & 0xf8) === 0xf0) {
-      string += String.fromCharCode(
-        ((byte_ & 0x07) << 18) |
-          ((view.getUint8(++i) & 0x3f) << 12) |
-          ((view.getUint8(++i) & 0x3f) << 6) |
-          ((view.getUint8(++i) & 0x3f) << 0),
-      );
-      continue;
-    }
-    throw new Error('Invalid byte ' + byte_.toString(16));
-  }
-  return string;
+  const decoder = new TextDecoder();
+  return decoder.decode(view.buffer.slice(offset, offset + length));
 }
 
-function utf8ByteCount(string: string) {
-  let count = 0;
-  for (let i = 0, l = string.length; i < l; i++) {
-    const codePoint = string.charCodeAt(i);
-    if (codePoint < 0x80) {
-      count += 1;
-      continue;
-    }
-    if (codePoint < 0x800) {
-      count += 2;
-      continue;
-    }
-    if (codePoint < 0x10000) {
-      count += 3;
-      continue;
-    }
-    if (codePoint < 0x110000) {
-      count += 4;
-      continue;
-    }
-    throw new Error('bad codepoint ' + codePoint);
-  }
-  return count;
+function utf8ByteCount(string: string): number {
+  const encoder = new TextEncoder();
+  return encoder.encode(string).length;
 }
 
 function encode(value: unknown, sparse?: boolean) {

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -662,6 +662,27 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /**
+     * check that string containing emoji correctly publishes on all transport and protocols
+     */
+    Helper.testOnAllTransportsAndProtocols(this, 'publish emoji string', function (realtimeOpts) {
+      return function (done) {
+        const helper = this.test.helper;
+        const realtime = helper.AblyRealtime(realtimeOpts);
+        const channel = realtime.channels.get('publish_emoji' + JSON.stringify(realtimeOpts));
+
+        channel
+          .subscribe((msg) => {
+            if (msg.data === '😅🎉🚀') {
+              helper.closeAndFinish(done, realtime);
+            }
+          })
+          .then(() => {
+            channel.publish('test', '😅🎉🚀');
+          });
+      };
+    });
+
+    /**
      * Authenticate with a clientId and ensure that the clientId is not sent in the Message
      * and is implicitly added when published.
      *

--- a/test/unit/msgpack.test.js
+++ b/test/unit/msgpack.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+define(['chai', 'ably'], function (chai, Ably) {
+  const { expect } = chai;
+  const msgpack = Ably.Realtime._MsgPack;
+
+  describe('msgpack.encode()', function () {
+    it('should handle emoji in strings', function () {
+      const emoji = '😅🎉🚀';
+      const encoded = new Uint8Array(msgpack.encode(emoji));
+      expect(encoded).deep.to.equal(new Uint8Array([172, 240, 159, 152, 133, 240, 159, 142, 137, 240, 159, 154, 128]));
+    });
+
+    it('should handle special characters in strings', function () {
+      const special = 'Hello\n\t\r"World"';
+      const encoded = new Uint8Array(msgpack.encode(special));
+      expect(encoded).deep.to.equal(
+        new Uint8Array([175, 72, 101, 108, 108, 111, 10, 9, 13, 34, 87, 111, 114, 108, 100, 34]),
+      );
+    });
+
+    it('should encode and then decode emojies in string', function () {
+      const emoji = '😅🎉🚀';
+      const encoded = msgpack.encode(emoji);
+      const decoded = msgpack.decode(encoded);
+      expect(emoji).to.equal(decoded);
+    });
+
+    it('should handle sparse encoding mode', function () {
+      // In sparse mode, undefined and null are omitted from objects
+      const obj = { a: 1, b: undefined, c: null, d: 2 };
+      const encoded = msgpack.encode(obj, true);
+      const decoded = msgpack.decode(encoded);
+      // When sparse, undefined/null values are not encoded
+      expect(decoded).to.not.have.property('b');
+      expect(decoded).to.not.have.property('c');
+      expect(decoded).to.have.property('a', 1);
+      expect(decoded).to.have.property('d', 2);
+    });
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/ably/ably-js/issues/2144

- Add test for emoji string encoding (multi-byte UTF-8 characters)

- Add test for special characters (\n, \t, \r, quotes)

- Add test for sparse encoding mode (omits undefined/null values)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of emoji and special-character text in messaging, ensuring reliable send/receive across transports and protocols.

* **Tests**
  * Added unit tests for message encoding/decoding covering emoji and special characters and sparse encoding behavior.
  * Added integration tests validating publishing and receiving emoji strings across all transports/protocols.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->