### PR TITLE
feat(react): allow omitting channelName to use the nearest ChannelProvider

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -71,6 +71,36 @@ const { channel } = useChannel('your-channel-name', (message) => {
 
 Every time a message is sent to `your-channel-name` it'll be logged to the console. You can do whatever you need to with those messages.
 
+#### Omitting the channel name
+
+When a channel-based hook (`useChannel`, `usePresence`, `usePresenceListener`, `useChannelStateListener`) is called without a channel name, it resolves to the channel of the closest enclosing `ChannelProvider`. This avoids repeating the name when there is a surrounding provider:
+
+```jsx
+<ChannelProvider channelName="your-channel-name">
+  <Component />
+</ChannelProvider>;
+
+// Inside Component — no channel name needed:
+const { channel } = useChannel((message) => {
+  console.log(message);
+});
+```
+
+When providers are nested, the nearest one wins. You can still pass an explicit channel name to target a specific enclosing provider by name:
+
+```jsx
+<ChannelProvider channelName="outer">
+  <ChannelProvider channelName="inner">
+    {/* useChannel(...) resolves to "inner"; useChannel("outer", ...) resolves to "outer" */}
+  </ChannelProvider>
+</ChannelProvider>
+```
+
+> [!NOTE]
+> Channel resolution is scoped by `ablyId`. A hook called without an `ablyId` uses the `default` one, so it only resolves to a `ChannelProvider` that also uses the `default` `ablyId`. If your `ChannelProvider` uses a non-default `ablyId`, you must pass it to the hook for the channel to be inferred, for example `useChannel({ ablyId: 'your-ably-id' })`.
+
+<!-- -->
+
 > [!NOTE]
 > Our react hooks are designed to run on the client-side, so if you are using server-side rendering, make sure that your components which use Ably react hooks are only rendered on the client side.
 
@@ -196,6 +226,13 @@ usePresence('your-channel-name', { foo: 'bar' });
 usePresence('another-channel-name', 123);
 usePresence('third-channel-name', 'initial status');
 ```
+
+> [!NOTE]
+> Unlike the other channel-based hooks, `usePresence` cannot infer the channel from the nearest `ChannelProvider` when you call it with presence data only. Because the presence data can itself be a string or object, it is indistinguishable from a channel name or options object, so `usePresence(presenceData)` would be treated as a channel name. To infer the channel while still passing presence data, pass `undefined` as the first argument:
+>
+> ```javascript
+> usePresence(undefined, { foo: 'bar' });
+> ```
 
 If you're using `TypeScript` there are type hints to make sure that value passed to `updateStatus` is of the same `type` as your initial constraint, or a provided generic type parameter:
 

--- a/src/platform/react-hooks/src/AblyContext.tsx
+++ b/src/platform/react-hooks/src/AblyContext.tsx
@@ -20,6 +20,10 @@ export type AblyContextValue = Record<string, AblyContextProviderProps>;
 export interface AblyContextProviderProps {
   client: Ably.RealtimeClient;
   _channelNameToChannelContext: Record<string, ChannelContextProps>;
+  // The channel named by the closest enclosing `ChannelProvider`. Channel hooks
+  // called without an explicit channel name resolve to this, so the name does
+  // not have to be repeated when there is a surrounding provider.
+  _nearestChannelName?: string;
 }
 
 export interface ChannelContextProps {

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -1,7 +1,13 @@
 import * as Ably from 'ably';
 
 export type ChannelNameAndOptions = {
-  channelName: string;
+  /**
+   * The name of the channel to use. When omitted, channel hooks resolve to the
+   * channel named by the closest enclosing `ChannelProvider`. Resolution is
+   * scoped by `ablyId`, so a channel is only inferred from a `ChannelProvider`
+   * that uses the same `ablyId` (the `default` one when none is provided).
+   */
+  channelName?: string;
   ablyId?: string;
   skip?: boolean;
 

--- a/src/platform/react-hooks/src/ChannelProvider.tsx
+++ b/src/platform/react-hooks/src/ChannelProvider.tsx
@@ -40,6 +40,7 @@ export const ChannelProvider = ({
             derived,
           },
         },
+        _nearestChannelName: channelName,
       },
     };
   }, [derived, client, channel, channelName, _channelNameToChannelContext, ablyId, context]);

--- a/src/platform/react-hooks/src/hooks/useChannel.ts
+++ b/src/platform/react-hooks/src/hooks/useChannel.ts
@@ -19,6 +19,8 @@ export interface ChannelResult {
 
 type SubscribeArgs = [string, AblyMessageCallback] | [AblyMessageCallback];
 
+// The channel name can be omitted to use the channel from the nearest ChannelProvider.
+export function useChannel(callbackOnMessage?: AblyMessageCallback): ChannelResult;
 export function useChannel(
   channelNameOrNameAndOptions: ChannelParameters,
   callbackOnMessage?: AblyMessageCallback,
@@ -30,19 +32,34 @@ export function useChannel(
 ): ChannelResult;
 
 export function useChannel(
-  channelNameOrNameAndOptions: ChannelParameters,
+  channelNameOrNameAndOptionsOrCallback?: ChannelParameters | AblyMessageCallback,
   eventOrCallback?: string | AblyMessageCallback,
   callback?: AblyMessageCallback,
 ): ChannelResult {
+  // The first argument is the message callback when the channel name is
+  // inferred from a surrounding ChannelProvider, e.g. useChannel(listener).
+  const inferChannelFromNearestProvider = typeof channelNameOrNameAndOptionsOrCallback === 'function';
+  const channelNameOrNameAndOptions = inferChannelFromNearestProvider
+    ? undefined
+    : (channelNameOrNameAndOptionsOrCallback as ChannelParameters | undefined);
+  const eventOrCallbackArg = inferChannelFromNearestProvider
+    ? (channelNameOrNameAndOptionsOrCallback as AblyMessageCallback)
+    : eventOrCallback;
+
   const channelHookOptions =
     typeof channelNameOrNameAndOptions === 'object'
       ? channelNameOrNameAndOptions
-      : { channelName: channelNameOrNameAndOptions };
+      : channelNameOrNameAndOptions === undefined
+        ? {}
+        : { channelName: channelNameOrNameAndOptions };
 
   const ably = useAbly(channelHookOptions.ablyId);
-  const { channelName, skip } = channelHookOptions;
+  const { skip } = channelHookOptions;
 
-  const { channel, derived } = useChannelInstance(channelHookOptions.ablyId, channelName);
+  const { channel, derived, channelName } = useChannelInstance(
+    channelHookOptions.ablyId,
+    channelHookOptions.channelName,
+  );
 
   const publish: Ably.RealtimeChannel['publish'] = useMemo(() => {
     if (!derived) return channel.publish.bind(channel);
@@ -51,8 +68,8 @@ export function useChannel(
     return regularChannel.publish.bind(regularChannel);
   }, [ably.channels, derived, channel, channelName]);
 
-  const channelEvent = typeof eventOrCallback === 'string' ? eventOrCallback : null;
-  const ablyMessageCallback = typeof eventOrCallback === 'string' ? callback : eventOrCallback;
+  const channelEvent = typeof eventOrCallbackArg === 'string' ? eventOrCallbackArg : null;
+  const ablyMessageCallback = typeof eventOrCallbackArg === 'string' ? callback : eventOrCallbackArg;
 
   const ablyMessageCallbackRef = useRef(ablyMessageCallback);
 

--- a/src/platform/react-hooks/src/hooks/useChannelInstance.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelInstance.ts
@@ -1,14 +1,28 @@
 import React from 'react';
 import { AblyContext, ChannelContextProps } from '../AblyContext.js';
 
-export function useChannelInstance(ablyId = 'default', channelName: string): ChannelContextProps {
-  const channelContext = React.useContext(AblyContext)[ablyId]._channelNameToChannelContext[channelName];
+export type ResolvedChannelContextProps = ChannelContextProps & { channelName: string };
 
-  if (!channelContext) {
+export function useChannelInstance(ablyId = 'default', channelName?: string): ResolvedChannelContextProps {
+  const { _channelNameToChannelContext, _nearestChannelName } = React.useContext(AblyContext)[ablyId];
+
+  // When no channel name is provided, resolve to the channel named by the
+  // closest enclosing `ChannelProvider`.
+  const resolvedChannelName = channelName ?? _nearestChannelName;
+
+  if (resolvedChannelName === undefined) {
     throw new Error(
-      `Could not find a parent ChannelProvider in the component tree for channelName="${channelName}". Make sure your channel based hooks (usePresence, useChannel, useChannelStateListener) are called inside a <ChannelProvider> component`,
+      'No channel name was provided and there is no parent ChannelProvider to infer one from. Make sure your channel based hooks (usePresence, useChannel, useChannelStateListener) are called inside a <ChannelProvider> component, or pass a channel name explicitly',
     );
   }
 
-  return channelContext;
+  const channelContext = _channelNameToChannelContext[resolvedChannelName];
+
+  if (!channelContext) {
+    throw new Error(
+      `Could not find a parent ChannelProvider in the component tree for channelName="${resolvedChannelName}". Make sure your channel based hooks (usePresence, useChannel, useChannelStateListener) are called inside a <ChannelProvider> component`,
+    );
+  }
+
+  return { ...channelContext, channelName: resolvedChannelName };
 }

--- a/src/platform/react-hooks/src/hooks/useChannelStateListener.ts
+++ b/src/platform/react-hooks/src/hooks/useChannelStateListener.ts
@@ -5,6 +5,9 @@ import { useChannelInstance } from './useChannelInstance.js';
 
 type ChannelStateListener = (stateChange: Ably.ChannelStateChange) => any;
 
+// The channel name can be omitted to use the channel from the nearest ChannelProvider.
+export function useChannelStateListener(listener?: ChannelStateListener);
+
 export function useChannelStateListener(channelName: string, listener?: ChannelStateListener);
 
 export function useChannelStateListener(options: ChannelNameAndAblyId, listener?: ChannelStateListener);
@@ -16,22 +19,39 @@ export function useChannelStateListener(
 );
 
 export function useChannelStateListener(
-  channelNameOrNameAndAblyId: ChannelNameAndAblyId | string,
+  channelNameOrNameAndAblyIdOrListener?: ChannelNameAndAblyId | string | ChannelStateListener,
   stateOrListener?: Ably.ChannelState | Ably.ChannelState[] | ChannelStateListener,
   listener?: (stateChange: Ably.ChannelStateChange) => any,
 ) {
+  // The first argument is the listener when the channel name is inferred from a
+  // surrounding ChannelProvider, e.g. useChannelStateListener(listener).
+  const inferChannelFromNearestProvider = typeof channelNameOrNameAndAblyIdOrListener === 'function';
+  const channelNameOrNameAndAblyId = inferChannelFromNearestProvider
+    ? undefined
+    : (channelNameOrNameAndAblyIdOrListener as ChannelNameAndAblyId | string | undefined);
+  const stateOrListenerArg = inferChannelFromNearestProvider
+    ? (channelNameOrNameAndAblyIdOrListener as ChannelStateListener)
+    : stateOrListener;
+
   const channelHookOptions =
     typeof channelNameOrNameAndAblyId === 'object'
       ? channelNameOrNameAndAblyId
-      : { channelName: channelNameOrNameAndAblyId };
+      : channelNameOrNameAndAblyId === undefined
+        ? {}
+        : { channelName: channelNameOrNameAndAblyId };
 
   const { ablyId, channelName } = channelHookOptions;
 
   const { channel } = useChannelInstance(ablyId, channelName);
 
-  const _listener = typeof listener === 'function' ? listener : (stateOrListener as ChannelStateListener);
+  const _listener =
+    typeof listener === 'function'
+      ? listener
+      : typeof stateOrListenerArg === 'function'
+        ? stateOrListenerArg
+        : undefined;
 
-  const state = typeof stateOrListener !== 'function' ? stateOrListener : undefined;
+  const state = typeof stateOrListenerArg === 'function' ? undefined : stateOrListenerArg;
 
   useEventListener<Ably.ChannelState, Ably.ChannelStateChange>(channel, _listener, state);
 }

--- a/src/platform/react-hooks/src/hooks/useInferredChannelName.test.tsx
+++ b/src/platform/react-hooks/src/hooks/useInferredChannelName.test.tsx
@@ -1,0 +1,241 @@
+import React, { useState } from 'react';
+import { it, beforeEach, describe, expect, vi } from 'vitest';
+import { render, renderHook, screen } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import * as Ably from 'ably';
+import { FakeAblySdk, FakeAblyChannels } from '../fakes/ably.js';
+import { AblyProvider } from '../AblyProvider.js';
+import { ChannelProvider } from '../ChannelProvider.js';
+import { useChannel } from './useChannel.js';
+import { usePresence } from './usePresence.js';
+import { usePresenceListener } from './usePresenceListener.js';
+import { useChannelStateListener } from './useChannelStateListener.js';
+
+// These tests cover resolving the channel from the nearest ChannelProvider when
+// the channel name is omitted from a channel based hook.
+describe('inferring the channel name from the nearest ChannelProvider', () => {
+  let channels: FakeAblyChannels;
+  let ablyClient: FakeAblySdk;
+  let otherClient: FakeAblySdk;
+
+  beforeEach(() => {
+    channels = new FakeAblyChannels(['outer', 'inner']);
+    ablyClient = new FakeAblySdk().connectTo(channels);
+    otherClient = new FakeAblySdk().connectTo(channels);
+  });
+
+  const wrapInProviders = (channelName: string, children: React.ReactNode) =>
+    render(
+      <AblyProvider client={ablyClient as unknown as Ably.RealtimeClient}>
+        <ChannelProvider channelName={channelName}>{children}</ChannelProvider>
+      </AblyProvider>,
+    );
+
+  /** @nospec */
+  it('useChannel(callback) subscribes to the surrounding channel', async () => {
+    const Component = () => {
+      const [messages, setMessages] = useState<Ably.Message[]>([]);
+      useChannel((message) => setMessages((prev) => [...prev, message]));
+      return (
+        <ul role="messages">
+          {messages.map((m, i) => (
+            <li key={i}>{m.data.text}</li>
+          ))}
+        </ul>
+      );
+    };
+
+    wrapInProviders('inner', <Component />);
+
+    await act(async () => {
+      await otherClient.channels.get('inner').publish({ text: 'hello' });
+    });
+
+    const list = screen.getAllByRole('messages')[0];
+    expect(list.childElementCount).toBe(1);
+    expect(list.children[0].innerHTML).toBe('hello');
+  });
+
+  /** @nospec */
+  it('useChannel() returns a publish bound to the surrounding channel', async () => {
+    const { result } = renderHook(() => useChannel(), {
+      wrapper: ({ children }) => (
+        <AblyProvider client={ablyClient as unknown as Ably.RealtimeClient}>
+          <ChannelProvider channelName="inner">{children}</ChannelProvider>
+        </AblyProvider>
+      ),
+    });
+
+    expect(result.current.channel.name).toBe('inner');
+    expect(typeof result.current.publish).toBe('function');
+  });
+
+  /** @nospec */
+  it('useChannel() publish works for a derived surrounding channel', async () => {
+    const { result } = renderHook(() => useChannel(), {
+      wrapper: ({ children }) => (
+        <AblyProvider client={ablyClient as unknown as Ably.RealtimeClient}>
+          <ChannelProvider channelName="inner" deriveOptions={{ filter: 'headers.user == `"robert.pike@domain.io"`' }}>
+            {children}
+          </ChannelProvider>
+        </AblyProvider>
+      ),
+    });
+
+    const { channel, publish } = result.current;
+
+    // Publishing directly on a derived channel is not allowed.
+    await expect(channel.publish('test', 'test')).rejects.toThrow();
+    // The publish returned by the hook uses a transient publish and works.
+    await publish('test', 'test');
+  });
+
+  /** @nospec */
+  it('resolves to the nearest provider when providers are nested', async () => {
+    const Component = () => {
+      const [messages, setMessages] = useState<Ably.Message[]>([]);
+      useChannel((message) => setMessages((prev) => [...prev, message]));
+      return (
+        <ul role="messages">
+          {messages.map((m, i) => (
+            <li key={i}>{m.data.text}</li>
+          ))}
+        </ul>
+      );
+    };
+
+    render(
+      <AblyProvider client={ablyClient as unknown as Ably.RealtimeClient}>
+        <ChannelProvider channelName="outer">
+          <ChannelProvider channelName="inner">
+            <Component />
+          </ChannelProvider>
+        </ChannelProvider>
+      </AblyProvider>,
+    );
+
+    await act(async () => {
+      await otherClient.channels.get('outer').publish({ text: 'from outer' });
+      await otherClient.channels.get('inner').publish({ text: 'from inner' });
+    });
+
+    const list = screen.getAllByRole('messages')[0];
+    expect(list.childElementCount).toBe(1);
+    expect(list.children[0].innerHTML).toBe('from inner');
+  });
+
+  /** @nospec */
+  it('an explicit channel name still resolves an outer provider when nested', async () => {
+    const Component = () => {
+      const [messages, setMessages] = useState<Ably.Message[]>([]);
+      useChannel('outer', (message) => setMessages((prev) => [...prev, message]));
+      return (
+        <ul role="messages">
+          {messages.map((m, i) => (
+            <li key={i}>{m.data.text}</li>
+          ))}
+        </ul>
+      );
+    };
+
+    render(
+      <AblyProvider client={ablyClient as unknown as Ably.RealtimeClient}>
+        <ChannelProvider channelName="outer">
+          <ChannelProvider channelName="inner">
+            <Component />
+          </ChannelProvider>
+        </ChannelProvider>
+      </AblyProvider>,
+    );
+
+    await act(async () => {
+      await otherClient.channels.get('outer').publish({ text: 'from outer' });
+    });
+
+    const list = screen.getAllByRole('messages')[0];
+    expect(list.childElementCount).toBe(1);
+    expect(list.children[0].innerHTML).toBe('from outer');
+  });
+
+  /** @nospec */
+  it('throws when there is no surrounding ChannelProvider to infer from', () => {
+    const Component = () => {
+      useChannel(vi.fn());
+      return null;
+    };
+
+    // React logs the error that is thrown during render; silence it for this test.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      expect(() =>
+        render(
+          <AblyProvider client={ablyClient as unknown as Ably.RealtimeClient}>
+            <Component />
+          </AblyProvider>,
+        ),
+      ).toThrowError(/no parent ChannelProvider to infer one from/);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  /** @nospec */
+  it('usePresenceListener(listener) listens on the surrounding channel', async () => {
+    const onPresence = vi.fn();
+    const Component = () => {
+      const { presenceData } = usePresenceListener<{ foo: string }>(onPresence);
+      return (
+        <ul role="presence">
+          {presenceData.map((m, i) => (
+            <li key={i}>{m.data?.foo}</li>
+          ))}
+        </ul>
+      );
+    };
+
+    wrapInProviders('inner', <Component />);
+
+    await act(async () => {
+      await otherClient.channels.get('inner').presence.enter({ foo: 'bar' });
+    });
+
+    const list = screen.getAllByRole('presence')[0];
+    expect(list.childElementCount).toBe(1);
+    expect(list.children[0].innerHTML).toBe('bar');
+    expect(onPresence).toHaveBeenCalled();
+  });
+
+  /** @nospec */
+  it('useChannelStateListener(listener) listens on the surrounding channel', async () => {
+    const Component = () => {
+      const [channelState, setChannelState] = useState<Ably.ChannelState>('initialized');
+      useChannelStateListener((stateChange) => setChannelState(stateChange.current));
+      return <p role="channelState">{channelState}</p>;
+    };
+
+    wrapInProviders('inner', <Component />);
+
+    act(() => {
+      ablyClient.channels.get('inner').emit('attached', { current: 'attached' });
+    });
+
+    expect(screen.getAllByRole('channelState')[0].innerHTML).toBe('attached');
+  });
+
+  /** @nospec */
+  it('usePresence(undefined, data) enters presence on the surrounding channel', async () => {
+    const Component = () => {
+      // The channel name is inferred, so `undefined` is passed as the first
+      // argument and the presence data is passed as the second argument.
+      usePresence(undefined, { foo: 'bar' });
+      return null;
+    };
+
+    await act(async () => {
+      wrapInProviders('inner', <Component />);
+    });
+
+    const presence = await ablyClient.channels.get('inner').presence.get();
+    expect(presence.length).toBe(1);
+  });
+});

--- a/src/platform/react-hooks/src/hooks/usePresence.ts
+++ b/src/platform/react-hooks/src/hooks/usePresence.ts
@@ -14,14 +14,25 @@ export interface PresenceResult<T> {
   channelError: Ably.ErrorInfo | null;
 }
 
+/**
+ * Enter the presence set of a channel.
+ *
+ * The channel name can be omitted to use the channel from the nearest `ChannelProvider`.
+ * Because the presence data can itself be a string or object, it is indistinguishable
+ * from a channel name or options object, so it cannot be passed as the first argument.
+ * To infer the channel while still providing presence data, pass `undefined` as the
+ * first argument: `usePresence(undefined, presenceData)`.
+ */
 export function usePresence<T = any>(
-  channelNameOrNameAndOptions: ChannelParameters,
+  channelNameOrNameAndOptions?: ChannelParameters,
   messageOrPresenceObject?: T,
 ): PresenceResult<T> {
   const params =
     typeof channelNameOrNameAndOptions === 'object'
       ? channelNameOrNameAndOptions
-      : { channelName: channelNameOrNameAndOptions };
+      : channelNameOrNameAndOptions === undefined
+        ? {}
+        : { channelName: channelNameOrNameAndOptions };
   const skip = params.skip;
 
   const ably = useAbly(params.ablyId);

--- a/src/platform/react-hooks/src/hooks/usePresenceListener.ts
+++ b/src/platform/react-hooks/src/hooks/usePresenceListener.ts
@@ -17,24 +17,45 @@ export interface PresenceListenerResult<T> {
 
 export type OnPresenceMessageReceived<T> = (presenceData: PresenceMessage<T>) => void;
 
+// The channel name can be omitted to use the channel from the nearest ChannelProvider.
+export function usePresenceListener<T = any>(
+  onPresenceMessageReceived?: OnPresenceMessageReceived<T>,
+): PresenceListenerResult<T>;
 export function usePresenceListener<T = any>(
   channelNameOrNameAndOptions: ChannelParameters,
   onPresenceMessageReceived?: OnPresenceMessageReceived<T>,
+): PresenceListenerResult<T>;
+
+export function usePresenceListener<T = any>(
+  channelNameOrNameAndOptionsOrListener?: ChannelParameters | OnPresenceMessageReceived<T>,
+  onPresenceMessageReceived?: OnPresenceMessageReceived<T>,
 ): PresenceListenerResult<T> {
+  // The first argument is the listener when the channel name is inferred from a
+  // surrounding ChannelProvider, e.g. usePresenceListener(listener).
+  const inferChannelFromNearestProvider = typeof channelNameOrNameAndOptionsOrListener === 'function';
+  const channelNameOrNameAndOptions = inferChannelFromNearestProvider
+    ? undefined
+    : (channelNameOrNameAndOptionsOrListener as ChannelParameters | undefined);
+  const listener = inferChannelFromNearestProvider
+    ? (channelNameOrNameAndOptionsOrListener as OnPresenceMessageReceived<T>)
+    : onPresenceMessageReceived;
+
   const params =
     typeof channelNameOrNameAndOptions === 'object'
       ? channelNameOrNameAndOptions
-      : { channelName: channelNameOrNameAndOptions };
+      : channelNameOrNameAndOptions === undefined
+        ? {}
+        : { channelName: channelNameOrNameAndOptions };
   const skip = params.skip;
 
   const { channel } = useChannelInstance(params.ablyId, params.channelName);
   const { connectionError, channelError } = useStateErrors(params);
   const [presenceData, updatePresenceData] = useState<Array<PresenceMessage<T>>>([]);
 
-  const onPresenceMessageReceivedRef = useRef(onPresenceMessageReceived);
+  const onPresenceMessageReceivedRef = useRef(listener);
   useEffect(() => {
-    onPresenceMessageReceivedRef.current = onPresenceMessageReceived;
-  }, [onPresenceMessageReceived]);
+    onPresenceMessageReceivedRef.current = listener;
+  }, [listener]);
 
   const updatePresence = useCallback(
     async (message?: Ably.PresenceMessage) => {


### PR DESCRIPTION
[AIT-985](https://ably.atlassian.net/browse/AIT-985)

Implements https://ably.atlassian.net/wiki/spaces/CHN/pages/5150801924/PSDR18+Optional+channelName+in+ably-js+React+channel+hooks

[AIT-985]: https://ably.atlassian.net/browse/AIT-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * React hooks now support omitting the channel name to infer it from the nearest `ChannelProvider`, with correct nested precedence and `ablyId` scoping.
  * Added listener-only/callback-only overloads for `useChannel`, `usePresenceListener`, and `useChannelStateListener`, plus optional channelName support in `useChannelInstance` and `usePresence`.
* **Documentation**
  * Expanded guidance on channel-name inference, including the required `usePresence(undefined, presenceData)` usage to avoid ambiguity.
* **Bug Fixes**
  * Improved error handling when neither an explicit channel name nor a nearby provider channel is available.
* **Tests**
  * Added coverage for inference, nested selection, presence behavior, and missing-provider failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->