### PR TITLE
Release 2.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.23.0](https://github.com/ably/ably-js/tree/2.23.0) (2026-06-19)
+
+[Full Changelog](https://github.com/ably/ably-js/compare/2.22.1...2.23.0)
+
+### What's Changed
+
+- Allow omitting `channelName` in the React channel hooks to use the nearest `ChannelProvider` [#2248](https://github.com/ably/ably-js/pull/2248)
+- Fix presence auto-reenter causing "Unable to perform operation on channel" NACKs after reconnecting from a transient disconnect; presence operations are now queued at the channel level until the channel next re-attaches [#2241](https://github.com/ably/ably-js/pull/2241)
+
 ## [2.22.1](https://github.com/ably/ably-js/tree/2.22.1) (2026-06-08)
 
 [Full Changelog](https://github.com/ably/ably-js/compare/2.22.0...2.22.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.22.1",
+      "version": "2.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -18,7 +18,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.22.1';
+export const version = '2.23.0';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * React channel hooks now allow omitting the channel name to use the nearest channel provider.

* **Bug Fixes**
  * Fixed presence auto-reenter causing NACKs after reconnect by queuing presence operations until re-attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->