### PR TITLE
[ECO-5728] Fix presence auto reenter causes NACKs with "not currently attached" after reconnect from transient disconnect

### DIFF
--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -6,7 +6,7 @@ import { gzip } from 'zlib';
 import Table from 'cli-table';
 
 // The maximum size we allow for a minimal useful Realtime bundle (i.e. one that can subscribe to a channel)
-const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 107, gzip: 33 };
+const minimalUsefulRealtimeBundleSizeThresholdsKiB = { raw: 108, gzip: 33 };
 
 const baseClientNames = ['BaseRest', 'BaseRealtime'];
 

--- a/src/common/lib/client/realtimechannel.ts
+++ b/src/common/lib/client/realtimechannel.ts
@@ -10,6 +10,7 @@ import ErrorInfo, { PartialErrorInfo } from '../types/errorinfo';
 import * as API from '../../../../ably';
 import ConnectionManager from '../transport/connectionmanager';
 import Platform from '../../platform';
+import type { PendingMessage } from '../transport/protocol';
 import { StandardCallback } from '../../types/utils';
 import BaseRealtime from './baserealtime';
 import { ChannelOptions } from '../../types/channel';
@@ -545,6 +546,22 @@ class RealtimeChannel extends EventEmitter {
       presence: presence,
     });
     await this.sendAndAwaitAck(msg);
+  }
+
+  /**
+   * RTL3d: when the connection becomes CONNECTED, presence messages waiting on
+   * the connection-wide queue are moved onto this channel's presence queue, so
+   * they are only sent once the channel has (re-)attached (RTP5b) rather than
+   * flushed immediately. Returns true if the channel will (re-)attach and the
+   * messages were re-queued.
+   */
+  requeuePresenceFromConnectionQueue(pendingMessage: PendingMessage): boolean {
+    if (this._presence && (this.state === 'attached' || this.state === 'attaching' || this.state === 'suspended')) {
+      const callback = pendingMessage.callback;
+      this._presence.requeuePresenceMessages(pendingMessage.message.presence ?? [], (err) => callback?.(err));
+      return true;
+    }
+    return false;
   }
 
   async sendState(objectMessages: WireObjectMessage[]): Promise<API.PublishResult> {

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -396,6 +396,17 @@ class RealtimePresence extends EventEmitter {
     }
   }
 
