### PR TITLE
Change `getFullPaths` candidate language from "priority" to "preference"

### DIFF
--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -309,7 +309,7 @@ export abstract class LiveObject<
     // notifyPathEvent() emits at most one event on each subscription, this
     // means that we emit at most one event per path-to-this.
     for (const pathToThis of pathsToThis) {
-      const priorityOrderedCandidatePaths: Path[] = [pathToThis];
+      const preferenceOrderedCandidatePaths: Path[] = [pathToThis];
 
       // For LiveMapUpdate, also add a candidate path per updated key. We insert these after
       // pathToThis so that notifyPathEvent() picks pathToThis in the case where a given subscription
@@ -318,12 +318,12 @@ export abstract class LiveObject<
         const updatedKeys = Object.keys(update.update);
 
         for (const key of updatedKeys) {
-          priorityOrderedCandidatePaths.push([...pathToThis, key]);
+          preferenceOrderedCandidatePaths.push([...pathToThis, key]);
         }
       }
 
       const pathEvent: PathEvent = {
-        priorityOrderedCandidatePaths,
+        preferenceOrderedCandidatePaths,
         message: operationObjectMessage,
       };
 

--- a/src/plugins/liveobjects/pathobjectsubscriptionregister.ts
+++ b/src/plugins/liveobjects/pathobjectsubscriptionregister.ts
@@ -24,10 +24,10 @@ export interface SubscriptionEntry {
 export interface PathEvent {
   /**
    * Candidate paths for surfacing this event to subscriptions, in order of
-   * decreasing priority. For a given subscription, the first candidate path
+   * decreasing preference. For a given subscription, the first candidate path
    * it covers is used as the path of `event.object` passed to its listener.
    */
-  priorityOrderedCandidatePaths: Path[];
+  preferenceOrderedCandidatePaths: Path[];
   /** Object message that caused this event */
   message?: ObjectMessage;
 }
@@ -90,12 +90,12 @@ export class PathObjectSubscriptionRegister {
 
   /**
    * Dispatches a {@link PathEvent} to subscriptions. Each subscription that
-   * covers any of the event's {@link PathEvent.priorityOrderedCandidatePaths}
+   * covers any of the event's {@link PathEvent.preferenceOrderedCandidatePaths}
    * receives at most one notification, at the first covered path.
    */
   notifyPathEvent(event: PathEvent): void {
     for (const subscription of this._subscriptions.values()) {
-      const chosenCoveredPath = event.priorityOrderedCandidatePaths.find((path) =>
+      const chosenCoveredPath = event.preferenceOrderedCandidatePaths.find((path) =>
         this._subscriptionCoversPath(subscription, path),
       );
       if (chosenCoveredPath === undefined) {


### PR DESCRIPTION
"Priority" implies something to do with importance; instead, use the "preference" language that I used in spec point [RTO24b2a](https://sdk.ably.com/builds/ably/specification/main/objects-features/#RTO24b2a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated routing for path-based subscription events to prefer more direct, shorter matching candidate paths.
  * For live map updates, each changed key now contributes an additional preferred candidate path, improving accuracy when multiple subscriptions match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->