### PR TITLE
feat(push): iOS Live Activity support via APNs broadcast channels

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3767,13 +3767,13 @@ export declare interface PushLiveActivityStartParams {
         /**
          * One or more Ably channel names. Devices subscribed to any of these channels will receive the push-to-start notification. Provide either `channels` or `deviceId`.
          */
-        channels?: string[];
+        channels: string[];
       }
     | {
         /**
          * Restrict the push-to-start notification to a single device. Provide either `channels` or `deviceId`.
          */
-        deviceId?: string;
+        deviceId: string;
       };
   /**
    * The `id` returned from {@link PushAdmin.createApnsBroadcast}.
@@ -3831,6 +3831,8 @@ export declare interface PushLiveActivityEndParams {
 export declare interface PushApnsBroadcastOptions {
   /**
    * Set to `1` to cache the last update payload so late-joining devices receive the current content state immediately on subscription. Set to `0` to disable caching.
+   *
+   * @see https://developer.apple.com/documentation/usernotifications/sending-channel-management-requests-to-apns
    */
   messageStoragePolicy: 0 | 1;
 }

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3703,6 +3703,39 @@ export declare interface PushAdmin {
    * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
    */
   publish(recipient: any, payload: any): Promise<void>;
+  /**
+   * Creates an APNs broadcast channel for use with an iOS Live Activity. Call once before starting the Live Activity and persist the returned ids for the session.
+   *
+   * @experimental This is a preview feature and may change in a future non-major release.
+   *
+   * @param options - Options for the broadcast, including the `messageStoragePolicy`.
+   * @returns A promise resolving to the broadcast `{ id, apnsChannelId }`.
+   */
+  createApnsBroadcast(options: PushApnsBroadcastOptions): Promise<PushApnsBroadcast>;
+}
+
+/**
+ * Options for creating an APNs broadcast channel via {@link PushAdmin.createApnsBroadcast}.
+ */
+export declare interface PushApnsBroadcastOptions {
+  /**
+   * Set to `1` to cache the last update payload so late-joining devices receive the current content state immediately on subscription. Set to `0` to disable caching.
+   */
+  messageStoragePolicy: 0 | 1;
+}
+
+/**
+ * The result of creating an APNs broadcast channel via {@link PushAdmin.createApnsBroadcast}.
+ */
+export declare interface PushApnsBroadcast {
+  /**
+   * The opaque Ably broadcast id.
+   */
+  id: string;
+  /**
+   * The Apple-assigned channel id.
+   */
+  apnsChannelId: string;
 }
 
 /**

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3712,6 +3712,117 @@ export declare interface PushAdmin {
    * @returns A promise resolving to the broadcast `{ id, apnsChannelId }`.
    */
   createApnsBroadcast(options: PushApnsBroadcastOptions): Promise<PushApnsBroadcast>;
