### PR TITLE
Add missing RestAnnotation#delete typings

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2568,6 +2568,27 @@ export declare interface RestAnnotations {
    */
   publish(messageSerial: string, annotation: OutboundAnnotation): Promise<void>;
   /**
+   * Publish an annotation removal request for a message, to remove it from the summary
+   * summaries. The semantics of the delete (and what fields are required) are different
+   * for each annotation type; see annotation types documentation for more details.
+   *
+   * @param message - The message which has an annotation that you want to delete.
+   * @param annotation - The annotation deletion request. (Must include at least the
+   * `type`, other required fields depend on the type).
+   */
+  delete(message: Message, annotation: OutboundAnnotation): Promise<void>;
+  /**
+   * Publish an annotation removal request for a message, to remove it from the summary
+   * summaries. The semantics of the delete (and what fields are required) are different
+   * for each annotation type; see annotation types documentation for more details.
+   *
+   * @param messageSerial - The serial field of the message which has an annotation that
+   * you want to delete.
+   * @param annotation - The annotation deletion request. (Must include at least the
+   * `type`, other required fields depend on the type).
+   */
+  delete(messageSerial: string, annotation: OutboundAnnotation): Promise<void>;
+  /**
    * Get all annotations for a given message (as a paginated result)
    *
    * @param message - The message to get annotations for.


### PR DESCRIPTION
just noticed these were missing from the d.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two deletion overloads for annotation removal in the REST annotations API and included JSDoc describing delete semantics and required fields.
* **Style**
  * Updated formatting and documentation structure in type definitions to improve consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->