### PR TITLE
feat(react): add useObject hook for LiveObjects

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -24,6 +24,7 @@ The hooks provide a simplified syntax for interacting with Ably, and manage the 
   - [useChannel](#usechannel)
   - [usePresence](#usepresence)
   - [usePresenceListener](#usepresencelistener)
+  - [useObject](#useobject)
 
 ## <!-- /code_chunk_output -->
 
@@ -318,6 +319,83 @@ interface MyPresenceType {
 ```
 
 `presenceData` is a good way to store synchronised, per-client metadata, so types here are especially valuable.
+
+### useObject
+
+The `useObject` hook subscribes to the [LiveObjects](https://ably.com/docs/liveobjects) state on a channel and re-renders your component when it changes. It is exported from its own entry point, `ably/liveobjects/react`, so apps that don't use LiveObjects don't need to import any of its code:
+
+```javascript
+import { useObject } from 'ably/liveobjects/react';
+```
+
+Using the hook requires:
+
+- the `LiveObjects` plugin passed to the Ably client (see the [LiveObjects documentation](https://ably.com/docs/liveobjects/quickstart/javascript)),
+- the `OBJECT_SUBSCRIBE` channel mode (plus `OBJECT_PUBLISH` if you write to objects), set via `ChannelProvider`'s channel options,
+- React 18 or later (the hook is built on `useSyncExternalStore`).
+
+```jsx
+<ChannelProvider channelName="your-channel-name" options={{ modes: ['OBJECT_SUBSCRIBE', 'OBJECT_PUBLISH'] }}>
+  <Component />
+</ChannelProvider>
+```
+
+Called with no arguments, `useObject` subscribes to the channel's root object. `value` is a plain-data snapshot of the object (the result of [`compact()`](https://ably.com/docs/liveobjects/concepts/objects#compact)), and `object` is the live `PathObject` for the subscribed node, which you can use to navigate and to write:
+
+```jsx
+const Scoreboard = () => {
+  const { value, object } = useObject();
+
+  if (!object) return <p>Loading…</p>;
+
+  return <button onClick={() => object.get('scores').get('alice').increment(1)}>Alice: {value.scores.alice}</button>;
+};
+```
+
+Pass a selector to subscribe to a nested node instead. The selector receives the root `PathObject` and must navigate to a descendant using `get`/`at`; the hook subscribes to the node it returns, so the component only re-renders for changes within that node. Navigating to the narrowest node you actually render is the main performance lever:
+
+```jsx
+const AliceScore = () => {
+  const { value, object } = useObject((root) => root.get('scores').get('alice'));
+
+  return <button onClick={() => object?.increment(1)}>Alice: {value ?? 0}</button>;
+};
+```
+
+If you're using TypeScript, annotate the selector's parameter with the shape of your channel's objects and the whole navigation chain is checked at compile time — `value` and `object` are then typed from the chain with no further annotation:
+
+```tsx
+import { LiveCounter, LiveMap, PathObject } from 'ably/liveobjects';
+
+type GameRoot = LiveMap<{
+  scores: LiveMap<{ alice: LiveCounter; bob: LiveCounter }>;
+  title: string;
+}>;
+
+const AliceScore = () => {
+  // value: number | undefined, object: PathObject<LiveCounter> | undefined
+  const { value, object } = useObject((root: PathObject<GameRoot>) => root.get('scores').get('alice'));
+
+  return <button onClick={() => object?.increment(1)}>Alice: {value ?? 0}</button>;
+};
+```
+
+For the no-selector form, provide the root type as a type parameter instead: `useObject<GameRoot>()`.
+
+The root object resolves asynchronously (after the channel attaches and the initial sync completes), so the hook's readiness is derived from the result: `object === undefined && error === null` means loading, `error !== null` means the object could not be resolved (for example the `LiveObjects` plugin is missing, or the channel lacks the object modes — `error` carries ably-js's own `ErrorInfo`), and a defined `object` means ready, with `value` carrying the data once the node exists.
+
+Two things to note about `value`:
+
+- It is a cached snapshot: its identity only changes when the subscribed node changes, so it is safe to use in dependency arrays.
+- It is a by-value copy: the same logical node reached through two different hooks is not reference-equal. Compare fields rather than snapshots, and use `object` when you need a stable identity.
+
+Like the other channel hooks, `useObject` accepts the standard options (`channelName`, `ablyId`, `skip`, `onConnectionError`, `onChannelError`) and returns `connectionError` / `channelError`:
+
+```javascript
+const { value, error, connectionError, channelError } = useObject((root) => root.get('scores'), {
+  channelName: 'your-channel-name',
+});
+```
 
 ### useConnectionStateListener
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -30,7 +30,7 @@ The hooks provide a simplified syntax for interacting with Ably, and manage the 
 
 ### Compatible React Versions
 
-The hooks are compatible with all versions of React above 16.8.0
+The hooks are compatible with all versions of React above 16.8.0, with the exception of `useObject`, which requires React 18 or later.
 
 ## Usage
 
@@ -340,7 +340,7 @@ Using the hook requires:
 </ChannelProvider>
 ```
 
-Called with no arguments, `useObject` subscribes to the channel's root object. `value` is a plain-data snapshot of the object (the result of [`compact()`](https://ably.com/docs/liveobjects/concepts/objects#compact)), and `object` is the live `PathObject` for the subscribed node, which you can use to navigate and to write:
+Called with no arguments, `useObject` subscribes to the channel's object. `value` is a plain-data snapshot of the object (the result of [`compact()`](https://ably.com/docs/liveobjects/concepts/objects#compact)), and `object` is the live `PathObject` for the subscribed node, which you can use to navigate and to write:
 
 ```jsx
 const Scoreboard = () => {
@@ -352,37 +352,50 @@ const Scoreboard = () => {
 };
 ```
 
-Pass a selector to subscribe to a nested node instead. The selector receives the root `PathObject` and must navigate to a descendant using `get`/`at`; the hook subscribes to the node it returns, so the component only re-renders for changes within that node. Navigating to the narrowest node you actually render is the main performance lever:
+Pass a selector to subscribe to a nested node instead. The selector receives the channel's object as a `PathObject` and must navigate to a descendant using `get`/`at`; the hook subscribes to the node it returns, so the component only re-renders for changes within that node. Navigating to the narrowest node you actually render is the main performance lever:
 
 ```jsx
 const AliceScore = () => {
-  const { value, object } = useObject((root) => root.get('scores').get('alice'));
+  const { value, object } = useObject((obj) => obj.get('scores').get('alice'));
 
   return <button onClick={() => object?.increment(1)}>Alice: {value ?? 0}</button>;
 };
 ```
 
-If you're using TypeScript, annotate the selector's parameter with the shape of your channel's objects and the whole navigation chain is checked at compile time — `value` and `object` are then typed from the chain with no further annotation:
+If you're using TypeScript, annotate the selector's parameter with the shape of your channel's object and the whole navigation chain is checked at compile time — `value` and `object` are then typed from the chain with no further annotation:
 
 ```tsx
 import { LiveCounter, LiveMap, PathObject } from 'ably/liveobjects';
 
-type GameRoot = LiveMap<{
+type Game = {
   scores: LiveMap<{ alice: LiveCounter; bob: LiveCounter }>;
   title: string;
-}>;
+};
 
 const AliceScore = () => {
   // value: number | undefined, object: PathObject<LiveCounter> | undefined
-  const { value, object } = useObject((root: PathObject<GameRoot>) => root.get('scores').get('alice'));
+  const { value, object } = useObject((obj: PathObject<LiveMap<Game>>) => obj.get('scores').get('alice'));
 
   return <button onClick={() => object?.increment(1)}>Alice: {value ?? 0}</button>;
 };
 ```
 
-For the no-selector form, provide the root type as a type parameter instead: `useObject<GameRoot>()`.
+For the no-selector form, provide the shape of the channel's object as a type parameter instead — `useObject<Game>()` — the same type parameter that `channel.object.get<Game>()` takes.
 
-The root object resolves asynchronously (after the channel attaches and the initial sync completes), so the hook's readiness is derived from the result: `object === undefined && error === null` means loading, `error !== null` means the object could not be resolved (for example the `LiveObjects` plugin is missing, or the channel lacks the object modes — `error` carries ably-js's own `ErrorInfo`), and a defined `object` means ready, with `value` carrying the data once the node exists.
+If the object cannot be resolved — for example the `LiveObjects` plugin is missing from the client, or the channel lacks the object modes — the hook reports this through the `error` return value, which carries ably-js's own `ErrorInfo` describing the failure:
+
+```jsx
+const Scoreboard = () => {
+  const { value, object, error } = useObject();
+
+  if (error) return <p>Objects failed to load: {error.message}</p>;
+  if (!object) return <p>Loading…</p>;
+
+  return <p>Alice: {value.scores.alice}</p>;
+};
+```
+
+The channel's object resolves asynchronously (after the channel attaches and the initial sync completes), so the hook's readiness is derived from the result: `object === undefined && error === null` means loading, `error !== null` means the object could not be resolved, and a defined `object` means ready, with `value` carrying the data once the node exists.
 
 Two things to note about `value`:
 
@@ -392,7 +405,7 @@ Two things to note about `value`:
 Like the other channel hooks, `useObject` accepts the standard options (`channelName`, `ablyId`, `skip`, `onConnectionError`, `onChannelError`) and returns `connectionError` / `channelError`:
 
 ```javascript
-const { value, error, connectionError, channelError } = useObject((root) => root.get('scores'), {
+const { value, error, connectionError, channelError } = useObject((obj) => obj.get('scores'), {
   channelName: 'your-channel-name',
 });
 ```

--- a/liveobjects/react.d.ts
+++ b/liveobjects/react.d.ts
@@ -1,0 +1,7 @@
+// Type declarations for the `ably/liveobjects/react` entry point under the
+// classic `node`/`node10` module resolution, which resolves this subpath by
+// filesystem path and does not read the package `exports` field. Modern
+// resolvers (`node16`, `bundler`) reach the real declarations through
+// `exports`. The runtime implementation is provided by `exports` in every
+// resolver, since Node itself honours `exports` at runtime.
+export * from '../react/cjs/liveobjects/index';

--- a/package.json
+++ b/package.json
@@ -45,8 +45,14 @@
       }
     },
     "./liveobjects/react": {
-      "require": "./react/cjs/liveobjects/index.js",
-      "import": "./react/mjs/liveobjects/index.js"
+      "import": {
+        "types": "./react/mjs/liveobjects/index.d.ts",
+        "default": "./react/mjs/liveobjects/index.js"
+      },
+      "require": {
+        "types": "./react/cjs/liveobjects/index.d.ts",
+        "default": "./react/cjs/liveobjects/index.js"
+      }
     },
     "./promises": {
       "types": "./promises.d.ts",

--- a/package.json
+++ b/package.json
@@ -45,14 +45,8 @@
       }
     },
     "./liveobjects/react": {
-      "import": {
-        "types": "./react/mjs/liveobjects/index.d.ts",
-        "default": "./react/mjs/liveobjects/index.js"
-      },
-      "require": {
-        "types": "./react/cjs/liveobjects/index.d.ts",
-        "default": "./react/cjs/liveobjects/index.js"
-      }
+      "require": "./react/cjs/liveobjects/index.js",
+      "import": "./react/mjs/liveobjects/index.js"
     },
     "./promises": {
       "types": "./promises.d.ts",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "callbacks.js",
     "liveobjects.d.ts",
     "liveobjects.d.mts",
+    "liveobjects/react.d.ts",
     "modular.d.ts",
     "promises.d.ts",
     "promises.js",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
         "default": "./build/liveobjects.js"
       }
     },