+  /**
+   * Controls the lifecycle of iOS Live Activities over an APNs broadcast channel created with {@link PushAdmin.createApnsBroadcast}.
+   *
+   * @experimental This is a preview feature and may change in a future non-major release.
+   */
+  liveActivity: PushLiveActivity;
+}
+
+/**
+ * Controls the lifecycle of an iOS Live Activity over an APNs broadcast channel.
+ *
+ * @experimental This is a preview feature and may change in a future non-major release.
+ */
+export declare interface PushLiveActivity {
+  /**
+   * Sends a push-to-start notification to all devices subscribed to the given Ably channels. Each targeted device starts a new Live Activity using its registered push-to-start token.
+   *
+   * @experimental This is a preview feature and may change in a future non-major release.
+   *
+   * @param params - The recipient channels, the broadcast `id`, and a valid APNs Live Activity start payload.
+   * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   */
+  start(params: PushLiveActivityStartParams): Promise<void>;
+  /**
+   * Sends a `content-state` update to all devices with an active Live Activity on the broadcast channel. A single push is sent to the channel; APNs handles fan-out to all subscribed devices.
+   *
+   * @experimental This is a preview feature and may change in a future non-major release.
+   *
+   * @param params - The broadcast `id` and a valid APNs Live Activity update payload.
+   * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   */
+  update(params: PushLiveActivityUpdateParams): Promise<void>;
+  /**
+   * Ends the Live Activity on all subscribed devices and cleans up the APNs channel. After this call, the broadcast `id` is no longer valid.
+   *
+   * @experimental This is a preview feature and may change in a future non-major release.
+   *
+   * @param params - The broadcast `id` and a valid APNs Live Activity end payload.
+   * @returns A promise which resolves upon success of the operation and rejects with an {@link ErrorInfo} object upon its failure.
+   */
+  end(params: PushLiveActivityEndParams): Promise<void>;
+}
+
+/**
+ * Parameters for {@link PushLiveActivity.start}.
+ */
+export declare interface PushLiveActivityStartParams {
+  /**
+   * The targeted recipients of the push-to-start notification.
+   */
+  recipient:
+    | {
+        /**
+         * One or more Ably channel names. Devices subscribed to any of these channels will receive the push-to-start notification. Provide either `channels` or `deviceId`.
+         */
+        channels?: string[];
+      }
+    | {
+        /**
+         * Restrict the push-to-start notification to a single device. Provide either `channels` or `deviceId`.
+         */
+        deviceId?: string;
+      };
+  /**
+   * The `id` returned from {@link PushAdmin.createApnsBroadcast}.
+   */
+  apnsBroadcast: string;
+  /**
+   * A valid APNs Live Activity start payload. The payload is passed through to APNs as-is.
+   */
+  apns: any;
+  /**
+   * Optional APNs delivery headers, such as `apns-priority` and `apns-expiration`. When supplied, these are included in the request body under a `headers` key.
+   */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Parameters for {@link PushLiveActivity.update}.
+ */
+export declare interface PushLiveActivityUpdateParams {
+  /**
+   * The `id` returned from {@link PushAdmin.createApnsBroadcast}.
+   */
+  apnsBroadcast: string;
+  /**
+   * A valid APNs Live Activity update payload. The payload is passed through to APNs as-is.
+   */
+  apns: any;
+  /**
+   * Optional APNs delivery headers, such as `apns-priority` and `apns-expiration`. When supplied, these are included in the request body under a `headers` key.
+   */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Parameters for {@link PushLiveActivity.end}.
+ */
+export declare interface PushLiveActivityEndParams {
+  /**
+   * The `id` returned from {@link PushAdmin.createApnsBroadcast}.
+   */
+  apnsBroadcast: string;
+  /**
+   * A valid APNs Live Activity end payload. The payload is passed through to APNs as-is.
+   */
+  apns: any;
+  /**
+   * Optional APNs delivery headers, such as `apns-priority` and `apns-expiration`. When supplied, these are included in the request body under a `headers` key.
+   */
+  headers?: Record<string, string>;
 }
 
 /**

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -90,11 +90,13 @@ class Admin {
   client: BaseClient;
   deviceRegistrations: DeviceRegistrations;
   channelSubscriptions: ChannelSubscriptions;
+  liveActivity: LiveActivity;
 
   constructor(client: BaseClient) {
     this.client = client;
     this.deviceRegistrations = new DeviceRegistrations(client);
     this.channelSubscriptions = new ChannelSubscriptions(client);
+    this.liveActivity = new LiveActivity(client);
   }
 
   async publish(recipient: any, payload: any): Promise<void> {
@@ -120,8 +122,6 @@ class Admin {
 
     Utils.mixin(headers, client.options.headers);
 
-    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
-
     const requestBody = Utils.encodeBody(
       { messageStoragePolicy: options.messageStoragePolicy },
       client._MsgPack,
@@ -141,6 +141,83 @@ class Admin {
       id: string;
       apnsChannelId: string;
     };
+  }
+}
+
+class LiveActivity {
+  client: BaseClient;
+
+  constructor(client: BaseClient) {
+    this.client = client;
+  }
+
+  async start(params: {
+    recipient: { channels?: string[]; deviceId?: string };
+    apnsBroadcast: string;
+    apns: any;
+    headers?: Record<string, string>;
+  }): Promise<void> {
+    const { recipient, apnsBroadcast, apns, headers } = params;
+
+    const hasChannels = Array.isArray(recipient.channels) && recipient.channels.length > 0;
+    const hasDeviceId = !!recipient.deviceId;
+    if (hasChannels === hasDeviceId) {
+      throw new ErrorInfo(
+        'LiveActivity.start() requires exactly one of recipient.channels or recipient.deviceId',
+        40000,
+        400,
+      );
+    }
+
+    const body: Record<string, any> = { apns };
+    if (hasChannels) {
+      body.channels = recipient.channels;
+    }
+    if (hasDeviceId) {
+      body.deviceId = recipient.deviceId;
+    }
+    if (headers) {
+      body.headers = headers;
+    }
+    await this._post(apnsBroadcast, 'start', body);
+  }
+
+  async update(params: { apnsBroadcast: string; apns: any; headers?: Record<string, string> }): Promise<void> {
+    const { apnsBroadcast, apns, headers } = params;
+    const body: Record<string, any> = { apns };
+    if (headers) {
+      body.headers = headers;
+    }
+    await this._post(apnsBroadcast, 'broadcast', body);
+  }
+
+  async end(params: { apnsBroadcast: string; apns: any; headers?: Record<string, string> }): Promise<void> {
+    const { apnsBroadcast, apns, headers } = params;
+    const body: Record<string, any> = { apns };
+    if (headers) {
+      body.headers = headers;
+    }
+    await this._post(apnsBroadcast, 'end', body);
+  }
+
+  private async _post(apnsBroadcast: string, action: string, body: Record<string, any>): Promise<void> {
+    const client = this.client;
+    const format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json;
+    const requestHeaders = Defaults.defaultPostHeaders(client.options);
+    const params = {};
+
+    Utils.mixin(requestHeaders, client.options.headers);
+
+    const requestBody = Utils.encodeBody(body, client._MsgPack, format);
+    await Resource.post(
+      client,
+      '/push/apnsBroadcastChannels/' + encodeURIComponent(apnsBroadcast) + '/' + action,
+      requestBody,
+      requestHeaders,
+      params,
+      null,
+      true,
+    );
   }
 }
 

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -111,6 +111,37 @@ class Admin {
     const requestBody = Utils.encodeBody(body, client._MsgPack, format);
     await Resource.post(client, '/push/publish', requestBody, headers, params, null, true);
   }
+
+  async createApnsBroadcast(options: { messageStoragePolicy: 0 | 1 }): Promise<{ id: string; apnsChannelId: string }> {
+    const client = this.client;
+    const format = client.options.useBinaryProtocol ? Utils.Format.msgpack : Utils.Format.json,
+      headers = Defaults.defaultPostHeaders(client.options),
+      params = {};
+
+    Utils.mixin(headers, client.options.headers);
+
+    if (client.options.pushFullWait) Utils.mixin(params, { fullWait: 'true' });
+
+    const requestBody = Utils.encodeBody(
+      { messageStoragePolicy: options.messageStoragePolicy },
+      client._MsgPack,
+      format,
+    );
+    const response = await Resource.post(
+      client,
+      '/push/apnsBroadcastChannels',
+      requestBody,
+      headers,
+      params,
+      null,
+      true,
+    );
+
+    return (response.unpacked ? response.body : Utils.decodeBody(response.body, client._MsgPack, format)) as {
+      id: string;
+      apnsChannelId: string;
+    };
+  }
 }
 
 class DeviceRegistrations {

--- a/test/uts/rest/unit/push/push_admin_apns_broadcast.test.ts
+++ b/test/uts/rest/unit/push/push_admin_apns_broadcast.test.ts
@@ -1,0 +1,127 @@
+/**
+ * UTS: Push Admin createApnsBroadcast Tests
+ *
+ * Spec points: RSH1, RSH1d
+ * Source: uts/test/rest/unit/push/push_admin_apns_broadcast.md
+ */
+
+import { expect } from 'chai';
+import { MockHttpClient } from '../../../mock_http';
+import { Ably, installMockHttp, restoreAll } from '../../../helpers';
+
+describe('uts/rest/unit/push/push_admin_apns_broadcast', function () {
+  afterEach(restoreAll);
+
+  /**
+   * createApnsBroadcast sends POST to /push/apnsBroadcastChannels
+   */
+  // UTS: rest/unit/RSH1d/create-apns-broadcast-post-0
+  it('RSH1d - createApnsBroadcast sends POST to /push/apnsBroadcastChannels', async function () {
+    const captured: any[] = [];
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        captured.push(req);
+        req.respond_with(201, { id: 'broadcast-1', apnsChannelId: 'apns-1' });
+      },
+    });
+    installMockHttp(mock);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    await client.push.admin.createApnsBroadcast({ messageStoragePolicy: 1 });
+
+    expect(captured).to.have.length(1);
+    expect(captured[0].method).to.equal('post');
+    expect(captured[0].path).to.equal('/push/apnsBroadcastChannels');
+  });
+
+  /**
+   * createApnsBroadcast body contains messageStoragePolicy
+   */
+  // UTS: rest/unit/RSH1d/message-storage-policy-1
+  it('RSH1d - createApnsBroadcast body contains messageStoragePolicy', async function () {
+    const captured: any[] = [];
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        captured.push(req);
+        req.respond_with(201, { id: 'broadcast-1', apnsChannelId: 'apns-1' });
+      },
+    });
+    installMockHttp(mock);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    await client.push.admin.createApnsBroadcast({ messageStoragePolicy: 0 });
+
+    expect(captured).to.have.length(1);
+    const body = JSON.parse(captured[0].body);
+    expect(body.messageStoragePolicy).to.equal(0);
+  });
+
+  /**
+   * createApnsBroadcast returns { id, apnsChannelId }
+   */
+  // UTS: rest/unit/RSH1d/returns-ids-2
+  it('RSH1d - createApnsBroadcast returns id and apnsChannelId', async function () {
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        req.respond_with(201, { id: 'broadcast-xyz', apnsChannelId: 'apple-channel-abc' });
+      },
+    });
+    installMockHttp(mock);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    const result = await client.push.admin.createApnsBroadcast({ messageStoragePolicy: 1 });
+
+    expect(result.id).to.equal('broadcast-xyz');
+    expect(result.apnsChannelId).to.equal('apple-channel-abc');
+  });
+
+  /**
+   * createApnsBroadcast request includes an auth header
+   */
+  // UTS: rest/unit/RSH1d/auth-header-3
+  it('RSH1d - createApnsBroadcast auth header included', async function () {
+    const captured: any[] = [];
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        captured.push(req);
+        req.respond_with(201, { id: 'broadcast-1', apnsChannelId: 'apns-1' });
+      },
+    });
+    installMockHttp(mock);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    await client.push.admin.createApnsBroadcast({ messageStoragePolicy: 1 });
+
+    expect(captured).to.have.length(1);
+    expect(captured[0].headers.authorization).to.match(/^Basic /);
+  });
+
+  /**
+   * createApnsBroadcast propagates server error
+   */
+  // UTS: rest/unit/RSH1d/server-error-4
+  it('RSH1d - createApnsBroadcast propagates server error', async function () {
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        req.respond_with(400, {
+          error: { code: 40000, statusCode: 400, message: 'Invalid request' },
+        });
+      },
+    });
+    installMockHttp(mock);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+
+    try {
+      await client.push.admin.createApnsBroadcast({ messageStoragePolicy: 1 });
+      expect.fail('Expected createApnsBroadcast to throw');
+    } catch (err: any) {
+      expect(err.code).to.equal(40000);
+    }
+  });
+});

