### PR TITLE
Mark public `ObjectMessage.id` and `.timestamp` as optional

### DIFF
--- a/liveobjects.d.ts
+++ b/liveobjects.d.ts
@@ -2034,7 +2034,7 @@ export interface ObjectMessage {
   /**
    * Unique ID assigned by Ably to this object message.
    */
-  id: string;
+  id?: string;
   /**
    * The client ID of the publisher of this object message (if any).
    */
@@ -2046,7 +2046,7 @@ export interface ObjectMessage {
   /**
    * Timestamp of when the object message was received by Ably, as milliseconds since the Unix epoch.
    */
-  timestamp: number;
+  timestamp?: number;
   /**
    * The name of the channel the object message was published to.
    */

--- a/src/plugins/liveobjects/objectmessage.ts
+++ b/src/plugins/liveobjects/objectmessage.ts
@@ -729,10 +729,10 @@ export class ObjectMessage {
 
   toUserFacingMessage(channel: RealtimeChannel): ObjectsApi.ObjectMessage {
     return {
-      id: this.id!,
+      id: this.id,
       clientId: this.clientId,
       connectionId: this.connectionId,
-      timestamp: this.timestamp!,
+      timestamp: this.timestamp,
       channel: channel.name,
       // we expose only operation messages to users, so operation field is always present
       operation: toUserFacingObjectOperation(this.operation!),


### PR DESCRIPTION
These declared types are incorrect since these values are not populated for `ObjectMessage`s created by apply-on-ACK.

This is a breaking change to the type declarations, but I think it's the right thing to do given that the declarations do not match the runtime behaviour. You could argue that we could try and fix the runtime behaviour; i.e backfill `timestamp` based on the server time or something, but I'm not sure it'd be easy to backfill `id`. Thoughts welcome.

Noticed this whilst working on the spec for the path-based API in https://github.com/ably/specification/pull/427; see PAOM2a/d there. I've incorporated the API change from the current commit into those points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Object messages no longer require an id or timestamp — these fields may be omitted. This makes message handling more tolerant of missing identifiers or time values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->