### PR TITLE
Remove dead _updateParentReferencesFromUpdate helper

### DIFF
--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -438,13 +438,13 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       return { noop: true };
     }
 
-    const previousDataRef = this._dataRef;
     let update: LiveMapUpdate<T>;
     if (objectState.tombstone) {
       // tombstone this object and ignore the data from the object state message
       update = this.tombstone(objectMessage);
     } else {
       // otherwise override data for this object with data from the object state
+      const previousDataRef = this._dataRef;
       this._createOperationIsMerged = false; // RTLM6b
       this._clearTimeserial = objectState.map?.clearTimeserial; // RTLM6i
       this._dataRef = this._liveMapDataFromMapEntries(objectState.map?.entries ?? {}); // RTLM6c
@@ -457,9 +457,6 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       update = this._updateFromDataDiff(previousDataRef, this._dataRef);
       update.objectMessage = objectMessage;
     }
-
-    // Update parent references based on the calculated diff
-    this._updateParentReferencesFromUpdate(update, previousDataRef);
 
     return update;
   }
@@ -1094,45 +1091,5 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
     }
 
     return false;
-  }
-
-  /**
-   * Update parent references based on the calculated update diff.
-   */
-  private _updateParentReferencesFromUpdate(update: LiveMapUpdate<T>, previousDataRef: LiveMapData): void {
-    for (const [key, changeType] of Object.entries(update.update)) {
-      if (changeType === 'removed') {
-        // Key was removed - remove parent reference from the old object if it was referencing one
-        const previousEntry = previousDataRef.data.get(key);
-        if (previousEntry?.data && 'objectId' in previousEntry.data) {
-          const oldReferencedObject = this._realtimeObject.getPool().get(previousEntry.data.objectId);
-          if (oldReferencedObject) {
-            oldReferencedObject.removeParentReference(this, key);
-          }
-        }
-      }
-
-      if (changeType === 'updated') {
-        // Key was updated - need to handle both removal of old reference and addition of new reference
-        const previousEntry = previousDataRef.data.get(key);
-        const newEntry = this._dataRef.data.get(key);
-
-        // Remove old parent reference if there was one
-        if (previousEntry?.data && 'objectId' in previousEntry.data) {
-          const oldReferencedObject = this._realtimeObject.getPool().get(previousEntry.data.objectId);
-          if (oldReferencedObject) {
-            oldReferencedObject.removeParentReference(this, key);
-          }
-        }
-
-        // Add new parent reference if the new value references an object
-        if (newEntry?.data && 'objectId' in newEntry.data) {
-          const newReferencedObject = this._realtimeObject.getPool().get(newEntry.data.objectId);
-          if (newReferencedObject) {
-            newReferencedObject.addParentReference(this, key);
-          }
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary

Removes the `_updateParentReferencesFromUpdate` helper from `LiveMap` along with its sole call site inside `overrideWithObjectState`. The helper was dead weight: every code path that invoked it was immediately followed by `RealtimeObject._rebuildAllParentReferences` (spec'd at `RTO5c10`), which unconditionally clears every `parentReferences` map and re-derives them from scratch based on the final post-sync pool state. The helper's intermediate updates were always overwritten before any external observer could see them.

## Why this was dead code

`_updateParentReferencesFromUpdate` had exactly **one** call site: `LiveMap.overrideWithObjectState`. That method, in turn, is invoked from only three places — all of them inside the OBJECT_SYNC processing flow under `RTO5c`:

| Caller | Spec |
|---|---|
| `RealtimeObject._applyObjectSync` (existing object) | `RTO5c1a1` |
| `LiveCounter.fromObjectState` factory | `RTO5c1b1a` |
| `LiveMap.fromObjectState` factory | `RTO5c1b1b` |

After `RTO5c1`/`RTO5c2` finish, `RTO5c10` (`_rebuildAllParentReferences`) executes unconditionally:

1. `RTO5c10a`: `clearParentReferences()` on every object in the pool.
2. `RTO5c10b`: re-iterate every `LiveMap` and re-establish parent refs via `addParentReference` for each objectId-valued entry.

So any parent refs set by `_updateParentReferencesFromUpdate` inside `overrideWithObjectState` were wiped by `RTO5c10a` and re-derived by `RTO5c10b` before sync completion was visible to subscribers.

### Tombstone branch — also redundant

In the tombstone path (`update = this.tombstone(objectMessage)`), `LiveObject.tombstone()` calls `clearData()`. For `LiveMap`, `clearData()` is overridden to iterate every entry and call `removeParentReference` per `RTLO4e5` — **before** the data is zeroed. By the time `overrideWithObjectState` reached `_updateParentReferencesFromUpdate`, all parent refs were already cleaned. The helper would iterate the `'removed'` diff keys and call `removeParentReference` again on the same objects — a harmless no-op (`removeParentReference` is idempotent when the parent is absent per `RTLO3f3a`) but wasted work.

## What changed

`src/plugins/liveobjects/livemap.ts`:

1. **Removed the call site** inside `LiveMap.overrideWithObjectState` (was lines 461–462).
2. **Removed the method definition** (was lines 1099–1137, 39 lines including JSDoc).
3. **Scope-tightened `previousDataRef`**: moved its declaration inside the `else` branch of `overrideWithObjectState` since it's only consumed there (by `_updateFromDataDiff`). The tombstone branch never reads it.

Total: 1 insertion, 44 deletions.

## Other parent-ref maintenance is unaffected

Outside the sync flow, `parentReferences` continues to be maintained by the per-operation handlers, each with its own spec coverage:

- `MAP_SET` → `RTLM7a2f` (remove old) and `RTLM7i` (add new)
- `MAP_REMOVE` → `RTLM8a2e`
- `MAP_CLEAR` → `RTLM24e1c`
- `LiveMap` tombstone → `RTLO4e5`
- Post-sync rebuild → `RTO5c10b1`

None of these call the removed helper.

## Spec impact

**None.** `RTLM6` (`overrideWithObjectState`) doesn't mention `parentReferences` maintenance, and the operation handlers above already cover every parent-ref mutation the SDK is required to perform.

## Test plan

- [x] `npm run build:liveobjects` — passes (TypeScript compiles cleanly).
- [x] `npm run lint` — passes (only pre-existing warnings in `react-hooks` fakes, unrelated).
- [x] Repo-wide ripgrep for `_updateParentReferencesFromUpdate` returns zero hits after the change.
- [ ] CI to run the full mocha suite (`npm test`), in particular `test/realtime/liveobjects.test.js`, which exercises the OBJECT_SYNC flow extensively.
- [ ] Reviewer to verify that sync scenarios involving nested `LiveMap` references and path-based subscriptions (`RTPO19`) still emit the expected events — these end-states depend on `RTO5c10`, which is unchanged.

## Risk

Low. The diff is a pure deletion in one file, the method is `private` (no external callers possible), and the call-graph audit confirms every invocation path runs `RTO5c10` immediately afterward. Rollback is a single-commit revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal handling of object state processing to reduce code complexity and improve efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->