### PR TITLE
ci: don't persist GITHUB_TOKEN in checkouts

### DIFF
--- a/.github/workflows/bundle-report.yml
+++ b/.github/workflows/bundle-report.yml
@@ -13,6 +13,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,6 +40,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       deployments: write
       id-token: write
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
       - name: Use Node.js 20.x
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
@@ -39,6 +41,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
       - name: Download typedoc artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
       repository-name: ably-js

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           ref: ${{ github.event.inputs.version }}
+          persist-credentials: false
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 20

--- a/.github/workflows/spec-coverage-report.yml
+++ b/.github/workflows/spec-coverage-report.yml
@@ -13,6 +13,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-browser:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
       - name: Reconfigure git to use HTTP authentication
         run: >
           git config --global url."https://github.com/".insteadOf

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-node:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: true
+          persist-credentials: false
       - name: Use Node.js 20.x
         uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-npm-package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**`persist-credentials: false`** on every `actions/checkout` block. By default the action writes the workflow `GITHUB_TOKEN` into `.git/config`, where any later step can read it.
  Nothing in this repo's workflows needs that — no step does `git push` / `tag` / `commit`, the submodule URL is HTTPS-public, and the two `git+ssh://git@github.com/ably-forks/…` entries
  in `package-lock.json` resolve to public repos via the existing URL rewrite, so `npm ci` clones them anonymously. Opt out so the token is wiped from disk once checkout completes.

 **Explicit `permissions:` blocks** on every workflow / reusable-workflow caller that didn't already have one. Most are `contents: read` set at the workflow level (so jobs inherit a
  restrictive default). The docs publish job keeps `deployments: write` + `id-token: write` for the AWS-OIDC role + GitHub Deployment that powers docs previews, and gains an explicit
  `contents: read` so the override doesn't drop checkout access. The features caller needs `id-token: write` so the reusable workflow's `configure-aws-credentials` step can assume its
  role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled credential persistence in checkout steps across CI workflows to reduce credential exposure.
  * Added explicit top-level workflow permissions (e.g., contents: read) for several pipelines.
  * Declared additional permission (id-token: write) for the features pipeline to support token-based operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->