### PR TITLE
fix: use error code 40106 for missing credentials (RSC1b)

### DIFF
--- a/src/common/lib/client/auth.ts
+++ b/src/common/lib/client/auth.ts
@@ -84,7 +84,7 @@ function logAndValidateTokenAuthMethod(authOptions: AuthOptions, logger: Logger)
   } else {
     const msg = 'authOptions must include valid authentication parameters';
     Logger.logAction(logger, Logger.LOG_ERROR, 'Auth()', msg);
-    throw new Error(msg);
+    throw new ErrorInfo(msg, 40106, 401);
   }
 }
 
@@ -158,7 +158,7 @@ class Auth {
         const msg =
           'No authentication options provided; need one of: key, authUrl, or authCallback (or for testing only, token or tokenDetails)';
         Logger.logAction(this.logger, Logger.LOG_ERROR, 'Auth()', msg);
-        throw new ErrorInfo(msg, 40160, 401);
+        throw new ErrorInfo(msg, 40106, 401);
       }
       Logger.logAction(this.logger, Logger.LOG_MINOR, 'Auth()', 'anonymous, using basic auth');
       this._saveBasicOptions(options);

--- a/test/uts/deviations.md
+++ b/test/uts/deviations.md
@@ -38,18 +38,6 @@ These tests assert spec behavior but are skipped by default because they are kno
 
 ---
 
-### client_options: RSC1b - wrong error code for missing credentials
-
-**Spec (RSC1b)**: Error code should be 40106.
-
-**ably-js behavior**: Uses error code 40160 instead of 40106. Additionally, `{ useTokenAuth: true }` alone throws with no error code set.
-
-**Tests**: `RSC1b - no credentials raises error`, `RSC1b - clientId alone raises error` (realtime), `RSC1b - Error when no auth method available` (REST).
-
-**Issue**: [#2204](https://github.com/ably/ably-js/issues/2204)
-
----
-
 ### channel_publish: RTL6i3 / RSL1e - null fields included in wire JSON
 
 **Spec (RTL6i3/RSL1e)**: Null values should be omitted from wire JSON.

--- a/test/uts/realtime/unit/client/client_options.test.ts
+++ b/test/uts/realtime/unit/client/client_options.test.ts
@@ -63,7 +63,6 @@ describe('uts/realtime/unit/client/client_options', function () {
    */
   // UTS: realtime/unit/RTC12/invalid-arguments-error-1.1
   it('RSC1b - no credentials raises error', function () {
-    if (!process.env.RUN_DEVIATIONS) this.skip(); // ably-js uses 40160 instead of 40106; see #2204
     try {
       new Ably.Realtime({ autoConnect: false } as any);
       expect.fail('Expected constructor to throw');
@@ -77,14 +76,13 @@ describe('uts/realtime/unit/client/client_options', function () {
     try {
       new Ably.Realtime({ useTokenAuth: true, autoConnect: false } as any);
       expect.fail('Expected constructor to throw');
-    } catch (e) {
-      expect(e).to.be.an('error');
+    } catch (e: any) {
+      expect(e.code).to.equal(40106);
     }
   });
 
   // UTS: realtime/unit/RTC12/invalid-arguments-error-1.3
   it('RSC1b - clientId alone raises error', function () {
-    if (!process.env.RUN_DEVIATIONS) this.skip(); // ably-js uses 40160 instead of 40106; see #2204
     try {
       new Ably.Realtime({ clientId: 'test', autoConnect: false } as any);
       expect.fail('Expected constructor to throw');

--- a/test/uts/rest/unit/auth/auth_scheme.test.ts
+++ b/test/uts/rest/unit/auth/auth_scheme.test.ts
@@ -198,8 +198,6 @@ describe('uts/rest/unit/auth/auth_scheme', function () {
    */
   // UTS: rest/unit/RSC1b/no-auth-method-error-0
   it('RSC1b - Error when no auth method available', function () {
-    // DEVIATION: see deviations.md
-    if (!process.env.RUN_DEVIATIONS) this.skip();
     const captured: any[] = [];
     installMockHttp(simpleMock(captured));
 


### PR DESCRIPTION
Fixes #2204

## Problem

Per spec **RSC1b**, constructing a client with no usable authentication method must fail with error code **40106**. `@ably/ably-js` deviated:

- The basic-auth path (no `key`) threw `ErrorInfo(msg, 40160, 401)` — wrong code.
- The `{ useTokenAuth: true }`-only path threw a plain `Error` with **no code set**.

This is tracked in `test/uts/deviations.md` and the corresponding UTS tests are skipped behind `RUN_DEVIATIONS`.

## Fix

Set both throw sites in `src/common/lib/client/auth.ts` to `ErrorInfo(msg, 40106, 401)`:
- the "No authentication options provided" throw (basic-auth path), and
- `logAndValidateTokenAuthMethod`'s "authOptions must include valid authentication parameters" throw (previously a bare `Error`).

Then resolve the deviation in the test suite:
- Un-skip the RSC1b UTS tests that assert `40106`: *no credentials raises error*, *clientId alone raises error* (realtime), and *Error when no auth method available* (REST).
- Tighten *RSC1b - useTokenAuth without means raises error* to assert `e.code === 40106` (it previously only checked that an error was thrown; `ErrorInfo extends Error`, so this still holds).
- Remove the RSC1b entry from `deviations.md`.

The other `40160` references in the test suite are unrelated (presence/permission errors) and are left untouched.

## Note

This is a customer-affecting behavior change (the error code surfaced on missing credentials changes 40160 → 40106, matching spec). I didn't add a CHANGELOG entry assuming that's handled at release; happy to add one if you'd prefer. I wasn't able to run the full browser UTS suite locally, but the change is minimal and the un-skipped tests assert exactly the new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now returns a consistent `40106` error when credentials or auth settings are missing or invalid.
  * Basic auth initialization also uses the same error code when required credentials are not provided.

* **Tests**
  * Updated test coverage to always verify the corrected error behavior and error code.
  * Removed an outdated skipped test note tied to the previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->