### PR TITLE
react: make react agent additive

### DIFF
--- a/src/platform/react-hooks/src/AblyReactHooks.test.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.test.ts
@@ -1,0 +1,32 @@
+import { it, describe, expect } from 'vitest';
+import { channelOptionsForReactHooks, version } from './AblyReactHooks.js';
+
+describe('channelOptionsForReactHooks', () => {
+  it('sets the react-hooks agent when no options are provided', () => {
+    const options = channelOptionsForReactHooks();
+    expect(options.params?.agent).toBe(`react-hooks/${version}`);
+    expect(options.attachOnSubscribe).toBe(false);
+  });
+
+  it('sets the react-hooks agent when no agent is supplied', () => {
+    const options = channelOptionsForReactHooks({ params: { rewind: '1' } });
+    expect(options.params?.agent).toBe(`react-hooks/${version}`);
+    expect(options.params?.rewind).toBe('1');
+  });
+
+  it('appends the react-hooks agent to a caller-supplied agent instead of overwriting it', () => {
+    const options = channelOptionsForReactHooks({ params: { agent: 'ai-transport-js/1.2.3' } });
+    expect(options.params?.agent).toBe(`ai-transport-js/1.2.3 react-hooks/${version}`);
+  });
+
+  it('preserves other caller-supplied params and options alongside the merged agent', () => {
+    const options = channelOptionsForReactHooks({
+      params: { agent: 'my-sdk/0.1.0', rewind: '5' },
+      modes: ['presence', 'subscribe'],
+    });
+    expect(options.params?.agent).toBe(`my-sdk/0.1.0 react-hooks/${version}`);
+    expect(options.params?.rewind).toBe('5');
+    expect(options.modes).toEqual(['presence', 'subscribe']);
+    expect(options.attachOnSubscribe).toBe(false);
+  });
+});

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -18,11 +18,17 @@ export const version = '2.21.0';
  * channel options for react-hooks
  */
 export function channelOptionsForReactHooks(options?: Ably.ChannelOptions): Ably.ChannelOptions {
+  const callerAgent = options?.params?.agent;
   return {
     ...options,
     params: {
       ...options?.params,
-      agent: `react-hooks/${version}`,
+      // Append rather than overwrite a caller-supplied agent, so SDKs that layer
+      // on top of the React hooks (e.g. @ably/ai-transport, @ably/chat) and pass
+      // their own channel agent via ChannelProvider's `options` keep it for
+      // attribution. Ably's agent param is a space-separated list of lib/version
+      // tokens. A re-attach is not triggered by an agent-only change.
+      agent: callerAgent ? `${callerAgent} react-hooks/${version}` : `react-hooks/${version}`,
     },
     // we explicitly attach channels in React hooks (useChannel, usePresence, usePresenceListener)
     // to avoid situations where implicit attachment could cause errors (when connection state is failed or disconnected)


### PR DESCRIPTION
This is a useful change for downstream SDKs so that the react agent doesn't replace the agent on the underlying realtime client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent string handling to preserve existing caller-supplied information instead of overwriting it.

* **Tests**
  * Added comprehensive test coverage for channel options configuration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-js/pull/2237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->