### PR TITLE
fix: replace in-flight presence sync sequences

### DIFF
--- a/src/common/lib/client/presencemap.ts
+++ b/src/common/lib/client/presencemap.ts
@@ -137,11 +137,9 @@ export class PresenceMap extends EventEmitter {
       'PresenceMap.startSync()',
       'channel = ' + this.presence.channel.name + '; syncInProgress = ' + syncInProgress,
     );
-    /* we might be called multiple times while a sync is in progress */
-    if (!this.syncInProgress) {
-      this.residualMembers = Utils.copy(map);
-      this.setInProgress(true);
-    }
+    /* RTP18a: a new sync replaces any sync already in progress */
+    this.residualMembers = Utils.copy(map);
+    this.setInProgress(true);
   }
 
   endSync() {

--- a/src/common/lib/client/presencemap.ts
+++ b/src/common/lib/client/presencemap.ts
@@ -139,7 +139,7 @@ export class PresenceMap extends EventEmitter {
     );
     /* RTP18a: a new sync replaces any sync already in progress. Exclude
      * tombstones that have already emitted their leave event. */
-    this.residualMembers = {};
+    this.residualMembers = Object.create(null) as Record<string, PresenceMessage>;
     for (const memberKey in map) {
       if (map[memberKey].action !== 'absent') {
         this.residualMembers[memberKey] = map[memberKey];

--- a/src/common/lib/client/presencemap.ts
+++ b/src/common/lib/client/presencemap.ts
@@ -137,8 +137,14 @@ export class PresenceMap extends EventEmitter {
       'PresenceMap.startSync()',
       'channel = ' + this.presence.channel.name + '; syncInProgress = ' + syncInProgress,
     );
-    /* RTP18a: a new sync replaces any sync already in progress */
-    this.residualMembers = Utils.copy(map);
+    /* RTP18a: a new sync replaces any sync already in progress. Exclude
+     * tombstones that have already emitted their leave event. */
+    this.residualMembers = {};
+    for (const memberKey in map) {
+      if (map[memberKey].action !== 'absent') {
+        this.residualMembers[memberKey] = map[memberKey];
+      }
+    }
     this.setInProgress(true);
   }
 

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -44,6 +44,7 @@ class RealtimePresence extends EventEmitter {
   _myMembers: PresenceMap;
   subscriptions: EventEmitter;
   name?: string;
+  private _syncId?: string;
 
   constructor(channel: RealtimeChannel) {
     super(channel.logger);
@@ -312,16 +313,20 @@ class RealtimePresence extends EventEmitter {
       'RealtimePresence.setPresence()',
       'received presence for ' + presenceSet.length + ' participants; syncChannelSerial = ' + syncChannelSerial,
     );
-    let syncCursor, match;
+    let syncId, syncCursor, match;
     const members = this.members,
       myMembers = this._myMembers,
       broadcastMessages = [],
       connId = this.channel.connectionManager.connectionId;
 
     if (isSync) {
-      this.members.startSync();
-      if (syncChannelSerial && (match = syncChannelSerial.match(/^[\w-]+:(.*)$/))) {
-        syncCursor = match[1];
+      if (syncChannelSerial && (match = syncChannelSerial.match(/^([\w-]+):(.*)$/))) {
+        syncId = match[1];
+        syncCursor = match[2];
+      }
+      if (!this.members.syncInProgress || syncId !== this._syncId) {
+        this.members.startSync();
+        this._syncId = syncId;
       }
     }
 
@@ -350,6 +355,7 @@ class RealtimePresence extends EventEmitter {
     /* if this is the last (or only) message in a sequence of sync updates, end the sync */
     if (isSync && !syncCursor) {
       members.endSync();
+      this._syncId = undefined;
       this.channel.syncChannelSerial = null;
     }
 

--- a/src/common/lib/client/realtimepresence.ts
+++ b/src/common/lib/client/realtimepresence.ts
@@ -324,8 +324,10 @@ class RealtimePresence extends EventEmitter {
         syncId = match[1];
         syncCursor = match[2];
       }
-      if (!this.members.syncInProgress || syncId !== this._syncId) {
+      if (!this.members.syncInProgress || (this._syncId !== undefined && syncId !== this._syncId)) {
         this.members.startSync();
+      }
+      if (syncId !== undefined) {
         this._syncId = syncId;
       }
     }

--- a/test/uts/realtime/unit/presence/presence_sync.test.ts
+++ b/test/uts/realtime/unit/presence/presence_sync.test.ts
@@ -10,8 +10,6 @@
  *
  * NOTE: In ably-js, endSync() returns void and calls _synthesizeLeaves() with
  * the residual members. Tests capture leaves via a mock _synthesizeLeaves.
- * Also, ably-js's startSync() during an active sync is a no-op (doesn't reset
- * residualMembers), which differs from the UTS spec's expectation.
  */
 
 import { expect } from 'chai';
@@ -165,14 +163,9 @@ describe('uts/realtime/unit/presence/presence_sync', function () {
 
   /**
    * RTP18a - New sync discards previous in-flight sync
-   *
-   * DEVIATION: In ably-js, startSync() during an active sync is a no-op
-   * (does not reset residualMembers). This test verifies ably-js behavior.
    */
   // UTS: realtime/unit/RTP18a/new-sync-discards-previous-1
   it('RTP18a - new sync discards previous in-flight sync', function () {
-    if (!process.env.RUN_DEVIATIONS) this.skip();
-
     const { map, mock } = createPresenceMap();
 
     map.put(msg({ action: 'enter', clientId: 'alice', connectionId: 'c1', id: 'c1:0:0', timestamp: 100 }));
@@ -181,7 +174,7 @@ describe('uts/realtime/unit/presence/presence_sync', function () {
     map.startSync();
     map.put(msg({ action: 'present', clientId: 'alice', connectionId: 'c1', id: 'c1:1:0', timestamp: 200 }));
 
-    // Second startSync — UTS expects residual reset, ably-js ignores
+    // The second sync starts from the current membership map.
     map.startSync();
     map.put(msg({ action: 'present', clientId: 'alice', connectionId: 'c1', id: 'c1:2:0', timestamp: 300 }));
     map.put(msg({ action: 'present', clientId: 'bob', connectionId: 'c2', id: 'c2:1:0', timestamp: 300 }));


### PR DESCRIPTION
## Summary

- reset residual presence members when a new sync sequence replaces one already in progress
- track the sync sequence ID so pages from the same multi-message sync continue accumulating normally
- enable the RTP18a UTS regression test as a conforming test

## Validation

- `npm run test:uts:unit` (1,052 passing, 55 pending)
- `npx mocha --no-config --require tsx/cjs test/uts/realtime/unit/presence/presence_sync.test.ts` (14 passing)
- `npx eslint src/common/lib/client/presencemap.ts src/common/lib/client/realtimepresence.ts`
- `npx prettier --check src/common/lib/client/presencemap.ts src/common/lib/client/realtimepresence.ts test/uts/realtime/unit/presence/presence_sync.test.ts`
- `git diff --check`

Fixes #2215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reworked realtime presence synchronization so repeated sync starts rebuild the residual membership snapshot from the latest state.
  * Improved sync-sequence handling by tracking a sync identifier from the sync channel serial, preventing duplicate/incorrect member-sync initialization.
  * Ensures absent entries are excluded when rebuilding residual state and clears the identifier when the sync sequence completes.
* **Tests**
  * Updated realtime presence sync tests and comments to reflect the “new sync discards previous in-flight sync” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->