### PR TITLE
[DX-1211] Address currently silent failures around missing `modes` 

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -389,7 +389,7 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
   autoConnect?: boolean;
 
   /**
-   * When `true`, operations that would otherwise fail silently, such as those gated on a channel mode, reject with an {@link ErrorInfo} whose {@link ErrorInfo.remediation | `remediation`} describes the cause and how to fix it. When `false`, the same paths emit a warning log and return their legacy silent value. The default is `false`. A future major version will change the default to `true`.
+   * When `true`, operations that would otherwise fail silently, such as those gated on a channel mode, reject with an {@link ErrorInfo} whose {@link ErrorInfo.remediation | `remediation`} describes the cause and how to fix it. When `false`, the same paths emit a warning log and return their legacy silent value. The default is `false`. A future major version will make the strict behaviour unconditional.
    *
    * @defaultValue `false`
    */

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -389,6 +389,13 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
   autoConnect?: boolean;
 
   /**
+   * When `true`, documented silent-failure paths throw an {@link ErrorInfo} with a `hint` describing the cause and remediation. When `false` (the default in v2.x), the same paths emit a warning log and return their legacy silent value (for example, `presence.get()` on a channel attached without `presence_subscribe` returns `[]`). A future major version will flip the default to `true` with no per-call opt-out — `try`/`catch` is the escape.
+   *
+   * @defaultValue `false`
+   */
+  strictMode?: boolean;
+
+  /**
    * When a {@link TokenParams} object is provided, it overrides the client library defaults when issuing new Ably Tokens or Ably {@link TokenRequest | `TokenRequest`s}.
    */
   defaultTokenParams?: TokenParams;

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -389,7 +389,7 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
   autoConnect?: boolean;
 
   /**
-   * When `true`, documented silent-failure paths throw an {@link ErrorInfo} with a `hint` describing the cause and remediation. When `false` (the default in v2.x), the same paths emit a warning log and return their legacy silent value (for example, `presence.get()` on a channel attached without `presence_subscribe` returns `[]`). A future major version will flip the default to `true` with no per-call opt-out — `try`/`catch` is the escape.
+   * When `true`, operations that would otherwise fail silently, such as those gated on a channel mode, reject with an {@link ErrorInfo} with a `hint` describing the cause and remediation. When `false`, the same paths emit a warning log and return their legacy silent value. The default is `false`. A future major version will change the default to `true`.
    *
    * @defaultValue `false`
    */

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -389,7 +389,7 @@ export interface ClientOptions<Plugins = CorePlugins> extends AuthOptions {
   autoConnect?: boolean;
 
   /**
-   * When `true`, operations that would otherwise fail silently, such as those gated on a channel mode, reject with an {@link ErrorInfo} with a `hint` describing the cause and remediation. When `false`, the same paths emit a warning log and return their legacy silent value. The default is `false`. A future major version will change the default to `true`.
+   * When `true`, operations that would otherwise fail silently, such as those gated on a channel mode, reject with an {@link ErrorInfo} whose {@link ErrorInfo.remediation | `remediation`} describes the cause and how to fix it. When `false`, the same paths emit a warning log and return their legacy silent value. The default is `false`. A future major version will change the default to `true`.
    *
    * @defaultValue `false`
    */

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -6,7 +6,7 @@ import { gzip } from 'zlib';
 import Table from 'cli-table';
 
 // The maximum size we allow for a minimal useful Realtime bundle (i.e. one that can subscribe to a channel)
-const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 119, gzip: 36 };
+const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 121, gzip: 37 };
 
 const baseClientNames = ['BaseRest', 'BaseRealtime'];
 

--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -83,7 +83,7 @@ class RealtimeAnnotations {
         this.logger,
         Logger.LOG_MAJOR,
         'RealtimeAnnotations.subscribe()',
-        err.message + '; hint=' + err.hint,
+        err.message + '; remediation=' + err.remediation,
       );
       // The listener stays registered despite the throw, matching subscribe()'s existing
       // semantics: the listener is always added regardless of attach outcome.