--- a/test/uts/rest/unit/push/push_admin_live_activity.test.ts
+++ b/test/uts/rest/unit/push/push_admin_live_activity.test.ts
@@ -1,0 +1,197 @@
+/**
+ * UTS: Push Admin Live Activity Tests
+ *
+ * Spec points: RSH1, RSH1e, RSH1e1, RSH1e2, RSH1e3
+ * Source: uts/test/rest/unit/push/push_admin_live_activity.md
+ */
+
+import { expect } from 'chai';
+import { MockHttpClient } from '../../../mock_http';
+import { Ably, installMockHttp, restoreAll } from '../../../helpers';
+
+describe('uts/rest/unit/push/push_admin_live_activity', function () {
+  afterEach(restoreAll);
+
+  function mockCapturing(captured: any[], status = 200, responseBody: any = {}) {
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        captured.push(req);
+        req.respond_with(status, responseBody);
+      },
+    });
+    installMockHttp(mock);
+  }
+
+  /**
+   * start sends POST to /push/apnsBroadcastChannels/{id}/start with channels and apns
+   */
+  // UTS: rest/unit/RSH1e1/start-post-0
+  it('RSH1e1 - start sends POST to /push/apnsBroadcastChannels/{id}/start', async function () {
+    const captured: any[] = [];
+    mockCapturing(captured);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    await client.push.admin.liveActivity.start({
+      recipient: { channels: ['nba:lakers', 'nba:celtics'] },
+      apnsBroadcast: 'broadcast-1',
+      apns: { aps: { event: 'start', 'attributes-type': 'GameAttributes' } },
+      headers: { 'apns-priority': '10', 'apns-expiration': '1782948701' },
+    });
+
+    expect(captured).to.have.length(1);
+    expect(captured[0].method).to.equal('post');
+    expect(captured[0].path).to.equal('/push/apnsBroadcastChannels/broadcast-1/start');
+
+    const body = JSON.parse(captured[0].body);
+    expect(body.channels).to.deep.equal(['nba:lakers', 'nba:celtics']);
+    expect(body.apns.aps.event).to.equal('start');
+    expect(body).to.not.have.property('deviceId');
+    // The optional APNs delivery headers are sent in the request body under a `headers` key.
+    expect(body.headers).to.deep.equal({ 'apns-priority': '10', 'apns-expiration': '1782948701' });
+    expect(captured[0].headers.authorization).to.match(/^Basic /);
+  });
+
+  /**
+   * start includes deviceId when supplied and url-encodes the broadcast id
+   */
+  // UTS: rest/unit/RSH1e1/start-deviceid-encode-1
+  it('RSH1e1 - start includes deviceId and url-encodes the broadcast id', async function () {
+    const captured: any[] = [];
+    mockCapturing(captured);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    await client.push.admin.liveActivity.start({
+      recipient: { deviceId: 'device-7' },
+      apnsBroadcast: 'broadcast/with space',
+      apns: { aps: { event: 'start' } },
+    });
+
+    expect(captured).to.have.length(1);
+    expect(captured[0].path).to.equal('/push/apnsBroadcastChannels/broadcast%2Fwith%20space/start');
+    const body = JSON.parse(captured[0].body);
+    expect(body.deviceId).to.equal('device-7');
+    expect(body).to.not.have.property('channels');
+  });
+
+  /**
+   * update sends POST to /push/apnsBroadcastChannels/{id}/broadcast with apns and headers
+   */
+  // UTS: rest/unit/RSH1e2/update-post-0
+  it('RSH1e2 - update sends POST to /push/apnsBroadcastChannels/{id}/broadcast', async function () {
+    const captured: any[] = [];
+    mockCapturing(captured);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    await client.push.admin.liveActivity.update({
+      apnsBroadcast: 'broadcast-1',
+      apns: { aps: { event: 'update', 'content-state': { homeScore: 14 } } },
+      headers: { 'apns-priority': '10', 'apns-expiration': '1782948701' },
+    });
+
+    expect(captured).to.have.length(1);
+    expect(captured[0].method).to.equal('post');
+    expect(captured[0].path).to.equal('/push/apnsBroadcastChannels/broadcast-1/broadcast');
+
+    const body = JSON.parse(captured[0].body);
+    expect(body.apns.aps.event).to.equal('update');
+    // The optional APNs delivery headers are sent in the request body under a `headers` key.
+    expect(body.headers).to.deep.equal({ 'apns-priority': '10', 'apns-expiration': '1782948701' });
+    expect(captured[0].headers.authorization).to.match(/^Basic /);
+  });
+
+  /**
+   * update omits headers when not supplied
+   */
+  // UTS: rest/unit/RSH1e2/update-no-headers-1
+  it('RSH1e2 - update omits headers when not supplied', async function () {
+    const captured: any[] = [];
+    mockCapturing(captured);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    await client.push.admin.liveActivity.update({
+      apnsBroadcast: 'broadcast-1',
+      apns: { aps: { event: 'update', 'content-state': {} } },
+    });
+
+    const body = JSON.parse(captured[0].body);
+    expect(body).to.not.have.property('headers');
+    expect(body.apns.aps.event).to.equal('update');
+  });
+
+  /**
+   * end sends POST to /push/apnsBroadcastChannels/{id}/end with apns
+   */
+  // UTS: rest/unit/RSH1e3/end-post-0
+  it('RSH1e3 - end sends POST to /push/apnsBroadcastChannels/{id}/end', async function () {
+    const captured: any[] = [];
+    mockCapturing(captured);
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+    await client.push.admin.liveActivity.end({
+      apnsBroadcast: 'broadcast-1',
+      apns: { aps: { event: 'end', 'content-state': { homeScore: 112 }, 'dismissal-date': 1700000000 } },
+    });
+
+    expect(captured).to.have.length(1);
+    expect(captured[0].method).to.equal('post');
+    expect(captured[0].path).to.equal('/push/apnsBroadcastChannels/broadcast-1/end');
+
+    const body = JSON.parse(captured[0].body);
+    expect(body.apns.aps.event).to.equal('end');
+    expect(body.apns.aps['dismissal-date']).to.equal(1700000000);
+    expect(captured[0].headers.authorization).to.match(/^Basic /);
+  });
+
+  /**
+   * server errors propagate for each method
+   */
+  // UTS: rest/unit/RSH1e1/server-error-2
+  it('RSH1e1 - start propagates server error', async function () {
+    const captured: any[] = [];
+    mockCapturing(captured, 400, { error: { code: 40000, statusCode: 400, message: 'Invalid request' } });
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+
+    try {
+      await client.push.admin.liveActivity.start({
+        recipient: { channels: ['nba:lakers'] },
+        apnsBroadcast: 'broadcast-1',
+        apns: {},
+      });
+      expect.fail('Expected start to throw');
+    } catch (err: any) {
+      expect(err.code).to.equal(40000);
+    }
+  });
+
+  // UTS: rest/unit/RSH1e2/server-error-2
+  it('RSH1e2 - update propagates server error', async function () {
+    const captured: any[] = [];
+    mockCapturing(captured, 400, { error: { code: 40000, statusCode: 400, message: 'Invalid request' } });
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+
+    try {
+      await client.push.admin.liveActivity.update({ apnsBroadcast: 'broadcast-1', apns: {} });
+      expect.fail('Expected update to throw');
+    } catch (err: any) {
+      expect(err.code).to.equal(40000);
+    }
+  });
+
+  // UTS: rest/unit/RSH1e3/server-error-1
+  it('RSH1e3 - end propagates server error', async function () {
+    const captured: any[] = [];
+    mockCapturing(captured, 400, { error: { code: 40000, statusCode: 400, message: 'Invalid request' } });
+
+    const client = new Ably.Rest({ key: 'appId.keyId:keySecret', useBinaryProtocol: false });
+
+    try {
+      await client.push.admin.liveActivity.end({ apnsBroadcast: 'broadcast-1', apns: {} });
+      expect.fail('Expected end to throw');
+    } catch (err: any) {
+      expect(err.code).to.equal(40000);
+    }
+  });
+});


