### PR TITLE
DX-1206 RealtimeChannel interface docstrings

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2820,9 +2820,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   presence: RealtimePresence;
   /**
-   * A {@link PushChannel} object that manages device push notification subscriptions for this channel.
-   *
-   * Accessing this property requires the `Push` plugin to be registered via {@link ClientOptions.plugins}. If the plugin is absent, the getter throws an {@link ErrorInfo}.
+   * A {@link PushChannel} object that manages device push notification subscriptions for this channel. Accessing this property requires the `Push` plugin to be registered via {@link ClientOptions.plugins}. The default and modular builds do not bundle the `Push` plugin. If the plugin is absent, the getter throws an {@link ErrorInfo} rather than returning a {@link PushChannel}.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#push
    */
@@ -2866,7 +2864,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link InboundMessage} objects for the channel.
    *
-   * Messages are returned from storage only when message persistence is enabled for the channel by a rule. If message persistence is not enabled, only messages from the last two minutes are returned.
+   * Messages are returned from storage only when message persistence is enabled for the channel by a [rule](https://ably.com/docs/channels#rules). If message persistence is not enabled, only messages from the last two minutes are returned.
    *
    * @param params - A set of parameters which are used to specify which messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link InboundMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2875,7 +2873,6 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    * const result = await channel.history({ limit: 25 });
    * ```
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#history
-   * @see https://ably.com/docs/storage-history/storage
    */
   history(params?: RealtimeHistoryParams): Promise<PaginatedResult<InboundMessage>>;
   /**

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2725,7 +2725,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * An {@link ErrorInfo} object describing the last error which occurred on the channel, if any. This is `null` until an error occurs, for example a transition in channel state to `failed` or `suspended`. Guard against `null` despite the declared type.
    *
-   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#error-reason
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#properties
    */
   errorReason: ErrorInfo;
   /**
@@ -2737,7 +2737,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    *
    * It is `undefined` before the channel attaches for the first time, so guard against `undefined` despite the declared type.
    *
-   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#params
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#properties
    */
   params: ChannelParams;
   /**
@@ -2745,11 +2745,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    *
    * It is `undefined` before the channel attaches for the first time. When the server grants no modes, it is also `undefined`, not an empty array. Guard against `undefined` despite the declared type.
    *
-   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#modes
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#properties
    */
   modes: ResolvedChannelMode[];
   /**
-   * Deregisters the given listener for the specified event name. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
+   * Deregisters the given listener for the specified event name. This removes local listeners only and does not detach the channel. The server keeps streaming messages to an attached channel, subject to the client's capabilities.
    *
    * @param event - The event name.
    * @param listener - An event listener function.
@@ -2757,7 +2757,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   unsubscribe(event: string, listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters the given listener from all event names in the array. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
+   * Deregisters the given listener from all event names in the array. This removes local listeners only and does not detach the channel. The server keeps streaming messages to an attached channel, subject to the client's capabilities.
    *
    * @param events - An array of event names.
    * @param listener - An event listener function.
@@ -2765,21 +2765,21 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   unsubscribe(events: Array<string>, listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters all listeners for the given event name. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
+   * Deregisters all listeners for the given event name. This removes local listeners only and does not detach the channel. The server keeps streaming messages to an attached channel, subject to the client's capabilities.
    *
    * @param event - The event name.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(event: string): void;
   /**
-   * Deregisters all listeners for all event names in the array. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
+   * Deregisters all listeners for all event names in the array. This removes local listeners only and does not detach the channel. The server keeps streaming messages to an attached channel, subject to the client's capabilities.
    *
    * @param events - An array of event names.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(events: Array<string>): void;
   /**
-   * Deregisters listeners registered with the supplied {@link MessageFilter}. The filter is compared by object identity, so it must be the same object previously passed to {@link RealtimeChannel.subscribe | `subscribe()`}. A filter object not previously passed to `subscribe()` removes nothing and no error is raised. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
+   * Deregisters listeners registered with the supplied {@link MessageFilter}. The filter is matched by object identity, so pass the same object given to {@link RealtimeChannel.subscribe | `subscribe()`}. Any other filter object removes nothing and no error is raised. This removes local listeners only and does not detach the channel. The server keeps streaming messages to an attached channel, subject to the client's capabilities.
    *
    * @param filter - A {@link MessageFilter}.
    * @param listener - An event listener function.
@@ -2787,14 +2787,14 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   unsubscribe(filter: MessageFilter, listener?: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters the given listener from all event names. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
+   * Deregisters the given listener from all event names. This removes local listeners only and does not detach the channel. The server keeps streaming messages to an attached channel, subject to the client's capabilities.
    *
    * @param listener - An event listener function.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters all listeners to messages on this channel. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
+   * Deregisters all listeners to messages on this channel. This removes local listeners only and does not detach the channel. The server keeps streaming messages to an attached channel, subject to the client's capabilities.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
@@ -2822,7 +2822,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * A {@link PushChannel} object that manages device push notification subscriptions for this channel. Accessing this property requires the `Push` plugin to be registered via {@link ClientOptions.plugins}. The default and modular builds do not bundle the `Push` plugin. If the plugin is absent, the getter throws an {@link ErrorInfo} rather than returning a {@link PushChannel}.
    *
-   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#push
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#properties
    */
   push: PushChannel;
   /**
@@ -2906,7 +2906,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   setOptions(options: ChannelOptions): Promise<void>;
   /**
-   * Registers a listener for messages with a given event name on this channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires and no error is raised.
+   * Registers a listener for messages with a given event name on this channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the server delivers no messages and the listener never fires.
    *
    * @param event - The event name.
    * @param listener - An event listener function.
@@ -2919,7 +2919,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   subscribe(event: string, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
-   * Registers a listener for messages on this channel for multiple event name values. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires and no error is raised.
+   * Registers a listener for messages on this channel for multiple event name values. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the server delivers no messages and the listener never fires.
    *
    * @param events - An array of event names.
    * @param listener - An event listener function.
@@ -2934,7 +2934,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * {@label WITH_MESSAGE_FILTER}
    *
-   * Registers a listener for messages on this channel that match the supplied filter. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires and no error is raised.
+   * Registers a listener for messages on this channel that match the supplied filter. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the server delivers no messages and the listener never fires.
    *
    * @param filter - A {@link MessageFilter}.
    * @param listener - An event listener function.
@@ -2947,7 +2947,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   subscribe(filter: MessageFilter, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
-   * Registers a listener for messages on this channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires and no error is raised.
+   * Registers a listener for messages on this channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the server delivers no messages and the listener never fires.
    *
    * @param callback - An event listener function.
    * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. The promise also resolves with `null` when {@link ChannelOptions.attachOnSubscribe} is `false`, in which case no attach is attempted. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2681,7 +2681,9 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   readonly name: string;
   /**
-   * An {@link ErrorInfo} object describing the last error which occurred on the channel, if any.
+   * An {@link ErrorInfo} object describing the last error which occurred on the channel, if any. This is `null` until an error occurs, for example a transition to `failed` or `suspended`, so guard against `null` despite the declared type; inspect it to diagnose a failed or suspended channel.
+   *
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#error-reason
    */
   errorReason: ErrorInfo;
   /**
@@ -2689,54 +2691,70 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   readonly state: ChannelState;
   /**
-   * Optional [channel parameters](https://ably.com/docs/realtime/channels/channel-parameters/overview) that configure the behavior of the channel.
+   * Optional [channel parameters](https://ably.com/docs/realtime/channels/channel-parameters/overview) that configure the behavior of the channel. After the channel attaches this reflects the parameters the server confirmed on the most recent attach, which may differ from those requested via {@link ChannelOptions.params}, and is `undefined` before the channel attaches for the first time, so guard against `undefined` despite the declared type.
+   *
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#params
    */
   params: ChannelParams;
   /**
-   * An array of {@link ResolvedChannelMode} objects.
+   * An array of {@link ResolvedChannelMode} objects reflecting the modes the server granted on the most recent attach, which may differ from the modes requested via {@link ChannelOptions.modes}. The value is `undefined` before the channel attaches for the first time, and is also `undefined` (rather than an empty array) when the server grants no modes, so callers should guard against `undefined` despite the declared type.
+   *
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#modes
    */
   modes: ResolvedChannelMode[];
   /**
-   * Deregisters the given listener for the specified event name. This removes an earlier event-specific subscription.
+   * Deregisters the given listener for the specified event name, removing an earlier event-specific subscription. This only removes the local listener and does not detach the channel, so messages may continue to arrive for any other registered listeners.
    *
    * @param event - The event name.
    * @param listener - An event listener function.
+   * @example
+   * ```ts
+   * channel.unsubscribe('event', listener);
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(event: string, listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters the given listener from all event names in the array.
+   * Deregisters the given listener from all event names in the array. This only removes the local listeners and does not detach the channel.
    *
    * @param events - An array of event names.
    * @param listener - An event listener function.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(events: Array<string>, listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters all listeners for the given event name.
+   * Deregisters all listeners for the given event name. This only removes the local listeners and does not detach the channel.
    *
    * @param event - The event name.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(event: string): void;
   /**
-   * Deregisters all listeners for all event names in the array.
+   * Deregisters all listeners for all event names in the array. This only removes the local listeners and does not detach the channel.
    *
    * @param events - An array of event names.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(events: Array<string>): void;
   /**
-   * Deregisters all listeners to messages on this channel that match the supplied filter.
+   * Deregisters listeners to messages on this channel that match the supplied filter, removing an earlier filtered subscription. This only removes the local listeners and does not detach the channel.
    *
    * @param filter - A {@link MessageFilter}.
    * @param listener - An event listener function.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(filter: MessageFilter, listener?: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters the given listener (for any/all event names). This removes an earlier subscription.
+   * Deregisters the given listener (for any/all event names), removing an earlier subscription. This only removes the local listener and does not detach the channel.
    *
    * @param listener - An event listener function.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters all listeners to messages on this channel. This removes all earlier subscriptions.
+   * Deregisters all listeners to messages on this channel, removing all earlier subscriptions. This only removes the local listeners and does not detach the channel, so the channel stays attached.
+   *
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(): void;
   /**
@@ -2760,7 +2778,9 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   presence: RealtimePresence;
   /**
-   * A {@link PushChannel} object.
+   * A {@link PushChannel} object that manages device push-notification subscriptions for this channel. Accessing this property requires the Push plugin to be registered via {@link ClientOptions.plugins}, which neither the default nor the modular build bundles; if the plugin is absent, the getter throws an {@link ErrorInfo} rather than returning a {@link PushChannel}.
+   *
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#push
    */
   push: PushChannel;
   /**
@@ -2768,22 +2788,38 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   annotations: RealtimeAnnotations;
   /**
-   * Attach to this channel ensuring the channel is created in the Ably system and all messages published on the channel are received by any channel listeners registered using {@link RealtimeChannel.subscribe | `subscribe()`}. Any resulting channel state change will be emitted to any listeners registered using the {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`} methods. As a convenience, `attach()` is called implicitly if {@link RealtimeChannel.subscribe | `subscribe()`} for the channel is called, or {@link RealtimePresence.enter | `enter()`} or {@link RealtimePresence.subscribe | `subscribe()`} are called on the {@link RealtimePresence} object for this channel, or `get()` is called on the `RealtimeObject` object for this channel.
+   * Attach to this channel, ensuring it is created in the Ably system so that messages published on the channel are received by any listeners registered with {@link RealtimeChannel.subscribe | `subscribe()`}, and emitting the resulting state change to any listeners registered via {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`}. As a convenience you need not call this directly: it is invoked implicitly when {@link RealtimeChannel.subscribe | `subscribe()`} is called, when {@link RealtimePresence.enter | `enter()`} or {@link RealtimePresence.subscribe | `subscribe()`} are called on this channel's {@link RealtimePresence} object, or when `get()` is called on its `RealtimeObject`. The returned promise rejects with an {@link ErrorInfo} if the connection is unusable or the channel transitions to `detached`, `suspended`, or `failed` instead of attaching.
    *
    * @returns A promise which, upon success, if the channel became attached will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be fulfilled with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @example
+   * ```ts
+   * await channel.attach();
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#attach
    */
   attach(): Promise<ChannelStateChange | null>;
   /**
-   * Detach from this channel. Any resulting channel state change is emitted to any listeners registered using the {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`} methods. Once all clients globally have detached from the channel, the channel will be released in the Ably service within two minutes.
+   * Detach from this channel. Any resulting channel state change is emitted to any listeners registered using the {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`} methods. Once all clients globally have detached from the channel, the channel is released in the Ably service within two minutes. Detaching from a `suspended` or already `detached` channel resolves without further action, but detaching from a `failed` channel rejects with an {@link ErrorInfo}, in which case release the channel and get it again to start afresh.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @example
+   * ```ts
+   * await channel.detach();
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#detach
    */
   detach(): Promise<void>;
   /**
-   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link InboundMessage} objects for the channel. If the channel is configured to persist messages, then messages can be retrieved from history for up to 72 hours in the past. If not, messages can only be retrieved from history for up to two minutes in the past.
+   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link InboundMessage} objects for the channel. Messages are returned from durable storage only when message persistence is enabled for the channel by a channel rule; without it, only messages from the last two minutes, the service's default retention, are returned.
    *
-   * @param params - A set of parameters which are used to specify which presence members should be retrieved.
+   * @param params - A set of parameters which are used to specify which messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link InboundMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const result = await channel.history({ limit: 25 });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#history
+   * @see https://ably.com/docs/storage-history/storage
    */
   history(params?: RealtimeHistoryParams): Promise<PaginatedResult<InboundMessage>>;
   /**
@@ -2801,43 +2837,68 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   history(params: RealtimeHistoryParams | null, callback: StandardCallback<PaginatedResult<InboundMessage>>): void;
   /**
-   * Sets the {@link ChannelOptions} for the channel.
+   * Sets the {@link ChannelOptions} for the channel. If the channel is already attached or attaching and the new {@link ChannelOptions.modes} or {@link ChannelOptions.params} differ from the current ones, this triggers a live re-attach to apply them, and the returned promise resolves only once the server confirms the new options, rejecting with an {@link ErrorInfo} if the channel detaches or fails in the meantime. Otherwise the new options are stored for the next attach. The promise also rejects with an {@link ErrorInfo} when the supplied options are invalid.
    *
    * @param options - A {@link ChannelOptions} object.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @example
+   * ```ts
+   * await channel.setOptions({ params: { rewind: '1' } });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#set-options
    */
   setOptions(options: ChannelOptions): Promise<void>;
   /**
-   * Registers a listener for messages with a given event name on this channel. The caller supplies a listener function, which is called each time one or more matching messages arrives on the channel.
+   * Registers a listener for messages with a given event name on this channel. The caller supplies a listener function, which is called each time one or more matching messages arrives on the channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers messages, so the listener silently never fires and a warning is logged rather than the call rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
    *
    * @param event - The event name.
    * @param listener - An event listener function.
    * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @example
+   * ```ts
+   * await channel.subscribe('event', (message) => console.log(message.data));
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#subscribe
    */
   subscribe(event: string, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
-   * Registers a listener for messages on this channel for multiple event name values.
+   * Registers a listener for messages on this channel for multiple event name values. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers messages, so the listener silently never fires and a warning is logged rather than the call rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
    *
    * @param events - An array of event names.
    * @param listener - An event listener function.
    * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @example
+   * ```ts
+   * await channel.subscribe(['event1', 'event2'], (message) => console.log(message.data));
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#subscribe
    */
   subscribe(events: Array<string>, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
    * {@label WITH_MESSAGE_FILTER}
    *
-   * Registers a listener for messages on this channel that match the supplied filter.
+   * Registers a listener for messages on this channel that match the supplied filter. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers messages, so the listener silently never fires and a warning is logged rather than the call rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
    *
    * @param filter - A {@link MessageFilter}.
    * @param listener - An event listener function.
    * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @example
+   * ```ts
+   * await channel.subscribe({ name: 'event' }, (message) => console.log(message.data));
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#subscribe
    */
   subscribe(filter: MessageFilter, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
-   * Registers a listener for messages on this channel. The caller supplies a listener function, which is called each time one or more messages arrives on the channel.
+   * Registers a listener for messages on this channel. The caller supplies a listener function, which is called each time one or more messages arrives on the channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers messages, so the listener silently never fires and a warning is logged rather than the call rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
    *
    * @param callback - An event listener function.
    * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @example
+   * ```ts
+   * await channel.subscribe((message) => console.log(message.data));
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#subscribe
    */
   subscribe(callback: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
@@ -2856,28 +2917,43 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   subscribe(event: string, listener: messageCallback<InboundMessage>, callback: ErrorCallback): void;
   /**
-   * Publishes a single message to the channel with the given event name and payload. When publish is called with this client library, it won't attempt to implicitly attach to the channel, so long as [transient publishing](https://ably.com/docs/realtime/channels#transient-publish) is available in the library. Otherwise, the client will implicitly attach.
+   * Publishes a single message to the channel with the given event name and payload. Publishing does not attach the channel, so unlike {@link RealtimeChannel.subscribe | `subscribe()`}, {@link RealtimePresence.enter | `enter()`}, and {@link RealtimePresence.get | `get()`} a publish-only client need not attach or subscribe first.
    *
    * @param name - The event name.
    * @param data - The message payload.
    * @param options - Optional parameters sent as part of the protocol message.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serial of the published message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * await channel.publish('event', { text: 'hello' });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#publish
    */
   publish(name: string, data: any, options?: PublishOptions): Promise<PublishResult>;
   /**
-   * Publishes an array of messages to the channel. When publish is called with this client library, it won't attempt to implicitly attach to the channel.
+   * Publishes an array of messages to the channel. Publishing does not attach the channel, so unlike {@link RealtimeChannel.subscribe | `subscribe()`}, {@link RealtimePresence.enter | `enter()`}, and {@link RealtimePresence.get | `get()`} a publish-only client need not attach or subscribe first.
    *
    * @param messages - An array of {@link Message} objects.
    * @param options - Optional parameters sent as part of the protocol message.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serials of the published messages. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * await channel.publish([{ name: 'event', data: { text: 'hello' } }]);
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#publish
    */
   publish(messages: Message[], options?: PublishOptions): Promise<PublishResult>;
   /**
-   * Publish a message to the channel. When publish is called with this client library, it won't attempt to implicitly attach to the channel.
+   * Publish a message to the channel. Publishing does not attach the channel, so unlike {@link RealtimeChannel.subscribe | `subscribe()`}, {@link RealtimePresence.enter | `enter()`}, and {@link RealtimePresence.get | `get()`} a publish-only client need not attach or subscribe first.
    *
    * @param message - A {@link Message} object.
    * @param options - Optional parameters sent as part of the protocol message.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serial of the published message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * await channel.publish({ name: 'event', data: { text: 'hello' } });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#publish
    */
   publish(message: Message, options?: PublishOptions): Promise<PublishResult>;
   /**
@@ -2896,51 +2972,81 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   publish(name: string, data: any, callback: ErrorCallback): void;
   /**
-   * If the channel is already in the given state, returns a promise which immediately resolves to `null`. Else, calls {@link EventEmitter.once | `once()`} to return a promise which resolves the next time the channel transitions to the given state.
+   * If the channel is already in the given state, returns a promise which immediately resolves to `null`. Else, calls {@link EventEmitter.once | `once()`} to return a promise which resolves with the {@link ChannelStateChange} the next time the channel transitions to the given state.
    *
    * @param targetState - The channel state to wait for.
+   * @example
+   * ```ts
+   * const stateChange = await channel.whenState('attached');
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#when-state
    */
   whenState(targetState: ChannelState): Promise<ChannelStateChange | null>;
   /**
-   * Retrieves the latest version of a specific message by its serial identifier.
+   * Retrieves the latest version of a specific message by its serial identifier. Retrievable messages require message interactions (mutable messages) to be enabled for the channel by a channel rule. The supplied serial or {@link Message} must carry a populated `serial`, which is present on a {@link Message} received from a subscribe callback but not on a freshly constructed one; if the serial is missing the promise rejects with an {@link ErrorInfo}.
    *
    * @param serialOrMessage - Either the serial identifier string of the message to retrieve, or a {@link Message} object containing a populated `serial` field.
    * @returns A promise which, upon success, will be fulfilled with a {@link Message} object representing the latest version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const message = await channel.getMessage(serial);
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#get-message
    */
   getMessage(serialOrMessage: string | Message): Promise<Message>;
   /**
-   * Publishes an update to an existing message with patch semantics. Non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged.
+   * Publishes an update to an existing message with patch semantics. Non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged. The namespace must have message interactions (updates) enabled by a channel rule, and the supplied `message` must carry the `serial` it was given when published (pass the {@link Message} received in a subscribe callback, not a freshly constructed object); otherwise the promise rejects with an {@link ErrorInfo}.
    *
    * @param message - A {@link Message} object containing a populated `serial` field and the fields to update.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the update operation.
    * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with an {@link UpdateDeleteResult} object containing the serial of the new version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * await channel.updateMessage({ ...message, data: 'edited text' });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#update-message
    */
   updateMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible. Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged (meaning that if you for example want the `MESSAGE_DELETE` to have an empty data, you should explicitly set the `data` to an empty object).
+   * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible. Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged (meaning that if you for example want the `MESSAGE_DELETE` to have an empty data, you should explicitly set the `data` to an empty object). Requires message interactions (deletes) to be enabled for the channel by a channel rule, and the message must carry a `serial`, so pass the {@link Message} you received from a subscribe callback rather than a freshly constructed object; otherwise the call rejects with an {@link ErrorInfo}.
    *
    * @param message - A {@link Message} object containing a populated `serial` field.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the delete operation.
    * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with an {@link UpdateDeleteResult} object containing the serial of the new version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const result = await channel.deleteMessage(message);
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#delete-message
    */
   deleteMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Appends data to an existing message. The supplied `data` field is appended to the previous message's data, while all other fields (`name`, `extras`) replace the previous values if provided.
+   * Appends data to an existing message. The supplied `data` field is appended to the previous message's data, while all other fields (`name`, `extras`) replace the previous values if provided. Requires message interactions (mutable messages) to be enabled for the channel by a channel rule, and the supplied {@link Message} must carry the `serial` it received from a subscribe callback, otherwise the call rejects with an {@link ErrorInfo}.
    *
    * @param message - A {@link Message} object containing a populated `serial` field and the data to append.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the append operation.
    * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with an {@link UpdateDeleteResult} object containing the serial of the new version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const result = await channel.appendMessage(message);
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#append-message
    */
   appendMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations.
+   * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations. The message must carry a `serial`, so pass the {@link Message} from a subscribe callback or its serial string, otherwise the call rejects with an {@link ErrorInfo}. Message versions exist only when message interactions (updates and deletes) are enabled for the channel by a channel rule.
    *
    * @param serialOrMessage - Either the serial identifier string of the message whose versions are to be retrieved, or a {@link Message} object containing a populated `serial` field.
    * @param params - Optional parameters sent as part of the query string.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link Message} objects representing all versions of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const versions = await channel.getMessageVersions(message);
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#get-message-versions
    */
   getMessageVersions(
     serialOrMessage: string | Message,

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2681,7 +2681,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   readonly name: string;
   /**
-   * An {@link ErrorInfo} object describing the last error which occurred on the channel, if any. This is `null` until an error occurs, for example a transition to `failed` or `suspended`, so guard against `null` despite the declared type; inspect it to diagnose a failed or suspended channel.
+   * An {@link ErrorInfo} object describing the last error which occurred on the channel, if any. This is `null` until an error occurs, for example a transition in channel state to `failed` or `suspended`. Guard against `null` despite the declared type and inspect it to diagnose a channel in the failed or suspended state.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#error-reason
    */
@@ -2691,19 +2691,21 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   readonly state: ChannelState;
   /**
-   * Optional [channel parameters](https://ably.com/docs/realtime/channels/channel-parameters/overview) that configure the behavior of the channel. After the channel attaches this reflects the parameters the server confirmed on the most recent attach, which may differ from those requested via {@link ChannelOptions.params}, and is `undefined` before the channel attaches for the first time, so guard against `undefined` despite the declared type.
+   * Optional channel parameters that configure the behavior of the channel. After the channel attaches this reflects the parameters the server confirmed on the most recent attach, which may differ from those requested via {@link ChannelOptions.params}. It is `undefined` before the channel attaches for the first time, so guard against `undefined` despite the declared type.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#params
    */
   params: ChannelParams;
   /**
-   * An array of {@link ResolvedChannelMode} objects reflecting the modes the server granted on the most recent attach, which may differ from the modes requested via {@link ChannelOptions.modes}. The value is `undefined` before the channel attaches for the first time, and is also `undefined` (rather than an empty array) when the server grants no modes, so callers should guard against `undefined` despite the declared type.
+   * An array of {@link ResolvedChannelMode} objects reflecting the modes the server granted on the most recent attach. The server grants only the modes the key or token capability permits, so this may be a subset of the modes requested via {@link ChannelOptions.modes}.
+   *
+   * It is `undefined` before the channel attaches for the first time, and also when the server grants no modes rather than an empty array, so guard against `undefined` despite the declared type.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#modes
    */
   modes: ResolvedChannelMode[];
   /**
-   * Deregisters the given listener for the specified event name, removing an earlier event-specific subscription. This only removes the local listener and does not detach the channel, so messages may continue to arrive for any other registered listeners.
+   * Deregisters the given listener for the specified event name, removing an earlier event-specific subscription. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
    *
    * @param event - The event name.
    * @param listener - An event listener function.
@@ -2715,7 +2717,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   unsubscribe(event: string, listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters the given listener from all event names in the array. This only removes the local listeners and does not detach the channel.
+   * Deregisters the given listener from all event names in the array. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
    *
    * @param events - An array of event names.
    * @param listener - An event listener function.
@@ -2723,21 +2725,21 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   unsubscribe(events: Array<string>, listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters all listeners for the given event name. This only removes the local listeners and does not detach the channel.
+   * Deregisters all listeners for the given event name. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
    *
    * @param event - The event name.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(event: string): void;
   /**
-   * Deregisters all listeners for all event names in the array. This only removes the local listeners and does not detach the channel.
+   * Deregisters all listeners for all event names in the array. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
    *
    * @param events - An array of event names.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(events: Array<string>): void;
   /**
-   * Deregisters listeners to messages on this channel that match the supplied filter, removing an earlier filtered subscription. This only removes the local listeners and does not detach the channel.
+   * Deregisters listeners to messages on this channel that match the supplied filter, removing an earlier filtered subscription. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
    *
    * @param filter - A {@link MessageFilter}.
    * @param listener - An event listener function.
@@ -2745,14 +2747,14 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   unsubscribe(filter: MessageFilter, listener?: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters the given listener (for any/all event names), removing an earlier subscription. This only removes the local listener and does not detach the channel.
+   * Deregisters the given listener from all event names, removing an earlier subscription. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
    *
    * @param listener - An event listener function.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters all listeners to messages on this channel, removing all earlier subscriptions. This only removes the local listeners and does not detach the channel, so the channel stays attached.
+   * Deregisters all listeners to messages on this channel, removing all earlier subscriptions. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
@@ -2778,7 +2780,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   presence: RealtimePresence;
   /**
-   * A {@link PushChannel} object that manages device push-notification subscriptions for this channel. Accessing this property requires the Push plugin to be registered via {@link ClientOptions.plugins}, which neither the default nor the modular build bundles; if the plugin is absent, the getter throws an {@link ErrorInfo} rather than returning a {@link PushChannel}.
+   * A {@link PushChannel} object that manages device push notification subscriptions for this channel. Accessing this property requires the `Push` plugin to be registered via {@link ClientOptions.plugins}. The default and modular builds do not bundle the `Push` plugin. Import it from `ably/push`. If the plugin is absent, the getter throws an {@link ErrorInfo} rather than returning a {@link PushChannel}.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#push
    */
@@ -2788,7 +2790,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   annotations: RealtimeAnnotations;
   /**
-   * Attach to this channel, ensuring it is created in the Ably system so that messages published on the channel are received by any listeners registered with {@link RealtimeChannel.subscribe | `subscribe()`}, and emitting the resulting state change to any listeners registered via {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`}. As a convenience you need not call this directly: it is invoked implicitly when {@link RealtimeChannel.subscribe | `subscribe()`} is called, when {@link RealtimePresence.enter | `enter()`} or {@link RealtimePresence.subscribe | `subscribe()`} are called on this channel's {@link RealtimePresence} object, or when `get()` is called on its `RealtimeObject`. The returned promise rejects with an {@link ErrorInfo} if the connection is unusable or the channel transitions to `detached`, `suspended`, or `failed` instead of attaching.
+   * Attach to this channel so that messages published on it are received by any listeners registered with {@link RealtimeChannel.subscribe | `subscribe()`}. It also emits the resulting state change to any registered listeners.
+   *
+   * As a convenience you need not call this directly. It is invoked implicitly by `subscribe()`, by presence `enter()`, `subscribe()`, `update()`, or `get()`, or by LiveObjects `get()`.
+   *
+   * The returned promise rejects with an {@link ErrorInfo} if the connection is unusable or the channel transitions to `detaching`, `detached`, `suspended`, or `failed` instead of attaching.
    *
    * @returns A promise which, upon success, if the channel became attached will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be fulfilled with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
    * @example
@@ -2799,7 +2805,13 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   attach(): Promise<ChannelStateChange | null>;
   /**
-   * Detach from this channel. Any resulting channel state change is emitted to any listeners registered using the {@link EventEmitter.on | `on()`} or {@link EventEmitter.once | `once()`} methods. Once all clients globally have detached from the channel, the channel is released in the Ably service within two minutes. Detaching from a `suspended` or already `detached` channel resolves without further action, but detaching from a `failed` channel rejects with an {@link ErrorInfo}, in which case release the channel and get it again to start afresh.
+   * Detach from this channel. Any resulting channel state change is emitted to any registered listeners.
+   *
+   * Detaching stops the server sending messages on this channel to the client. Locally registered listeners remain registered.
+   *
+   * Once all clients globally have detached from the channel, the channel is released in the Ably service within two minutes.
+   *
+   * Detaching from a channel in the `suspended` or `detached` state resolves without further action. Calling `detach()` while the channel is already detaching does not start a second detach, and the returned promise resolves once the channel reaches `detached`. Detaching from a channel in the `failed` state rejects with an {@link ErrorInfo}. Release the channel with {@link Channels.release | `release()`} and get it again with {@link Channels.get | `get()`} to start afresh.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
    * @example
@@ -2810,7 +2822,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   detach(): Promise<void>;
   /**
-   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link InboundMessage} objects for the channel. Messages are returned from durable storage only when message persistence is enabled for the channel by a channel rule; without it, only messages from the last two minutes, the service's default retention, are returned.
+   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link InboundMessage} objects for the channel. Messages are returned from storage only when message persistence is enabled for the channel by a rule. If message persistence is not enabled, only messages from the last two minutes are returned.
    *
    * @param params - A set of parameters which are used to specify which messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link InboundMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2837,7 +2849,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   history(params: RealtimeHistoryParams | null, callback: StandardCallback<PaginatedResult<InboundMessage>>): void;
   /**
-   * Sets the {@link ChannelOptions} for the channel. If the channel is already attached or attaching and the new {@link ChannelOptions.modes} or {@link ChannelOptions.params} differ from the current ones, this triggers a live re-attach to apply them, and the returned promise resolves only once the server confirms the new options, rejecting with an {@link ErrorInfo} if the channel detaches or fails in the meantime. Otherwise the new options are stored for the next attach. The promise also rejects with an {@link ErrorInfo} when the supplied options are invalid.
+   * Sets the {@link ChannelOptions} for the channel.
+   *
+   * Changing {@link ChannelOptions.modes} or {@link ChannelOptions.params} while the channel is attached or attaching re-attaches it to apply them, and the promise resolves only once the server confirms the new options. It rejects with an {@link ErrorInfo} if the channel detaches or fails first. Otherwise the new options are stored for the next attach.
+   *
+   * The promise also rejects with an {@link ErrorInfo} when the supplied options are invalid.
    *
    * @param options - A {@link ChannelOptions} object.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
@@ -2849,7 +2865,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   setOptions(options: ChannelOptions): Promise<void>;
   /**
-   * Registers a listener for messages with a given event name on this channel. The caller supplies a listener function, which is called each time one or more matching messages arrives on the channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers messages, so the listener silently never fires and a warning is logged rather than the call rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
+   * Registers a listener for messages with a given event name on this channel. The caller supplies a listener function, which is called each time one or more matching messages arrives on the channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires.
    *
    * @param event - The event name.
    * @param listener - An event listener function.
@@ -2862,7 +2878,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   subscribe(event: string, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
-   * Registers a listener for messages on this channel for multiple event name values. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers messages, so the listener silently never fires and a warning is logged rather than the call rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
+   * Registers a listener for messages on this channel for multiple event name values. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires.
    *
    * @param events - An array of event names.
    * @param listener - An event listener function.
@@ -2877,7 +2893,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * {@label WITH_MESSAGE_FILTER}
    *
-   * Registers a listener for messages on this channel that match the supplied filter. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers messages, so the listener silently never fires and a warning is logged rather than the call rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
+   * Registers a listener for messages on this channel that match the supplied filter. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires.
    *
    * @param filter - A {@link MessageFilter}.
    * @param listener - An event listener function.
@@ -2890,7 +2906,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   subscribe(filter: MessageFilter, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
-   * Registers a listener for messages on this channel. The caller supplies a listener function, which is called each time one or more messages arrives on the channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers messages, so the listener silently never fires and a warning is logged rather than the call rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
+   * Registers a listener for messages on this channel. The caller supplies a listener function, which is called each time one or more messages arrives on the channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires.
    *
    * @param callback - An event listener function.
    * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
@@ -2917,7 +2933,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   subscribe(event: string, listener: messageCallback<InboundMessage>, callback: ErrorCallback): void;
   /**
-   * Publishes a single message to the channel with the given event name and payload. Publishing does not attach the channel, so unlike {@link RealtimeChannel.subscribe | `subscribe()`}, {@link RealtimePresence.enter | `enter()`}, and {@link RealtimePresence.get | `get()`} a publish-only client need not attach or subscribe first.
+   * Publishes a single message to the channel with the given event name and payload.
    *
    * @param name - The event name.
    * @param data - The message payload.
@@ -2931,7 +2947,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   publish(name: string, data: any, options?: PublishOptions): Promise<PublishResult>;
   /**
-   * Publishes an array of messages to the channel. Publishing does not attach the channel, so unlike {@link RealtimeChannel.subscribe | `subscribe()`}, {@link RealtimePresence.enter | `enter()`}, and {@link RealtimePresence.get | `get()`} a publish-only client need not attach or subscribe first.
+   * Publishes an array of messages to the channel.
    *
    * @param messages - An array of {@link Message} objects.
    * @param options - Optional parameters sent as part of the protocol message.
@@ -2944,7 +2960,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   publish(messages: Message[], options?: PublishOptions): Promise<PublishResult>;
   /**
-   * Publish a message to the channel. Publishing does not attach the channel, so unlike {@link RealtimeChannel.subscribe | `subscribe()`}, {@link RealtimePresence.enter | `enter()`}, and {@link RealtimePresence.get | `get()`} a publish-only client need not attach or subscribe first.
+   * Publishes a message to the channel.
    *
    * @param message - A {@link Message} object.
    * @param options - Optional parameters sent as part of the protocol message.
@@ -2972,7 +2988,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   publish(name: string, data: any, callback: ErrorCallback): void;
   /**
-   * If the channel is already in the given state, returns a promise which immediately resolves to `null`. Else, calls {@link EventEmitter.once | `once()`} to return a promise which resolves with the {@link ChannelStateChange} the next time the channel transitions to the given state.
+   * If the channel is already in the given state, resolves immediately with `null`. Otherwise resolves with the {@link ChannelStateChange} the next time the channel transitions to the given state.
    *
    * @param targetState - The channel state to wait for.
    * @example
@@ -2983,7 +2999,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   whenState(targetState: ChannelState): Promise<ChannelStateChange | null>;
   /**
-   * Retrieves the latest version of a specific message by its serial identifier. Retrievable messages require message interactions (mutable messages) to be enabled for the channel by a channel rule. The supplied serial or {@link Message} must carry a populated `serial`, which is present on a {@link Message} received from a subscribe callback but not on a freshly constructed one; if the serial is missing the promise rejects with an {@link ErrorInfo}.
+   * Retrieves the latest version of a specific message by its serial identifier.
+   *
+   * The channel must be configured to allow message updates, enabled by a rule.
+   *
+   * The supplied serial or {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
    * @param serialOrMessage - Either the serial identifier string of the message to retrieve, or a {@link Message} object containing a populated `serial` field.
    * @returns A promise which, upon success, will be fulfilled with a {@link Message} object representing the latest version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2995,7 +3015,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   getMessage(serialOrMessage: string | Message): Promise<Message>;
   /**
-   * Publishes an update to an existing message with patch semantics. Non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged. The namespace must have message interactions (updates) enabled by a channel rule, and the supplied `message` must carry the `serial` it was given when published (pass the {@link Message} received in a subscribe callback, not a freshly constructed object); otherwise the promise rejects with an {@link ErrorInfo}.
+   * Publishes an update to an existing message with patch semantics. Non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged.
+   *
+   * The channel must be configured to allow message updates, enabled by a rule.
+   *
+   * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
    * @param message - A {@link Message} object containing a populated `serial` field and the fields to update.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the update operation.
@@ -3009,7 +3033,13 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   updateMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible. Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged (meaning that if you for example want the `MESSAGE_DELETE` to have an empty data, you should explicitly set the `data` to an empty object). Requires message interactions (deletes) to be enabled for the channel by a channel rule, and the message must carry a `serial`, so pass the {@link Message} you received from a subscribe callback rather than a freshly constructed object; otherwise the call rejects with an {@link ErrorInfo}.
+   * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible.
+   *
+   * Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message replace the corresponding fields, while null fields are left unchanged.
+   *
+   * The channel must be configured to allow message deletes, enabled by a rule.
+   *
+   * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
    * @param message - A {@link Message} object containing a populated `serial` field.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the delete operation.
@@ -3023,7 +3053,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   deleteMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Appends data to an existing message. The supplied `data` field is appended to the previous message's data, while all other fields (`name`, `extras`) replace the previous values if provided. Requires message interactions (mutable messages) to be enabled for the channel by a channel rule, and the supplied {@link Message} must carry the `serial` it received from a subscribe callback, otherwise the call rejects with an {@link ErrorInfo}.
+   * Appends data to an existing message. The supplied `data` field is appended to the previous message's data, while all other fields (`name`, `extras`) replace the previous values if provided.
+   *
+   * The channel must be configured to allow message appends, enabled by a rule.
+   *
+   * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
    * @param message - A {@link Message} object containing a populated `serial` field and the data to append.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the append operation.
@@ -3037,7 +3071,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   appendMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations. The message must carry a `serial`, so pass the {@link Message} from a subscribe callback or its serial string, otherwise the call rejects with an {@link ErrorInfo}. Message versions exist only when message interactions (updates and deletes) are enabled for the channel by a channel rule.
+   * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations.
+   *
+   * The supplied serial or {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
+   *
+   * Message versions exist only when the channel is configured to allow updating and deleting messages, enabled by a rule.
    *
    * @param serialOrMessage - Either the serial identifier string of the message whose versions are to be retrieved, or a {@link Message} object containing a populated `serial` field.
    * @param params - Optional parameters sent as part of the query string.

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2568,43 +2568,85 @@ export declare interface Channel {
   /**
    * Retrieves the latest version of a specific message by its serial identifier.
    *
+   * The channel must be configured to allow message updates, enabled by a [rule](https://ably.com/docs/channels#rules).
+   *
+   * The supplied serial or {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
+   *
    * @param serialOrMessage - Either the serial identifier string of the message to retrieve, or a {@link Message} object containing a populated `serial` field.
    * @returns A promise which, upon success, will be fulfilled with a {@link Message} object representing the latest version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const message = await channel.getMessage(serial);
+   * ```
    */
   getMessage(serialOrMessage: string | Message): Promise<Message>;
   /**
-   * Publishes an update to an existing message with patch semantics. Non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged.
+   * Publishes an update to an existing message with patch semantics. Non-null `name`, `data`, and `extras` fields in the provided message replace the corresponding fields in the existing message, while null fields are left unchanged.
+   *
+   * The channel must be configured to allow message updates, enabled by a [rule](https://ably.com/docs/channels#rules).
+   *
+   * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
    * @param message - A {@link Message} object containing a populated `serial` field and the fields to update.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the update operation.
    * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with an {@link UpdateDeleteResult} object containing the serial of the new version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * await channel.updateMessage({ ...message, data: 'edited text' });
+   * ```
    */
   updateMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible. Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged (meaning that if you for example want the `MESSAGE_DELETE` to have an empty data, you should explicitly set the `data` to an empty object).
+   * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible.
+   *
+   * Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message replace the corresponding fields in the existing message, while null fields are left unchanged. A deleted message keeps its previous `data` unless the delete explicitly sets `data` to an empty value.
+   *
+   * The channel must be configured to allow message deletes, enabled by a [rule](https://ably.com/docs/channels#rules).
+   *
+   * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
    * @param message - A {@link Message} object containing a populated `serial` field.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the delete operation.
    * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with an {@link UpdateDeleteResult} object containing the serial of the new version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const result = await channel.deleteMessage(message);
+   * ```
    */
   deleteMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
    * Appends data to an existing message. The supplied `data` field is appended to the previous message's data, while all other fields (`name`, `extras`) replace the previous values if provided.
    *
+   * The channel must be configured to allow message appends, enabled by a [rule](https://ably.com/docs/channels#rules).
+   *
+   * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
+   *
    * @param message - A {@link Message} object containing a populated `serial` field and the data to append.
    * @param operation - An optional {@link MessageOperation} object containing metadata about the append operation.
    * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with an {@link UpdateDeleteResult} object containing the serial of the new version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const result = await channel.appendMessage({ ...message, data: ' more text' });
+   * ```
    */
   appendMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations.
+   * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent update, delete, or append operations.
+   *
+   * The supplied serial or {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
+   *
+   * Message versions exist only when the channel is configured to allow updating, deleting, or appending messages, enabled by a [rule](https://ably.com/docs/channels#rules).
    *
    * @param serialOrMessage - Either the serial identifier string of the message whose versions are to be retrieved, or a {@link Message} object containing a populated `serial` field.
    * @param params - Optional parameters sent as part of the query string.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link Message} objects representing all versions of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const versions = await channel.getMessageVersions(message);
+   * ```
    */
   getMessageVersions(
     serialOrMessage: string | Message,
@@ -2681,7 +2723,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   readonly name: string;
   /**
-   * An {@link ErrorInfo} object describing the last error which occurred on the channel, if any. This is `null` until an error occurs, for example a transition in channel state to `failed` or `suspended`. Guard against `null` despite the declared type and inspect it to diagnose a channel in the failed or suspended state.
+   * An {@link ErrorInfo} object describing the last error which occurred on the channel, if any. This is `null` until an error occurs, for example a transition in channel state to `failed` or `suspended`. Guard against `null` despite the declared type.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#error-reason
    */
@@ -2691,7 +2733,9 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   readonly state: ChannelState;
   /**
-   * Optional channel parameters that configure the behavior of the channel. After the channel attaches this reflects the parameters the server confirmed on the most recent attach, which may differ from those requested via {@link ChannelOptions.params}. It is `undefined` before the channel attaches for the first time, so guard against `undefined` despite the declared type.
+   * Optional channel parameters that configure the behavior of the channel. After the channel attaches this reflects the parameters the server confirmed on the most recent attach.
+   *
+   * It is `undefined` before the channel attaches for the first time, so guard against `undefined` despite the declared type.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#params
    */
@@ -2699,25 +2743,21 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * An array of {@link ResolvedChannelMode} objects reflecting the modes the server granted on the most recent attach. The server grants only the modes the key or token capability permits, so this may be a subset of the modes requested via {@link ChannelOptions.modes}.
    *
-   * It is `undefined` before the channel attaches for the first time, and also when the server grants no modes rather than an empty array, so guard against `undefined` despite the declared type.
+   * It is `undefined` before the channel attaches for the first time. When the server grants no modes, it is also `undefined`, not an empty array. Guard against `undefined` despite the declared type.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#modes
    */
   modes: ResolvedChannelMode[];
   /**
-   * Deregisters the given listener for the specified event name, removing an earlier event-specific subscription. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
+   * Deregisters the given listener for the specified event name. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
    *
    * @param event - The event name.
    * @param listener - An event listener function.
-   * @example
-   * ```ts
-   * channel.unsubscribe('event', listener);
-   * ```
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(event: string, listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters the given listener from all event names in the array. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
+   * Deregisters the given listener from all event names in the array. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
    *
    * @param events - An array of event names.
    * @param listener - An event listener function.
@@ -2725,21 +2765,21 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   unsubscribe(events: Array<string>, listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters all listeners for the given event name. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
+   * Deregisters all listeners for the given event name. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
    *
    * @param event - The event name.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(event: string): void;
   /**
-   * Deregisters all listeners for all event names in the array. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
+   * Deregisters all listeners for all event names in the array. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
    *
    * @param events - An array of event names.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(events: Array<string>): void;
   /**
-   * Deregisters listeners to messages on this channel that match the supplied filter, removing an earlier filtered subscription. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
+   * Deregisters listeners registered with the supplied {@link MessageFilter}. The filter is compared by object identity, so it must be the same object previously passed to {@link RealtimeChannel.subscribe | `subscribe()`}. A filter object not previously passed to `subscribe()` removes nothing and no error is raised. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
    *
    * @param filter - A {@link MessageFilter}.
    * @param listener - An event listener function.
@@ -2747,14 +2787,14 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   unsubscribe(filter: MessageFilter, listener?: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters the given listener from all event names, removing an earlier subscription. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
+   * Deregisters the given listener from all event names. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
    *
    * @param listener - An event listener function.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
   unsubscribe(listener: messageCallback<InboundMessage>): void;
   /**
-   * Deregisters all listeners to messages on this channel, removing all earlier subscriptions. This only removes the local listeners and does not detach the channel. The server keeps sending messages on the channel and they are billed accordingly.
+   * Deregisters all listeners to messages on this channel. This only removes the local listeners and does not detach the channel. The channel stays attached, so the server keeps streaming its messages to the client while the client's capability permits.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#unsubscribe
    */
@@ -2780,7 +2820,9 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   presence: RealtimePresence;
   /**
-   * A {@link PushChannel} object that manages device push notification subscriptions for this channel. Accessing this property requires the `Push` plugin to be registered via {@link ClientOptions.plugins}. The default and modular builds do not bundle the `Push` plugin. Import it from `ably/push`. If the plugin is absent, the getter throws an {@link ErrorInfo} rather than returning a {@link PushChannel}.
+   * A {@link PushChannel} object that manages device push notification subscriptions for this channel.
+   *
+   * Accessing this property requires the `Push` plugin to be registered via {@link ClientOptions.plugins}. If the plugin is absent, the getter throws an {@link ErrorInfo}.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#push
    */
@@ -2790,11 +2832,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   annotations: RealtimeAnnotations;
   /**
-   * Attach to this channel so that messages published on it are received by any listeners registered with {@link RealtimeChannel.subscribe | `subscribe()`}. It also emits the resulting state change to any registered listeners.
+   * Attach to this channel so that messages published on it are received by any listeners registered with {@link RealtimeChannel.subscribe | `subscribe()`}. It also emits the resulting channel state change to listeners registered with `on()` or `once()`.
    *
-   * As a convenience you need not call this directly. It is invoked implicitly by `subscribe()`, by presence `enter()`, `subscribe()`, `update()`, or `get()`, or by LiveObjects `get()`.
+   * As a convenience you need not call this directly. It is invoked implicitly by {@link RealtimeChannel.subscribe | `channel.subscribe()`}, by {@link RealtimePresence.enter | `presence.enter()`}, {@link RealtimePresence.enterClient | `presence.enterClient()`}, {@link RealtimePresence.update | `presence.update()`}, {@link RealtimePresence.updateClient | `presence.updateClient()`}, {@link RealtimePresence.subscribe | `presence.subscribe()`}, or {@link RealtimePresence.get | `presence.get()`}, by {@link RealtimeAnnotations.subscribe | `annotations.subscribe()`}, or by LiveObjects `get()`.
    *
-   * The returned promise rejects with an {@link ErrorInfo} if the connection is unusable or the channel transitions to `detaching`, `detached`, `suspended`, or `failed` instead of attaching.
+   * The returned promise rejects with an {@link ErrorInfo} if the connection is in the `suspended`, `closing`, `closed`, or `failed` state. It also rejects if the channel transitions to `detaching`, `detached`, `suspended`, or `failed` instead of attaching.
    *
    * @returns A promise which, upon success, if the channel became attached will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be fulfilled with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
    * @example
@@ -2805,13 +2847,13 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   attach(): Promise<ChannelStateChange | null>;
   /**
-   * Detach from this channel. Any resulting channel state change is emitted to any registered listeners.
+   * Detach from this channel. Any resulting channel state change is emitted to listeners registered with `on()` or `once()`.
    *
-   * Detaching stops the server sending messages on this channel to the client. Locally registered listeners remain registered.
+   * Detaching stops the server sending this channel's messages and any other channel traffic to the client. Locally registered listeners remain registered.
    *
    * Once all clients globally have detached from the channel, the channel is released in the Ably service within two minutes.
    *
-   * Detaching from a channel in the `suspended` or `detached` state resolves without further action. Calling `detach()` while the channel is already detaching does not start a second detach, and the returned promise resolves once the channel reaches `detached`. Detaching from a channel in the `failed` state rejects with an {@link ErrorInfo}. Release the channel with {@link Channels.release | `release()`} and get it again with {@link Channels.get | `get()`} to start afresh.
+   * Detaching from a channel in the `suspended` or `detached` state resolves without further action. Calling `detach()` on a channel in the `detaching` state does not start a second detach, and the returned promise resolves once the channel transitions to the `detached` state. Detaching from a channel in the `failed` state rejects with an {@link ErrorInfo}. Release the channel with {@link Channels.release | `release()`} and get it again with {@link Channels.get | `get()`} to start afresh.
    *
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
    * @example
@@ -2822,7 +2864,9 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   detach(): Promise<void>;
   /**
-   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link InboundMessage} objects for the channel. Messages are returned from storage only when message persistence is enabled for the channel by a rule. If message persistence is not enabled, only messages from the last two minutes are returned.
+   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link InboundMessage} objects for the channel.
+   *
+   * Messages are returned from storage only when message persistence is enabled for the channel by a rule. If message persistence is not enabled, only messages from the last two minutes are returned.
    *
    * @param params - A set of parameters which are used to specify which messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link InboundMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2851,7 +2895,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * Sets the {@link ChannelOptions} for the channel.
    *
-   * Changing {@link ChannelOptions.modes} or {@link ChannelOptions.params} while the channel is attached or attaching re-attaches it to apply them, and the promise resolves only once the server confirms the new options. It rejects with an {@link ErrorInfo} if the channel detaches or fails first. Otherwise the new options are stored for the next attach.
+   * Changing {@link ChannelOptions.modes} or {@link ChannelOptions.params} while the channel is attached or attaching re-attaches it to apply them, and the promise resolves only once the server confirms the new options. It rejects with an {@link ErrorInfo} if the channel transitions to `detached` or `failed` instead. If the channel is not attached or attaching, changed {@link ChannelOptions.modes} or {@link ChannelOptions.params} are stored and applied on the next attach. Other options, such as a cipher, take effect immediately.
    *
    * The promise also rejects with an {@link ErrorInfo} when the supplied options are invalid.
    *
@@ -2865,11 +2909,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   setOptions(options: ChannelOptions): Promise<void>;
   /**
-   * Registers a listener for messages with a given event name on this channel. The caller supplies a listener function, which is called each time one or more matching messages arrives on the channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires.
+   * Registers a listener for messages with a given event name on this channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires and no error is raised.
    *
    * @param event - The event name.
    * @param listener - An event listener function.
-   * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. The promise also resolves with `null` when {@link ChannelOptions.attachOnSubscribe} is `false`, in which case no attach is attempted. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
    * @example
    * ```ts
    * await channel.subscribe('event', (message) => console.log(message.data));
@@ -2878,11 +2922,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   subscribe(event: string, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
-   * Registers a listener for messages on this channel for multiple event name values. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires.
+   * Registers a listener for messages on this channel for multiple event name values. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires and no error is raised.
    *
    * @param events - An array of event names.
    * @param listener - An event listener function.
-   * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. The promise also resolves with `null` when {@link ChannelOptions.attachOnSubscribe} is `false`, in which case no attach is attempted. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
    * @example
    * ```ts
    * await channel.subscribe(['event1', 'event2'], (message) => console.log(message.data));
@@ -2893,11 +2937,11 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * {@label WITH_MESSAGE_FILTER}
    *
-   * Registers a listener for messages on this channel that match the supplied filter. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires.
+   * Registers a listener for messages on this channel that match the supplied filter. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires and no error is raised.
    *
    * @param filter - A {@link MessageFilter}.
    * @param listener - An event listener function.
-   * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. The promise also resolves with `null` when {@link ChannelOptions.attachOnSubscribe} is `false`, in which case no attach is attempted. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
    * @example
    * ```ts
    * await channel.subscribe({ name: 'event' }, (message) => console.log(message.data));
@@ -2906,10 +2950,10 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   subscribe(filter: MessageFilter, listener?: messageCallback<InboundMessage>): Promise<ChannelStateChange | null>;
   /**
-   * Registers a listener for messages on this channel. The caller supplies a listener function, which is called each time one or more messages arrives on the channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires.
+   * Registers a listener for messages on this channel. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `subscribe` mode the listener never fires and no error is raised.
    *
    * @param callback - An event listener function.
-   * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
+   * @returns A promise which, upon successful attachment to the channel, will be fulfilled with a {@link ChannelStateChange} object. If the channel was already attached the promise will be resolved with `null`. The promise also resolves with `null` when {@link ChannelOptions.attachOnSubscribe} is `false`, in which case no attach is attempted. Upon failure, the promise will be rejected with an {@link ErrorInfo} object.
    * @example
    * ```ts
    * await channel.subscribe((message) => console.log(message.data));
@@ -2937,7 +2981,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    *
    * @param name - The event name.
    * @param data - The message payload.
-   * @param options - Optional parameters sent as part of the protocol message.
+   * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serial of the published message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    * @example
    * ```ts
@@ -2950,7 +2994,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    * Publishes an array of messages to the channel.
    *
    * @param messages - An array of {@link Message} objects.
-   * @param options - Optional parameters sent as part of the protocol message.
+   * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serials of the published messages. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    * @example
    * ```ts
@@ -2963,7 +3007,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    * Publishes a message to the channel.
    *
    * @param message - A {@link Message} object.
-   * @param options - Optional parameters sent as part of the protocol message.
+   * @param options - Optional parameters to modify how the publish is made.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serial of the published message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    * @example
    * ```ts
@@ -2988,7 +3032,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   publish(name: string, data: any, callback: ErrorCallback): void;
   /**
-   * If the channel is already in the given state, resolves immediately with `null`. Otherwise resolves with the {@link ChannelStateChange} the next time the channel transitions to the given state.
+   * If the channel is already in the given state, resolves immediately with `null`. Otherwise resolves with the {@link ChannelStateChange} the next time the channel transitions to the given state. If the channel never transitions to the given state, the promise never settles and no error is raised.
    *
    * @param targetState - The channel state to wait for.
    * @example
@@ -3001,7 +3045,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * Retrieves the latest version of a specific message by its serial identifier.
    *
-   * The channel must be configured to allow message updates, enabled by a rule.
+   * The channel must be configured to allow message updates, enabled by a [rule](https://ably.com/docs/channels#rules).
    *
    * The supplied serial or {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
@@ -3015,9 +3059,9 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    */
   getMessage(serialOrMessage: string | Message): Promise<Message>;
   /**
-   * Publishes an update to an existing message with patch semantics. Non-null `name`, `data`, and `extras` fields in the provided message will replace the corresponding fields in the existing message, while null fields will be left unchanged.
+   * Publishes an update to an existing message with patch semantics. Non-null `name`, `data`, and `extras` fields in the provided message replace the corresponding fields in the existing message, while null fields are left unchanged.
    *
-   * The channel must be configured to allow message updates, enabled by a rule.
+   * The channel must be configured to allow message updates, enabled by a [rule](https://ably.com/docs/channels#rules).
    *
    * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
@@ -3035,9 +3079,9 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * Marks a message as deleted by publishing an update with an action of `MESSAGE_DELETE`. This does not remove the message from the server, and the full message history remains accessible.
    *
-   * Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message replace the corresponding fields, while null fields are left unchanged.
+   * Uses patch semantics: non-null `name`, `data`, and `extras` fields in the provided message replace the corresponding fields in the existing message, while null fields are left unchanged. A deleted message keeps its previous `data` unless the delete explicitly sets `data` to an empty value.
    *
-   * The channel must be configured to allow message deletes, enabled by a rule.
+   * The channel must be configured to allow message deletes, enabled by a [rule](https://ably.com/docs/channels#rules).
    *
    * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
@@ -3055,7 +3099,7 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
   /**
    * Appends data to an existing message. The supplied `data` field is appended to the previous message's data, while all other fields (`name`, `extras`) replace the previous values if provided.
    *
-   * The channel must be configured to allow message appends, enabled by a rule.
+   * The channel must be configured to allow message appends, enabled by a [rule](https://ably.com/docs/channels#rules).
    *
    * The supplied {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
@@ -3065,17 +3109,17 @@ export declare interface RealtimeChannel extends EventEmitter<channelEventCallba
    * @returns A promise which, upon success, will be fulfilled with an {@link UpdateDeleteResult} object containing the serial of the new version of the message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    * @example
    * ```ts
-   * const result = await channel.appendMessage(message);
+   * const result = await channel.appendMessage({ ...message, data: ' more text' });
    * ```
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-channel#append-message
    */
   appendMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
-   * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent updates or delete operations.
+   * Retrieves all historical versions of a specific message, ordered by version. This includes the original message and all subsequent update, delete, or append operations.
    *
    * The supplied serial or {@link Message} must carry a populated `serial`. A newly constructed {@link Message} has none, so the call rejects with an {@link ErrorInfo}.
    *
-   * Message versions exist only when the channel is configured to allow updating and deleting messages, enabled by a rule.
+   * Message versions exist only when the channel is configured to allow updating, deleting, or appending messages, enabled by a [rule](https://ably.com/docs/channels#rules).
    *
    * @param serialOrMessage - Either the serial identifier string of the message whose versions are to be retrieved, or a {@link Message} object containing a populated `serial` field.
    * @param params - Optional parameters sent as part of the query string.


### PR DESCRIPTION
Stacked on #2242 (Auth docstrings, base `DX-1211/auth-docstrings`); review/merge that first. Rewrites the JSDoc on the `RealtimeChannel` public surface in `ably.d.ts` per `docstringRules.md`: terse folded prose that surfaces call-site prerequisites, side-effects, and failure modes (the DX-1211 silent-failure class), with an `@see` companion link to the canonical reference.

## Scope
`ably.d.ts` only (+135/−29). 19 members rewritten, 2 deliberately left as-is.

## Highlights
- **`subscribe()` (DX-1211 core):** documents the silent missing-`subscribe`-mode trap — the listener never fires, the SDK warn-logs rather than rejecting (or rejects with a hinted `ErrorInfo` under `strictMode`). On all four active overloads.
- **`params` / `errorReason`:** declared non-optional but actually `undefined`/`null` until first attach/error — now carry a guard-against-undefined/null caveat (parallel to `modes`).
- **`history()`:** non-code persistence channel-rule prerequisite; fixes a `@param` copy-paste bug ("presence members" → "messages").
- **Message ops** (`getMessage`/`updateMessage`/`deleteMessage`/`appendMessage`/`getMessageVersions`): async **reject** framing (not synchronous throw) + message-interactions channel-rule prerequisite.
- **`push`:** universal missing-plugin throw kept at the call site; `presence`/`annotations` left unchanged (bundled by the default build, so the throw is modular-only).

## Validation
`npm run docs` (TypeDoc `treatWarningsAsErrors`), `prettier --check`, and `eslint` all pass. A clean TypeDoc build confirms every `{@link}` resolves and nothing became undocumented.

## Reviewer notes
- `@see` anchors follow the kebab-case convention (matching the Auth PR) but are unverified — ably/docs #3400 isn't live yet and `@see` is not TypeDoc-validated.
- A secondary feature-page `@see` for the five message-interaction members was deliberately omitted pending a confirmed slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified message lifecycle behavior, including requirements and semantics for updating, deleting, appending, and retrieving message versions.
  * Expanded realtime channel documentation for states, options, subscriptions, attachment, history, push notifications, and promise behavior.
  * Documented runtime cases where certain channel properties may be unavailable.
  * Clarified that unsubscribing removes local listeners without detaching the channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->