### PR TITLE
DX-1206: RealtimePresence interface docstrings

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2230,6 +2230,8 @@ export declare interface RealtimePresence {
    *
    * Requires the `presence_subscribe` mode. Without it the call resolves with an empty array.
    *
+   * On a channel in the `suspended` state the call rejects with an {@link ErrorInfo}, unless `waitForSync` is `false` in {@link RealtimePresenceParams}, which resolves with the last known members.
+   *
    * @param params - A set of parameters which are used to specify which presence members should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
    * @example

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2168,51 +2168,69 @@ export declare interface Presence {
  */
 export declare interface RealtimePresence {
   /**
-   * Indicates whether the presence set synchronization between Ably and the clients on the channel has been completed. Set to `true` when the sync is complete.
+   * Indicates whether the presence set synchronization between Ably and the clients on the channel has been completed. Set to `true` when the sync is complete, and back to `false` whenever a new sync starts (typically after a (re)attach). The value is also `true` after the local presence set is cleared (when the channel becomes detached or failed, or attaches without the server reporting any presence members), so it indicates only that no sync is in progress (though it is initially `false`, before any sync has started), not that the channel is attached or that a sync ever ran. To wait for an in-progress sync, call {@link RealtimePresence.get | `get()`}, which by default resolves only once the sync completes.
+   *
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#sync-complete
    */
   syncComplete: boolean;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This only removes the local listener; it does not detach the channel or remove this client from the presence set (use {@link RealtimePresence.leave | `leave()`} for that), and presence events may continue to arrive for any other registered listeners.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listener for.
    * @param listener - An event listener function.
+   * @example
+   * ```ts
+   * channel.presence.unsubscribe('enter', listener);
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: PresenceAction, listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given array of {@link PresenceAction} objects.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given array of {@link PresenceAction} objects. This only removes the local listener and does not detach the channel.
    *
    * @param presence - An array of {@link PresenceAction} objects to deregister the listener for.
    * @param listener - An event listener function.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: Array<PresenceAction>, listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for a specific {@link PresenceAction}
+   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for a specific {@link PresenceAction}. This only removes the local listeners and does not detach the channel.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listeners for.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: PresenceAction): void;
   /**
-   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for an array of {@link PresenceAction} objects
+   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for an array of {@link PresenceAction} objects. This only removes the local listeners and does not detach the channel.
    *
    * @param presence - An array of {@link PresenceAction} objects to deregister the listeners for.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: Array<PresenceAction>): void;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel. This only removes the local listener and does not detach the channel.
    *
    * @param listener - An event listener function.
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel.
+   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel. This only removes the local listeners and does not detach the channel or remove this client from the presence set, so the channel stays attached and an entered client remains present.
+   *
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(): void;
 
   /**
-   * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Returns an array of {@link PresenceMessage} objects.
+   * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Implicitly attaches the channel if it is not already attached. Requires the `presence_subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); without it the call resolves with an empty array rather than rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
    *
    * @param params - A set of parameters which are used to specify which presence members should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const members = await channel.presence.get();
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#get
    */
   get(params?: RealtimePresenceParams): Promise<PresenceMessage[]>;
   /**
@@ -2230,10 +2248,16 @@ export declare interface RealtimePresence {
    */
   get(params: RealtimePresenceParams | null, callback: StandardCallback<PresenceMessage[]>): void;
   /**
-   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link PresenceMessage} objects for the channel. If the channel is configured to persist messages, then presence messages can be retrieved from history for up to 72 hours in the past. If not, presence messages can only be retrieved from history for up to two minutes in the past.
+   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link PresenceMessage} objects for the channel. Presence messages are retrievable for up to 72 hours in the past when message persistence is enabled for the channel by a channel rule; without it, only presence messages from the last two minutes, the service's default retention, are returned.
    *
    * @param params - A set of parameters which are used to specify which presence messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @example
+   * ```ts
+   * const result = await channel.presence.history();
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#history
+   * @see https://ably.com/docs/storage-history/storage
    */
   history(params?: RealtimeHistoryParams): Promise<PaginatedResult<PresenceMessage>>;
   /**
@@ -2251,18 +2275,28 @@ export declare interface RealtimePresence {
    */
   history(params: RealtimeHistoryParams | null, callback: StandardCallback<PaginatedResult<PresenceMessage>>): void;
   /**
-   * Registers a listener that is called each time a {@link PresenceMessage} matching a given {@link PresenceAction}, or an action within an array of {@link PresenceAction | `PresenceAction`s}, is received on the channel, such as a new member entering the presence set.
+   * Registers a listener that is called each time a {@link PresenceMessage} matching a given {@link PresenceAction}, or an action within an array of {@link PresenceAction | `PresenceAction`s}, is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `presence_subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers presence events, so the listener silently never fires: the call still resolves and nothing is logged.
    *
    * @param action - A {@link PresenceAction} or an array of {@link PresenceAction | `PresenceAction`s} to register the listener for.
    * @param listener - An event listener function.
-   * @returns A promise which resolves upon success of the channel {@link RealtimeChannel.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @returns A promise which resolves upon success of the channel {@link RealtimeChannel.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure. When {@link ChannelOptions.attachOnSubscribe} is `false`, no attach is performed.
+   * @example
+   * ```ts
+   * await channel.presence.subscribe('enter', (member) => console.log(member.clientId));
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#subscribe
    */
   subscribe(action: PresenceAction | Array<PresenceAction>, listener?: messageCallback<PresenceMessage>): Promise<void>;
   /**
-   * Registers a listener that is called each time a {@link PresenceMessage} is received on the channel, such as a new member entering the presence set.
+   * Registers a listener that is called each time a {@link PresenceMessage} is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `presence_subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers presence events, so the listener silently never fires: the call still resolves and nothing is logged.
    *
    * @param listener - An event listener function.
-   * @returns A promise which resolves upon success of the channel {@link RealtimeChannel.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @returns A promise which resolves upon success of the channel {@link RealtimeChannel.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure. When {@link ChannelOptions.attachOnSubscribe} is `false`, no attach is performed.
+   * @example
+   * ```ts
+   * await channel.presence.subscribe((member) => console.log(member.clientId));
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#subscribe
    */
   subscribe(listener?: messageCallback<PresenceMessage>): Promise<void>;
   /**
@@ -2285,10 +2319,15 @@ export declare interface RealtimePresence {
     callback: ErrorCallback,
   ): void;
   /**
-   * Enters the presence set for the channel, optionally passing a `data` payload. A `clientId` is required to be present on a channel.
+   * Enters the presence set for the channel, optionally passing a `data` payload. A `clientId` is required: if the client has no `clientId` (or the wildcard `*`), the call rejects with an {@link ErrorInfo}; set a `clientId` in {@link ClientOptions} or in the token, or use {@link RealtimePresence.enterClient | `enterClient()`} to enter on behalf of another identity. Implicitly attaches the channel if it is not already attached. Once entered, the member is automatically re-entered whenever the channel re-attaches after a disconnection; if that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo}, not as a rejection.
    *
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @example
+   * ```ts
+   * await channel.presence.enter({ status: 'online' });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#enter
    */
   enter(data?: any): Promise<void>;
   /**
@@ -2306,10 +2345,15 @@ export declare interface RealtimePresence {
    */
   enter(data: any, callback: ErrorCallback): void;
   /**
-   * Updates the `data` payload for a presence member. If called before entering the presence set, this is treated as an {@link PresenceActions.ENTER} event.
+   * Updates the `data` payload for a presence member. If called before entering the presence set, this is treated as an {@link PresenceActions.ENTER} event. Requires an identified client: if the client has no `clientId` (or the wildcard `*`) set in the {@link ClientOptions} or the token, the call rejects with an {@link ErrorInfo} (use {@link RealtimePresence.updateClient | `updateClient()`} to update on behalf of another identity). Implicitly attaches the channel if it is not already attached.
    *
    * @param data - The payload to update for the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @example
+   * ```ts
+   * await channel.presence.update({ status: 'busy' });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#update
    */
   update(data?: any): Promise<void>;
   /**
@@ -2327,10 +2371,15 @@ export declare interface RealtimePresence {
    */
   update(data: any, callback: ErrorCallback): void;
   /**
-   * Leaves the presence set for the channel. A client must have previously entered the presence set before they can leave it.
+   * Leaves the presence set for the channel. A client must have previously entered the presence set before they can leave it. Requires the client to be identified: when the `clientId` is unset or a wildcard, the call rejects with an {@link ErrorInfo}; to leave on behalf of another identity use {@link RealtimePresence.leaveClient | `leaveClient()`}, which requires a wildcard `clientId` on the API key or token. Unlike {@link RealtimePresence.enter | `enter()`}, leaving does not implicitly attach the channel: the call proceeds only while the channel is `attached` or `attaching`, and rejects with an {@link ErrorInfo} in any other channel state or when the connection is unusable.
    *
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @example
+   * ```ts
+   * await channel.presence.leave();
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#leave
    */
   leave(data?: any): Promise<void>;
   /**
@@ -2348,27 +2397,42 @@ export declare interface RealtimePresence {
    */
   leave(data: any, callback: ErrorCallback): void;
   /**
-   * Enters the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`.
+   * Enters the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`; this is enforced by the server rather than the client, so without it the call rejects with an {@link ErrorInfo} returned by the server. Implicitly attaches the channel if it is not already attached. After a transient disconnection the library automatically re-enters the member on re-attach; if that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo}, not as a rejection.
    *
    * @param clientId - The ID of the client to enter into the presence set.
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @example
+   * ```ts
+   * await channel.presence.enterClient('bob', { status: 'online' });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#enter-client
    */
   enterClient(clientId: string, data?: any): Promise<void>;
   /**
-   * Updates the `data` payload for a presence member using a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`.
+   * Updates the `data` payload for a presence member using a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`; this is enforced by the server rather than the client, so without it the call rejects with an {@link ErrorInfo} returned by the server. Implicitly attaches the channel if it is not already attached.
    *
    * @param clientId - The ID of the client to update in the presence set.
    * @param data - The payload to update for the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @example
+   * ```ts
+   * await channel.presence.updateClient('bob', { status: 'busy' });
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#update-client
    */
   updateClient(clientId: string, data?: any): Promise<void>;
   /**
-   * Leaves the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`.
+   * Leaves the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`; this is enforced by the server rather than the client, so without it the call rejects with an {@link ErrorInfo} returned by the server. Unlike {@link RealtimePresence.enterClient | `enterClient()`}, this call does not implicitly attach the channel; when the channel is neither attached nor attaching it rejects with an {@link ErrorInfo} rather than attaching just to leave.
    *
    * @param clientId - The ID of the client to leave the presence set for.
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   * @example
+   * ```ts
+   * await channel.presence.leaveClient('bob');
+   * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#leave-client
    */
   leaveClient(clientId: string, data?: any): Promise<void>;
 }

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2384,11 +2384,11 @@ export declare interface RealtimePresence {
    */
   update(data: any, callback: ErrorCallback): void;
   /**
-   * Leaves the presence set for the channel. A client must have entered the presence set before it can leave.
+   * Leaves the presence set for the channel.
    *
    * Requires an identified client. If the `clientId` is unset, or is the wildcard `*`, the call rejects with an {@link ErrorInfo}. Use {@link RealtimePresence.leaveClient | `leaveClient()`} to leave on behalf of another identity, which requires a wildcard `clientId` on the API key or token.
    *
-   * Leaving does not implicitly attach the channel. The call proceeds only on a channel in the `attached` or `attaching` state, and rejects with an {@link ErrorInfo} in any other channel state or when the connection is unusable.
+   * Leaving does not implicitly attach the channel. It requires a channel in the `attached` state. On an `attaching` channel the call is queued until the channel attaches, unless {@link ClientOptions.queueMessages} is disabled. In any other channel state, or when the connection is unusable, it rejects with an {@link ErrorInfo}.
    *
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
@@ -2450,7 +2450,7 @@ export declare interface RealtimePresence {
    *
    * Requires an API key or token bound to a wildcard `clientId`. The server enforces this, so without it the call rejects with an {@link ErrorInfo} returned by the server.
    *
-   * Leaving does not implicitly attach the channel. On a channel in neither the `attached` nor the `attaching` state the call rejects with an {@link ErrorInfo}.
+   * Leaving does not implicitly attach the channel. It requires a channel in the `attached` state. On an `attaching` channel the call is queued until the channel attaches, unless {@link ClientOptions.queueMessages} is disabled. In any other channel state, or when the connection is unusable, it rejects with an {@link ErrorInfo}.
    *
    * @param clientId - The ID of the client to leave the presence set for.
    * @param data - The payload associated with the presence member.

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2178,7 +2178,7 @@ export declare interface RealtimePresence {
    */
   syncComplete: boolean;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set. The server keeps streaming presence events to an attached channel, subject to the client's capabilities.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listener for.
    * @param listener - An event listener function.
@@ -2190,7 +2190,7 @@ export declare interface RealtimePresence {
    */
   unsubscribe(presence: PresenceAction, listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set. The server keeps streaming presence events to an attached channel, subject to the client's capabilities.
    *
    * @param presence - An array of {@link PresenceAction} objects to deregister the listener for.
    * @param listener - An event listener function.
@@ -2198,28 +2198,28 @@ export declare interface RealtimePresence {
    */
   unsubscribe(presence: Array<PresenceAction>, listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for a specific {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set.
+   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for a specific {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set. The server keeps streaming presence events to an attached channel, subject to the client's capabilities.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listeners for.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: PresenceAction): void;
   /**
-   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for an array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set.
+   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for an array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set. The server keeps streaming presence events to an attached channel, subject to the client's capabilities.
    *
    * @param presence - An array of {@link PresenceAction} objects to deregister the listeners for.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: Array<PresenceAction>): void;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set. The server keeps streaming presence events to an attached channel, subject to the client's capabilities.
    *
    * @param listener - An event listener function.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set.
+   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set. The server keeps streaming presence events to an attached channel, subject to the client's capabilities.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
@@ -2384,7 +2384,7 @@ export declare interface RealtimePresence {
   /**
    * Leaves the presence set for the channel.
    *
-   * Requires an identified client. If the `clientId` is unset, or is the wildcard `*`, the call rejects with an {@link ErrorInfo}. Use {@link RealtimePresence.leaveClient | `leaveClient()`} to leave on behalf of another identity, which requires a wildcard `clientId` on the API key or token.
+   * Requires an identified client. If the `clientId` is unset, or is the wildcard `*`, the call rejects with an {@link ErrorInfo}. Use {@link RealtimePresence.leaveClient | `leaveClient()`} to leave on behalf of another identity.
    *
    * Leaving does not implicitly attach the channel. It requires a channel in the `attached` state. On an `attaching` channel the call is queued until the channel attaches, unless {@link ClientOptions.queueMessages} is disabled. In any other channel state, or when the connection is unusable, it rejects with an {@link ErrorInfo}.
    *

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2168,13 +2168,17 @@ export declare interface Presence {
  */
 export declare interface RealtimePresence {
   /**
-   * Indicates whether the presence set synchronization between Ably and the clients on the channel has been completed. Set to `true` when the sync is complete, and back to `false` whenever a new sync starts, typically after a re-attach. The value is initially `false`, before any sync has started. It is also `true` after the local presence set is cleared, which happens when the channel becomes detached or failed, or attaches without the server reporting any presence members. It therefore indicates only that no sync is in progress, not that the channel is attached or that a sync ever ran. To wait for an in-progress sync, call {@link RealtimePresence.get | `get()`}, which by default resolves only once the sync completes.
+   * Indicates whether the presence set synchronization between Ably and the clients on the channel has been completed.
+   *
+   * A `true` value means only that no sync is in progress. It does not mean the presence set is populated, since the flag is also `true` once the local set is cleared, and it returns to `false` whenever a new sync starts.
+   *
+   * To wait for an in-progress sync, call {@link RealtimePresence.get | `get()`}, which by default resolves only once the sync completes.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#properties
    */
   syncComplete: boolean;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This only removes the local listener. It does not detach the channel or remove this client from the presence set, and presence events may continue to arrive for any other registered listeners. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listener for.
    * @param listener - An event listener function.
@@ -2186,7 +2190,7 @@ export declare interface RealtimePresence {
    */
   unsubscribe(presence: PresenceAction, listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given array of {@link PresenceAction} objects. This only removes the local listener and does not detach the channel.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
    *
    * @param presence - An array of {@link PresenceAction} objects to deregister the listener for.
    * @param listener - An event listener function.
@@ -2194,35 +2198,37 @@ export declare interface RealtimePresence {
    */
   unsubscribe(presence: Array<PresenceAction>, listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for a specific {@link PresenceAction}. This only removes the local listeners and does not detach the channel.
+   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for a specific {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listeners for.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: PresenceAction): void;
   /**
-   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for an array of {@link PresenceAction} objects. This only removes the local listeners and does not detach the channel.
+   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for an array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
    *
    * @param presence - An array of {@link PresenceAction} objects to deregister the listeners for.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: Array<PresenceAction>): void;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel. This only removes the local listener and does not detach the channel.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
    *
    * @param listener - An event listener function.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel. This only removes the local listeners and does not detach the channel or remove this client from the presence set, so the channel stays attached and an entered client remains present.
+   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(): void;
 
   /**
-   * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Implicitly attaches the channel if it is not already attached. Requires the `presence_subscribe` mode. Without it the call resolves with an empty array rather than rejecting. When {@link ClientOptions.strictMode} is enabled, it instead rejects with a hinted {@link ErrorInfo}.
+   * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Implicitly attaches the channel if it is not already attached.
+   *
+   * Requires the `presence_subscribe` mode. Without it the call resolves with an empty array.
    *
    * @param params - A set of parameters which are used to specify which presence members should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2248,7 +2254,7 @@ export declare interface RealtimePresence {
    */
   get(params: RealtimePresenceParams | null, callback: StandardCallback<PresenceMessage[]>): void;
   /**
-   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link PresenceMessage} objects for the channel. Presence messages are retrievable for up to 72 hours in the past when message persistence is enabled for the channel by a [rule](https://ably.com/docs/channels#rules). If message persistence is not enabled, only presence messages from the last two minutes are returned.
+   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link PresenceMessage} objects for the channel. Presence messages are returned from storage only when message persistence is enabled for the channel by a [rule](https://ably.com/docs/channels#rules). If message persistence is not enabled, only presence messages from the last two minutes are returned.
    *
    * @param params - A set of parameters which are used to specify which presence messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2274,7 +2280,7 @@ export declare interface RealtimePresence {
    */
   history(params: RealtimeHistoryParams | null, callback: StandardCallback<PaginatedResult<PresenceMessage>>): void;
   /**
-   * Registers a listener that is called each time a {@link PresenceMessage} matching a given {@link PresenceAction}, or an action within an array of {@link PresenceAction | `PresenceAction`s}, is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `presence_subscribe` mode. If the channel attaches without it the server never delivers presence events, so the listener silently never fires. The call still resolves and nothing is logged.
+   * Registers a listener that is called each time a {@link PresenceMessage} matching a given {@link PresenceAction}, or an action within an array of {@link PresenceAction | `PresenceAction`s}, is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `presence_subscribe` mode the server delivers no presence events and the listener never fires.
    *
    * @param action - A {@link PresenceAction} or an array of {@link PresenceAction | `PresenceAction`s} to register the listener for.
    * @param listener - An event listener function.
@@ -2287,7 +2293,7 @@ export declare interface RealtimePresence {
    */
   subscribe(action: PresenceAction | Array<PresenceAction>, listener?: messageCallback<PresenceMessage>): Promise<void>;
   /**
-   * Registers a listener that is called each time a {@link PresenceMessage} is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `presence_subscribe` mode. If the channel attaches without it the server never delivers presence events, so the listener silently never fires. The call still resolves and nothing is logged.
+   * Registers a listener that is called each time a {@link PresenceMessage} is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Without the `presence_subscribe` mode the server delivers no presence events and the listener never fires.
    *
    * @param listener - An event listener function.
    * @returns A promise which resolves upon success of the channel {@link RealtimeChannel.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure. When {@link ChannelOptions.attachOnSubscribe} is `false`, no attach is performed.
@@ -2318,7 +2324,11 @@ export declare interface RealtimePresence {
     callback: ErrorCallback,
   ): void;
   /**
-   * Enters the presence set for the channel, optionally passing a `data` payload. A `clientId` is required: if the client has no `clientId`, or only the wildcard `*`, the call rejects with an {@link ErrorInfo}. Set a `clientId` in {@link ClientOptions} or in the token, or use {@link RealtimePresence.enterClient | `enterClient()`} to enter on behalf of another identity. Implicitly attaches the channel if it is not already attached. Once entered, the member is automatically re-entered whenever the channel re-attaches after a disconnection; if that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo}, not as a rejection.
+   * Enters the presence set for the channel, optionally passing a `data` payload. Implicitly attaches the channel if it is not already attached.
+   *
+   * Requires an identified client. If the `clientId` is unset, or is the wildcard `*`, the call rejects with an {@link ErrorInfo}. Set a `clientId` in {@link ClientOptions} or in the token, or use {@link RealtimePresence.enterClient | `enterClient()`} to enter on behalf of another identity.
+   *
+   * Once entered, the member is automatically re-entered whenever the channel re-attaches after a disconnection. If that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo} rather than as a rejection.
    *
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
@@ -2344,7 +2354,9 @@ export declare interface RealtimePresence {
    */
   enter(data: any, callback: ErrorCallback): void;
   /**
-   * Updates the `data` payload for a presence member. If called before entering the presence set, this is treated as an {@link PresenceActions.ENTER} event. Requires an identified client: if the client has no `clientId`, or only the wildcard `*`, set in the {@link ClientOptions} or the token, the call rejects with an {@link ErrorInfo}. Use {@link RealtimePresence.updateClient | `updateClient()`} to update on behalf of another identity. Implicitly attaches the channel if it is not already attached.
+   * Updates the `data` payload for a presence member. If called before entering the presence set, this is treated as an {@link PresenceActions.ENTER} event. Implicitly attaches the channel if it is not already attached.
+   *
+   * Requires an identified client. If the `clientId` is unset, or is the wildcard `*`, the call rejects with an {@link ErrorInfo}. Use {@link RealtimePresence.updateClient | `updateClient()`} to update on behalf of another identity.
    *
    * @param data - The payload to update for the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
@@ -2370,7 +2382,11 @@ export declare interface RealtimePresence {
    */
   update(data: any, callback: ErrorCallback): void;
   /**
-   * Leaves the presence set for the channel. A client must have previously entered the presence set before they can leave it. Requires the client to be identified: when the `clientId` is unset or a wildcard, the call rejects with an {@link ErrorInfo}; to leave on behalf of another identity use {@link RealtimePresence.leaveClient | `leaveClient()`}, which requires a wildcard `clientId` on the API key or token. Unlike {@link RealtimePresence.enter | `enter()`}, leaving does not implicitly attach the channel: the call proceeds only while the channel is `attached` or `attaching`, and rejects with an {@link ErrorInfo} in any other channel state or when the connection is unusable.
+   * Leaves the presence set for the channel. A client must have entered the presence set before it can leave.
+   *
+   * Requires an identified client. If the `clientId` is unset, or is the wildcard `*`, the call rejects with an {@link ErrorInfo}. Use {@link RealtimePresence.leaveClient | `leaveClient()`} to leave on behalf of another identity, which requires a wildcard `clientId` on the API key or token.
+   *
+   * Leaving does not implicitly attach the channel. The call proceeds only on a channel in the `attached` or `attaching` state, and rejects with an {@link ErrorInfo} in any other channel state or when the connection is unusable.
    *
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
@@ -2396,7 +2412,11 @@ export declare interface RealtimePresence {
    */
   leave(data: any, callback: ErrorCallback): void;
   /**
-   * Enters the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`; this is enforced by the server rather than the client, so without it the call rejects with an {@link ErrorInfo} returned by the server. Implicitly attaches the channel if it is not already attached. After a transient disconnection the library automatically re-enters the member on re-attach; if that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo}, not as a rejection.
+   * Enters the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. Implicitly attaches the channel if it is not already attached.
+   *
+   * Requires an API key or token bound to a wildcard `clientId`. The server enforces this, so without it the call rejects with an {@link ErrorInfo} returned by the server.
+   *
+   * After a transient disconnection the library automatically re-enters the member on re-attach. If that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo} rather than as a rejection.
    *
    * @param clientId - The ID of the client to enter into the presence set.
    * @param data - The payload associated with the presence member.
@@ -2409,7 +2429,9 @@ export declare interface RealtimePresence {
    */
   enterClient(clientId: string, data?: any): Promise<void>;
   /**
-   * Updates the `data` payload for a presence member using a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`; this is enforced by the server rather than the client, so without it the call rejects with an {@link ErrorInfo} returned by the server. Implicitly attaches the channel if it is not already attached.
+   * Updates the `data` payload for a presence member using a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. Implicitly attaches the channel if it is not already attached.
+   *
+   * Requires an API key or token bound to a wildcard `clientId`. The server enforces this, so without it the call rejects with an {@link ErrorInfo} returned by the server.
    *
    * @param clientId - The ID of the client to update in the presence set.
    * @param data - The payload to update for the presence member.
@@ -2422,7 +2444,11 @@ export declare interface RealtimePresence {
    */
   updateClient(clientId: string, data?: any): Promise<void>;
   /**
-   * Leaves the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. The library must have been instantiated with an API key or a token bound to a wildcard `clientId`; this is enforced by the server rather than the client, so without it the call rejects with an {@link ErrorInfo} returned by the server. Unlike {@link RealtimePresence.enterClient | `enterClient()`}, this call does not implicitly attach the channel; when the channel is neither attached nor attaching it rejects with an {@link ErrorInfo} rather than attaching just to leave.
+   * Leaves the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection.
+   *
+   * Requires an API key or token bound to a wildcard `clientId`. The server enforces this, so without it the call rejects with an {@link ErrorInfo} returned by the server.
+   *
+   * Leaving does not implicitly attach the channel. On a channel in neither the `attached` nor the `attaching` state the call rejects with an {@link ErrorInfo}.
    *
    * @param clientId - The ID of the client to leave the presence set for.
    * @param data - The payload associated with the presence member.

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2170,7 +2170,7 @@ export declare interface RealtimePresence {
   /**
    * Indicates whether the presence set synchronization between Ably and the clients on the channel has been completed. Set to `true` when the sync is complete, and back to `false` whenever a new sync starts, typically after a re-attach. The value is initially `false`, before any sync has started. It is also `true` after the local presence set is cleared, which happens when the channel becomes detached or failed, or attaches without the server reporting any presence members. It therefore indicates only that no sync is in progress, not that the channel is attached or that a sync ever ran. To wait for an in-progress sync, call {@link RealtimePresence.get | `get()`}, which by default resolves only once the sync completes.
    *
-   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#sync-complete
+   * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#properties
    */
   syncComplete: boolean;
   /**

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2178,7 +2178,7 @@ export declare interface RealtimePresence {
    */
   syncComplete: boolean;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listener for.
    * @param listener - An event listener function.
@@ -2190,7 +2190,7 @@ export declare interface RealtimePresence {
    */
   unsubscribe(presence: PresenceAction, listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set.
    *
    * @param presence - An array of {@link PresenceAction} objects to deregister the listener for.
    * @param listener - An event listener function.
@@ -2198,39 +2198,37 @@ export declare interface RealtimePresence {
    */
   unsubscribe(presence: Array<PresenceAction>, listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for a specific {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
+   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for a specific {@link PresenceAction}. This removes local listeners only and does not detach the channel or remove this client from the presence set.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listeners for.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: PresenceAction): void;
   /**
-   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for an array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
+   * Deregisters any listener that is registered to receive {@link PresenceMessage} on the channel for an array of {@link PresenceAction} objects. This removes local listeners only and does not detach the channel or remove this client from the presence set.
    *
    * @param presence - An array of {@link PresenceAction} objects to deregister the listeners for.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(presence: Array<PresenceAction>): void;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set.
    *
    * @param listener - An event listener function.
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(listener: messageCallback<PresenceMessage>): void;
   /**
-   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
+   * Deregisters all listeners currently receiving {@link PresenceMessage} for the channel. This removes local listeners only and does not detach the channel or remove this client from the presence set.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#unsubscribe
    */
   unsubscribe(): void;
 
   /**
-   * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Implicitly attaches the channel if it is not already attached.
+   * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Implicitly attaches the channel if it is not already attached. Without the `presence_subscribe` mode the call resolves with an empty array.
    *
-   * Requires the `presence_subscribe` mode. Without it the call resolves with an empty array.
-   *
-   * On a channel in the `suspended` state the call rejects with an {@link ErrorInfo}, unless `waitForSync` is `false` in {@link RealtimePresenceParams}, which resolves with the last known members.
+   * On a channel in the `suspended` state the call rejects with an {@link ErrorInfo}. Pass `waitForSync: false` to resolve with the last known members instead.
    *
    * @param params - A set of parameters which are used to specify which presence members should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2330,7 +2328,7 @@ export declare interface RealtimePresence {
    *
    * Requires an identified client. If the `clientId` is unset, or is the wildcard `*`, the call rejects with an {@link ErrorInfo}. Set a `clientId` in {@link ClientOptions} or in the token, or use {@link RealtimePresence.enterClient | `enterClient()`} to enter on behalf of another identity.
    *
-   * Once entered, the member is automatically re-entered whenever the channel re-attaches after a disconnection. If that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo} rather than as a rejection.
+   * The member is automatically re-entered when the channel re-attaches after a disconnection. If that fails, the {@link ErrorInfo} arrives as a channel `update` event rather than as a rejection.
    *
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
@@ -2416,9 +2414,9 @@ export declare interface RealtimePresence {
   /**
    * Enters the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. Implicitly attaches the channel if it is not already attached.
    *
-   * Requires an API key or token bound to a wildcard `clientId`. The server enforces this, so without it the call rejects with an {@link ErrorInfo} returned by the server.
+   * Requires an API key or token bound to a wildcard `clientId`. Without one the call rejects with an {@link ErrorInfo} from the server.
    *
-   * After a transient disconnection the library automatically re-enters the member on re-attach. If that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo} rather than as a rejection.
+   * The member is automatically re-entered when the channel re-attaches after a disconnection. If that fails, the {@link ErrorInfo} arrives as a channel `update` event rather than as a rejection.
    *
    * @param clientId - The ID of the client to enter into the presence set.
    * @param data - The payload associated with the presence member.
@@ -2433,7 +2431,7 @@ export declare interface RealtimePresence {
   /**
    * Updates the `data` payload for a presence member using a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection. Implicitly attaches the channel if it is not already attached.
    *
-   * Requires an API key or token bound to a wildcard `clientId`. The server enforces this, so without it the call rejects with an {@link ErrorInfo} returned by the server.
+   * Requires an API key or token bound to a wildcard `clientId`. Without one the call rejects with an {@link ErrorInfo} from the server.
    *
    * @param clientId - The ID of the client to update in the presence set.
    * @param data - The payload to update for the presence member.
@@ -2448,7 +2446,7 @@ export declare interface RealtimePresence {
   /**
    * Leaves the presence set of the channel for a given `clientId`. Enables a single client to update presence on behalf of any number of clients using a single connection.
    *
-   * Requires an API key or token bound to a wildcard `clientId`. The server enforces this, so without it the call rejects with an {@link ErrorInfo} returned by the server.
+   * Requires an API key or token bound to a wildcard `clientId`. Without one the call rejects with an {@link ErrorInfo} from the server.
    *
    * Leaving does not implicitly attach the channel. It requires a channel in the `attached` state. On an `attaching` channel the call is queued until the channel attaches, unless {@link ClientOptions.queueMessages} is disabled. In any other channel state, or when the connection is unusable, it rejects with an {@link ErrorInfo}.
    *

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2382,9 +2382,7 @@ export declare interface RealtimePresence {
    */
   update(data: any, callback: ErrorCallback): void;
   /**
-   * Leaves the presence set for the channel.
-   *
-   * Requires an identified client. If the `clientId` is unset, or is the wildcard `*`, the call rejects with an {@link ErrorInfo}. Use {@link RealtimePresence.leaveClient | `leaveClient()`} to leave on behalf of another identity.
+   * Leaves the presence set for the channel. Use {@link RealtimePresence.leaveClient | `leaveClient()`} to leave on behalf of another identity.
    *
    * Leaving does not implicitly attach the channel. It requires a channel in the `attached` state. On an `attaching` channel the call is queued until the channel attaches, unless {@link ClientOptions.queueMessages} is disabled. In any other channel state, or when the connection is unusable, it rejects with an {@link ErrorInfo}.
    *

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2168,13 +2168,13 @@ export declare interface Presence {
  */
 export declare interface RealtimePresence {
   /**
-   * Indicates whether the presence set synchronization between Ably and the clients on the channel has been completed. Set to `true` when the sync is complete, and back to `false` whenever a new sync starts (typically after a (re)attach). The value is also `true` after the local presence set is cleared (when the channel becomes detached or failed, or attaches without the server reporting any presence members), so it indicates only that no sync is in progress (though it is initially `false`, before any sync has started), not that the channel is attached or that a sync ever ran. To wait for an in-progress sync, call {@link RealtimePresence.get | `get()`}, which by default resolves only once the sync completes.
+   * Indicates whether the presence set synchronization between Ably and the clients on the channel has been completed. Set to `true` when the sync is complete, and back to `false` whenever a new sync starts, typically after a re-attach. The value is initially `false`, before any sync has started. It is also `true` after the local presence set is cleared, which happens when the channel becomes detached or failed, or attaches without the server reporting any presence members. It therefore indicates only that no sync is in progress, not that the channel is attached or that a sync ever ran. To wait for an in-progress sync, call {@link RealtimePresence.get | `get()`}, which by default resolves only once the sync completes.
    *
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#sync-complete
    */
   syncComplete: boolean;
   /**
-   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This only removes the local listener; it does not detach the channel or remove this client from the presence set (use {@link RealtimePresence.leave | `leave()`} for that), and presence events may continue to arrive for any other registered listeners.
+   * Deregisters a specific listener that is registered to receive {@link PresenceMessage} on the channel for a given {@link PresenceAction}. This only removes the local listener. It does not detach the channel or remove this client from the presence set, and presence events may continue to arrive for any other registered listeners. To leave the presence set, call {@link RealtimePresence.leave | `leave()`}.
    *
    * @param presence - A specific {@link PresenceAction} to deregister the listener for.
    * @param listener - An event listener function.
@@ -2222,7 +2222,7 @@ export declare interface RealtimePresence {
   unsubscribe(): void;
 
   /**
-   * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Implicitly attaches the channel if it is not already attached. Requires the `presence_subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); without it the call resolves with an empty array rather than rejecting (or it rejects with a hinted {@link ErrorInfo} when {@link ClientOptions.strictMode} is enabled).
+   * Retrieves the current members present on the channel and the metadata for each member, such as their {@link PresenceAction} and ID. Implicitly attaches the channel if it is not already attached. Requires the `presence_subscribe` mode. Without it the call resolves with an empty array rather than rejecting. When {@link ClientOptions.strictMode} is enabled, it instead rejects with a hinted {@link ErrorInfo}.
    *
    * @param params - A set of parameters which are used to specify which presence members should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2248,7 +2248,7 @@ export declare interface RealtimePresence {
    */
   get(params: RealtimePresenceParams | null, callback: StandardCallback<PresenceMessage[]>): void;
   /**
-   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link PresenceMessage} objects for the channel. Presence messages are retrievable for up to 72 hours in the past when message persistence is enabled for the channel by a channel rule; without it, only presence messages from the last two minutes, the service's default retention, are returned.
+   * Retrieves a {@link PaginatedResult} object, containing an array of historical {@link PresenceMessage} objects for the channel. Presence messages are retrievable for up to 72 hours in the past when message persistence is enabled for the channel by a [rule](https://ably.com/docs/channels#rules). If message persistence is not enabled, only presence messages from the last two minutes are returned.
    *
    * @param params - A set of parameters which are used to specify which presence messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
@@ -2257,7 +2257,6 @@ export declare interface RealtimePresence {
    * const result = await channel.presence.history();
    * ```
    * @see https://ably.com/docs/pub-sub/api/javascript/realtime/realtime-presence#history
-   * @see https://ably.com/docs/storage-history/storage
    */
   history(params?: RealtimeHistoryParams): Promise<PaginatedResult<PresenceMessage>>;
   /**
@@ -2275,7 +2274,7 @@ export declare interface RealtimePresence {
    */
   history(params: RealtimeHistoryParams | null, callback: StandardCallback<PaginatedResult<PresenceMessage>>): void;
   /**
-   * Registers a listener that is called each time a {@link PresenceMessage} matching a given {@link PresenceAction}, or an action within an array of {@link PresenceAction | `PresenceAction`s}, is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `presence_subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers presence events, so the listener silently never fires: the call still resolves and nothing is logged.
+   * Registers a listener that is called each time a {@link PresenceMessage} matching a given {@link PresenceAction}, or an action within an array of {@link PresenceAction | `PresenceAction`s}, is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `presence_subscribe` mode. If the channel attaches without it the server never delivers presence events, so the listener silently never fires. The call still resolves and nothing is logged.
    *
    * @param action - A {@link PresenceAction} or an array of {@link PresenceAction | `PresenceAction`s} to register the listener for.
    * @param listener - An event listener function.
@@ -2288,7 +2287,7 @@ export declare interface RealtimePresence {
    */
   subscribe(action: PresenceAction | Array<PresenceAction>, listener?: messageCallback<PresenceMessage>): Promise<void>;
   /**
-   * Registers a listener that is called each time a {@link PresenceMessage} is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `presence_subscribe` mode (granted by default unless {@link ChannelOptions.modes} excludes it); if the channel attaches without it the server never delivers presence events, so the listener silently never fires: the call still resolves and nothing is logged.
+   * Registers a listener that is called each time a {@link PresenceMessage} is received on the channel, such as a new member entering the presence set. Implicitly attaches the channel unless {@link ChannelOptions.attachOnSubscribe} is `false`. Requires the `presence_subscribe` mode. If the channel attaches without it the server never delivers presence events, so the listener silently never fires. The call still resolves and nothing is logged.
    *
    * @param listener - An event listener function.
    * @returns A promise which resolves upon success of the channel {@link RealtimeChannel.attach | `attach()`} operation and rejects with an {@link ErrorInfo} object upon its failure. When {@link ChannelOptions.attachOnSubscribe} is `false`, no attach is performed.
@@ -2319,7 +2318,7 @@ export declare interface RealtimePresence {
     callback: ErrorCallback,
   ): void;
   /**
-   * Enters the presence set for the channel, optionally passing a `data` payload. A `clientId` is required: if the client has no `clientId` (or the wildcard `*`), the call rejects with an {@link ErrorInfo}; set a `clientId` in {@link ClientOptions} or in the token, or use {@link RealtimePresence.enterClient | `enterClient()`} to enter on behalf of another identity. Implicitly attaches the channel if it is not already attached. Once entered, the member is automatically re-entered whenever the channel re-attaches after a disconnection; if that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo}, not as a rejection.
+   * Enters the presence set for the channel, optionally passing a `data` payload. A `clientId` is required: if the client has no `clientId`, or only the wildcard `*`, the call rejects with an {@link ErrorInfo}. Set a `clientId` in {@link ClientOptions} or in the token, or use {@link RealtimePresence.enterClient | `enterClient()`} to enter on behalf of another identity. Implicitly attaches the channel if it is not already attached. Once entered, the member is automatically re-entered whenever the channel re-attaches after a disconnection; if that re-enter fails, the failure surfaces as a channel `update` event carrying the {@link ErrorInfo}, not as a rejection.
    *
    * @param data - The payload associated with the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
@@ -2345,7 +2344,7 @@ export declare interface RealtimePresence {
    */
   enter(data: any, callback: ErrorCallback): void;
   /**
-   * Updates the `data` payload for a presence member. If called before entering the presence set, this is treated as an {@link PresenceActions.ENTER} event. Requires an identified client: if the client has no `clientId` (or the wildcard `*`) set in the {@link ClientOptions} or the token, the call rejects with an {@link ErrorInfo} (use {@link RealtimePresence.updateClient | `updateClient()`} to update on behalf of another identity). Implicitly attaches the channel if it is not already attached.
+   * Updates the `data` payload for a presence member. If called before entering the presence set, this is treated as an {@link PresenceActions.ENTER} event. Requires an identified client: if the client has no `clientId`, or only the wildcard `*`, set in the {@link ClientOptions} or the token, the call rejects with an {@link ErrorInfo}. Use {@link RealtimePresence.updateClient | `updateClient()`} to update on behalf of another identity. Implicitly attaches the channel if it is not already attached.
    *
    * @param data - The payload to update for the presence member.
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.


### PR DESCRIPTION
Rewrites the JSDoc on the `RealtimePresence` public surface in `ably.d.ts` per `docstringRules.md`: terse folded prose that surfaces call-site prerequisites, side-effects, and failure modes (the DX-1211 silent-failure class), with an `@see` companion link to the canonical reference. Previously stacked on #2243, now rebased onto `main` since that merged.

## Scope
`ably.d.ts` only (+108/−19). 11 members rewritten (counting overload groups once).

## Highlights
- **`subscribe()` (DX-1211 core):** documents the silent missing-`presence_subscribe`-mode trap — the channel attaches but the server never delivers presence events, so the listener never fires; also notes `attachOnSubscribe: false` skips the implicit attach. On both active overloads.
- **`get()`:** same mode prerequisite, but the failure shape differs — resolves with an **empty array** rather than rejecting. Also documents the one state that does reject: `suspended`, unless `waitForSync: false` is passed to read the last known members.
- **`syncComplete`:** the trap that a `true` value means only "no sync in progress" — it is also `true` once the local set is cleared, so it does not mean the set is populated — and points to `get()` as the way to wait for a sync.
- **`enter()`/`update()`/`leave()`:** identified-client prerequisite (rejects on missing/wildcard `clientId`), with pointers to the `*Client()` variants; `enter()` documents automatic re-enter on re-attach and that a re-enter failure surfaces as a channel `update` event, not a rejection.
- **`leave()`/`leaveClient()`:** neither implicitly attaches. Requires an `attached` channel; on an `attaching` channel the call is queued until it attaches unless `ClientOptions.queueMessages` is disabled, and it rejects in any other state or when the connection is unusable.
- **`enterClient()`/`updateClient()`/`leaveClient()`:** wildcard-`clientId` key/token prerequisite is server-enforced, so violations reject with a server-returned `ErrorInfo`.
- **`unsubscribe()`:** all six overloads clarify the removal is local-only — no detach, no presence leave.
- **`history()`:** non-code persistence channel-rule prerequisite, and the 2-minute default retention without it.

## Review passes since the first push
- Consistency and concision pass against the merged #2242 and #2243 prose: blank-line paragraphs, no semicolons, one shared wording per repeated prerequisite, and the merged `subscribe()` mode clause and `unsubscribe()` tail adopted verbatim. The `strictMode` mechanism moved out of `get()` to the `@see`, matching how RealtimeChannel shipped.
- Two claims corrected against `realtimepresence.ts`: `leave()` no longer asserts a client must have entered before leaving (the SDK enforces no such thing), and the `attaching` case is now described as queued rather than as proceeding.

## Validation
`npx typedoc --skipErrorChecking` and `prettier --check` pass; a clean TypeDoc build confirms every `{@link}` resolves and nothing became undocumented. (`npm run docs` is red on this branch and on `main` for an unrelated reason: `test/uts` sits in the TypeDoc tsconfig.)

## Reviewer notes
- `@see` anchors are now verified against the live reference pages, which went live with ably/docs #3400. All eleven resolve. `syncComplete` points at `#properties` rather than `#sync-complete`: the pages carry member-name alias anchors inside method headings, but properties are table rows under one `#properties` heading, so a per-property anchor does not exist. #2280 adds a CI check for exactly this.
- During this pass a **confirmed library bug** was found (presence ops queued while the channel is `attaching` can resolve silently without ever reaching the server in some failure paths). The queueing itself is now documented, but the bug is deliberately *not*, pending a decision on whether to fix the code instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified TypeScript documentation for realtime presence operations, including `syncComplete`, `get`, `subscribe`, `unsubscribe`, and `history`.
  * Expanded guidance on attach/queuing behavior, server delivery constraints, client identification rules (identified vs wildcard), and implicit-attach differences.
  * Documented when historical presence messages are returned and how presence membership is re-established after re-attaches.
  * Confirmed no public type signatures or APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->