### PR DESCRIPTION
Spec: https://github.com/ably/specification/pull/500

Summary

Adds Push Admin support for managing iOS Live Activities through APNs broadcast channels. This introduces a two-part API: creating a broadcast channel, then driving the Live Activity lifecycle (start → update → end) over it.

1. push.admin.createApnsBroadcast(options)

Creates an APNs broadcast channel for an iOS Live Activity. Call once before starting the activity and persist the returned ids for the session.

```js
const { id, apnsChannelId } = await rest.push.admin.createApnsBroadcast({
  messageStoragePolicy: 1, // 1 = cache last update so late-joining devices get current state; 0 = disabled
});
```

- New `Admin.createApnsBroadcast` method (`POST /push/apnsBroadcastChannels`).
- New types: `PushApnsBroadcastOptions`, `PushApnsBroadcast`.

2. `push.admin.liveActivity` lifecycle API

A new LiveActivity class exposed as push.admin.liveActivity, managing the lifecycle of a Live Activity over a broadcast channel:

```js
// Push-to-start to all devices subscribed to the given channels
await rest.push.admin.liveActivity.start({
  recipient: { channels: ['channel-1'], deviceId: 'optional-device' },
  apnsBroadcast: id,
  apns: { /* APNs Live Activity start payload */ },
});

// Update content-state (single push; APNs fans out to subscribers)
await rest.push.admin.liveActivity.update({
  apnsBroadcast: id,
  apns: { /* APNs update payload */ },
  headers: { 'apns-priority': 5 },
});

// End the activity on all devices and clean up the channel
await rest.push.admin.liveActivity.end({
  apnsBroadcast: id,
  apns: { /* APNs end payload */ },
});
```

- start → `POST /push/apnsBroadcastChannels/{id}/start` (supports targeting all subscribed channels, optionally restricted to a single deviceId).
- update → `POST /push/apnsBroadcastChannels/{id}/broadcast` (optional apns-priority / apns-expiration headers).
- end → `POST /push/apnsBroadcastChannels/{id}/end`; the broadcast id is no longer valid afterwards.
- APNs payloads are passed through as-is.
- New types: `PushLiveActivity`, `PushLiveActivityStartParams`, `PushLiveActivityUpdateParams`, `PushLiveActivityEndParams`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added iOS Live Activity support via APNs broadcast channels.
  * Introduced APIs to create APNs broadcast channels and manage Live Activities (start, update, end), including support for APNs payload and optional request headers.
* **Tests**
  * Added REST unit tests for APNs broadcast channel creation and Live Activity start/update/end requests, validating request structure and HTTP error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->