### PR TITLE
[AIT-242] Fix CDN deploy script for LiveObjects plugin

### DIFF
--- a/docs/migration-guides/v2/liveobjects.md
+++ b/docs/migration-guides/v2/liveobjects.md
@@ -76,7 +76,10 @@ const client = new Ably.Realtime({
 });
 ```
 
-**Note:** If you're using the UMD bundle via a `<script>` tag, the global variable name is now `AblyLiveObjectsPlugin` instead of `AblyObjectsPlugin`.
+**Note:** If you're using the UMD bundle via a `<script>` tag:
+
+- The bundle filename has changed from `objects.umd.js` to `liveobjects.umd.js` (e.g., `https://cdn.ably.com/lib/liveobjects.umd.min-2.js` instead of `https://cdn.ably.com/lib/objects.umd.min-2.js`)
+- The global variable name is now `AblyLiveObjectsPlugin` instead of `AblyObjectsPlugin`
 
 #### Update the entrypoint: `channel.objects` → `channel.object`
 

--- a/scripts/cdn_deploy.js
+++ b/scripts/cdn_deploy.js
@@ -21,7 +21,7 @@ async function run() {
     // Comma separated directories (relative to `path`) to exclude from upload
     excludeDirs: 'node_modules,.git',
     // Regex to match files against for upload
-    fileRegex: '^(ably|push\\.umd|objects\\.umd)?(\\.min)?\\.js$',
+    fileRegex: '^(ably|push\\.umd|liveobjects\\.umd)?(\\.min)?\\.js$',
     ...argv,
   };
 


### PR DESCRIPTION
We changed the name of the build file in https://github.com/ably/ably-js/pull/2133 but forgot to update the CDN deploy script to reference the new name.

Resolves [AIT-242](https://ably.atlassian.net/browse/AIT-242)

[AIT-242]: https://ably.atlassian.net/browse/AIT-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide with UMD bundle filename changes (objects.umd.js → liveobjects.umd.js)
  * Updated global variable name documentation (AblyObjectsPlugin → AblyLiveObjectsPlugin)

* **Chores**
  * Updated CDN deployment configuration to reflect bundle naming changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->