### PR TITLE
Introduce `Path` type alias for path arrays in LiveObjects code

### DIFF
--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -4,6 +4,7 @@ import type { EventCallback, Subscription } from '../../../ably';
 import { ROOT_OBJECT_ID } from './constants';
 import { InstanceEvent } from './instance';
 import { ObjectData, ObjectMessage, ObjectOperation } from './objectmessage';
+import { Path } from './path';
 import { PathEvent } from './pathobjectsubscriptionregister';
 import { ObjectsOperationSource, RealtimeObject } from './realtimeobject';
 
@@ -204,10 +205,10 @@ export abstract class LiveObject<
    *
    * @internal
    */
-  getFullPaths(): string[][] {
-    const paths: string[][] = [];
+  getFullPaths(): Path[] {
+    const paths: Path[] = [];
 
-    const stack: { obj: LiveObject; currentPath: string[]; visited: Set<LiveObject> }[] = [
+    const stack: { obj: LiveObject; currentPath: Path; visited: Set<LiveObject> }[] = [
       { obj: this, currentPath: [], visited: new Set() },
     ];
 

--- a/src/plugins/liveobjects/path.ts
+++ b/src/plugins/liveobjects/path.ts
@@ -1,0 +1,2 @@
+/** A path through the object graph, as an array of `LiveMap` key segments. */
+export type Path = string[];

--- a/src/plugins/liveobjects/pathobject.ts
+++ b/src/plugins/liveobjects/pathobject.ts
@@ -18,6 +18,7 @@ import { DefaultInstance } from './instance';
 import { LiveCounter } from './livecounter';
 import { LiveMap } from './livemap';
 import { LiveObject } from './liveobject';
+import { Path } from './path';
 import { RealtimeObject } from './realtimeobject';
 import { RootBatchContext } from './rootbatchcontext';
 
@@ -27,12 +28,12 @@ import { RootBatchContext } from './rootbatchcontext';
  */
 export class DefaultPathObject implements AnyPathObject {
   private _client: BaseClient;
-  private _path: string[];
+  private _path: Path;
 
   constructor(
     private _realtimeObject: RealtimeObject,
     private _root: LiveMap,
-    path: string[],
+    path: Path,
     parent?: DefaultPathObject,
   ) {
     this._client = this._realtimeObject.getClient();
@@ -139,7 +140,7 @@ export class DefaultPathObject implements AnyPathObject {
     // (based on https://github.com/ably/ably-js/pull/2037/files), like Safari before 16.4.
     // See full list https://caniuse.com/?search=negative%20lookbehind.
     // So instead we do splitting manually.
-    const pathAsArray: string[] = [];
+    const pathAsArray: Path = [];
     let currentSegment = '';
     let escaping = false;
     for (const char of path) {
@@ -436,7 +437,7 @@ export class DefaultPathObject implements AnyPathObject {
     }
   }
 
-  private _resolvePath(path: string[]): Value {
+  private _resolvePath(path: Path): Value {
     let current: Value = this._root;
 
     for (let i = 0; i < path.length; i++) {
@@ -478,7 +479,7 @@ export class DefaultPathObject implements AnyPathObject {
     return undefined;
   }
 
-  private _escapePath(path: string[]): string[] {
+  private _escapePath(path: Path): Path {
     return path.map((x) => x.replace(/\./g, '\\.'));
   }
 }

--- a/src/plugins/liveobjects/pathobjectsubscriptionregister.ts
+++ b/src/plugins/liveobjects/pathobjectsubscriptionregister.ts
@@ -2,6 +2,7 @@ import type BaseClient from 'common/lib/client/baseclient';
 import type { EventCallback, Subscription } from '../../../ably';
 import type { PathObjectSubscriptionEvent, PathObjectSubscriptionOptions } from '../../../liveobjects';
 import { ObjectMessage } from './objectmessage';
+import { Path } from './path';
 import { DefaultPathObject } from './pathobject';
 import { RealtimeObject } from './realtimeobject';
 
@@ -14,7 +15,7 @@ export interface SubscriptionEntry {
   /** The subscription options including depth */
   options: PathObjectSubscriptionOptions;
   /** The path this subscription is registered for */
-  path: string[];
+  path: Path;
 }
 
 /**
@@ -22,7 +23,7 @@ export interface SubscriptionEntry {
  */
 export interface PathEvent {
   /** The path where the event occurred */
-  path: string[];
+  path: Path;
   /** Object message that caused this event */
   message?: ObjectMessage;
   /** Whether this event should bubble up to parent paths. Defaults to true if not specified. */
@@ -53,7 +54,7 @@ export class PathObjectSubscriptionRegister {
    * @returns Unsubscribe function
    */
   subscribe(
-    path: string[],
+    path: Path,
     listener: EventCallback<PathObjectSubscriptionEvent>,
     options: PathObjectSubscriptionOptions,
   ): Subscription {
@@ -180,7 +181,7 @@ export class PathObjectSubscriptionRegister {
    * @param subscriptionPath - The path that was subscribed to
    * @returns true if eventPath starts with subscriptionPath
    */
-  private _pathStartsWith(eventPath: string[], subscriptionPath: string[]): boolean {
+  private _pathStartsWith(eventPath: Path, subscriptionPath: Path): boolean {
     if (subscriptionPath.length > eventPath.length) {
       return false;
     }
@@ -201,7 +202,7 @@ export class PathObjectSubscriptionRegister {
    * @param path2 - Second path to compare
    * @returns true if paths are exactly equal
    */
-  private _pathsAreEqual(path1: string[], path2: string[]): boolean {
+  private _pathsAreEqual(path1: Path, path2: Path): boolean {
     return this._client.Utils.arrEquals(path1, path2);
   }
 }


### PR DESCRIPTION
Slightly more readable, I think, especially for `string[][]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized path representation across the live-objects plugin and updated related APIs for consistent type usage. No functional behavior changes; improvements are internal and aimed at better consistency and type safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->