### PR TITLE
[AIT-318] Remove the `createOperationIsMerged` flag

### DIFF
--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -44,7 +44,6 @@ export abstract class LiveObject<
    */
   protected _dataRef: TData;
   protected _siteTimeserials: Record<string, string>;
-  protected _createOperationIsMerged: boolean;
   private _tombstone: boolean;
   private _tombstonedAt: number | undefined;
   /**
@@ -63,7 +62,6 @@ export abstract class LiveObject<
     this._dataRef = this._getZeroValueData();
     // use empty map of serials by default, so any future operation can be applied to this object
     this._siteTimeserials = {};
-    this._createOperationIsMerged = false;
     this._tombstone = false;
     this._parentReferences = new Map<LiveObject, Set<string>>();
   }


### PR DESCRIPTION
This flag served as an idempotency mechanism from the time when we were applying `*_CREATE` ops on `ACK` in `createMap()` and `createCounter()`. Since the removal of these methods in 0dc0ce6, we no longer perform these ops locally, so this flag isn't needed.

Discussed in [this Slack thread](https://ably-real-time.slack.com/archives/C09SY1AQGK0/p1769195388456439).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified handling of create operations for live objects and maps: initial create operations are always merged and previous special-case skipping logic has been removed, allowing repeated create processing to merge per-entry changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->