### PR TITLE
Remove unused `removeParentReferenceAll`

### DIFF
--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -182,15 +182,6 @@ export abstract class LiveObject<
   }
 
   /**
-   * Remove all parent references for a specific parent (when parent is being deleted or cleared).
-   *
-   * @internal
-   */
-  removeParentReferenceAll(parent: LiveObject): void {
-    this._parentReferences.delete(parent);
-  }
-
-  /**
    * Clears all parent references for this object.
    *
    * @internal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated parent reference handling in the LiveObjects plugin.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->