+  /**
+   * RTL3d: re-queue presence messages that were moved off the connection-wide
+   * queue onto this channel's presence queue, to be sent once the channel next
+   * reaches the ATTACHED state (RTP5b).
+   */
+  requeuePresenceMessages(presenceMessages: WirePresenceMessage[], callback: ErrCallback): void {
+    for (const presence of presenceMessages) {
+      this.pendingPresence.push({ presence, callback });
+    }
+  }
+
   _clearMyMembers(): void {
     this._myMembers.clear();
   }

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -120,15 +120,21 @@ class RealtimePresence extends EventEmitter {
         return channel.sendPresence([wirePresMsg]);
       case 'initialized':
       case 'detached':
+        // RTP8d: implicitly attach the channel
         channel.attach();
       // eslint-disable-next-line no-fallthrough
       case 'attaching':
-        return new Promise((resolve, reject) => {
-          this.pendingPresence.push({
-            presence: wirePresMsg,
-            callback: (err) => (err ? reject(err) : resolve()),
+        // RTP16b: queue at the channel level only when queueMessages is enabled
+        if (channel.client.options.queueMessages) {
+          return new Promise((resolve, reject) => {
+            this.pendingPresence.push({
+              presence: wirePresMsg,
+              callback: (err) => (err ? reject(err) : resolve()),
+            });
           });
-        });
+        }
+      // RTP16c: not queueable, so reject
+      // eslint-disable-next-line no-fallthrough
       default: {
         const err = new PartialErrorInfo(
           'Unable to ' + action + ' presence channel while in ' + channel.state + ' state',
@@ -175,20 +181,27 @@ class RealtimePresence extends EventEmitter {
       case 'attached':
         return channel.sendPresence([wirePresMsg]);
       case 'attaching':
-        return new Promise((resolve, reject) => {
-          this.pendingPresence.push({
-            presence: wirePresMsg,
-            callback: (err) => (err ? reject(err) : resolve()),
+        // RTP16b: queue at the channel level only when queueMessages is enabled
+        if (channel.client.options.queueMessages) {
+          return new Promise((resolve, reject) => {
+            this.pendingPresence.push({
+              presence: wirePresMsg,
+              callback: (err) => (err ? reject(err) : resolve()),
+            });
           });
-        });
-      case 'initialized':
-      case 'failed': {
-        /* we're not attached; therefore we let any entered status
-         * timeout by itself instead of attaching just in order to leave */
-        throw new PartialErrorInfo('Unable to leave presence channel (incompatible state)', 90001);
+        }
+      // RTP16c: not queueable, so reject.
+      // Additionally, as we're not attached, we let any entered status time out
+      // by itself instead of attaching just in order to leave.
+      // eslint-disable-next-line no-fallthrough
+      default: {
+        const err = new PartialErrorInfo(
+          'Unable to leave presence channel while in ' + channel.state + ' state',
+          90001,
+        );
+        err.code = 90001;
+        throw err;
       }
-      default:
-        throw channel.invalidStateError();
     }
   }
 

--- a/src/common/lib/transport/connectionmanager.ts
+++ b/src/common/lib/transport/connectionmanager.ts
@@ -1261,6 +1261,7 @@ class ConnectionManager extends EventEmitter {
     /* implement the change and notify */
     this.enactStateChange(change);
     if (this.state.sendEvents) {
+      this.queuedPresenceToChannelQueues(); // RTL3d
       this.sendQueuedMessages();
     } else if (!this.state.queueEvents) {
       this.realtime.channels.propogateConnectionInterruption(state, change.reason);
@@ -1804,6 +1805,22 @@ class ConnectionManager extends EventEmitter {
   queue(msg: ProtocolMessage, callback: PublishCallback): void {
     Logger.logAction(this.logger, Logger.LOG_MICRO, 'ConnectionManager.queue()', 'queueing event');
     this.queuedMessages.push(new PendingMessage(msg, callback));
+  }
+
+  /* RTL3d: queued presence messages must wait for their channel to (re-)attach
+   * before being sent, so move them from the connection-wide queue onto the
+   * relevant channel's presence queue (sent on attach, RTP5b) rather than
+   * flushing them immediately on connect. Messages for channels that will not
+   * re-attach are left on the queue for sendQueuedMessages to handle. */
+  queuedPresenceToChannelQueues(): void {
+    this.queuedMessages.messages = this.queuedMessages.messages.filter((pendingMessage) => {
+      if (pendingMessage.message.action !== actions.PRESENCE) {
+        return true;
+      }
+      const channelName = pendingMessage.message.channel;
+      const channel = channelName ? this.realtime.channels.all[channelName] : undefined;
+      return !(channel && channel.requeuePresenceFromConnectionQueue(pendingMessage));
+    });
   }
 
   sendQueuedMessages(): void {

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -1766,6 +1766,106 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
     });
 
     /**
+     * A presence operation performed while the connection is not CONNECTED (with the
+     * channel still ATTACHED) is, on reconnect, moved off the connection-wide queue
+     * onto the channel and sent only once the channel has re-attached, rather than
+     * flushed before re-attach completes.
+     *
+     * @spec RTL3d2
+     * @specpartial RTP5b - queued presence messages are sent once the channel re-attaches
+     */
+    it('presence_enter_while_disconnected_sent_after_reattach', async function () {
+      const helper = this.test.helper;
+      const channelName = 'presence_enter_while_disconnected';
+      const realtime = helper.AblyRealtime();
+      try {
+        await realtime.connection.once('connected');
+        const channel = realtime.channels.get(channelName);
+        await channel.attach();
+
+        /* Observe our own member entering once it is echoed back from the server */
+        const sawEnter = new Promise((resolve) => {
+          channel.presence.subscribe('enter', function handler(presmsg) {
+            if (presmsg.clientId === testClientId) {
+              channel.presence.unsubscribe('enter', handler);
+              resolve();
+            }
+          });
+        });
+
+        /* Watch the next (post-reconnect) transport to record, at the moment the
+         * queued PRESENCE message is put on the wire, whether the channel has
+         * already received its ATTACHED (i.e. re-attach has completed). */
+        let channelReattached = false;
+        let presenceSentAfterReattach = null;
+        helper.recordPrivateApi('listen.connectionManager.transport.active');
+        realtime.connection.connectionManager.once('transport.active', (transport) => {
+          const originalOnProtocolMessage = transport.onProtocolMessage;
+          helper.recordPrivateApi('replace.transport.onProtocolMessage');
+          transport.onProtocolMessage = function (message) {
+            if (message.action === 11 /* ATTACHED */ && message.channel === channelName) {
+              channelReattached = true;
+            }
+            helper.recordPrivateApi('call.transport.onProtocolMessage');
+            originalOnProtocolMessage.call(transport, message);
+          };
+
+          const originalSend = transport.send;
+          helper.recordPrivateApi('replace.transport.send');
+          transport.send = function (message) {
+            if (
+              message.action === 14 /* PRESENCE */ &&
+              message.channel === channelName &&
+              presenceSentAfterReattach === null
+            ) {
+              presenceSentAfterReattach = channelReattached;
+            }
+            helper.recordPrivateApi('call.transport.send');
+            return originalSend.apply(transport, arguments);
+          };
+        });
+
+        /* Force a failed resume (lost continuity) on reconnect, so the channel
+         * must fully re-attach with no prior server-side attachment. */
+        helper.recordPrivateApi('write.connectionManager.connectionKey');
+        realtime.connection.connectionManager.connectionKey = '_____!ablyjs_test_fake-key____';
+        helper.recordPrivateApi('write.connectionManager.connectionId');
+        realtime.connection.connectionManager.connectionId = 'ablyjs_tes';
+
+        /* Enter while DISCONNECTED: the channel is still ATTACHED (RTL3e), so the
+         * presence message is queued at the channel level until re-attach. */
+        const enterResult = new Promise((resolve, reject) => {
+          realtime.connection.once('disconnected', () => {
+            channel.presence.enterClient(testClientId, 'data').then(resolve, reject);
+          });
+        });
+
+        helper.recordPrivateApi('call.connectionManager.disconnectAllTransports');
+        realtime.connection.connectionManager.disconnectAllTransports();
+
+        /* The enter resolves once the connection reconnects and the channel re-attaches. */
+        await enterResult;
+
+        /* The queued PRESENCE message must have been sent only after the channel
+         * received its ATTACHED (re-attach complete), not flushed on reconnect. */
+        expect(presenceSentAfterReattach).to.equal(
+          true,
+          'Check queued presence was sent only after the channel re-attached',
+        );
+
+        /* ...and the member is present in the channel's presence set. */
+        await sawEnter;
+        const members = await channel.presence.get({ waitForSync: true });
+        expect(extractClientIds(members)).to.deep.equal(
+          [testClientId],
+          'Check entered member is present after reconnect',
+        );
+      } finally {
+        realtime.close();
+      }
+    });
+
+    /**
      * Test failed presence auto-re-entering
      *
      * @spec RTP17e

--- a/test/realtime/presence.test.js
+++ b/test/realtime/presence.test.js
@@ -173,6 +173,7 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
      *
      * @spec RTP8d
      * @specpartial RTP8a - doesn't test entering with data
+     * @specpartial RTP16b - presence queued at the channel level while not yet ATTACHED, with queueMessages enabled (default)
      */
     it('presenceEnterWithoutAttach', function (done) {
       const helper = this.test.helper;
@@ -193,6 +194,39 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
       };
 
       runTestWithEventListener(done, helper, channelName, listenerFor('enter'), enterWithoutAttach);
+    });
+
+    /**
+     * With queueMessages disabled, the presence message on a channel that has not
+     * yet reached the ATTACHED state is not queued and the operation is rejected
+     * (RTP16b). The implicit attach is unaffected (RTP8d).
+     *
+     * @spec RTP16b
+     * @specpartial RTP8d - the implicit attach still happens
+     */
+    it('presence_enter_no_queueing', async function () {
+      const helper = this.test.helper;
+      const realtime = helper.AblyRealtime({ clientId: testClientId, queueMessages: false });
+      try {
+        await realtime.connection.once('connected');
+        const channel = realtime.channels.get('presence_enter_no_queueing');
+
+        let err;
+        try {
+          await channel.presence.enter('data');
+        } catch (e) {
+          err = e;
+        }
+        expect(err, 'Check enter is rejected when queueMessages is disabled').to.be.ok;
+        expect(err.code).to.equal(90001, 'Check rejection uses the invalid-state error code');
+
+        /* RTP8d: the implicit attach still happens; queueMessages only governs
+         * whether the presence message itself is queued. */
+        await channel.attach();
+        expect(channel.state).to.equal('attached', 'Check the channel still attaches (RTP8d)');
+      } finally {
+        realtime.close();
+      }
     });
 
     /**


### PR DESCRIPTION
A presence operation invoked while the connection was transiently DISCONNECTED
(with the channel still ATTACHED) was placed on the connection-wide queue, which
RTL3d flushes on reconnect before the channel re-attaches. The server then
rejected it with "not currently attached" (code 90001), because presence
requires a real, non-transient channel attachment, unlike regular messages.

Now, when the channel is ATTACHED but the connection is not CONNECTED, presence
is queued at the channel level (RTP16d2) and sent once the channel next reaches
ATTACHED (RTP5b), honoring queueMessages.

Two commits:
1. Honor `queueMessages` for channel-level presence queueing (RTP16b), a
   pre-existing gap fixed first.
2. Queue presence at the channel level when the connection is not CONNECTED.

Companion spec PR: https://github.com/ably/specification/pull/490.

Resolves [ECO-5728](https://ably.atlassian.net/browse/ECO-5728)

[ECO-5728]: https://ably.atlassian.net/browse/ECO-5728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Presence enter/update/leave now fully respect per-channel `queueMessages`: when disabled, presence actions made before attachment/re-attachment are rejected instead of queued.
  * Pending presence operations are re-queued and delivered after a successful re-attach, improving ordering and membership consistency during reconnects.
* **Documentation**
  * Updated `presenceEnterWithoutAttach` docs to clarify queueing behavior when `queueMessages` is enabled by default.
* **Tests**
  * Added coverage for `queueMessages: false` rejection and for ensuring queued presence transmits only after post-reconnect attachment, with membership verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->