### PR TITLE
ci: grant deployments:write to features workflow

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     permissions:
       contents: read
+      deployments: write
       id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:


### PR DESCRIPTION
## Summary

PR #2228 ("ci: harden workflows") scoped the `GITHUB_TOKEN` to least privilege. The `features.yml` `build` job calls the reusable workflow `ably/features/.github/workflows/sdk-features.yml`, which declares it requires:

```yaml
permissions:
  deployments: write
  id-token: write
```

However `features.yml` granted only `contents: read` and `id-token: write` — missing `deployments: write`. A called reusable workflow cannot request a permission the caller did not grant, so this caused an invisible failure at workflow startup (the Features job never ran).

This restores the missing `deployments: write` permission.

## Background

Flagged by @VeskeR on [ably-dotnet#1328](https://github.com/ably/ably-dotnet/pull/1328#pullrequestreview-4448617848), who noted the same regression landed across multiple SDKs (ably-js, ably-python). Broken ably-js run: https://github.com/ably/ably-js/actions/runs/26302842757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an automation workflow’s permissions to support deployment-related actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->