### PR TITLE
DX-1205: throw on legacy v1 ably/promises and ably/callbacks imports

### DIFF
--- a/callbacks.d.ts
+++ b/callbacks.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @deprecated `'ably/callbacks'` was the v1 callback API entry point and has been removed in ably-js v2.
+ * v2 is promise-only — import from `'ably'` directly and switch to `await` / `.then()`.
+ *
+ * Importing this subpath throws at module load with the migration link.
+ *
+ * @see https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md
+ */
+declare const ablyCallbacksV1EntryPointRemoved: never;
+export = ablyCallbacksV1EntryPointRemoved;

--- a/callbacks.js
+++ b/callbacks.js
@@ -1,5 +1,6 @@
 'use strict';
 
-throw new Error(
-  "'ably/callbacks' was the v1 callback API entry point and is no longer available. ably-js v2 is promise-only — import from 'ably' directly and switch to await / .then(). See https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md",
-);
+const err = new Error("'ably/callbacks' was the v1 callback API entry point and is no longer available.");
+err.hint =
+  "ably-js v2 is promise-only — import from 'ably' directly and switch to await / .then(). See https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md";
+throw err;

--- a/callbacks.js
+++ b/callbacks.js
@@ -1,0 +1,5 @@
+'use strict';
+
+throw new Error(
+  "'ably/callbacks' was the v1 callback API entry point and is no longer available. ably-js v2 is promise-only — import from 'ably' directly and switch to await / .then(). See https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md",
+);

--- a/package.json
+++ b/package.json
@@ -39,14 +39,26 @@
         "types": "./liveobjects.d.ts",
         "default": "./build/liveobjects.js"
       }