+    "./liveobjects/react": {
+      "require": "./react/cjs/liveobjects/index.js",
+      "import": "./react/mjs/liveobjects/index.js"
+    },
     "./promises": {
       "types": "./promises.d.ts",
       "default": "./promises.js"

--- a/src/platform/react-hooks/src/fakes/liveobjects.ts
+++ b/src/platform/react-hooks/src/fakes/liveobjects.ts
@@ -1,0 +1,134 @@
+// A fake, in-memory implementation of the LiveObjects surface used by
+// useObject: plain JSON data addressed by path segments, with mutation helpers
+// that notify path subscriptions the way nested observation does.
+
+interface PathListener {
+  path: string[];
+  callback: () => void;
+}
+
+export class FakeRealtimeObject {
+  public data: Record<string, unknown>;
+  public getCalls = 0;
+  public listeners = new Set<PathListener>();
+
+  private releaseGate?: () => void;
+  private getGate?: Promise<void>;
+  private getError?: unknown;
+
+  constructor(data: Record<string, unknown> = {}) {
+    this.data = data;
+  }
+
+  /** Make get() wait until releaseGet() is called. */
+  public deferGet() {
+    this.getGate = new Promise((resolve) => (this.releaseGate = resolve));
+  }
+
+  /** Resolve a get() previously deferred with deferGet(). */
+  public releaseGet() {
+    this.releaseGate?.();
+  }
+
+  /** Make get() reject with the given error. */
+  public failGet(error: unknown) {
+    this.getError = error;
+  }
+
+  public async get(): Promise<FakePathObject> {
+    this.getCalls++;
+    if (this.getError) {
+      throw this.getError;
+    }
+    if (this.getGate) {
+      await this.getGate;
+    }
+    return new FakePathObject(this, []);
+  }
+
+  /** Set the value at a path and notify overlapping subscriptions. */
+  public set(path: string[], value: unknown) {
+    if (path.length === 0) {
+      throw new Error('cannot replace the root');
+    }
+    let target = this.data;
+    for (const segment of path.slice(0, -1)) {
+      if (typeof target[segment] !== 'object' || target[segment] === null) {
+        target[segment] = {};
+      }
+      target = target[segment] as Record<string, unknown>;
+    }
+    target[path[path.length - 1]] = value;
+    this.notify(path);
+  }
+
+  public valueAt(path: string[]): unknown {
+    let current: unknown = this.data;
+    for (const segment of path) {
+      if (current === null || typeof current !== 'object') {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+    return current;
+  }
+
+  private notify(changedPath: string[]) {
+    for (const listener of this.listeners) {
+      // nested observation: a subscription at a path observes changes at or
+      // below its path, and a change to an ancestor also affects the path
+      const overlap = Math.min(listener.path.length, changedPath.length);
+      let matches = true;
+      for (let i = 0; i < overlap; i++) {
+        if (listener.path[i] !== changedPath[i]) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) {
+        listener.callback();
+      }
+    }
+  }
+}
+
+export class FakePathObject {
+  private owner: FakeRealtimeObject;
+  private segments: string[];
+
+  constructor(owner: FakeRealtimeObject, segments: string[]) {
+    this.owner = owner;
+    this.segments = segments;
+  }
+
+  public get(key: string): FakePathObject {
+    return new FakePathObject(this.owner, [...this.segments, key]);
+  }
+
+  public at(path: string): FakePathObject {
+    return new FakePathObject(this.owner, [...this.segments, ...path.split('.')]);
+  }
+
+  public path(): string {
+    return this.segments.join('.');
+  }
+
+  /** Like the real compact(), returns a fresh copy on every call. */
+  public compact(): unknown {
+    const value = this.owner.valueAt(this.segments);
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  public subscribe(callback: () => void) {
+    const listener: PathListener = { path: this.segments, callback };
+    this.owner.listeners.add(listener);
+    return {
+      unsubscribe: () => {
+        this.owner.listeners.delete(listener);
+      },
+    };
+  }
+}

--- a/src/platform/react-hooks/src/fakes/liveobjects.ts
+++ b/src/platform/react-hooks/src/fakes/liveobjects.ts
@@ -11,6 +11,8 @@ export class FakeRealtimeObject {
   public data: Record<string, unknown>;
   public getCalls = 0;
   public listeners = new Set<PathListener>();
+  /** Called at the start of every subscribe(), before the listener registers. */
+  public onSubscribe?: () => void;
 
   private releaseGate?: () => void;
   private getGate?: Promise<void>;
@@ -123,6 +125,7 @@ export class FakePathObject {
   }
 
   public subscribe(callback: () => void) {
+    this.owner.onSubscribe?.();
     const listener: PathListener = { path: this.segments, callback };
     this.owner.listeners.add(listener);
     return {

--- a/src/platform/react-hooks/src/liveobjects/index.ts
+++ b/src/platform/react-hooks/src/liveobjects/index.ts
@@ -1,0 +1,1 @@
+export * from './useObject.js';

--- a/src/platform/react-hooks/src/liveobjects/useObject.test.tsx
+++ b/src/platform/react-hooks/src/liveobjects/useObject.test.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import type * as Ably from 'ably';
+import { it, beforeEach, describe, expect } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { FakeAblySdk, FakeAblyChannels } from '../fakes/ably.js';
+import { FakeRealtimeObject } from '../fakes/liveobjects.js';
+import { AblyProvider } from '../AblyProvider.js';
+import { ChannelProvider } from '../ChannelProvider.js';
+import { useObject, UseObjectOptions, UseObjectResult } from './useObject.js';
+
+const testChannelName = 'testChannel';
+
+// flush the effects that resolve the root object and start the subscription
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function renderInCtxProvider(client: FakeAblySdk, children: React.ReactNode | React.ReactNode[]) {
+  const renderResult = render(
+    <AblyProvider client={client as unknown as Ably.RealtimeClient}>
+      <ChannelProvider channelName={testChannelName}>{children}</ChannelProvider>
+    </AblyProvider>,
+  );
+
+  const originalRerender = renderResult.rerender;
+  renderResult.rerender = (children: React.ReactNode | React.ReactNode[]) => {
+    return originalRerender(
+      <AblyProvider client={client as unknown as Ably.RealtimeClient}>
+        <ChannelProvider channelName={testChannelName}>{children}</ChannelProvider>
+      </AblyProvider>,
+    );
+  };
+
+  return renderResult;
+}
+
+const ResultView = ({ result }: { result: UseObjectResult<any> }) => (
+  <div>
+    <p role="value">{result.value === undefined ? 'undefined' : JSON.stringify(result.value)}</p>
+    <p role="object">{result.object ? `path:${result.object.path()}` : 'undefined'}</p>
+    <p role="error">{result.error ? result.error.message : 'null'}</p>
+  </div>
+);
+
+const RootObjectComponent = ({
+  options,
+  results,
+}: {
+  options?: UseObjectOptions;
+  results?: UseObjectResult<any>[];
+}) => {
+  const result = useObject(options);
+  results?.push(result);
+  return <ResultView result={result} />;
+};
+
+const SelectorComponent = ({
+  selector,
+  options,
+  results,
+  nonce,
+}: {
+  selector: (root: any) => any;
+  options?: UseObjectOptions;
+  results?: UseObjectResult<any>[];
+  nonce?: number;
+}) => {
+  const result = useObject(selector, options);
+  results?.push(result);
+  return (
+    <div>
+      <p role="nonce">{nonce ?? 0}</p>
+      <ResultView result={result} />
+    </div>
+  );
+};
+
+const PlayerScoreComponent = ({ player }: { player: string }) => {
+  const result = useObject((root) => root.get('scores').get(player));
+  return <ResultView result={result} />;
+};
+
+describe('useObject', () => {
+  let channels: FakeAblyChannels;
+  let ablyClient: FakeAblySdk;
+  let fakeObject: FakeRealtimeObject;
+
+  beforeEach(() => {
+    channels = new FakeAblyChannels([testChannelName]);
+    ablyClient = new FakeAblySdk().connectTo(channels);
+    fakeObject = new FakeRealtimeObject({ scores: { alice: 1, bob: 2 }, title: 'hello' });
+    (ablyClient.channels.get(testChannelName) as any).object = fakeObject;
+  });
+
+  /** @nospec */
+  it('returns undefined value and object while the root object is resolving', async () => {
+    fakeObject.deferGet();
+
+    renderInCtxProvider(ablyClient, <RootObjectComponent />);
+
+    expect(screen.getByRole('value').innerHTML).toBe('undefined');
+    expect(screen.getByRole('object').innerHTML).toBe('undefined');
+    expect(screen.getByRole('error').innerHTML).toBe('null');
+
+    await act(async () => {
+      fakeObject.releaseGet();
+    });
+
+    expect(screen.getByRole('object').innerHTML).toBe('path:');
+  });
+
+  /** @nospec */
+  it('returns the root snapshot and root object once resolved', async () => {
+    renderInCtxProvider(ablyClient, <RootObjectComponent />);
+
+    await flushEffects();
+
+    expect(JSON.parse(screen.getByRole('value').innerHTML)).toEqual({ scores: { alice: 1, bob: 2 }, title: 'hello' });
+    expect(screen.getByRole('object').innerHTML).toBe('path:');
+    expect(screen.getByRole('error').innerHTML).toBe('null');
+  });
+
+  /** @nospec */
+  it('subscribes to the node returned by the selector', async () => {
+    renderInCtxProvider(ablyClient, <SelectorComponent selector={(root) => root.get('scores').get('alice')} />);
+
+    await flushEffects();
+
+    expect(screen.getByRole('value').innerHTML).toBe('1');
+    expect(screen.getByRole('object').innerHTML).toBe('path:scores.alice');
+  });
+
+  /** @nospec */
+  it('re-renders with a fresh snapshot when the subscribed node changes', async () => {
+    renderInCtxProvider(ablyClient, <SelectorComponent selector={(root) => root.get('scores')} />);
+
+    await flushEffects();
+    expect(JSON.parse(screen.getByRole('value').innerHTML)).toEqual({ alice: 1, bob: 2 });
+
+    act(() => {
+      fakeObject.set(['scores', 'alice'], 5);
+    });
+
+    expect(JSON.parse(screen.getByRole('value').innerHTML)).toEqual({ alice: 5, bob: 2 });
+  });
+
+  /** @nospec */
+  it('does not re-render for changes outside the selected node', async () => {
+    const results: UseObjectResult<any>[] = [];
+    renderInCtxProvider(ablyClient, <SelectorComponent selector={(root) => root.get('scores')} results={results} />);
+
+    await flushEffects();
+    const renderCount = results.length;
+
+    act(() => {
+      fakeObject.set(['title'], 'changed');
+    });
+
+    expect(results.length).toBe(renderCount);
+    expect(JSON.parse(screen.getByRole('value').innerHTML)).toEqual({ alice: 1, bob: 2 });
+  });
+
+  /** @nospec */
+  it('keeps the same snapshot and object identity across unrelated re-renders', async () => {
+    const results: UseObjectResult<any>[] = [];
+    const { rerender } = renderInCtxProvider(
+      ablyClient,
+      <SelectorComponent selector={(root) => root.get('scores')} results={results} nonce={1} />,
+    );
+
+    await flushEffects();
+    const before = results[results.length - 1];
+
+    rerender(<SelectorComponent selector={(root) => root.get('scores')} results={results} nonce={2} />);
+
+    const after = results[results.length - 1];
+    expect(results.length).toBeGreaterThan(1);
+    expect(after.value).toBe(before.value);
+    expect(after.object).toBe(before.object);
+  });
+
+  /** @nospec */
+  it('surfaces the error when the root object fails to resolve', async () => {
+    fakeObject.failGet({ message: 'channel is missing the object modes', code: 40024, statusCode: 400 });
+
+    renderInCtxProvider(ablyClient, <RootObjectComponent />);
+
+    await flushEffects();
+
+    expect(screen.getByRole('error').innerHTML).toBe('channel is missing the object modes');
+    expect(screen.getByRole('value').innerHTML).toBe('undefined');
+    expect(screen.getByRole('object').innerHTML).toBe('undefined');
+  });
+
+  /** @nospec */
+  it('does not resolve the object when skip is set', async () => {
+    renderInCtxProvider(ablyClient, <RootObjectComponent options={{ skip: true }} />);
+
+    await flushEffects();
+
+    expect(fakeObject.getCalls).toBe(0);
+    expect(screen.getByRole('value').innerHTML).toBe('undefined');
+    expect(screen.getByRole('object').innerHTML).toBe('undefined');
+  });
+
+  /** @nospec */
+  it('unsubscribes from the node on unmount', async () => {
+    const { unmount } = renderInCtxProvider(ablyClient, <SelectorComponent selector={(root) => root.get('scores')} />);
+
+    await flushEffects();
+    expect(fakeObject.listeners.size).toBe(1);
+
+    unmount();
+
+    expect(fakeObject.listeners.size).toBe(0);
+  });
+
+  /** @nospec */
+  it('moves the subscription when the selector navigates to a different node', async () => {
+    const { rerender } = renderInCtxProvider(ablyClient, <PlayerScoreComponent player="alice" />);
+
+    await flushEffects();
+    expect(screen.getByRole('value').innerHTML).toBe('1');
+    expect(screen.getByRole('object').innerHTML).toBe('path:scores.alice');
+
+    rerender(<PlayerScoreComponent player="bob" />);
+    await flushEffects();
+
+    expect(screen.getByRole('value').innerHTML).toBe('2');
+    expect(screen.getByRole('object').innerHTML).toBe('path:scores.bob');
+    expect(fakeObject.listeners.size).toBe(1);
+
+    act(() => {
+      fakeObject.set(['scores', 'bob'], 7);
+    });
+
+    expect(screen.getByRole('value').innerHTML).toBe('7');
+  });
+
+  /** @nospec */
+  it('accepts an explicit channel name', async () => {
+    renderInCtxProvider(ablyClient, <RootObjectComponent options={{ channelName: testChannelName }} />);
+
+    await flushEffects();
+
+    expect(JSON.parse(screen.getByRole('value').innerHTML)).toEqual({ scores: { alice: 1, bob: 2 }, title: 'hello' });
+  });
+});

--- a/src/platform/react-hooks/src/liveobjects/useObject.test.tsx
+++ b/src/platform/react-hooks/src/liveobjects/useObject.test.tsx
@@ -147,6 +147,21 @@ describe('useObject', () => {
   });
 
   /** @nospec */
+  it('renders a change that lands between the render snapshot and the subscription', async () => {
+    fakeObject.onSubscribe = () => {
+      // mutate the data directly, without notifying: no listener is registered
+      // yet, so only the post-subscribe snapshot refresh can observe the change
+      (fakeObject.data.scores as Record<string, unknown>).alice = 42;
+    };
+
+    renderInCtxProvider(ablyClient, <SelectorComponent selector={(root) => root.get('scores').get('alice')} />);
+
+    await flushEffects();
+
+    expect(screen.getByRole('value').innerHTML).toBe('42');
+  });
+
+  /** @nospec */
   it('does not re-render for changes outside the selected node', async () => {
     const results: UseObjectResult<any>[] = [];
     renderInCtxProvider(ablyClient, <SelectorComponent selector={(root) => root.get('scores')} results={results} />);

--- a/src/platform/react-hooks/src/liveobjects/useObject.ts
+++ b/src/platform/react-hooks/src/liveobjects/useObject.ts
@@ -1,5 +1,6 @@
 import type * as Ably from 'ably';
 import type { LiveMap, PathObject, Value } from 'ably/liveobjects';
+import { dequal } from 'dequal';
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { ChannelNameAndOptions } from '../AblyReactHooks.js';
 import { INACTIVE_CONNECTION_STATES } from '../hooks/constants.js';
@@ -17,10 +18,16 @@ export type UseObjectOptions = ChannelNameAndOptions;
 
 /**
  * The surface common to every {@link PathObject} variant that {@link useObject}
- * relies on. Every node a selector can return satisfies this type; it exists so
- * the hook's signatures can constrain and infer concrete `PathObject` subtypes
- * (which is what makes the selector's navigation chain determine the result
- * type) without forcing them into a single `PathObject<V>` shape.
+ * relies on. Every node a selector can return satisfies this type.
+ *
+ * The hook's signatures constrain and infer over this structural type rather
+ * than over `PathObject<T>` because `PathObject<T>` is a conditional type:
+ * TypeScript cannot infer `T` from a value of the variant the conditional
+ * resolves to, and the resolved variants are not assignable to a common
+ * `PathObject<Value>` (two `LiveMapPathObject`s with different shapes have
+ * incompatible `get` signatures). Constraining and inferring the concrete
+ * variant directly is what lets the selector's navigation chain determine the
+ * result type.
  */
 export interface ObjectNode {
   /** The fully-qualified path string for this node. */
@@ -38,13 +45,14 @@ export interface ObjectNode {
 export type ObjectNodeValue<N extends ObjectNode> = N extends { compact(): infer C } ? Exclude<C, undefined> : never;
 
 /**
- * Navigates from the channel's root object to the node to subscribe to.
- * Receives the live root PathObject and returns a descendant via `get`/`at`;
- * the chain's types flow through, so the hook result is typed without manual
- * annotation. The function must only navigate — the node it returns is the one
- * the hook subscribes to. To subscribe to the whole object, omit the selector.
+ * Navigates from the channel's object to the node to subscribe to. Receives
+ * the channel's live object as a PathObject and returns a descendant via
+ * `get`/`at`; the chain's types flow through, so the hook result is typed
+ * without manual annotation. The function must only navigate — the node it
+ * returns is the one the hook subscribes to. To subscribe to the channel's
+ * whole object, omit the selector.
  */
-export type ObjectSelector<Root extends ObjectNode, N extends ObjectNode> = (root: Root) => N;
+export type ObjectSelector<Obj extends ObjectNode, N extends ObjectNode> = (object: Obj) => N;
 
 /**
  * Result of {@link useObject} for a subscribed node of type `N`.
@@ -59,7 +67,7 @@ export interface UseObjectResult<N extends ObjectNode> {
   /**
    * The live PathObject for the subscribed node. Use it to navigate (`get`/`at`)
    * and to write (`set`/`remove`/`increment`/`decrement`/`batch`). `undefined`
-   * until the channel's root object has resolved and synced — this is the
+   * until the channel's object has resolved and synced — this is the
    * readiness signal: `object === undefined && error === null` is loading,
    * `error !== null` is failed, and a defined `object` is ready (with `value`
    * carrying the data once the node exists).
@@ -109,44 +117,45 @@ const emptyStore: ObjectStore = {
 const getServerSnapshot = () => undefined;
 
 /**
- * Subscribe to the channel's root LiveObjects node and re-render on change.
+ * Subscribe to the channel's object and re-render on change.
  *
  * The channel is taken from the nearest `ChannelProvider` unless `channelName`
- * is given. `Root` describes the channel's root LiveMap and defaults to an
- * untyped map.
+ * is given. `T` describes the shape of the channel's object — the same type
+ * parameter `RealtimeObject.get<T>()` takes — and defaults to an untyped map.
  *
  * Requires the `LiveObjects` plugin on the Realtime client and the
  * `OBJECT_SUBSCRIBE` channel mode (plus `OBJECT_PUBLISH` to write); otherwise
  * `error` carries ably-js's reason. Readiness is derived from the result (see
  * {@link UseObjectResult.object}), not a status enum.
  */
-export function useObject<Root extends Value = LiveMap<Record<string, Value>>>(
+export function useObject<T extends Record<string, Value> = Record<string, Value>>(
   options?: UseObjectOptions,
-): UseObjectResult<PathObject<Root>>;
+): UseObjectResult<PathObject<LiveMap<T>>>;
 /**
  * Subscribe to a nested LiveObjects node, selected by navigating from the
- * channel's untyped root, and re-render on change. The node the selector
+ * channel's (untyped) object, and re-render on change. The node the selector
  * returns determines `N`, so `value` and `object` are typed from the
- * navigation chain, e.g. `useObject((root) => root.get('scores').get('alice'))`.
+ * navigation chain, e.g. `useObject((obj) => obj.get('scores').get('alice'))`.
  *
  * Channel resolution, readiness, and plugin/modes requirements are as for the
- * root overload.
+ * no-selector overload.
  */
 export function useObject<N extends ObjectNode>(
   selector: ObjectSelector<PathObject<LiveMap<Record<string, Value>>>, N>,
   options?: UseObjectOptions,
 ): UseObjectResult<N>;
 /**
- * Subscribe to a nested LiveObjects node, selected by navigating from a typed
- * root, and re-render on change. Annotate the selector's parameter with the
- * channel's root shape (`(root: PathObject<MyRoot>) => ...`) and the whole
- * navigation chain — wrong keys included — is checked at compile time.
+ * Subscribe to a nested LiveObjects node, selected by navigating from the
+ * channel's object with a typed shape, and re-render on change. Annotate the
+ * selector's parameter with the shape of the channel's object
+ * (`(obj: PathObject<LiveMap<MyShape>>) => ...`) and the whole navigation
+ * chain — wrong keys included — is checked at compile time.
  *
  * Channel resolution, readiness, and plugin/modes requirements are as for the
- * root overload.
+ * no-selector overload.
  */
-export function useObject<Root extends ObjectNode, N extends ObjectNode>(
-  selector: ObjectSelector<Root, N>,
+export function useObject<Obj extends ObjectNode, N extends ObjectNode>(
+  selector: ObjectSelector<Obj, N>,
   options?: UseObjectOptions,
 ): UseObjectResult<N>;
 
@@ -244,6 +253,16 @@ export function useObject(
           value = node.compact();
           onStoreChange();
         });
+        // The subscription is only established in an effect, after commit, so
+        // catch up on a change that landed since the render-time snapshot was
+        // taken — such a change fired no notification. compact() returns a
+        // fresh object on every call, so a deep-equality check is needed to
+        // keep the snapshot identity stable when nothing actually changed.
+        const latest = node.compact();
+        if (!dequal(latest, value)) {
+          value = latest;
+          onStoreChange();
+        }
         return () => subscription.unsubscribe();
       },
       getSnapshot: () => value,

--- a/src/platform/react-hooks/src/liveobjects/useObject.ts
+++ b/src/platform/react-hooks/src/liveobjects/useObject.ts
@@ -1,0 +1,262 @@
+import type * as Ably from 'ably';
+import type { LiveMap, PathObject, Value } from 'ably/liveobjects';
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { ChannelNameAndOptions } from '../AblyReactHooks.js';
+import { INACTIVE_CONNECTION_STATES } from '../hooks/constants.js';
+import { useChannelAttach } from '../hooks/useChannelAttach.js';
+import { useChannelInstance } from '../hooks/useChannelInstance.js';
+import { useStateErrors } from '../hooks/useStateErrors.js';
+
+/**
+ * Options for {@link useObject}. The standard channel-hook options: the channel
+ * is resolved from the nearest `ChannelProvider` unless `channelName` is
+ * provided, `ablyId` selects the client from a surrounding `AblyProvider`, and
+ * `skip` short-circuits the hook.
+ */
+export type UseObjectOptions = ChannelNameAndOptions;
+
+/**
+ * The surface common to every {@link PathObject} variant that {@link useObject}
+ * relies on. Every node a selector can return satisfies this type; it exists so
+ * the hook's signatures can constrain and infer concrete `PathObject` subtypes
+ * (which is what makes the selector's navigation chain determine the result
+ * type) without forcing them into a single `PathObject<V>` shape.
+ */
+export interface ObjectNode {
+  /** The fully-qualified path string for this node. */
+  path(): string;
+  /** A plain-data snapshot of the node, or `undefined` if the node does not exist. */
+  compact(): unknown;
+  /** Registers a listener called on each change to the node or its subtree. */
+  subscribe(listener: () => void): Ably.Subscription;
+}
+
+/**
+ * The plain-data snapshot type produced by a node's `compact()` method — the
+ * type of {@link UseObjectResult.value} for the node type `N`.
+ */
+export type ObjectNodeValue<N extends ObjectNode> = N extends { compact(): infer C } ? Exclude<C, undefined> : never;
+
+/**
+ * Navigates from the channel's root object to the node to subscribe to.
+ * Receives the live root PathObject and returns a descendant via `get`/`at`;
+ * the chain's types flow through, so the hook result is typed without manual
+ * annotation. The function must only navigate — the node it returns is the one
+ * the hook subscribes to. To subscribe to the whole object, omit the selector.
+ */
+export type ObjectSelector<Root extends ObjectNode, N extends ObjectNode> = (root: Root) => N;
+
+/**
+ * Result of {@link useObject} for a subscribed node of type `N`.
+ */
+export interface UseObjectResult<N extends ObjectNode> {
+  /**
+   * Reactive snapshot of the subscribed node (`PathObject.compact()`), cached
+   * so its identity is stable between renders. `undefined` before the object
+   * has synced, or if the node does not exist.
+   */
+  value: ObjectNodeValue<N> | undefined;
+  /**
+   * The live PathObject for the subscribed node. Use it to navigate (`get`/`at`)
+   * and to write (`set`/`remove`/`increment`/`decrement`/`batch`). `undefined`
+   * until the channel's root object has resolved and synced — this is the
+   * readiness signal: `object === undefined && error === null` is loading,
+   * `error !== null` is failed, and a defined `object` is ready (with `value`
+   * carrying the data once the node exists).
+   */
+  object: N | undefined;
+  /**
+   * The error that prevented the object from resolving — e.g. the `LiveObjects`
+   * plugin is missing, the channel lacks object modes, or the initial sync
+   * failed. ably-js's own `ErrorInfo`, surfaced unmodified. `null` otherwise.
+   */
+  error: Ably.ErrorInfo | null;
+  /** Connection-level error, per the standard channel-hook convention. */
+  connectionError: Ably.ErrorInfo | null;
+  /** Channel-level error, per the standard channel-hook convention. */
+  channelError: Ably.ErrorInfo | null;
+}
+
+interface RootState {
+  /** The channel the root was resolved (or failed to resolve) for. */
+  channel?: Ably.RealtimeChannel;
+  root?: PathObject<LiveMap<Record<string, Value>>>;
+  error: Ably.ErrorInfo | null;
+}
+
+interface SelectedNode {
+  /** The root the node was selected from; a new root invalidates the selection. */
+  root: PathObject<LiveMap<Record<string, Value>>>;
+  /** The node's fully-qualified path, used to detect a change of selection. */
+  path: string;
+  node: ObjectNode;
+}
+
+interface ObjectStore {
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSnapshot: () => unknown;
+}
+
+const noop = () => undefined;
+
+const emptyStore: ObjectStore = {
+  subscribe: () => noop,
+  getSnapshot: () => undefined,
+};
+
+// The root object only resolves in an effect, so on the server (and during
+// hydration) the snapshot is always undefined.
+const getServerSnapshot = () => undefined;
+
+/**
+ * Subscribe to the channel's root LiveObjects node and re-render on change.
+ *
+ * The channel is taken from the nearest `ChannelProvider` unless `channelName`
+ * is given. `Root` describes the channel's root LiveMap and defaults to an
+ * untyped map.
+ *
+ * Requires the `LiveObjects` plugin on the Realtime client and the
+ * `OBJECT_SUBSCRIBE` channel mode (plus `OBJECT_PUBLISH` to write); otherwise
+ * `error` carries ably-js's reason. Readiness is derived from the result (see
+ * {@link UseObjectResult.object}), not a status enum.
+ */
+export function useObject<Root extends Value = LiveMap<Record<string, Value>>>(
+  options?: UseObjectOptions,
+): UseObjectResult<PathObject<Root>>;
+/**
+ * Subscribe to a nested LiveObjects node, selected by navigating from the
+ * channel's untyped root, and re-render on change. The node the selector
+ * returns determines `N`, so `value` and `object` are typed from the
+ * navigation chain, e.g. `useObject((root) => root.get('scores').get('alice'))`.
+ *
+ * Channel resolution, readiness, and plugin/modes requirements are as for the
+ * root overload.
+ */
+export function useObject<N extends ObjectNode>(
+  selector: ObjectSelector<PathObject<LiveMap<Record<string, Value>>>, N>,
+  options?: UseObjectOptions,
+): UseObjectResult<N>;
+/**
+ * Subscribe to a nested LiveObjects node, selected by navigating from a typed
+ * root, and re-render on change. Annotate the selector's parameter with the
+ * channel's root shape (`(root: PathObject<MyRoot>) => ...`) and the whole
+ * navigation chain — wrong keys included — is checked at compile time.
+ *
+ * Channel resolution, readiness, and plugin/modes requirements are as for the
+ * root overload.
+ */
+export function useObject<Root extends ObjectNode, N extends ObjectNode>(
+  selector: ObjectSelector<Root, N>,
+  options?: UseObjectOptions,
+): UseObjectResult<N>;
+
+export function useObject(
+  selectorOrOptions?: ObjectSelector<ObjectNode, ObjectNode> | UseObjectOptions,
+  maybeOptions?: UseObjectOptions,
+): UseObjectResult<ObjectNode> {
+  const selector = typeof selectorOrOptions === 'function' ? selectorOrOptions : undefined;
+  const options = (typeof selectorOrOptions === 'function' ? maybeOptions : selectorOrOptions) ?? {};
+  const skip = options.skip ?? false;
+
+  const { channel } = useChannelInstance(options.ablyId, options.channelName);
+  const { connectionError, channelError } = useStateErrors(options);
+  const { connectionState } = useChannelAttach(channel, options.ablyId, skip);
+
+  const [rootState, setRootState] = useState<RootState>({ error: null });
+  const rootStateRef = useRef(rootState);
+  rootStateRef.current = rootState;
+
+  // object.get() attaches implicitly, so resolution is gated the same way
+  // useChannelAttach gates attachment: wait out connection states in which an
+  // attach would fail outright. When the connection later becomes usable the
+  // effect re-runs, which also retries a resolution that failed in such a state.
+  const canResolve = !skip && !INACTIVE_CONNECTION_STATES.includes(connectionState);
+
+  useEffect(() => {
+    if (!canResolve) {
+      return;
+    }
+    // An already-resolved root stays valid across detach/re-attach cycles, so
+    // there is nothing to re-resolve for the same channel.
+    const current = rootStateRef.current;
+    if (current.channel === channel && current.root) {
+      return;
+    }
+
+    let cancelled = false;
+    const resolveRoot = async () => {
+      try {
+        const root = await channel.object.get();
+        if (!cancelled) {
+          setRootState({ channel, root, error: null });
+        }
+      } catch (error) {
+        if (!cancelled) {
+          // object.get() rejects with the ErrorInfo describing why the object
+          // could not be resolved (missing plugin, missing modes, failed sync)
+          setRootState({ channel, error: error as Ably.ErrorInfo });
+        }
+      }
+    };
+    // fire-and-forget: resolveRoot captures failures into state itself
+    resolveRoot();
+    return () => {
+      cancelled = true;
+    };
+  }, [channel, canResolve]);
+
+  const root = !skip && rootState.channel === channel ? rootState.root : undefined;
+  const error = !skip && rootState.channel === channel ? rootState.error : null;
+
+  // Apply the selector on every render (navigation is cheap and pure), but keep
+  // a stable node identity for as long as the selection addresses the same path
+  // from the same root, so that re-renders do not churn the subscription. This
+  // reconciles state during render (rather than in an effect) so the resolved
+  // node is available within the same render pass.
+  const candidate = root ? (selector ? selector(root) : root) : undefined;
+  const candidatePath = candidate?.path();
+
+  const [selected, setSelected] = useState<SelectedNode | undefined>(undefined);
+  let reconciled = selected;
+  if (root && candidate && candidatePath !== undefined) {
+    if (!reconciled || reconciled.root !== root || reconciled.path !== candidatePath) {
+      reconciled = { root, path: candidatePath, node: candidate };
+      setSelected(reconciled);
+    }
+  } else if (reconciled) {
+    reconciled = undefined;
+    setSelected(undefined);
+  }
+  const node = reconciled?.node;
+
+  const store: ObjectStore = useMemo(() => {
+    if (!node) {
+      return emptyStore;
+    }
+    // The snapshot is cached and recomputed only inside the subscription
+    // callback: a getSnapshot that called compact() directly would return a
+    // fresh object on every call and send useSyncExternalStore into an
+    // infinite re-render loop.
+    let value = node.compact();
+    return {
+      subscribe: (onStoreChange: () => void) => {
+        const subscription = node.subscribe(() => {
+          value = node.compact();
+          onStoreChange();
+        });
+        return () => subscription.unsubscribe();
+      },
+      getSnapshot: () => value,
+    };
+  }, [node]);
+
+  const value = useSyncExternalStore(store.subscribe, store.getSnapshot, getServerSnapshot);
+
+  return {
+    value,
+    object: node,
+    error,
+    connectionError,
+    channelError,
+  };
+}

--- a/src/platform/react-hooks/src/liveobjects/useObject.ts
+++ b/src/platform/react-hooks/src/liveobjects/useObject.ts
@@ -20,14 +20,17 @@ export type UseObjectOptions = ChannelNameAndOptions;
  * The surface common to every {@link PathObject} variant that {@link useObject}
  * relies on. Every node a selector can return satisfies this type.
  *
- * The hook's signatures constrain and infer over this structural type rather
- * than over `PathObject<T>` because `PathObject<T>` is a conditional type:
- * TypeScript cannot infer `T` from a value of the variant the conditional
- * resolves to, and the resolved variants are not assignable to a common
- * `PathObject<Value>` (two `LiveMapPathObject`s with different shapes have
- * incompatible `get` signatures). Constraining and inferring the concrete
- * variant directly is what lets the selector's navigation chain determine the
- * result type.
+ * The node a selector returns can be any `PathObject` variant, so the hook's
+ * result-side type parameter constrains and infers over this structural type
+ * rather than over `PathObject<V>`: `PathObject<V>` is a conditional type that
+ * TypeScript cannot infer `V` through for an arbitrary `V`, and the resolved
+ * variants are not assignable to a common `PathObject<Value>` (two
+ * `LiveMapPathObject`s with different shapes have incompatible `get`
+ * signatures). Constraining and inferring the concrete variant directly is
+ * what lets the selector's navigation chain determine the result type. The
+ * selector's parameter needs no such treatment: it is always a map, and
+ * `PathObject<LiveMap<T>>` reduces eagerly for every `T`, so TypeScript can
+ * infer `T` through it.
  */
 export interface ObjectNode {
   /** The fully-qualified path string for this node. */
@@ -148,14 +151,16 @@ export function useObject<N extends ObjectNode>(
  * Subscribe to a nested LiveObjects node, selected by navigating from the
  * channel's object with a typed shape, and re-render on change. Annotate the
  * selector's parameter with the shape of the channel's object
- * (`(obj: PathObject<LiveMap<MyShape>>) => ...`) and the whole navigation
- * chain — wrong keys included — is checked at compile time.
+ * (`(obj: PathObject<LiveMap<MyShape>>) => ...`) — `T` is inferred from the
+ * annotation, and is the same type parameter `RealtimeObject.get<T>()` takes —
+ * and the whole navigation chain, wrong keys included, is checked at compile
+ * time.
  *
  * Channel resolution, readiness, and plugin/modes requirements are as for the
  * no-selector overload.
  */
-export function useObject<Obj extends ObjectNode, N extends ObjectNode>(
-  selector: ObjectSelector<Obj, N>,
+export function useObject<T extends Record<string, Value>, N extends ObjectNode>(
+  selector: ObjectSelector<PathObject<LiveMap<T>>, N>,
   options?: UseObjectOptions,
 ): UseObjectResult<N>;
 

--- a/src/platform/react-hooks/tsconfig.json
+++ b/src/platform/react-hooks/tsconfig.json
@@ -16,7 +16,8 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "types": ["vitest/globals"],
     "paths": {
-      "ably": ["../../../"]
+      "ably": ["../../../"],
+      "ably/liveobjects": ["../../../liveobjects.d.ts"]
     }
   }
 }

--- a/test/package/browser/template/src/ReactApp.tsx
+++ b/test/package/browser/template/src/ReactApp.tsx
@@ -1,4 +1,6 @@
 import * as Ably from 'ably';
+import type { LiveCounter, LiveMap, PathObject } from 'ably/liveobjects';
+import { useObject } from 'ably/liveobjects/react';
 import { useChannel } from 'ably/react';
 import { useEffect, useState } from 'react';
 
@@ -37,7 +39,38 @@ export function App() {
         <h2>Messages</h2>
         <ul>{messagePreviews}</ul>
       </div>
+      <LiveObjectsTypeChecks />
     </div>
+  );
+}
+
+type Game = {
+  scores: LiveMap<{ alice: LiveCounter; bob: LiveCounter }>;
+  title: string;
+};
+
+// check that useObject result types flow through the typed navigation selector.
+// skip is set so the hook makes no use of the LiveObjects plugin at runtime;
+// these checks only need to compile.
+function LiveObjectsTypeChecks() {
+  // no-selector form: the type parameter is the shape of the channel's object,
+  // as for channel.object.get<Game>()
+  const whole = useObject<Game>({ skip: true });
+  const wholeValue: { scores: { alice: number; bob: number }; title: string } | undefined = whole.value;
+  const wholeObject: PathObject<LiveMap<Game>> | undefined = whole.object;
+
+  // selector form: annotating the selector's parameter types the whole navigation chain
+  const counter = useObject((obj: PathObject<LiveMap<Game>>) => obj.get('scores').get('alice'), { skip: true });
+  const counterValue: number | undefined = counter.value;
+  const counterObject: PathObject<LiveCounter> | undefined = counter.object;
+
+  return (
+    <ul hidden>
+      <li>{wholeValue?.title}</li>
+      <li>{wholeObject?.path()}</li>
+      <li>{counterValue}</li>
+      <li>{counterObject?.path()}</li>
+    </ul>
   );
 }
 


### PR DESCRIPTION
[AIT-1133](https://ably.atlassian.net/browse/AIT-1133)

Implements [PSDR20](https://ably.atlassian.net/wiki/spaces/CHN/pages/5171445785/PSDR20+LiveObjects+react+hooks+for+ably-js)

Adds a new `ably/liveobjects/react` entry point exporting `useObject`, which subscribes to a channel's LiveObjects state (optionally a nested node selected by navigating from the root) and re-renders on change, built on useSyncExternalStore with a cached compact() snapshot.

[AIT-1133]: https://ably.atlassian.net/browse/AIT-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `useObject` for React LiveObjects, supporting root and nested object nodes, selector-based subscriptions, cached reactive `value`, and layered loading/error states (`error`, `connectionError`, `channelError`).
  * Added a new package entry point for React LiveObjects (`ably/liveobjects/react`) with CommonJS and ESM support.
* **Documentation**
  * Documented `useObject`, including React 18+ requirements, supported subscription patterns, and loading/error/ready behavior.
* **Tests**
  * Added React hook tests covering lifecycle, selector changes, identity stability, timing edge cases, and cleanup.
* **Chores**
  * Added TypeScript type support and exports for the new React LiveObjects entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->