### PR TITLE
fix(liveobjects): reject live object references as map values

### DIFF
--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -9,10 +9,12 @@ import {
   Primitive,
   Value,
 } from '../../../liveobjects';
+import { DefaultInstance } from './instance';
 import { LiveCounter } from './livecounter';
 import { LiveCounterValueType } from './livecountervaluetype';
 import { LiveMapValueType } from './livemapvaluetype';
 import { LiveObject, LiveObjectData, LiveObjectUpdate, LiveObjectUpdateNoop } from './liveobject';
+import { DefaultPathObject } from './pathobject';
 import {
   getObjectDataPrimitive,
   MapRemove,
@@ -185,6 +187,19 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
         typeof value !== 'object')
     ) {
       throw new client.ErrorInfo('Map value data type is unsupported', 40013, 400); // OD4a
+    }
+
+    // RTLMV4c1 - live objects obtained from the channel, and the public objects that wrap them,
+    // are not valid map values. Without this check they would fall through to the JSON encoding
+    // branch and fail with a confusing serialization error (or leak internal state to the wire).
+    // To assign an object to a key, a new object must be created via the LiveMap.create() or
+    // LiveCounter.create() value types instead.
+    if (value instanceof LiveObject || value instanceof DefaultPathObject || value instanceof DefaultInstance) {
+      throw new client.ErrorInfo(
+        'Map value data type is unsupported: a reference to an existing object cannot be assigned as a map value; use LiveMap.create() or LiveCounter.create() to create a new object',
+        40013,
+        400,
+      );
     }
   }
 

--- a/test/realtime/liveobjects.test.js
+++ b/test/realtime/liveobjects.test.js
@@ -4060,7 +4060,7 @@ define(['ably', 'shared_helper', 'chai', 'liveobjects', 'liveobjects_helper'], f
         {
           description: 'LiveMap.set throws on invalid input',
           action: async (ctx) => {
-            const { objectsHelper, channelName, entryInstance } = ctx;
+            const { objectsHelper, channelName, entryInstance, entryPathObject } = ctx;
 
             const mapCreatedPromise = waitForMapKeyUpdate(entryInstance, 'map');
             await objectsHelper.createAndSetOnMap(channelName, {
@@ -4086,6 +4086,12 @@ define(['ably', 'shared_helper', 'chai', 'liveobjects', 'liveobjects_helper'], f
             await expectToThrowAsync(async () => map.set('key', null), 'Map value data type is unsupported');
             await expectToThrowAsync(async () => map.set('key', BigInt(1)), 'Map value data type is unsupported');
             await expectToThrowAsync(async () => map.set('key', Symbol()), 'Map value data type is unsupported');
+
+            // RTLMV4c1 - references to existing objects (Instance or PathObject) are not valid
+            // map values; only LiveMap.create()/LiveCounter.create() value types can assign objects
+            await expectToThrowAsync(async () => map.set('key', map), 'Map value data type is unsupported');
+            await expectToThrowAsync(async () => map.set('key', entryInstance), 'Map value data type is unsupported');
+            await expectToThrowAsync(async () => map.set('key', entryPathObject), 'Map value data type is unsupported');
           },
         },
 


### PR DESCRIPTION
## Problem

Passing an object obtained from the channel — an `Instance` or `PathObject` wrapper, or an internal `LiveObject` — as a *value* to a map write was not caught by validation. A very natural call like:

```js
const a = map.get('a');     // returns an Instance
await map.set('b', a);      // 💥
```

passed `LiveMap.validateKeyValue` (which accepts any non-null `object`), fell through to the JSON encoding branch in `primitiveToObjectData` (`{ json: value }`), and then blew up at publish time inside wire encoding with:

```
TypeError: Converting circular structure to JSON
```

— a raw `TypeError` rather than a proper `ErrorInfo`, with no hint about what the user did wrong. (For a non-circular object it would instead silently serialize internal SDK state onto the wire.)

The TypeScript typings don't fully guard this either: the public `LiveMap`/`LiveCounter` branded types are inhabited by both the `create()` value types and the live objects in user type schemas, so this mistake can type-check.

## Why rejecting (rather than supporting) is correct

Per the objects spec, object-valued writes accept only the **creation value types** returned by `LiveMap.create()` / `LiveCounter.create()`, which are evaluated into `*_CREATE` operations at write time (RTLM20a3, RTLM20e7g, validated per RTLMV4c). Assigning a *reference to an existing object* was deliberately removed from the write API when the value-type design replaced the old RTLM20e5a behaviour. A new spec point making the rejection explicit (RTLMV4c1: live objects and their `PathObject`/`Instance` wrappers must be rejected with `40013`) is being added in the specification repo alongside this PR.

## Fix

Add a check to `LiveMap.validateKeyValue` rejecting `LiveObject`, `DefaultPathObject` and `DefaultInstance` instances with `ErrorInfo(40013, 400)` and an actionable message pointing the user at `LiveMap.create()` / `LiveCounter.create()`.

Because `validateKeyValue` is the single validation chokepoint, this covers all write paths: `LiveMap.set`, `Instance.set`, `PathObject.set`, `BatchContext` writes, and entry evaluation in `LiveMap.create()`.

## Testing

Extended the existing `LiveMap.set throws on invalid input` scenario with three cases: passing the map's own `Instance`, another `Instance`, and a `PathObject` as values. Verified the new assertions fail before the fix (with the `Converting circular structure to JSON` error above) and pass after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to prevent assignment of existing live objects as map values. The system now properly rejects such operations with a helpful error message and guides users to create new values using the designated creation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->