### PR TITLE
ci: harden workflows

### DIFF
--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -12,13 +12,13 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 20.x
       - run: npm ci
@@ -26,12 +26,12 @@ jobs:
         run: |
           mkdir bundle-reports
           npm run sourcemap -- --html bundle-reports/index.html
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-js
           role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
-      - uses: ably/sdk-upload-action@v1
+      - uses: ably/sdk-upload-action@8c6179796fc7ee8fc9bb28d5223ffef005b985cc # v1
         with:
           sourcePath: bundle-reports
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,13 +9,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 20.x
       - run: npm ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      deployments: write
-      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -26,6 +23,28 @@ jobs:
 
       - name: Build Documentation
         run: npm run docs
+
+      - name: Upload typedoc artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: typedoc-generated
+          path: typedoc/generated
+          retention-days: 1
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download typedoc artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: typedoc-generated
+          path: typedoc/generated
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 20.x
 
@@ -25,7 +25,7 @@ jobs:
         run: npm run docs
 
       - name: Upload typedoc artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: typedoc-generated
           path: typedoc/generated
@@ -38,23 +38,23 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Download typedoc artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: typedoc-generated
           path: typedoc/generated
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-js
           role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
 
       - name: Upload Documentation
-        uses: ably/sdk-upload-action@v1
+        uses: ably/sdk-upload-action@8c6179796fc7ee8fc9bb28d5223ffef005b985cc # v1
         with:
           sourcePath: typedoc/generated
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -11,4 +11,5 @@ jobs:
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
       repository-name: ably-js
-    secrets: inherit
+    secrets:
+      ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: ably/features/.github/workflows/sdk-features.yml@main
+    uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
       repository-name: ably-js
     secrets:

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -14,17 +14,17 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           ref: ${{ github.event.inputs.version }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/prod-ably-sdk-cdn
           role-session-name: '${{ github.run_id }}-${{ github.run_number }}'
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 20.x
       - run: npm ci

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -28,4 +28,6 @@ jobs:
         with:
           node-version: 20.x
       - run: npm ci
-      - run: node scripts/cdn_deploy.js --skipCheckout --tag=${{ github.event.inputs.version }}
+      - env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: node scripts/cdn_deploy.js --skipCheckout --tag="$VERSION"

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 20
       - run: npm ci

--- a/.github/workflows/spec-coverage-report.yml
+++ b/.github/workflows/spec-coverage-report.yml
@@ -12,13 +12,13 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 20.x
       - run: npm ci

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
       - name: Reconfigure git to use HTTP authentication
@@ -22,7 +22,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 20.x
       - run: npm ci
@@ -34,7 +34,7 @@ jobs:
       - name: Generate private API usage reports
         run: npm run process-private-api-data private-api-usage/*.json
       - name: Save private API usage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: private-api-usage-${{ matrix.browser }}
           path: |
@@ -42,7 +42,7 @@ jobs:
             private-api-usage-reports
       - name: Upload test results
         if: always()
-        uses: ably/test-observability-action@v1
+        uses: ably/test-observability-action@5b61d9c59f356b83426cab1b8243dd8bf03c1bea # v1
         with:
           server-auth: ${{ secrets.TEST_OBSERVABILITY_SERVER_AUTH_KEY }}
           path: './junit'

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         node-version: [16.x, 18.x, 20.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
       - name: Reconfigure git to use HTTP authentication
@@ -22,7 +22,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf
           ssh://git@github.com/
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
@@ -32,7 +32,7 @@ jobs:
       - name: Generate private API usage reports
         run: npm run process-private-api-data private-api-usage/*.json
       - name: Save private API usage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: private-api-usage-${{ matrix.node-version }}
           path: |
@@ -40,7 +40,7 @@ jobs:
             private-api-usage-reports
       - name: Upload test results
         if: always()
-        uses: ably/test-observability-action@v1
+        uses: ably/test-observability-action@5b61d9c59f356b83426cab1b8243dd8bf03c1bea # v1
         with:
           server-auth: ${{ secrets.TEST_OBSERVABILITY_SERVER_AUTH_KEY }}
           path: './junit'

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -9,11 +9,11 @@ jobs:
   test-npm-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: true
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 20.x
       - run: npm ci


### PR DESCRIPTION
Four independent commits addressing findings on `.github/workflows/`:

  - **template-injection in `publish-cdn.yml`** — the `workflow_dispatch` `version` input was interpolated directly into a `run:` shell command. Now passed via a step `env:` var so the shell handles it as a
  variable instead of splicing it into the command string.
  - **secrets-inherit in `features.yml`** — replaced `secrets: inherit` with an explicit passthrough of `ABLY_AWS_ACCOUNT_ID_SDK`, the only secret the called reusable workflow
  (`ably/features/.github/workflows/sdk-features.yml`) declares.
  - **cache-poisoning in `docs.yml`** — split the single job into a `build` job (uses `setup-node`, uploads typedoc as an artifact) and a `publish` job (downloads the artifact, configures AWS, runs
  `sdk-upload-action`). The publishing job no longer uses any cache-restoring setup action.
  - **SHA-pin every action** — every external action across all 10 workflows, plus the `ably/features` reusable-workflow `@main` ref, pinned to its current 40-char commit SHA, with the version preserved in a
  trailing `# vN` comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment pipelines to use pinned versions of build tools for improved stability and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->