### PR TITLE
Improve idle timer and connection log messages

### DIFF
--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -644,6 +644,7 @@ class ConnectionManager extends EventEmitter {
     this.activeProtocol = new Protocol(transport);
     this.host = transport.params.host;
 
+    const prevConnId = this.connectionId;
     const connectionKey = connectionDetails.connectionKey;
     if (connectionKey && this.connectionKey != connectionKey) {
       this.setConnection(connectionId, connectionDetails, !!error);
@@ -673,6 +674,19 @@ class ConnectionManager extends EventEmitter {
         this.emit('update', new ConnectionStateChange(connectedState, connectedState, null, error));
       }
     } else {
+      if (existingState.state === this.states.disconnected.state) {
+        const resumed = prevConnId === connectionId;
+        Logger.logAction(
+          this.logger,
+          Logger.LOG_MINOR,
+          'ConnectionManager.activateTransport()',
+          'Connection ' +
+            (resumed ? 'resumed' : 'reestablished') +
+            ' after disconnection; connectionId: ' +
+            connectionId +
+            (prevConnId && !resumed ? ' (previously: ' + prevConnId + ')' : ''),
+        );
+      }
       this.notifyState({ state: 'connected', error: error });
       this.errorReason = this.realtime.connection.errorReason = error || null;
     }
@@ -876,7 +890,13 @@ class ConnectionManager extends EventEmitter {
         this.logger,
         Logger.LOG_MINOR,
         'ConnectionManager.checkConnectionStateFreshness()',
-        'Last known activity from realtime was ' + sinceLast + 'ms ago; discarding connection state',
+        'Last known activity from Ably was ' +
+          sinceLast +
+          'ms ago (exceeds freshness threshold of ' +
+          (this.connectionStateTtl + (this.maxIdleInterval as number)) +
+          'ms); discarding connection state. ' +
+          'A new connection will be established and channels will reattach' +
+          (this.connectionId ? '; connectionId: ' + this.connectionId : ''),
       );
       this.clearConnection();
       this.states.connecting.failState = 'suspended';

--- a/src/common/lib/transport/transport.ts
+++ b/src/common/lib/transport/transport.ts
@@ -290,7 +290,14 @@ abstract class Transport extends EventEmitter {
     const sinceLast = Date.now() - this.lastActivity;
     const timeRemaining = this.maxIdleInterval - sinceLast;
     if (timeRemaining <= 0) {
-      const msg = 'No activity seen from realtime in ' + sinceLast + 'ms; assuming connection has dropped';
+      const connId = this.connectionManager.connectionId;
+      const msg =
+        'No activity seen from Ably in ' +
+        sinceLast +
+        'ms; assuming connection has dropped. ' +
+        'Will disconnect and reconnect automatically (error code: 80003, status: 408' +
+        (connId ? ', connectionId: ' + connId : '') +
+        ')';
       Logger.logAction(this.logger, Logger.LOG_ERROR, 'Transport.onIdleTimerExpire()', msg);
       this.disconnect(new ErrorInfo(msg, 80003, 408));
     } else {


### PR DESCRIPTION
## Summary

When running Ably in a server-side environment (e.g. Temporal durable execution where connections are long-lived and transported), I started seeing repeated idle timer error log messages like:

```
19:53:09.769 Ably: Transport.onIdleTimerExpire(): No activity seen from realtime in 158448ms; assuming connection has dropped
20:08:14.963 Ably: Transport.onIdleTimerExpire(): No activity seen from realtime in 904542ms; assuming connection has dropped
20:15:46.999 Ably: Transport.onIdleTimerExpire(): No activity seen from realtime in 436798ms; assuming connection has dropped
21:17:06.799 Ably: Transport.onIdleTimerExpire(): No activity seen from realtime in 379413ms; assuming connection has dropped
```

These are confusing for developers because:
- They don't explain what the SDK will do next (is it disconnecting? reconnecting? is this fatal?)
- They don't include a connection ID, so with multiple connections you can't tell which one is affected
- There's no corresponding log when the connection recovers, so you see alarming messages with no resolution
- The error code (80003) is created internally but never shown in the log
- They refer to "realtime" instead of "Ably"

_Note: I believe these disconnects are expected, they are probably triggered by me opening & closing my laptop_

As we think about how Ably is increasingly used server-side, these messages need to be more useful. This is a quick win to make the logs actionable.

### Changes

- **Idle timer expiry**: now includes connection ID, error code 80003/408, and states the SDK will disconnect and reconnect automatically
- **Reconnection log**: new LOG_MINOR message when connection is resumed or reestablished after disconnection — a bookend so you can see the resolution
- **Connection state freshness**: now explains that the connection state TTL was exceeded and a new connection will be established with channels reattaching; includes connection ID
- **Naming**: replace "realtime" with "Ably" in user-facing log messages

## Test plan

- [x] Existing `idle_transport_timeout` test passes
- [x] Linter clean
- [ ] Review log output in a real server-side environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved logging clarity for connection transitions by indicating whether a connection was resumed or reestablished, and including the prior connection identifier when different.
  * Made idle-timeout disconnect messages more informative and Ably-specific, reporting freshness thresholds and (when available) the connection identifier; the message now includes the fixed error code 80003 and status 408.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->