### PR TITLE
[AIT-1138] fix(liveobjects): `PathObject.instance()` wraps primitives per RTPO8f

### DIFF
--- a/liveobjects.d.ts
+++ b/liveobjects.d.ts
@@ -1014,10 +1014,11 @@ export interface AnyPathObject
   value<T extends number | Primitive = number | Primitive>(): T | undefined;
 
   /**
-   * Get the specific object instance currently at this path.
-   * If the path does not resolve to any specific instance, returns `undefined`.
+   * Get an instance wrapping the value currently at this path, whether it is a
+   * {@link LiveMap}, {@link LiveCounter} or a primitive value.
+   * If the path does not resolve, returns `undefined`.
    *
-   * @returns The object instance at this path, or `undefined` if none exists.
+   * @returns An {@link Instance} wrapping the value at this path, or `undefined` if the path does not resolve.
    */
   instance<T extends Value = Value>(): Instance<T> | undefined;
 

--- a/src/plugins/liveobjects/pathobject.ts
+++ b/src/plugins/liveobjects/pathobject.ts
@@ -218,6 +218,10 @@ export class DefaultPathObject implements AnyPathObject {
     }
   }
 
+  /**
+   * Get an Instance wrapping the value currently at this path, whether it is a LiveObject or a primitive.
+   * If the path does not resolve, returns `undefined`.
+   */
   instance<T extends Value = Value>(): Instance<T> | undefined {
     this._realtimeObject.throwIfInvalidAccessApiConfiguration();
 
@@ -419,8 +423,7 @@ export class DefaultPathObject implements AnyPathObject {
   async batch<T extends LiveObjectType = LiveObjectType>(fn: BatchFunction<T>): Promise<void> {
     this._realtimeObject.throwIfInvalidWriteApiConfiguration();
 
-    // _resolveInstance now wraps primitives too (RTPO8f), so check the resolved value
-    // is a LiveObject explicitly before batching
+    // a path may resolve to a primitive (RTPO8f), but only LiveObjects can host batch operations
     const resolved = this._resolvePath(this._path);
     if (!(resolved instanceof LiveObject)) {
       throw new this._client.ErrorInfo(

--- a/src/plugins/liveobjects/pathobject.ts
+++ b/src/plugins/liveobjects/pathobject.ts
@@ -222,7 +222,7 @@ export class DefaultPathObject implements AnyPathObject {
     this._realtimeObject.throwIfInvalidAccessApiConfiguration();
 
     try {
-      return this._resolveInstance();
+      return this._resolveInstance<T>();
     } catch (error) {
       if (this._client.Utils.isErrorInfoOrPartialErrorInfo(error) && error.code === 92005) {
         // ignore path resolution errors and return undefined
@@ -419,8 +419,10 @@ export class DefaultPathObject implements AnyPathObject {
   async batch<T extends LiveObjectType = LiveObjectType>(fn: BatchFunction<T>): Promise<void> {
     this._realtimeObject.throwIfInvalidWriteApiConfiguration();
 
-    const instance = this._resolveInstance();
-    if (!instance) {
+    // _resolveInstance now wraps primitives too (RTPO8f), so check the resolved value
+    // is a LiveObject explicitly before batching
+    const resolved = this._resolvePath(this._path);
+    if (!(resolved instanceof LiveObject)) {
       throw new this._client.ErrorInfo(
         `Cannot batch operations on a non-LiveObject at path: ${this._escapePath(this._path).join('.')}`,
         92007,
@@ -428,6 +430,7 @@ export class DefaultPathObject implements AnyPathObject {
       );
     }
 
+    const instance = new DefaultInstance(this._realtimeObject, resolved) as unknown as Instance<Value>;
     const ctx = new RootBatchContext(this._realtimeObject, instance);
     try {
       fn(ctx as unknown as BatchContext<T>);
@@ -467,16 +470,11 @@ export class DefaultPathObject implements AnyPathObject {
     return current;
   }
 
-  private _resolveInstance<T extends Value = Value>(): Instance<T> | undefined {
+  private _resolveInstance<T extends Value = Value>(): Instance<T> {
     const value = this._resolvePath(this._path);
 
-    if (value instanceof LiveObject) {
-      // only return an Instance for LiveObject values
-      return new DefaultInstance(this._realtimeObject, value) as unknown as Instance<T>;
-    }
-
-    // return undefined for non live objects
-    return undefined;
+    // wrap the resolved value in an Instance, whether a LiveObject or a primitive (RTPO8c, RTPO8f)
+    return new DefaultInstance(this._realtimeObject, value) as unknown as Instance<T>;
   }
 
   private _escapePath(path: Path): Path {

--- a/test/realtime/liveobjects.test.js
+++ b/test/realtime/liveobjects.test.js
@@ -5194,10 +5194,11 @@ define(['ably', 'shared_helper', 'chai', 'liveobjects', 'liveobjects_helper'], f
             // next methods silently handle incorrect underlying type
             expect(mapPathObj.value(), 'Check PathObject.value() for wrong underlying object type returns undefined').to
               .be.undefined;
-            expect(
-              primitivePathObj.instance(),
-              'Check PathObject.instance() for wrong underlying object type returns undefined',
-            ).to.be.undefined;
+            // instance() is not type-constrained: it wraps primitives too (RTPO8f)
+            const primitiveInstance = primitivePathObj.instance();
+            expect(primitiveInstance, 'Check PathObject.instance() for primitive path returns an Instance').to.exist;
+            expect(primitiveInstance.id, 'Check primitive instance has no object id').to.be.undefined;
+            expect(primitiveInstance.value(), 'Check primitive instance wraps the primitive value').to.equal('value');
             expect([...primitivePathObj.entries()]).to.deep.equal(
               [],
               'Check PathObject.entries() for wrong underlying object type returns empty iterator',

--- a/test/uts/objects/unit/path_object.test.ts
+++ b/test/uts/objects/unit/path_object.test.ts
@@ -133,11 +133,14 @@ describe('uts/objects/unit/path_object', function () {
     expect(mapInst!.id).to.equal('map:profile@1000');
   });
 
-  // UTS: objects/unit/RTPO8c/instance-primitive-null-0
-  it('RTPO8c - instance() returns undefined for primitive', async function () {
-    const { root } = await setupSyncedChannel('test-RTPO8c');
+  // UTS: objects/unit/RTPO8f/instance-primitive-wrapped-0
+  it('RTPO8f - instance() returns Instance for primitive', async function () {
+    const { root } = await setupSyncedChannel('test-RTPO8f');
 
-    expect(root.get('name').instance()).to.be.undefined;
+    const nameInst = root.get('name').instance();
+    expect(nameInst).to.exist;
+    expect(nameInst!.id).to.be.undefined;
+    expect(nameInst!.value()).to.equal('Alice');
   });
 
   // UTS: objects/unit/RTPO9/entries-yields-pairs-0


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-1138

## What

Implements the RTPO8 spec change from ably/specification#504: `PathObject.instance()` now returns an `Instance` wrapping **any** resolved value — a `LiveObject` or a primitive — instead of returning `undefined` for primitives. `undefined` is now returned only when the path does not resolve (`RTPO8e`).

## Why

The spec deprecated `RTPO8d` (primitive → undefined) in favour of the new `RTPO8f` (primitive → `Instance` wrapping the primitive value). The old behaviour was inconsistent with the `Instance` model: `RTINS1` defines `Instance` as a view of "a `LiveObject` or primitive value", and primitives already surfaced as `Instance`s through `Instance.get()` (`RTINS5c`) — `PathObject.instance()` was the one entry point that refused them.

No new plumbing was needed: `DefaultInstance` already fully supports primitive values (`id` returns `undefined` per `RTINS3b`, `value()` returns the primitive directly per `RTINS4c`, and all write/subscribe methods guard with 92007 per `RTINS16c`).

## Changes

### `src/plugins/liveobjects/pathobject.ts`

- `_resolveInstance()` wraps the resolved value unconditionally (`RTPO8c`/`RTPO8f`). Since `_resolvePath` throws on resolution failure, the method can no longer return `undefined` and its return type is narrowed accordingly.
- `instance()` passes its type parameter explicitly (`_resolveInstance<T>()`) — inference through the conditional `Instance<T>` type no longer resolves once `undefined` left the signature.
- `batch()` previously relied on `_resolveInstance()` truthiness as its implicit "is this a LiveObject" check. It now checks the resolved value with an explicit `instanceof LiveObject` guard. **Behaviour is preserved exactly**: 92007 for a non-LiveObject at the path, 92005 propagated for an unresolved path.

### `liveobjects.d.ts`

- `AnyPathObject.instance()` docstring updated to state the new contract (wraps LiveObjects and primitives; `undefined` only for unresolved paths).

### Tests

- `test/uts/objects/unit/path_object.test.ts` — the derived UTS test `RTPO8c/instance-primitive-null-0` becomes `RTPO8f/instance-primitive-wrapped-0`, asserting the returned `Instance` exists, has no `id`, and exposes the primitive via `value()`.
- `test/realtime/liveobjects.test.js` — the sandbox assertion that `instance()` on a primitive path returns `undefined` is replaced with the equivalent positive assertions.

## Testing

- Full UTS unit suite: **1350 passing**.
- Targeted sandbox runs of the two affected blocks (`PathObject handling of operations on wrong underlying object type`, including the `batch()` 92007 non-LiveObject case that exercises the new guard): **passing**.
- `tsc --noEmit`, eslint and prettier clean.

## Related

- Spec change: ably/specification#504
- ably-java adopts the same behaviour on its LiveObjects branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `PathObject.instance()` now returns an instance wrapper for primitive values (for example, strings), exposing the primitive via `value()` with no object ID.
* **Bug Fixes**
  * `PathObject.instance()` returns `undefined` only when the requested path cannot be resolved.
  * Batch operations now reject paths that do not resolve to supported live objects.
* **Documentation**
  * Updated JSDoc for `PathObject.instance()` to clarify behavior for primitive-backed paths and unresolved paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->