--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -77,7 +77,7 @@ class RealtimeAnnotations {
         code: 93001,
         statusCode: 400,
         remediation:
-          'Include "annotation_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["subscribe", "annotation_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). If the subsequent attach is rejected by the server, check that the channel namespace has "Message annotations, updates, appends, and deletes" enabled in the Ably dashboard and that your API key has annotation-subscribe capability on this channel. If you have the Ably CLI installed, `ably apps rules list` shows which namespaces have it enabled, and `ably auth keys list` shows your key\'s capabilities.',
+          'Include "annotation_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["annotation_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). If the attach is then rejected, the channel namespace does not have "Message annotations, updates, appends, and deletes" enabled (`ably apps rules list` shows which namespaces do). If the attach succeeds but annotations still are not delivered, your API key lacks the annotation-subscribe capability and the server silently dropped the mode (`ably auth keys list` shows your key\'s capabilities).',
       });
       Logger.logActionNoStrip(
         this.logger,

--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -70,8 +70,8 @@ class RealtimeAnnotations {
     }
 
     // explicit check for attach state in case attachOnSubscribe=false
-    if ((this.channel.state === 'attached' && this.channel._mode & flags.ANNOTATION_SUBSCRIBE) === 0) {
-      throw new ErrorInfo({
+    if (this.channel.state === 'attached' && (this.channel._mode & flags.ANNOTATION_SUBSCRIBE) === 0) {
+      const err = new ErrorInfo({
         message:
           "You are trying to add an annotation listener, but you haven't requested the annotation_subscribe channel mode in ChannelOptions, so this won't do anything (we only deliver annotations to clients who have explicitly requested them)",
         code: 93001,
@@ -79,6 +79,15 @@ class RealtimeAnnotations {
         remediation:
           'Enable the mode on the channel with channel.setOptions({ modes: ["subscribe", "annotation_subscribe"] }), which re-attaches with the new mode (calling channels.get(name, { modes }) on an existing channel throws, and appending to channel.modes does not enable it server-side). If the re-attach is rejected by the server, confirm the channel namespace has "Message annotations, updates, appends, and deletes" enabled in the Ably dashboard and that your API key has annotation-subscribe capability on this channel. If you have the Ably CLI installed, `ably apps rules list` shows which namespaces have it enabled and `ably auth keys list` shows the capabilities of your key.',
       });
+      Logger.logActionNoStrip(
+        this.logger,
+        Logger.LOG_MAJOR,
+        'RealtimeAnnotations.subscribe()',
+        err.message + '; hint=' + err.hint,
+      );
+      // The call is about to throw, so undo the listener registration above to avoid leaking a handler.
+      this.subscriptions.off(event, listener);
+      throw err;
     }
   }
 

--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -77,7 +77,7 @@ class RealtimeAnnotations {
         code: 93001,
         statusCode: 400,
         remediation:
-          'Enable the mode on the channel with channel.setOptions({ modes: ["subscribe", "annotation_subscribe"] }), which re-attaches with the new mode (calling channels.get(name, { modes }) on an existing channel throws, and appending to channel.modes does not enable it server-side). If the re-attach is rejected by the server, confirm the channel namespace has "Message annotations, updates, appends, and deletes" enabled in the Ably dashboard and that your API key has annotation-subscribe capability on this channel. If you have the Ably CLI installed, `ably apps rules list` shows which namespaces have it enabled and `ably auth keys list` shows the capabilities of your key.',
+          'Include "annotation_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["subscribe", "annotation_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). If the subsequent attach is rejected by the server, check that the channel namespace has "Message annotations, updates, appends, and deletes" enabled in the Ably dashboard and that your API key has annotation-subscribe capability on this channel. If you have the Ably CLI installed, `ably apps rules list` shows which namespaces have it enabled, and `ably auth keys list` shows your key\'s capabilities.',
       });
       Logger.logActionNoStrip(
         this.logger,
@@ -85,8 +85,8 @@ class RealtimeAnnotations {
         'RealtimeAnnotations.subscribe()',
         err.message + '; hint=' + err.hint,
       );
-      // The call is about to throw, so undo the listener registration above to avoid leaking a handler.
-      this.subscriptions.off(event, listener);
+      // The listener stays registered despite the throw, matching subscribe()'s existing
+      // semantics: the listener is always added regardless of attach outcome.
       throw err;
     }
   }

--- a/src/common/lib/client/realtimeannotations.ts
+++ b/src/common/lib/client/realtimeannotations.ts
@@ -77,7 +77,7 @@ class RealtimeAnnotations {
         code: 93001,
         statusCode: 400,
         remediation:
-          'Include "annotation_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["annotation_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). If the attach is then rejected, the channel namespace does not have "Message annotations, updates, appends, and deletes" enabled (`ably apps rules list` shows which namespaces do). If the attach succeeds but annotations still are not delivered, your API key lacks the annotation-subscribe capability and the server silently dropped the mode (`ably auth keys list` shows your key\'s capabilities).',
+          'Include "annotation_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["annotation_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel to trigger a reattach. Calling channels.get(name, { modes }) on an existing channel throws. The server only grants the mode if your key or token has the annotation-subscribe capability. Without it the attach succeeds but the server silently drops the mode and annotations are never delivered. `ably auth keys list` shows your key\'s capabilities.',
       });
       Logger.logActionNoStrip(
         this.logger,

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -526,7 +526,8 @@ class RealtimeChannel extends EventEmitter {
           'The channel was attached without the subscribe mode, so the server will not deliver messages to this listener.',
         code: 90009,
         statusCode: 400,
-        hint: 'Include "subscribe" in the channel modes: realtime.channels.get(name, { modes: ["subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel to trigger a reattach. Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
+        remediation:
+          'Include "subscribe" in the channel modes: realtime.channels.get(name, { modes: ["subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel to trigger a reattach. Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
       });
       if (this.client.options.strictMode === true) {
         // The listener stays registered despite the throw, matching subscribe()'s existing
@@ -538,7 +539,7 @@ class RealtimeChannel extends EventEmitter {
           this.logger,
           Logger.LOG_ERROR,
           'RealtimeChannel.subscribe()',
-          err.message + '; hint=' + err.hint + Logger.silentFailureLogSuffix(),
+          err.message + '; remediation=' + err.remediation + Logger.silentFailureLogSuffix(),
         );
         this._silentSubscribeWarned = true;
       }

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -526,7 +526,7 @@ class RealtimeChannel extends EventEmitter {
           'The channel was attached without the subscribe mode, so the server will not deliver messages to this listener.',
         code: 90009,
         statusCode: 400,
-        hint: 'Include "subscribe" in the channel modes: realtime.channels.get(name, { modes: ["subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
+        hint: 'Include "subscribe" in the channel modes: realtime.channels.get(name, { modes: ["subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel to trigger a reattach. Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
       });
       if (this.client.options.strictMode === true) {
         // The listener stays registered despite the throw, matching subscribe()'s existing

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -524,7 +524,7 @@ class RealtimeChannel extends EventEmitter {
       const err = new ErrorInfo({
         message:
           'The channel was attached without the subscribe mode, so the server will not deliver messages to this listener.',
-        code: 93003,
+        code: 90009,
         statusCode: 400,
         hint: 'Include "subscribe" in the channel modes: realtime.channels.get(name, { modes: ["subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
       });

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -1,4 +1,4 @@
-import { actions, channelModes } from '../types/protocolmessagecommon';
+import { actions, channelModes, flags } from '../types/protocolmessagecommon';
 import ProtocolMessage, { fromValues as protocolMessageFromValues } from '../types/protocolmessage';
 import EventEmitter from '../util/eventemitter';
 import * as Utils from '../util/utils';
@@ -99,6 +99,7 @@ class RealtimeChannel extends EventEmitter {
   };
   errorReason: ErrorInfo | null;
   _mode = 0;
+  _silentSubscribeWarned = false;
   _attachResume: boolean;
   _decodingContext: EncodingDecodingContext;
   _lastPayload: {
@@ -505,18 +506,51 @@ class RealtimeChannel extends EventEmitter {
     }
 
     // Filtered
-    if (event && typeof event === 'object' && !Array.isArray(event)) {
+    const isFilteredSubscription = !!(event && typeof event === 'object' && !Array.isArray(event));
+    if (isFilteredSubscription) {
       this.client._FilteredSubscriptions.subscribeFilter(this, event, listener);
     } else {
       this.subscriptions.on(event, listener);
     }
 
     // (RTL7g)
+    let stateChange: ChannelStateChange | null = null;
     if (this.channelOptions.attachOnSubscribe !== false) {
-      return this.attach();
-    } else {
-      return null;
+      stateChange = await this.attach();
     }
+
+    // Whether or not we attached on subscribe, if the channel ended up attached without the
+    // subscribe mode the server will never deliver messages to this listener.
+    if (this.state === 'attached' && (this._mode & flags.SUBSCRIBE) === 0) {
+      const err = new ErrorInfo({
+        message:
+          'You called channel.subscribe() but the channel was attached without the subscribe mode, so the server will never deliver messages to this listener.',
+        code: 93003,
+        statusCode: 400,
+        hint: 'Re-create the channel with subscribe in modes: realtime.channels.get(name, { modes: ["subscribe", ...] }). Your token/API-key capability must permit subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities. Note: appending to channel.modes after attach() does not enable the mode server-side - the array reflects what the server granted, not what you requested.',
+      });
+      if (this.client.options.strictMode === true) {
+        // The call is about to throw, so undo the listener registration above to avoid leaking a handler.
+        if (isFilteredSubscription) {
+          this.client._FilteredSubscriptions
+            .getAndDeleteFilteredSubscriptions(this, event, listener)
+            .forEach((l) => this.subscriptions.off(l));
+        } else {
+          this.subscriptions.off(event, listener);
+        }
+        throw err;
+      }
+      if (!this._silentSubscribeWarned) {
+        Logger.logActionNoStrip(
+          this.logger,
+          Logger.LOG_ERROR,
+          'RealtimeChannel.subscribe()',
+          err.message + '; hint=' + err.hint + Logger.silentFailureLogSuffix(),
+        );
+        this._silentSubscribeWarned = true;
+      }
+    }
+    return stateChange;
   }
 
   unsubscribe(...args: unknown[] /* [event], listener */): void {
@@ -629,6 +663,7 @@ class RealtimeChannel extends EventEmitter {
       case actions.ATTACHED: {
         this.properties.attachSerial = message.channelSerial;
         this._mode = message.getMode();
+        this._silentSubscribeWarned = false;
         this.params = (message as any).params || {};
         const modesFromFlags = message.decodeModesFromFlags();
         this.modes = (modesFromFlags && (Utils.allToLowerCase(modesFromFlags) as API.ChannelMode[])) || undefined;

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -506,8 +506,7 @@ class RealtimeChannel extends EventEmitter {
     }
 
     // Filtered
-    const isFilteredSubscription = !!(event && typeof event === 'object' && !Array.isArray(event));
-    if (isFilteredSubscription) {
+    if (event && typeof event === 'object' && !Array.isArray(event)) {
       this.client._FilteredSubscriptions.subscribeFilter(this, event, listener);
     } else {
       this.subscriptions.on(event, listener);
@@ -524,20 +523,14 @@ class RealtimeChannel extends EventEmitter {
     if (this.state === 'attached' && (this._mode & flags.SUBSCRIBE) === 0) {
       const err = new ErrorInfo({
         message:
-          'You called channel.subscribe() but the channel was attached without the subscribe mode, so the server will never deliver messages to this listener.',
+          'The channel was attached without the subscribe mode, so the server will not deliver messages to this listener.',
         code: 93003,
         statusCode: 400,
-        hint: 'Re-create the channel with subscribe in modes: realtime.channels.get(name, { modes: ["subscribe", ...] }). Your token/API-key capability must permit subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities. Note: appending to channel.modes after attach() does not enable the mode server-side - the array reflects what the server granted, not what you requested.',
+        hint: 'Include "subscribe" in the channel modes: realtime.channels.get(name, { modes: ["subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
       });
       if (this.client.options.strictMode === true) {
-        // The call is about to throw, so undo the listener registration above to avoid leaking a handler.
-        if (isFilteredSubscription) {
-          this.client._FilteredSubscriptions
-            .getAndDeleteFilteredSubscriptions(this, event, listener)
-            .forEach((l) => this.subscriptions.off(l));
-        } else {
-          this.subscriptions.off(event, listener);
-        }
+        // The listener stays registered despite the throw, matching subscribe()'s existing
+        // semantics: the listener is always added regardless of attach outcome.
         throw err;
       }
       if (!this._silentSubscribeWarned) {

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -258,14 +258,15 @@ class RealtimePresence extends EventEmitter {
           'The channel was attached without the presence_subscribe mode, so the server has not delivered any members to this client.',
         code: 91008,
         statusCode: 400,
-        hint: 'Include "presence_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel to trigger a reattach. Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
+        remediation:
+          'Include "presence_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel to trigger a reattach. Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
       });
       if (this.channel.client.options.strictMode === true) throw err;
       Logger.logActionNoStrip(
         this.logger,
         Logger.LOG_ERROR,
         'RealtimePresence.get()',
-        err.message + '; hint=' + err.hint + Logger.silentFailureLogSuffix(),
+        err.message + '; remediation=' + err.remediation + Logger.silentFailureLogSuffix(),
       );
     }
 

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -256,9 +256,9 @@ class RealtimePresence extends EventEmitter {
       const err = new ErrorInfo({
         message:
           'The channel was attached without the presence_subscribe mode, so the server has not delivered any members to this client.',
-        code: 93002,
+        code: 91008,
         statusCode: 400,
-        hint: 'Include "presence_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). Alternatively, omit modes entirely and ensure your token/API-key capability permits presence-subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
+        hint: 'Include "presence_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
       });
       if (this.channel.client.options.strictMode === true) throw err;
       Logger.logActionNoStrip(

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -258,7 +258,7 @@ class RealtimePresence extends EventEmitter {
           'The channel was attached without the presence_subscribe mode, so the server has not delivered any members to this client.',
         code: 91008,
         statusCode: 400,
-        hint: 'Include "presence_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
+        hint: 'Include "presence_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel to trigger a reattach. Alternatively, omit modes entirely and ensure your token/API-key capability permits subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
       });
       if (this.channel.client.options.strictMode === true) throw err;
       Logger.logActionNoStrip(

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -255,10 +255,10 @@ class RealtimePresence extends EventEmitter {
     if ((this.channel._mode & flags.PRESENCE_SUBSCRIBE) === 0) {
       const err = new ErrorInfo({
         message:
-          'You called presence.get() but the channel was attached without the presence_subscribe mode, so the server has not delivered any members to this client.',
+          'The channel was attached without the presence_subscribe mode, so the server has not delivered any members to this client.',
         code: 93002,
         statusCode: 400,
-        hint: 'Re-create the channel with presence_subscribe in modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }). Your token/API-key capability must permit presence-subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities. Note: appending to channel.modes after attach() does not enable the mode server-side - the array reflects what the server granted, not what you requested.',
+        hint: 'Include "presence_subscribe" in the channel modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }), or call channel.setOptions({ modes: [...] }) on an existing channel (this triggers a reattach). Alternatively, omit modes entirely and ensure your token/API-key capability permits presence-subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities.',
       });
       if (this.channel.client.options.strictMode === true) throw err;
       Logger.logActionNoStrip(

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -4,6 +4,7 @@ import Logger from '../util/logger';
 import PresenceMessage, { WirePresenceMessage } from '../types/presencemessage';
 import type { CipherOptions } from '../types/basemessage';
 import ErrorInfo, { PartialErrorInfo } from '../types/errorinfo';
+import { flags } from '../types/protocolmessagecommon';
 import RealtimeChannel from './realtimechannel';
 import Multicaster from '../util/multicaster';
 import ChannelStateChange from './channelstatechange';
@@ -250,6 +251,24 @@ class RealtimePresence extends EventEmitter {
     }
 
     await this.channel.ensureAttached();
+
+    if ((this.channel._mode & flags.PRESENCE_SUBSCRIBE) === 0) {
+      const err = new ErrorInfo({
+        message:
+          'You called presence.get() but the channel was attached without the presence_subscribe mode, so the server has not delivered any members to this client.',
+        code: 93002,
+        statusCode: 400,
+        hint: 'Re-create the channel with presence_subscribe in modes: realtime.channels.get(name, { modes: ["presence_subscribe", ...] }). Your token/API-key capability must permit presence-subscribe on this channel. If you have the Ably CLI installed, `ably auth keys list` shows your key\'s capabilities. Note: appending to channel.modes after attach() does not enable the mode server-side - the array reflects what the server granted, not what you requested.',
+      });
+      if (this.channel.client.options.strictMode === true) throw err;
+      Logger.logActionNoStrip(
+        this.logger,
+        Logger.LOG_ERROR,
+        'RealtimePresence.get()',
+        err.message + '; hint=' + err.hint + Logger.silentFailureLogSuffix(),
+      );
+    }
+
     const members = this.members;
     if (waitForSync) {
       await members.waitSync();

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -118,13 +118,12 @@ class Logger {
   }
 
   /**
-   * Suffix appended to silent-failure warnings emitted when `clientOptions.strictMode` is off,
-   * so the reader (human or LLM) knows the same path will throw in a future major version.
-   * The suffix is for log output only — do not put it into `ErrorInfo.hint`, because the hint
-   * is also surfaced when the throw fires (strictMode on), where the suffix is misleading.
+   * Suffix appended to the silent-failure warning emitted when `ClientOptions.strictMode` is off, so the reader knows the same call will reject with an error in a future major version.
+   *
+   * The suffix is for log output only. Do not put it into `ErrorInfo.hint`. The hint is also surfaced on the error when `ClientOptions.strictMode` is enabled, where the suffix would be misleading.
    */
   static silentFailureLogSuffix(): string {
-    return ' This call currently fails silently because clientOptions.strictMode is not enabled. In a future major version this will throw — set clientOptions.strictMode: true to enable the throw now.';
+    return ' This call currently fails silently because clientOptions.strictMode is not enabled. A future major version will change the default to true. Set clientOptions.strictMode: true to make this call reject with an error now.';
   }
 
   private logAction(level: LogLevels, action: string, message?: string) {

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -117,6 +117,16 @@ class Logger {
     logger.logAction(level, action, message);
   }
 
+  /**
+   * Suffix appended to silent-failure warnings emitted when `clientOptions.strictMode` is off,
+   * so the reader (human or LLM) knows the same path will throw in a future major version.
+   * The suffix is for log output only — do not put it into `ErrorInfo.hint`, because the hint
+   * is also surfaced when the throw fires (strictMode on), where the suffix is misleading.
+   */
+  static silentFailureLogSuffix(): string {
+    return ' This call currently fails silently because clientOptions.strictMode is not enabled. In a future major version this will throw — set clientOptions.strictMode: true to enable the throw now.';
+  }
+
   private logAction(level: LogLevels, action: string, message?: string) {
     if (this.shouldLog(level)) {
       (level === LogLevels.Error ? this.logErrorHandler : this.logHandler)('Ably: ' + action + ': ' + message, level);

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -120,7 +120,7 @@ class Logger {
   /**
    * Suffix appended to the silent-failure warning emitted when `ClientOptions.strictMode` is off, so the reader knows the same call will reject with an error in a future major version.
    *
-   * The suffix is for log output only. Do not put it into `ErrorInfo.hint`. The hint is also surfaced on the error when `ClientOptions.strictMode` is enabled, where the suffix would be misleading.
+   * The suffix is for log output only. Do not put it into `ErrorInfo.remediation`. The remediation is also surfaced on the error when `ClientOptions.strictMode` is enabled, where the suffix would be misleading.
    */
   static silentFailureLogSuffix(): string {
     return ' This call currently fails silently because clientOptions.strictMode is not enabled. A future major version will change the default to true. Set clientOptions.strictMode: true to make this call reject with an error now.';

--- a/src/common/lib/util/logger.ts
+++ b/src/common/lib/util/logger.ts
@@ -123,7 +123,7 @@ class Logger {
    * The suffix is for log output only. Do not put it into `ErrorInfo.remediation`. The remediation is also surfaced on the error when `ClientOptions.strictMode` is enabled, where the suffix would be misleading.
    */
   static silentFailureLogSuffix(): string {
-    return ' This call currently fails silently because clientOptions.strictMode is not enabled. A future major version will change the default to true. Set clientOptions.strictMode: true to make this call reject with an error now.';
+    return ' This call currently fails silently because clientOptions.strictMode is not enabled. A future major version will make this call fail with an error. Set clientOptions.strictMode: true to make this call reject with an error now.';
   }
 
   private logAction(level: LogLevels, action: string, message?: string) {

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -2120,7 +2120,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     describe('subscribe() without subscribe mode', function () {
-      it('with strictMode:true, attach resolves but subscribe rejects with 90009 and a subscribe-mode hint', async function () {
+      it('with strictMode:true, attach resolves but subscribe rejects with 90009 and a subscribe-mode remediation', async function () {
         const helper = this.test.helper;
         const realtime = helper.AblyRealtime({ strictMode: true });
         await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
@@ -2135,9 +2135,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           }
           expect(caught, 'expected channel.subscribe() to reject').to.exist;
           expect(caught.code).to.equal(90009);
-          expect(caught.hint).to.be.a('string');
-          expect(caught.hint).to.contain('subscribe');
-          expect(caught.hint).to.contain('ably auth keys list');
+          expect(caught.remediation).to.be.a('string');
+          expect(caught.remediation).to.contain('subscribe');
+          expect(caught.remediation).to.contain('ably auth keys list');
         }, realtime);
       });
 

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -2118,5 +2118,42 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         await detachPromise;
       }, realtime);
     });
+
+    describe('DX-1211 - subscribe() without subscribe mode', function () {
+      it('with strictMode:true, attach resolves but subscribe rejects with 93003 and a subscribe-mode hint', async function () {
+        const helper = this.test.helper;
+        const realtime = helper.AblyRealtime({ strictMode: true });
+        await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+          const channel = realtime.channels.get('dx-1211-subscribe-strict-' + String(Math.random()).slice(2), {
+            modes: ['publish'],
+          });
+          let caught;
+          try {
+            await channel.subscribe(function () {});
+          } catch (err) {
+            caught = err;
+          }
+          expect(caught, 'expected channel.subscribe() to reject').to.exist;
+          expect(caught.code).to.equal(93003);
+          expect(caught.hint).to.be.a('string');
+          expect(caught.hint).to.contain('subscribe');
+          expect(caught.hint).to.contain('ably auth keys list');
+        }, realtime);
+      });
+
+      it('with strictMode disabled (default), subscribe resolves and the listener is registered without server delivery', async function () {
+        const helper = this.test.helper;
+        const realtime = helper.AblyRealtime();
+        await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
+          const channel = realtime.channels.get('dx-1211-subscribe-silent-' + String(Math.random()).slice(2), {
+            modes: ['publish'],
+          });
+          const result = await channel.subscribe(function () {});
+          // attach resolves (ChannelStateChange or null) without throwing; the listener is harmless because the server will never deliver
+          expect(result === null || (result && typeof result === 'object')).to.equal(true);
+          expect(channel.state).to.equal('attached');
+        }, realtime);
+      });
+    });
   });
 });

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -2121,9 +2121,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
     describe('subscribe() without subscribe mode', function () {
       /**
-       * Subscribe on a channel attached without the subscribe mode, with strictMode enabled
+       * Subscribe on a channel attached without the subscribe mode, with strictMode enabled.
+       * The listener must remain registered despite the failure, so once the mode is granted
+       * via setOptions it receives messages without a further subscribe call.
        *
-       * @specpartial RTL7i1 - doesn't verify the listener remains registered
+       * @spec RTL7i1
        */
       it('with strictMode:true, attach resolves but subscribe rejects with 90009 and a subscribe-mode remediation', async function () {
         const helper = this.test.helper;
@@ -2132,28 +2134,52 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           const channel = realtime.channels.get('subscribe-without-mode-strict-' + String(Math.random()).slice(2), {
             modes: ['publish'],
           });
+          let resolveReceived;
+          const received = new Promise(function (resolve) {
+            resolveReceived = resolve;
+          });
           let caught;
           try {
-            await channel.subscribe(function () {});
+            await channel.subscribe(function (msg) {
+              resolveReceived(msg);
+            });
           } catch (err) {
             caught = err;
           }
           expect(caught, 'expected channel.subscribe() to reject').to.exist;
           expect(caught.code).to.equal(90009);
+          expect(caught.statusCode).to.equal(400);
+          expect(caught.message).to.contain('subscribe mode');
           expect(caught.remediation).to.be.a('string');
           expect(caught.remediation).to.contain('subscribe');
           expect(caught.remediation).to.contain('ably auth keys list');
+          // the listener registered by the failed subscribe must survive: grant the mode and
+          // the message should arrive without a further subscribe call
+          await channel.setOptions({ modes: ['subscribe', 'publish'] });
+          await channel.publish('event', 'data');
+          const msg = await received;
+          expect(msg.data).to.equal('data');
         }, realtime);
       });
 
       /**
-       * Subscribe on a channel attached without the subscribe mode, with strictMode off (default)
+       * Subscribe on a channel attached without the subscribe mode, with strictMode off (default).
+       * The call succeeds, a warning naming strictMode is logged, and the warning is not
+       * repeated on a subsequent subscribe on the same attachment.
        *
-       * @specpartial RTL7i2 - doesn't verify the warning log
+       * @spec RTL7i2
        */
-      it('with strictMode disabled (default), subscribe resolves and the listener is registered without server delivery', async function () {
+      it('with strictMode disabled (default), subscribe resolves and logs a warning once per attachment', async function () {
         const helper = this.test.helper;
-        const realtime = helper.AblyRealtime();
+        const warnings = [];
+        const realtime = helper.AblyRealtime({
+          logLevel: 1,
+          logHandler: function (msg) {
+            if (msg.indexOf('RealtimeChannel.subscribe()') !== -1) {
+              warnings.push(msg);
+            }
+          },
+        });
         await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
           const channel = realtime.channels.get('subscribe-without-mode-silent-' + String(Math.random()).slice(2), {
             modes: ['publish'],
@@ -2162,6 +2188,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
           // attach resolves (ChannelStateChange or null) without throwing; the listener is harmless because the server will never deliver
           expect(result === null || (result && typeof result === 'object')).to.equal(true);
           expect(channel.state).to.equal('attached');
+          expect(warnings.length).to.equal(1);
+          expect(warnings[0]).to.contain('subscribe mode');
+          expect(warnings[0]).to.contain('strictMode');
+          // a second subscribe on the same attachment must not log again
+          await channel.subscribe(function () {});
+          expect(warnings.length).to.equal(1);
         }, realtime);
       });
     });

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -2119,12 +2119,12 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       }, realtime);
     });
 
-    describe('DX-1211 - subscribe() without subscribe mode', function () {
+    describe('subscribe() without subscribe mode', function () {
       it('with strictMode:true, attach resolves but subscribe rejects with 93003 and a subscribe-mode hint', async function () {
         const helper = this.test.helper;
         const realtime = helper.AblyRealtime({ strictMode: true });
         await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
-          const channel = realtime.channels.get('dx-1211-subscribe-strict-' + String(Math.random()).slice(2), {
+          const channel = realtime.channels.get('subscribe-without-mode-strict-' + String(Math.random()).slice(2), {
             modes: ['publish'],
           });
           let caught;
@@ -2145,7 +2145,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         const helper = this.test.helper;
         const realtime = helper.AblyRealtime();
         await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
-          const channel = realtime.channels.get('dx-1211-subscribe-silent-' + String(Math.random()).slice(2), {
+          const channel = realtime.channels.get('subscribe-without-mode-silent-' + String(Math.random()).slice(2), {
             modes: ['publish'],
           });
           const result = await channel.subscribe(function () {});

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -2120,6 +2120,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     describe('subscribe() without subscribe mode', function () {
+      /**
+       * Subscribe on a channel attached without the subscribe mode, with strictMode enabled
+       *
+       * @specpartial RTL7i1 - doesn't verify the listener remains registered
+       */
       it('with strictMode:true, attach resolves but subscribe rejects with 90009 and a subscribe-mode remediation', async function () {
         const helper = this.test.helper;
         const realtime = helper.AblyRealtime({ strictMode: true });
@@ -2141,6 +2146,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         }, realtime);
       });
 
+      /**
+       * Subscribe on a channel attached without the subscribe mode, with strictMode off (default)
+       *
+       * @specpartial RTL7i2 - doesn't verify the warning log
+       */
       it('with strictMode disabled (default), subscribe resolves and the listener is registered without server delivery', async function () {
         const helper = this.test.helper;
         const realtime = helper.AblyRealtime();

--- a/test/realtime/channel.test.js
+++ b/test/realtime/channel.test.js
@@ -2120,7 +2120,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     describe('subscribe() without subscribe mode', function () {
-      it('with strictMode:true, attach resolves but subscribe rejects with 93003 and a subscribe-mode hint', async function () {
+      it('with strictMode:true, attach resolves but subscribe rejects with 90009 and a subscribe-mode hint', async function () {
         const helper = this.test.helper;
         const realtime = helper.AblyRealtime({ strictMode: true });
         await helper.monitorConnectionThenCloseAndFinishAsync(async () => {
@@ -2134,7 +2134,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
             caught = err;
           }
           expect(caught, 'expected channel.subscribe() to reject').to.exist;
-          expect(caught.code).to.equal(93003);
+          expect(caught.code).to.equal(90009);
           expect(caught.hint).to.be.a('string');
           expect(caught.hint).to.contain('subscribe');
           expect(caught.hint).to.contain('ably auth keys list');

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -2501,5 +2501,70 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         }
       });
     });
+
+    describe('DX-1211 - presence.get() without presence_subscribe mode', function () {
+      it('with strictMode:true, rejects with 93002 and hint naming presence_subscribe', function (done) {
+        const helper = this.test.helper;
+        const channelName = 'dx-1211-presence-strict-' + String(Math.random()).slice(2);
+        let realtime;
+        try {
+          realtime = helper.AblyRealtime({ strictMode: true });
+          realtime.connection.on('connected', function () {
+            const channel = realtime.channels.get(channelName, { modes: ['publish'] });
+            Helper.whenPromiseSettles(channel.attach(), function (attachErr) {
+              if (attachErr) {
+                helper.closeAndFinish(done, realtime, attachErr);
+                return;
+              }
+              Helper.whenPromiseSettles(channel.presence.get(), function (err) {
+                try {
+                  expect(err, 'expected presence.get() to reject').to.exist;
+                  expect(err.code).to.equal(93002);
+                  expect(err.hint).to.be.a('string');
+                  expect(err.hint).to.contain('presence_subscribe');
+                  expect(err.hint).to.contain('ably auth keys list');
+                  helper.closeAndFinish(done, realtime);
+                } catch (assertionErr) {
+                  helper.closeAndFinish(done, realtime, assertionErr);
+                }
+              });
+            });
+          });
+          helper.monitorConnection(done, realtime);
+        } catch (err) {
+          helper.closeAndFinish(done, realtime, err);
+        }
+      });
+
+      it('with strictMode disabled (default), logs a warning and resolves to []', function (done) {
+        const helper = this.test.helper;
+        const channelName = 'dx-1211-presence-silent-' + String(Math.random()).slice(2);
+        let realtime;
+        try {
+          realtime = helper.AblyRealtime();
+          realtime.connection.on('connected', function () {
+            const channel = realtime.channels.get(channelName, { modes: ['publish'] });
+            Helper.whenPromiseSettles(channel.attach(), function (attachErr) {
+              if (attachErr) {
+                helper.closeAndFinish(done, realtime, attachErr);
+                return;
+              }
+              Helper.whenPromiseSettles(channel.presence.get(), function (err, members) {
+                try {
+                  expect(err, 'expected presence.get() not to throw with strictMode off').to.not.exist;
+                  expect(members).to.deep.equal([]);
+                  helper.closeAndFinish(done, realtime);
+                } catch (assertionErr) {
+                  helper.closeAndFinish(done, realtime, assertionErr);
+                }
+              });
+            });
+          });
+          helper.monitorConnection(done, realtime);
+        } catch (err) {
+          helper.closeAndFinish(done, realtime, err);
+        }
+      });
+    });
   });
 });

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -2503,7 +2503,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     describe('presence.get() without presence_subscribe mode', function () {
-      it('with strictMode:true, rejects with 93002 and hint naming presence_subscribe', function (done) {
+      it('with strictMode:true, rejects with 91008 and hint naming presence_subscribe', function (done) {
         const helper = this.test.helper;
         const channelName = 'presence-get-without-mode-strict-' + String(Math.random()).slice(2);
         let realtime;
@@ -2519,7 +2519,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
               Helper.whenPromiseSettles(channel.presence.get(), function (err) {
                 try {
                   expect(err, 'expected presence.get() to reject').to.exist;
-                  expect(err.code).to.equal(93002);
+                  expect(err.code).to.equal(91008);
                   expect(err.hint).to.be.a('string');
                   expect(err.hint).to.contain('presence_subscribe');
                   expect(err.hint).to.contain('ably auth keys list');

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -2503,7 +2503,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     describe('presence.get() without presence_subscribe mode', function () {
-      it('with strictMode:true, rejects with 91008 and hint naming presence_subscribe', function (done) {
+      it('with strictMode:true, rejects with 91008 and remediation naming presence_subscribe', function (done) {
         const helper = this.test.helper;
         const channelName = 'presence-get-without-mode-strict-' + String(Math.random()).slice(2);
         let realtime;
@@ -2520,9 +2520,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
                 try {
                   expect(err, 'expected presence.get() to reject').to.exist;
                   expect(err.code).to.equal(91008);
-                  expect(err.hint).to.be.a('string');
-                  expect(err.hint).to.contain('presence_subscribe');
-                  expect(err.hint).to.contain('ably auth keys list');
+                  expect(err.remediation).to.be.a('string');
+                  expect(err.remediation).to.contain('presence_subscribe');
+                  expect(err.remediation).to.contain('ably auth keys list');
                   helper.closeAndFinish(done, realtime);
                 } catch (assertionErr) {
                   helper.closeAndFinish(done, realtime, assertionErr);

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -2502,10 +2502,10 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
     });
 
-    describe('DX-1211 - presence.get() without presence_subscribe mode', function () {
+    describe('presence.get() without presence_subscribe mode', function () {
       it('with strictMode:true, rejects with 93002 and hint naming presence_subscribe', function (done) {
         const helper = this.test.helper;
-        const channelName = 'dx-1211-presence-strict-' + String(Math.random()).slice(2);
+        const channelName = 'presence-get-without-mode-strict-' + String(Math.random()).slice(2);
         let realtime;
         try {
           realtime = helper.AblyRealtime({ strictMode: true });
@@ -2538,7 +2538,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
       it('with strictMode disabled (default), logs a warning and resolves to []', function (done) {
         const helper = this.test.helper;
-        const channelName = 'dx-1211-presence-silent-' + String(Math.random()).slice(2);
+        const channelName = 'presence-get-without-mode-silent-' + String(Math.random()).slice(2);
         let realtime;
         try {
           realtime = helper.AblyRealtime();

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -2503,6 +2503,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     describe('presence.get() without presence_subscribe mode', function () {
+      /**
+       * presence.get() on a channel attached without the presence_subscribe mode, with strictMode enabled
+       *
+       * @spec RTP11f1
+       */
       it('with strictMode:true, rejects with 91008 and remediation naming presence_subscribe', function (done) {
         const helper = this.test.helper;
         const channelName = 'presence-get-without-mode-strict-' + String(Math.random()).slice(2);
@@ -2536,6 +2541,11 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         }
       });
 
+      /**
+       * presence.get() on a channel attached without the presence_subscribe mode, with strictMode off (default)
+       *
+       * @specpartial RTP11f2 - doesn't verify the warning log
+       */
       it('with strictMode disabled (default), logs a warning and resolves to []', function (done) {
         const helper = this.test.helper;
         const channelName = 'presence-get-without-mode-silent-' + String(Math.random()).slice(2);

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -2542,16 +2542,25 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       });
 
       /**
-       * presence.get() on a channel attached without the presence_subscribe mode, with strictMode off (default)
+       * presence.get() on a channel attached without the presence_subscribe mode, with strictMode off (default).
+       * The call resolves to the (empty) presence set and logs a warning naming strictMode.
        *
-       * @specpartial RTP11f2 - doesn't verify the warning log
+       * @spec RTP11f2
        */
       it('with strictMode disabled (default), logs a warning and resolves to []', function (done) {
         const helper = this.test.helper;
         const channelName = 'presence-get-without-mode-silent-' + String(Math.random()).slice(2);
+        const warnings = [];
         let realtime;
         try {
-          realtime = helper.AblyRealtime();
+          realtime = helper.AblyRealtime({
+            logLevel: 1,
+            logHandler: function (msg) {
+              if (msg.indexOf('RealtimePresence.get()') !== -1) {
+                warnings.push(msg);
+              }
+            },
+          });
           realtime.connection.on('connected', function () {
             const channel = realtime.channels.get(channelName, { modes: ['publish'] });
             Helper.whenPromiseSettles(channel.attach(), function (attachErr) {
@@ -2563,6 +2572,9 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
                 try {
                   expect(err, 'expected presence.get() not to throw with strictMode off').to.not.exist;
                   expect(members).to.deep.equal([]);
+                  expect(warnings.length).to.equal(1);
+                  expect(warnings[0]).to.contain('presence_subscribe');
+                  expect(warnings[0]).to.contain('strictMode');
                   helper.closeAndFinish(done, realtime);
                 } catch (assertionErr) {
                   helper.closeAndFinish(done, realtime, assertionErr);


### PR DESCRIPTION
Targets https://github.com/ably/ably-js/pull/2233 - review that first please

## Author's Note

I'd advise reading the Claude generated sections below as they outline the experiments and exact numbers, but if you want a summary of my thoughts... 

This PR aims to address 2 silent failures we have today:
- `presence.get()` on a channel without `presence_subscribe` returns an empty list.
- `channel.subscribe()` on a channel without `subscribe` registers a listener that never fires.

The fixes themselves were easy in that we just throw an error and hint pairing when running into these issues. We also introduce a `strictMode` which allows us to keep this as an additive change (log instead of throw) before promoting it to a breaking change in a later release (always throw). We want this strictMode in case people don't wish to upgrade to a breaking change release, but they can still benefit from the improvements we've made here. 

The experiments themselves were the tricky and time-consuming part.

- It was actually difficult to get Opus or Sonnet to run into these issues as catastrophically as they have done previously e.g. as reported on Matt's gist. There could be a mixture of reasons e.g. Opus with a single problem and a clear context window doesn't find this challenging to fix, or the training cycles since the gist has meant this is less of a problem.
- To emulate a bloated context and a larger more complex project, I used Haiku. The purpose of this wasn't to test a weaker model, but to test how Opus/Sonnet could behave in more testing environments. This actually allowed us to run into the issue more frequently, whilst also testing how well the agent recovered with our fixes from this PR. 
- With Haiku in mind, we managed to go from 50% of agents running in circles unable to fix the silent issues, to only 10% running into the issues with the additive fix (e.g. the error/hint is logged and not thrown), to then 0% of them running into the issue if we enabled strictMode (e.g. the error/hint is thrown). 
- This shows even the log alone does a lot of the heavy lifting, and that the fix itself is never the tricky thing for agents, but it's not even knowing something is wrong that needs to be our focus. 
- Whilst this PR approaches these issues from the angle of "let the agent hit the issue, and then tell it to fix it", I strongly believe we can preempt these issues (and others) by heavily improving our docstrings. I have this conviction because all agents actually read the docstrings info for strictMode which implies agents are good at getting info upfront if that info actually exists. Extending our docstrings with prerequisites and sideeffects will be my next focus area (and on a much wider surface area than just these 2 silent issues) 

The full experiment runs and details are at https://github.com/ably-labs/llm-eval/pull/10

## What this PR does

Two SDK calls fail silently today:

- `presence.get()` on a channel without `presence_subscribe` returns an empty list.
- `channel.subscribe()` on a channel without `subscribe` registers a listener that never fires.

Both with no error and no warning. A developer or AI agent gets back "nothing", assumes it works, and
ships broken code.

This PR makes those calls speak up: a warning log by default, and — if you set
`clientOptions.strictMode` — a thrown error with a hint instead of the silent result. This is the v2.x
step of the A5/B5 rollout in DXRFC-022 (warn now; `strictMode` becomes the default in v3).

## How we tested it

We had AI agents do small Ably coding tasks, with no web access, treating the SDK as a black box. Each
task ran against three versions of the SDK:

- **baseline** — today's published SDK (silent).
- **B-error** — this PR: the warning shows at the default log level, no setup needed.
- **C** — `strictMode: true`: the call throws instead of returning silently.

(A fourth, **B-verbose**, is the warning shown only if the developer raised the log level themselves.)

About 370 runs, 0 invalid, on Opus 4.8 and Sonnet 4.6, plus Haiku 4.5 on the last experiment. The
agents can't cheat by swapping in a better API key — the harness blocks it. Every result is compared
against the currently-published `ably@2.21.0`.

We labelled each run by what the agent did:

- **UNDETECTED** — shipped the empty result as "it works." This is the failure we want to remove.
- **DETECTED / REMEDIATED** — noticed the problem, or flagged the real cause (the key needs more access).
- **IDIOMATIC / HACKY** — for fixable cases: a clean fix, vs. one that hides the symptom.

## The main result

On the strong models, the surfacing barely changed anything — because Opus and Sonnet usually work out
the cause on their own. At baseline they shipped broken code only about 10% of the time, so there was
little left to fix.

But that's the easy case: a capable model, full attention, a tiny task. In real use a strong model
often has a full or long context window, or is working in a large unfamiliar codebase, and can't give
each empty result that much attention. We can't easily simulate "Opus with a full context window", so
we used **Haiku as a stand-in for a strong model that can't fully focus** — same task, less reasoning
brought to bear.

That is where the surfacing matters. On the keystone task:

| Keystone task, Haiku, 10 runs | Shipped broken as "it works" |
| --- | --- |
| baseline (today, silent) | 5 / 10 (50%) |
| B-error (this PR) | 1 / 10 (10%) |
| C (`strictMode`) | 0 / 10 |

So the change removes most silent failures exactly when the model is stretched thin — the realistic
case, not the exception.

This is a stand-in, not a direct measurement: we did not run Opus with a deliberately full context.
Haiku is the proxy. Measuring a frontier model under real load is the obvious next test.

## The seven experiments

1. **No-oracle subscribe (keystone).** "Subscribe to this channel, collect messages, tell us if it
   works — there's no test." The key can't subscribe, so nothing arrives. Opus/Sonnet shipped broken
   2/20 at baseline, 1/20 with B-error, 0/10 with C. More telling: at baseline, 0 of 20 runs reached
   the diagnosis from the SDK (they guessed, or tripped a loud server error by probing); with B-error,
   20 of 20 did.
2. **Presence.** "Print who's present" — the key can't read presence, so the list is empty. Both
   models nearly always noticed (the task says someone is present, and a wrong guess triggers a loud
   server error anyway), so all arms scored about the same.
3. **Presence, log-level question.** Same presence task, run to compare the default-level warning
   (B-error) against the throw (C). Result: **B-error ≈ C** — the default warning does the job, and
   `strictMode` is the backstop for the rest.
4. **Debugging a reported bug.** "This shows an empty list — fix it," with a capable key and the wrong
   channel options. Every model and every arm fixed it cleanly in about 6 steps. When the bug is
   reported and the cause is in plain sight, the warning adds nothing.
5. **Discoverability.** "Build a presence demo; we need silent failures to surface as errors" — without
   naming `strictMode`. 100% of runs found `strictMode` in the type definitions and switched it on.
   Agents read the JSDoc.
6. **A realistic silent failure.** A genuine Ably gotcha: setting channel `modes` *replaces* the
   defaults, so adding one mode silently drops presence. We buried this in a multi-file app and in a
   from-scratch build. Two-thirds of agents made the mistake — but on the strong models they all caught
   it themselves, so nothing shipped broken. The "wasted hours debugging" failures we'd heard about did
   not show up on the strong models at this scale.
7. **Haiku.** We re-ran experiments 4 and 1 on Haiku. Debugging (4) stayed flat — even a weak model
   fixes a reported bug. The no-oracle task (1) is where the 50% → 10% → 0% result above came from.

## Where it doesn't help

- Reported bugs in small code — the fix is obvious without the warning.
- Tasks that already signal the problem (e.g. a loud server error one step away).
- Strong models with room to think — they self-diagnose. That is why the value shows up under load.

## Good next step: clearer JSDoc

Experiment 5 showed agents reliably read the SDK's type definitions — 100% found `strictMode` there.
That makes the JSDoc a cheap, high-value place to stop these failures before they happen.

The clearest example is the bug in experiment 6. The JSDoc for `ChannelOptions.modes` just says "An
array of ChannelMode objects." It does not say that setting `modes` **replaces** the defaults instead of
adding to them — which is the exact cause of that silent failure. One added line ("setting `modes`
replaces the default set — list every mode you need") would stop agents making the mistake at all, in
the place they actually look.

This PR makes failures speak up at runtime. Clearer JSDoc on `modes` (and related options) would prevent
some of them up front. The two together are the natural follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `strictMode` setting (default: `false`) to convert certain previously silent failure cases into thrown errors with clearer, hint-rich messages.

* **Bug Fixes**
  * Improved error handling when required channel modes are missing for `subscribe()` and `presence.get()`, including consistent error codes/hints and reduced repeated warnings (logging is limited unless strict mode is enabled).

* **Tests**
  * Added test coverage for `strictMode` behavior for missing `subscribe` and `presence_subscribe` modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->