+    },
+    "./promises": {
+      "types": "./promises.d.ts",
+      "default": "./promises.js"
+    },
+    "./callbacks": {
+      "types": "./callbacks.d.ts",
+      "default": "./callbacks.js"
     }
   },
   "files": [
     "build/**",
     "ably.d.ts",
+    "callbacks.d.ts",
+    "callbacks.js",
     "liveobjects.d.ts",
     "liveobjects.d.mts",
     "modular.d.ts",
+    "promises.d.ts",
+    "promises.js",
     "push.d.ts",
     "resources/**",
     "src/**",

--- a/promises.d.ts
+++ b/promises.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @deprecated `'ably/promises'` was the v1 entry point and is no longer available in ably-js v2.
+ * v2 is promise-only — import from `'ably'` directly.
+ *
+ * Importing this subpath throws at module load with the migration link.
+ *
+ * @see https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md
+ */
+declare const ablyPromisesV1EntryPointRemoved: never;
+export = ablyPromisesV1EntryPointRemoved;

--- a/promises.js
+++ b/promises.js
@@ -1,0 +1,5 @@
+'use strict';
+
+throw new Error(
+  "'ably/promises' was the v1 entry point. ably-js v2 is promise-only — import from 'ably' directly. See https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md",
+);

--- a/promises.js
+++ b/promises.js
@@ -1,5 +1,6 @@
 'use strict';
 
-throw new Error(
-  "'ably/promises' was the v1 entry point. ably-js v2 is promise-only — import from 'ably' directly. See https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md",
-);
+const err = new Error("'ably/promises' was the v1 entry point and is no longer available.");
+err.hint =
+  "ably-js v2 is promise-only — import from 'ably' directly. See https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md";
+throw err;

--- a/test/unit/legacy-import-shims.test.js
+++ b/test/unit/legacy-import-shims.test.js
@@ -13,20 +13,32 @@ define(['chai'], function (chai) {
       require(abs);
     }
 
-    it("'ably/promises' shim throws naming the v1 entry point and migration guide", function () {
-      expect(() => loadShim('promises.js'))
-        .to.throw(Error)
-        .with.property('message')
-        .that.matches(/'ably\/promises' was the v1 entry point/)
-        .and.matches(/migration-guides\/v2\/lib\.md/);
+    it("'ably/promises' shim throws naming the v1 entry point, with a hint pointing at the migration guide", function () {
+      let caught;
+      try {
+        loadShim('promises.js');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).to.be.an.instanceOf(Error);
+      expect(caught.message).to.match(/'ably\/promises' was the v1 entry point/);
+      expect(caught.hint).to.be.a('string');
+      expect(caught.hint).to.match(/promise-only/);
+      expect(caught.hint).to.match(/migration-guides\/v2\/lib\.md/);
     });
 
-    it("'ably/callbacks' shim throws naming the v1 callback API and migration guide", function () {
-      expect(() => loadShim('callbacks.js'))
-        .to.throw(Error)
-        .with.property('message')
-        .that.matches(/'ably\/callbacks' was the v1 callback API entry point/)
-        .and.matches(/migration-guides\/v2\/lib\.md/);
+    it("'ably/callbacks' shim throws naming the v1 callback API, with a hint pointing at the migration guide", function () {
+      let caught;
+      try {
+        loadShim('callbacks.js');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).to.be.an.instanceOf(Error);
+      expect(caught.message).to.match(/'ably\/callbacks' was the v1 callback API entry point/);
+      expect(caught.hint).to.be.a('string');
+      expect(caught.hint).to.match(/await/);
+      expect(caught.hint).to.match(/migration-guides\/v2\/lib\.md/);
     });
 
     it('package.json exports map wires the legacy subpaths to the shim files and their types', function () {

--- a/test/unit/legacy-import-shims.test.js
+++ b/test/unit/legacy-import-shims.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+define(['chai'], function (chai) {
+  const { expect } = chai;
+  const fs = require('fs');
+  const path = require('path');
+  const repoRoot = path.resolve(__dirname, '..', '..');
+
+  describe('legacy v1 import-path shims', function () {
+    function loadShim(relPath) {
+      const abs = path.join(repoRoot, relPath);
+      delete require.cache[abs];
+      require(abs);
+    }
+
+    it("'ably/promises' shim throws naming the v1 entry point and migration guide", function () {
+      expect(() => loadShim('promises.js'))
+        .to.throw(Error)
+        .with.property('message')
+        .that.matches(/'ably\/promises' was the v1 entry point/)
+        .and.matches(/migration-guides\/v2\/lib\.md/);
+    });
+
+    it("'ably/callbacks' shim throws naming the v1 callback API and migration guide", function () {
+      expect(() => loadShim('callbacks.js'))
+        .to.throw(Error)
+        .with.property('message')
+        .that.matches(/'ably\/callbacks' was the v1 callback API entry point/)
+        .and.matches(/migration-guides\/v2\/lib\.md/);
+    });
+
+    it('package.json exports map wires the legacy subpaths to the shim files and their types', function () {
+      const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+
+      expect(pkg.exports['./promises'], "exports['./promises']").to.deep.equal({
+        types: './promises.d.ts',
+        default: './promises.js',
+      });
+      expect(pkg.exports['./callbacks'], "exports['./callbacks']").to.deep.equal({
+        types: './callbacks.d.ts',
+        default: './callbacks.js',
+      });
+
+      for (const file of ['promises.js', 'promises.d.ts', 'callbacks.js', 'callbacks.d.ts']) {
+        expect(fs.existsSync(path.join(repoRoot, file)), file).to.equal(true);
+      }
+    });
+
+    it("'files' array ships the legacy shim files in the published package", function () {
+      const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+      for (const file of ['promises.js', 'promises.d.ts', 'callbacks.js', 'callbacks.d.ts']) {
+        expect(pkg.files, `files[] should include ${file}`).to.include(file);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `./promises` and `./callbacks` subpath exports to `package.json`, each pointing at a tiny `.js` shim that throws on module load. The throw is a structured `Error` whose `message` names the dropped v1 entry point and whose `hint` directs the user at the v2 import and the migration guide.
- Closes the v1→v2 self-heal gap on the **import surface**, complementing DX-1204 which closed it on the **call surface** (v1 trailing-callback shapes). The `message` (what failed) / `hint` (how to fix) split matches the convention DX-1204 / DX-1209 use for `ErrorInfo` throws elsewhere in the SDK.
- Today these imports fail with Node's generic `ERR_PACKAGE_PATH_NOT_EXPORTED`, which gives an agent or migrating user no signal that the path was renamed. The shim turns that into an actionable error naming the new entry point.

## Background — were these real?

Yes. Both were genuine v1 entry points at the package root, removed as separate commits during v2 prep:

- `ably/callbacks` — `callbacks.js` removed in `2a2ed49e` ("Remove the callbacks public API", Jun 2023). The v1 file re-exported `./build/ably-node`.
- `ably/promises` — `promises.js` removed in `6cf248fb` ("Remove promises.js / .d.ts", Jun 2023). The v1 file wrapped the constructors to set `options.internal.promises = true`.

`docs/migration-guides/v2/lib.md:68-70` already documents both as v1 spellings users would have written.

## Implementation notes

- Single `.js` file per subpath: works for both `require` and `import` because the package is not `"type": "module"`. Module-evaluation `throw` propagates synchronously out of both.
- Shim files live at the package root (`promises.js`, `callbacks.js`) alongside their `.d.ts` siblings — hand-written, kept separate from `build/` so they aren't wiped by `grunt build`. Added to `files[]` individually so they ship in the npm package.
- The thrown value is a plain `Error` with `err.hint` stamped on, rather than an `ErrorInfo`. Pulling in `ErrorInfo` would mean `require`ing the built bundle just to throw out of an alias path, defeating the point of a top-level shim. The `err.message` + `err.hint` shape is what LLM-eval tooling already inspects everywhere else, so the structural alignment with `ErrorInfo`-based throws is preserved without the runtime cost.
- The matching `.d.ts` files (`promises.d.ts`, `callbacks.d.ts`) declare each subpath as `@deprecated never` so TypeScript users get a strikethrough at the import site and an IDE-rendered migration message before the runtime throw ever fires.
- URL points at the in-repo migration guide (`https://github.com/ably/ably-js/blob/main/docs/migration-guides/v2/lib.md`), matching the convention introduced by DX-1204 in `src/common/lib/util/utils.ts:293`.

## Base branch

⚠️ This PR targets **`DX-1204/v1-callback-overloads`**, not `main`. Merge DX-1204 first; this branch will then auto-retarget to `main` or can be rebased.

## Test plan

- [x] `npx mocha test/unit/legacy-import-shims.test.js` → 4 passing:
  - `ably/promises` shim throws naming the v1 entry point, with a hint pointing at the migration guide
  - `ably/callbacks` shim throws naming the v1 callback API, with a hint pointing at the migration guide
  - `package.json` `exports` map wires the legacy subpaths to the shim files and their types
  - `files[]` ships the legacy shim `.js` / `.d.ts` files in the published package
- [ ] Smoke-test the published `exports` resolution (e.g. `npm pack` + `require('ably/promises')` from a temp project) — optional, the unit-level wiring test already covers the mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed legacy v1 callback and promises entry points and added explicit legacy shims that throw at import with migration guidance directing consumers to the v2 promise-only API; type declarations for those shims are marked as unavailable.
  * Updated package exports and published files list to expose the legacy shim entrypoints and their type artifacts.

* **Tests**
  * Added unit tests verifying shim behavior, error messages, and package export/files configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
