### PR TITLE
fix: replace outdated Next.js patterns in README troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ export default function AblyClientProvider({ children }) {
     return () => { ably.close(); };
   }, []);
 
-  if (!client) return <>{children}</>;
+  if (!client) return <div>Loading...</div>;
 
   return (
     <AblyProvider client={client}>

--- a/README.md
+++ b/README.md
@@ -195,16 +195,35 @@ If you're hitting a "connection limit exceeded" error and see rising connection 
 
 Even for `use client` components, Next.js may execute them on the server during pre-rendering. This can create unintended `Ably.Realtime` connections from Node.js that remain open until you restart the development server.
 
-Prevent server-side connections using `autoConnect` and a window check:
+To prevent server-side connections, create the Ably client inside a `useEffect` hook so it only runs in the browser:
 
-```typescript
-const client = new Ably.Realtime({
-  key: 'your-ably-api-key',
-  autoConnect: typeof window !== 'undefined',
-});
+```tsx
+'use client'
+
+import { useEffect, useState } from 'react';
+import * as Ably from 'ably';
+import { AblyProvider } from 'ably/react';
+
+export default function AblyClientProvider({ children }) {
+  const [client, setClient] = useState(null);
+
+  useEffect(() => {
+    const ably = new Ably.Realtime({ authUrl: '/token', authMethod: 'POST', clientId: 'demo' });
+    setClient(ably);
+    return () => { ably.close(); };
+  }, []);
+
+  if (!client) return <>{children}</>;
+
+  return (
+    <AblyProvider client={client}>
+      {children}
+    </AblyProvider>
+  );
+}
 ```
 
-Creating the client inside [React](https://github.com/ably/ably-js/blob/main/docs/react.md#Usage) components can lead to a new connection on every render. To prevent this, move the new `Ably.Realtime()` call outside of component functions.
+Avoid creating the client inside [React](https://github.com/ably/ably-js/blob/main/docs/react.md#Usage) component bodies, as this leads to a new connection on every render. Use the `useEffect` + `useState` pattern shown above, or move the client to a shared provider at the layout level.
 
 In development environments that use Hot Module Replacement (HMR), such as React, Vite, or Next.js, saving a file can recreate the Ably.Realtime client, while previous instances remain connected. Over time, this leads to a growing number of active connections with each code edit. To fix: Move the client to a separate file (e.g., `ably-client.js`) and import it. This ensures the client is recreated only when that file changes.
 
@@ -246,15 +265,32 @@ If you encounter an error such as `connection limit exceeded` during development
 
 #### Server-side rendering (SSR)
 
-Use the `autoConnect` option to prevent the client from connecting when rendered on the server:
+Create the Ably client inside a `useEffect` hook to prevent it from connecting when rendered on the server:
 
-```typescript
-const client = new Ably.Realtime({ key: 'your-ably-api-key', autoConnect: typeof window !== 'undefined' });
+```tsx
+'use client'
+
+import { useEffect, useState } from 'react';
+import * as Ably from 'ably';
+
+export default function MyComponent() {
+  const [client, setClient] = useState(null);
+
+  useEffect(() => {
+    const ably = new Ably.Realtime({ authUrl: '/token', authMethod: 'POST', clientId: 'demo' });
+    setClient(ably);
+    return () => { ably.close(); };
+  }, []);
+
+  if (!client) return <div>Loading...</div>;
+
+  // Use client here
+}
 ```
 
 #### Component re-renders
 
-Avoid creating the client inside React components. Instead, move the client instantiation outside of the component to prevent it from being recreated on every render.
+Avoid creating the client inside React component bodies, as this creates a new connection on every render. Use the `useEffect` + `useState` pattern shown above to ensure the client is created once.
 
 #### Hot module replacement (HMR)
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Even for `use client` components, Next.js may execute them on the server during 
 To prevent server-side connections, create the Ably client inside a `useEffect` hook so it only runs in the browser:
 
 ```tsx
-'use client'
+'use client';
 
 import { useEffect, useState } from 'react';
 import * as Ably from 'ably';
@@ -210,16 +210,14 @@ export default function AblyClientProvider({ children }) {
   useEffect(() => {
     const ably = new Ably.Realtime({ authUrl: '/token', authMethod: 'POST', clientId: 'demo' });
     setClient(ably);
-    return () => { ably.close(); };
+    return () => {
+      ably.close();
+    };
   }, []);
 
   if (!client) return <div>Loading...</div>;
 
-  return (
-    <AblyProvider client={client}>
-      {children}
-    </AblyProvider>
-  );
+  return <AblyProvider client={client}>{children}</AblyProvider>;
 }
 ```
 
@@ -268,7 +266,7 @@ If you encounter an error such as `connection limit exceeded` during development
 Create the Ably client inside a `useEffect` hook to prevent it from connecting when rendered on the server:
 
 ```tsx
-'use client'
+'use client';
 
 import { useEffect, useState } from 'react';
 import * as Ably from 'ably';
@@ -279,7 +277,9 @@ export default function MyComponent() {
   useEffect(() => {
     const ably = new Ably.Realtime({ authUrl: '/token', authMethod: 'POST', clientId: 'demo' });
     setClient(ably);
-    return () => { ably.close(); };
+    return () => {
+      ably.close();
+    };
   }, []);
 
   if (!client) return <div>Loading...</div>;

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ This is a common problem in App Router for a number of packages (for example, se
 
 </details>
 
-### Genral errors during development
+### General errors during development
 
 If you encounter an error such as `connection limit exceeded` during development, it may be caused by several issues.
 


### PR DESCRIPTION
## Summary

- Replace `autoConnect: typeof window !== 'undefined'` pattern with `useEffect` + `useState` in both README troubleshooting sections ("Connection limit exceeded" and "General errors")
- The `useEffect` approach is the recommended way to prevent server-side Ably connections in Next.js, as implemented in ably/ably-nextjs-fundamentals-kit#11

References: [AIT-540](https://ably.atlassian.net/browse/AIT-540)

## Test plan

- [ ] Verify code samples in README render correctly on GitHub
- [ ] Confirm no other references to `autoConnect: typeof window` remain in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIT-540]: https://ably.atlassian.net/browse/AIT-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved troubleshooting for connection-limit errors with browser/SSR apps, recommending initialization during browser lifecycle and gating rendering until ready.
  * Added SSR-focused examples and clarified cleanup guidance to avoid repeated reconnects during renders.
  * Fixed a heading typo and clarified best practices for client lifecycle management in React/Next.js.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2189)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->