### PR TITLE
[AIT-850] feat: react native push plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,7 +73,14 @@ module.exports = function (grunt) {
     });
   });
 
-  grunt.registerTask('build', ['webpack:all', 'build:browser', 'build:node', 'build:push', 'build:liveobjects']);
+  grunt.registerTask('build', [
+    'webpack:all',
+    'build:browser',
+    'build:node',
+    'build:push',
+    'build:react-native-push',
+    'build:liveobjects',
+  ]);
 
   grunt.registerTask('all', ['build', 'requirejs']);
 
@@ -130,6 +137,19 @@ module.exports = function (grunt) {
       esbuild.build(esbuildConfig.pushPluginCdnConfig),
       esbuild.build(esbuildConfig.minifiedPushPluginCdnConfig),
     ])
+      .then(() => {
+        done(true);
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  grunt.registerTask('build:react-native-push', function () {
+    var done = this.async();
+
+    esbuild
+      .build(esbuildConfig.reactNativePushPluginConfig)
       .then(() => {
         done(true);
       })

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -1880,8 +1880,16 @@ export declare interface RestClient {
    * Retrieves a {@link LocalDevice} object that represents the current state of the device as a target for push notifications.
    *
    * @returns A {@link LocalDevice} object.
+   *
+   * @deprecated Use {@link getDevice} instead. `device()` reads the device state from storage synchronously, which is not possible on platforms with asynchronous storage such as React Native. In the next major release `device()` will become asynchronous.
    */
   device(): LocalDevice;
+  /**
+   * Retrieves a {@link LocalDevice} object that represents the current state of the device as a target for push notifications, loading it from persistent storage if necessary.
+   *
+   * @returns A promise which resolves to a {@link LocalDevice} object.
+   */
+  getDevice(): Promise<LocalDevice>;
 }
 
 /**
@@ -1976,8 +1984,16 @@ export declare interface RealtimeClient {
    * Retrieves a {@link LocalDevice} object that represents the current state of the device as a target for push notifications.
    *
    * @returns A {@link LocalDevice} object.
+   *
+   * @deprecated Use {@link getDevice} instead. `device()` reads the device state from storage synchronously, which is not possible on platforms with asynchronous storage such as React Native. In the next major release `device()` will become asynchronous.
    */
   device(): LocalDevice;
+  /**
+   * Retrieves a {@link LocalDevice} object that represents the current state of the device as a target for push notifications, loading it from persistent storage if necessary.
+   *
+   * @returns A promise which resolves to a {@link LocalDevice} object.
+   */
+  getDevice(): Promise<LocalDevice>;
 }
 
 /**
@@ -4008,6 +4024,7 @@ export declare class Rest implements RestClient {
   batchPresence(channels: string[]): Promise<BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult>[]>;
   push: Push;
   device(): LocalDevice;
+  getDevice(): Promise<LocalDevice>;
 }
 
 /**
@@ -4068,6 +4085,7 @@ export declare class Realtime implements RealtimeClient {
   batchPresence(channels: string[]): Promise<BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult>[]>;
   push: Push;
   device(): LocalDevice;
+  getDevice(): Promise<LocalDevice>;
 }
 
 /**

--- a/ably.d.ts
+++ b/ably.d.ts
@@ -1880,7 +1880,6 @@ export declare interface RestClient {
    * Retrieves a {@link LocalDevice} object that represents the current state of the device as a target for push notifications.
    *
    * @returns A {@link LocalDevice} object.
-   *
    * @deprecated Use {@link getDevice} instead. `device()` reads the device state from storage synchronously, which is not possible on platforms with asynchronous storage such as React Native. In the next major release `device()` will become asynchronous.
    */
   device(): LocalDevice;
@@ -1984,7 +1983,6 @@ export declare interface RealtimeClient {
    * Retrieves a {@link LocalDevice} object that represents the current state of the device as a target for push notifications.
    *
    * @returns A {@link LocalDevice} object.
-   *
    * @deprecated Use {@link getDevice} instead. `device()` reads the device state from storage synchronously, which is not possible on platforms with asynchronous storage such as React Native. In the next major release `device()` will become asynchronous.
    */
   device(): LocalDevice;

--- a/grunt/esbuild/build.js
+++ b/grunt/esbuild/build.js
@@ -77,6 +77,17 @@ const minifiedPushPluginCdnConfig = {
   minify: true,
 };
 
+// no CDN (.umd/.umd.min) variants: there is no script-tag consumption path in React Native.
+// 'react-native' stays external so the bundle carries no native module dependency; the UMD
+// wrapper requires externals at module load, which Metro resolves statically in an RN app.
+const reactNativePushPluginConfig = {
+  ...createBaseConfig(),
+  entryPoints: ['src/plugins/react-native-push/index.ts'],
+  plugins: [umdWrapper.default({ libraryName: 'AblyReactNativePushPlugin', amdNamedModule: false })],
+  outfile: 'build/react-native-push.js',
+  external: ['ulid', 'react-native'],
+};
+
 const liveObjectsPluginConfig = {
   ...createBaseConfig(),
   entryPoints: ['src/plugins/liveobjects/index.ts'],
@@ -117,6 +128,7 @@ module.exports = {
   pushPluginConfig,
   pushPluginCdnConfig,
   minifiedPushPluginCdnConfig,
+  reactNativePushPluginConfig,
   liveObjectsPluginConfig,
   liveObjectsPluginEsmConfig,
   liveObjectsPluginCdnConfig,

--- a/modular.d.ts
+++ b/modular.d.ts
@@ -329,6 +329,7 @@ export declare class BaseRest implements RestClient {
   batchPresence(channels: string[]): Promise<BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult>[]>;
   push: Push;
   device(): LocalDevice;
+  getDevice(): Promise<LocalDevice>;
 }
 
 /**
@@ -383,6 +384,7 @@ export declare class BaseRealtime implements RealtimeClient {
   batchPresence(channels: string[]): Promise<BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult>[]>;
   push: Push;
   device(): LocalDevice;
+  getDevice(): Promise<LocalDevice>;
 }
 
 export { ErrorInfo };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
       "types": "./push.d.ts",
       "import": "./build/push.js"
     },
+    "./react-native-push": {
+      "types": "./react-native-push.d.ts",
+      "default": "./build/react-native-push.js"
+    },
     "./liveobjects": {
       "import": {
         "types": "./liveobjects.d.mts",
@@ -60,6 +64,7 @@
     "promises.d.ts",
     "promises.js",
     "push.d.ts",
+    "react-native-push.d.ts",
     "resources/**",
     "src/**",
     "react/**"
@@ -183,6 +188,7 @@
     "build:react:mjs": "tsc --project src/platform/react-hooks/tsconfig.mjs.json && cp src/platform/react-hooks/res/package.mjs.json react/mjs/package.json",
     "build:react:cjs": "tsc --project src/platform/react-hooks/tsconfig.cjs.json && cp src/platform/react-hooks/res/package.cjs.json react/cjs/package.json",
     "build:push": "grunt build:push",
+    "build:react-native-push": "grunt build:react-native-push",
     "build:liveobjects": "grunt build:liveobjects",
     "requirejs": "grunt requirejs",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "promises.js",
     "push.d.ts",
     "react-native-push.d.ts",
+    "react-native-push.js",
     "resources/**",
     "src/**",
     "react/**"

--- a/react-native-push.d.ts
+++ b/react-native-push.d.ts
@@ -1,0 +1,113 @@
+// The ESLint warning is triggered because we only use these types in a documentation comment.
+/* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
+import { RealtimeClient, RestClient } from './ably';
+/* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
+
+/**
+ * Asynchronous key-value storage used to persist push activation state. Matches the interface of
+ * `@react-native-async-storage/async-storage`, so its default export can be passed directly.
+ */
+export interface ReactNativePushStorage {
+  /**
+   * Retrieves a stored value.
+   *
+   * @param key - The key to read.
+   * @returns A promise which resolves to the stored value, or `null` if absent.
+   */
+  getItem(key: string): Promise<string | null>;
+  /**
+   * Stores a value.
+   *
+   * @param key - The key to write.
+   * @param value - The value to store.
+   * @returns A promise which resolves once the value is persisted.
+   */
+  setItem(key: string, value: string): Promise<void>;
+  /**
+   * Removes a stored value.
+   *
+   * @param key - The key to remove.
+   * @returns A promise which resolves once the value is removed.
+   */
+  removeItem(key: string): Promise<void>;
+}
+
+/**
+ * A push token obtained by the application, along with the transport it belongs to.
+ *
+ * Return `transportType: 'fcm'` for a Firebase Cloud Messaging registration token (what
+ * `messaging().getToken()` from `@react-native-firebase/messaging` returns, on both Android and
+ * iOS), or `transportType: 'apns'` for a raw APNs device token (e.g. from
+ * `messaging().getAPNSToken()`).
+ */
+export interface ReactNativePushToken {
+  /**
+   * The push transport the token belongs to.
+   */
+  transportType: 'fcm' | 'apns';
+  /**
+   * The token itself: an FCM registration token or an APNs device token.
+   */
+  token: string;
+}
+
+/**
+ * Options for {@link ReactNativePush.create}.
+ */
+export interface ReactNativePushOptions {
+  /**
+   * Persistent storage for push activation state, e.g. the default export of
+   * `@react-native-async-storage/async-storage`.
+   */
+  storage: ReactNativePushStorage;
+  /**
+   * Called by the plugin whenever it needs a push token. Requesting notification permissions
+   * beforehand is the application's responsibility.
+   */
+  requestToken: () => Promise<ReactNativePushToken>;
+}
+
+/**
+ * Provides a {@link RestClient} or {@link RealtimeClient} instance with the ability to be activated as a target for push notifications in a React Native application.
+ *
+ * Unlike the web `ably/push` plugin, the push environment is supplied by your application: pass an
+ * async storage implementation and a token callback to `create()`, then register the returned
+ * object under the `Push` plugin key:
+ *
+ * ```javascript
+ * import { Realtime } from 'ably';
+ * import ReactNativePush from 'ably/react-native-push';
+ * import AsyncStorage from '@react-native-async-storage/async-storage';
+ * import messaging from '@react-native-firebase/messaging';
+ *
+ * const Push = ReactNativePush.create({
+ *   storage: AsyncStorage,
+ *   requestToken: async () => {
+ *     // permission prompts are your responsibility, e.g. via messaging().requestPermission()
+ *     return { transportType: 'fcm', token: await messaging().getToken() };
+ *   },
+ * });
+ *
+ * const realtime = new Realtime({ ...options, plugins: { Push } });
+ * await realtime.push.activate();
+ * ```
+ */
+declare const ReactNativePush: {
+  /**
+   * Creates a push plugin configured for this React Native application.
+   *
+   * @param options - The storage and token acquisition hooks supplied by your application.
+   * @returns A plugin object to pass as `plugins: { Push }` in the client options.
+   */
+  create(options: ReactNativePushOptions): any;
+};
+
+/**
+ * Creates a push plugin configured for this React Native application.
+ *
+ * @param options - The storage and token acquisition hooks supplied by your application.
+ * @returns A plugin object to pass as `plugins: { Push }` in the client options.
+ */
+export declare function create(options: ReactNativePushOptions): any;
+
+export default ReactNativePush;

--- a/react-native-push.d.ts
+++ b/react-native-push.d.ts
@@ -4,70 +4,6 @@ import { RealtimeClient, RestClient } from './ably';
 /* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
 
 /**
- * Asynchronous key-value storage used to persist push activation state. Matches the interface of
- * `@react-native-async-storage/async-storage`, so its default export can be passed directly.
- */
-export interface ReactNativePushStorage {
-  /**
-   * Retrieves a stored value.
-   *
-   * @param key - The key to read.
-   * @returns A promise which resolves to the stored value, or `null` if absent.
-   */
-  getItem(key: string): Promise<string | null>;
-  /**
-   * Stores a value.
-   *
-   * @param key - The key to write.
-   * @param value - The value to store.
-   * @returns A promise which resolves once the value is persisted.
-   */
-  setItem(key: string, value: string): Promise<void>;
-  /**
-   * Removes a stored value.
-   *
-   * @param key - The key to remove.
-   * @returns A promise which resolves once the value is removed.
-   */
-  removeItem(key: string): Promise<void>;
-}
-
-/**
- * A push token obtained by the application, along with the transport it belongs to.
- *
- * Return `transportType: 'fcm'` for a Firebase Cloud Messaging registration token (what
- * `messaging().getToken()` from `@react-native-firebase/messaging` returns, on both Android and
- * iOS), or `transportType: 'apns'` for a raw APNs device token (e.g. from
- * `messaging().getAPNSToken()`).
- */
-export interface ReactNativePushToken {
-  /**
-   * The push transport the token belongs to.
-   */
-  transportType: 'fcm' | 'apns';
-  /**
-   * The token itself: an FCM registration token or an APNs device token.
-   */
-  token: string;
-}
-
-/**
- * Options for {@link ReactNativePush.create}.
- */
-export interface ReactNativePushOptions {
-  /**
-   * Persistent storage for push activation state, e.g. the default export of
-   * `@react-native-async-storage/async-storage`.
-   */
-  storage: ReactNativePushStorage;
-  /**
-   * Called by the plugin whenever it needs a push token. Requesting notification permissions
-   * beforehand is the application's responsibility.
-   */
-  requestToken: () => Promise<ReactNativePushToken>;
-}
-
-/**
  * Provides a {@link RestClient} or {@link RealtimeClient} instance with the ability to be activated as a target for push notifications in a React Native application.
  *
  * Unlike the web `ably/push` plugin, the push environment is supplied by your application: pass an
@@ -92,22 +28,78 @@ export interface ReactNativePushOptions {
  * await realtime.push.activate();
  * ```
  */
-declare const ReactNativePush: {
+declare namespace ReactNativePush {
+  /**
+   * Asynchronous key-value storage used to persist push activation state. Matches the interface of
+   * `@react-native-async-storage/async-storage`, so its default export can be passed directly.
+   */
+  interface ReactNativePushStorage {
+    /**
+     * Retrieves a stored value.
+     *
+     * @param key - The key to read.
+     * @returns A promise which resolves to the stored value, or `null` if absent.
+     */
+    getItem(key: string): Promise<string | null>;
+    /**
+     * Stores a value.
+     *
+     * @param key - The key to write.
+     * @param value - The value to store.
+     * @returns A promise which resolves once the value is persisted.
+     */
+    setItem(key: string, value: string): Promise<void>;
+    /**
+     * Removes a stored value.
+     *
+     * @param key - The key to remove.
+     * @returns A promise which resolves once the value is removed.
+     */
+    removeItem(key: string): Promise<void>;
+  }
+
+  /**
+   * A push token obtained by the application, along with the transport it belongs to.
+   *
+   * Return `transportType: 'fcm'` for a Firebase Cloud Messaging registration token (what
+   * `messaging().getToken()` from `@react-native-firebase/messaging` returns, on both Android and
+   * iOS), or `transportType: 'apns'` for a raw APNs device token (e.g. from
+   * `messaging().getAPNSToken()`).
+   */
+  interface ReactNativePushToken {
+    /**
+     * The push transport the token belongs to.
+     */
+    transportType: 'fcm' | 'apns';
+    /**
+     * The token itself: an FCM registration token or an APNs device token.
+     */
+    token: string;
+  }
+
+  /**
+   * Options for {@link create}.
+   */
+  interface ReactNativePushOptions {
+    /**
+     * Persistent storage for push activation state, e.g. the default export of
+     * `@react-native-async-storage/async-storage`.
+     */
+    storage: ReactNativePushStorage;
+    /**
+     * Called by the plugin whenever it needs a push token. Requesting notification permissions
+     * beforehand is the application's responsibility.
+     */
+    requestToken: () => Promise<ReactNativePushToken>;
+  }
+
   /**
    * Creates a push plugin configured for this React Native application.
    *
    * @param options - The storage and token acquisition hooks supplied by your application.
    * @returns A plugin object to pass as `plugins: { Push }` in the client options.
    */
-  create(options: ReactNativePushOptions): any;
-};
+  function create(options: ReactNativePushOptions): any;
+}
 
-/**
- * Creates a push plugin configured for this React Native application.
- *
- * @param options - The storage and token acquisition hooks supplied by your application.
- * @returns A plugin object to pass as `plugins: { Push }` in the client options.
- */
-export declare function create(options: ReactNativePushOptions): any;
-
-export default ReactNativePush;
+export = ReactNativePush;

--- a/react-native-push.js
+++ b/react-native-push.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// Entry point for resolvers that do not support the package `exports` map, such as Metro before
+// React Native 0.79. Resolvers with `exports` support use the "./react-native-push" entry in
+// package.json instead.
+module.exports = require('./build/react-native-push.js');

--- a/scripts/moduleReport.ts
+++ b/scripts/moduleReport.ts
@@ -46,8 +46,13 @@ interface PluginInfo {
   external?: string[];
 }
 
-const buildablePlugins: Record<'push' | 'liveobjects', PluginInfo> = {
+const buildablePlugins: Record<'push' | 'reactNativePush' | 'liveobjects', PluginInfo> = {
   push: { description: 'Push', path: './build/push.js', external: ['ulid'] },
+  reactNativePush: {
+    description: 'ReactNativePush',
+    path: './build/react-native-push.js',
+    external: ['ulid', 'react-native'],
+  },
   liveobjects: { description: 'LiveObjects', path: './build/liveobjects.js', external: ['dequal'] },
 };
 
@@ -217,6 +222,10 @@ async function calculatePushPluginSize(): Promise<Output> {
   return calculatePluginSize(buildablePlugins.push);
 }
 
+async function calculateReactNativePushPluginSize(): Promise<Output> {
+  return calculatePluginSize(buildablePlugins.reactNativePush);
+}
+
 async function calculateLiveObjectsPluginSize(): Promise<Output> {
   return calculatePluginSize(buildablePlugins.liveobjects);
 }
@@ -321,6 +330,23 @@ async function checkPushPluginFiles() {
   return checkBundleFiles(pushPluginBundleInfo, allowedFiles, 100);
 }
 
+async function checkReactNativePushPluginFiles() {
+  const { path, external } = buildablePlugins.reactNativePush;
+  const pluginBundleInfo = getBundleInfo(path, undefined, external);
+
+  // These are the files that are allowed to contribute >= `threshold` bytes to the ReactNativePush
+  // bundle. The plugin re-exports the push plugin's state machine, so the push files appear too.
+  const allowedFiles = new Set([
+    'src/plugins/react-native-push/index.ts',
+    'src/plugins/react-native-push/getReactNativePushDeviceDetails.ts',
+    'src/plugins/push/pushchannel.ts',
+    'src/plugins/push/getW3CDeviceDetails.ts',
+    'src/plugins/push/pushactivation.ts',
+  ]);
+
+  return checkBundleFiles(pluginBundleInfo, allowedFiles, 100);
+}
+
 async function checkLiveObjectsPluginFiles() {
   const { path, external } = buildablePlugins.liveobjects;
   const pluginBundleInfo = getBundleInfo(path, undefined, external);
@@ -400,6 +426,7 @@ async function checkBundleFiles(bundleInfo: BundleInfo, allowedFiles: Set<string
       calculateAndCheckExportSizes(),
       calculateAndCheckFunctionSizes(),
       calculatePushPluginSize(),
+      calculateReactNativePushPluginSize(),
       calculateLiveObjectsPluginSize(),
     ])
   ).reduce((accum, current) => ({
@@ -409,6 +436,7 @@ async function checkBundleFiles(bundleInfo: BundleInfo, allowedFiles: Set<string
 
   output.errors.push(...(await checkBaseRealtimeFiles()));
   output.errors.push(...(await checkPushPluginFiles()));
+  output.errors.push(...(await checkReactNativePushPluginFiles()));
   output.errors.push(...(await checkLiveObjectsPluginFiles()));
 
   const table = new Table({

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -190,8 +190,16 @@ class BaseClient {
       throwMissingPluginError('Push');
     }
     if (!this._device) {
-      this._devicePromise ??= this.push.LocalDevice.loadAsync(this);
-      this._device = await this._devicePromise;
+      const devicePromise = (this._devicePromise ??= this.push.LocalDevice.loadAsync(this));
+      try {
+        this._device = await devicePromise;
+      } catch (err) {
+        // drop the failed load so a later call can retry after a transient storage failure
+        if (this._devicePromise === devicePromise) {
+          this._devicePromise = undefined;
+        }
+        throw err;
+      }
     }
     return this._device;
   }

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -54,6 +54,7 @@ class BaseClient {
   readonly _liveObjectsPlugin: typeof LiveObjectsPlugin | null;
   readonly logger: Logger;
   _device?: LocalDevice;
+  private _devicePromise?: Promise<LocalDevice>;
 
   constructor(options: ClientOptions) {
     this._additionalHTTPRequestImplementations = options.plugins ?? null;
@@ -145,13 +146,40 @@ class BaseClient {
     return this.rest.push;
   }
 
-  /** RSH8 */
+  /**
+   * RSH8
+   *
+   * @deprecated Use {@link getDevice} instead. `device()` reads the device state from storage
+   * synchronously, which is not possible on platforms with asynchronous storage such as React
+   * Native. In the next major release `device()` will become asynchronous.
+   */
   device(): LocalDevice & API.LocalDevice {
     if (!this.options.plugins?.Push || !this.push.LocalDevice) {
       throwMissingPluginError('Push');
     }
     if (!this._device) {
+      if (Platform.Config.push?.storageIsAsync) {
+        throw new ErrorInfo({
+          message: 'client.device() cannot load the local device synchronously: push storage on this platform is asynchronous',
+          code: 40000,
+          statusCode: 400,
+          remediation:
+            'Use await client.getDevice() instead. device() is deprecated and will become asynchronous in the next major release.',
+        });
+      }
       this._device = this.push.LocalDevice.load(this);
+    }
+    return this._device;
+  }
+
+  /** RSH8 */
+  async getDevice(): Promise<LocalDevice & API.LocalDevice> {
+    if (!this.options.plugins?.Push || !this.push.LocalDevice) {
+      throwMissingPluginError('Push');
+    }
+    if (!this._device) {
+      this._devicePromise ??= this.push.LocalDevice.loadAsync(this);
+      this._device = await this._devicePromise;
     }
     return this._device;
   }

--- a/src/common/lib/client/baseclient.ts
+++ b/src/common/lib/client/baseclient.ts
@@ -18,6 +18,7 @@ import { MsgPack } from 'common/types/msgpack';
 import { HTTPRequestImplementations } from 'platform/web/lib/http/http';
 import { FilteredSubscriptions } from './filteredsubscriptions';
 import type { LocalDevice } from 'plugins/push/pushactivation';
+import type { IPlatformPushConfig } from 'common/types/IPlatformConfig';
 import EventEmitter from '../util/eventemitter';
 import { MessageEncoding } from '../types/basemessage';
 import type * as LiveObjectsPlugin from 'plugins/liveobjects';
@@ -147,6 +148,16 @@ class BaseClient {
   }
 
   /**
+   * The effective platform push config for this client. A config carried by the client's Push
+   * plugin (e.g. ReactNativePush, whose storage and token callbacks are supplied per client)
+   * takes precedence over the platform-level Platform.Config.push (set statically on web), so
+   * multiple clients never share plugin-supplied storage or callbacks.
+   */
+  get pushConfig(): IPlatformPushConfig | undefined {
+    return this.options.plugins?.Push?.pushConfig ?? Platform.Config.push;
+  }
+
+  /**
    * RSH8
    *
    * @deprecated Use {@link getDevice} instead. `device()` reads the device state from storage
@@ -158,9 +169,10 @@ class BaseClient {
       throwMissingPluginError('Push');
     }
     if (!this._device) {
-      if (Platform.Config.push?.storageIsAsync) {
+      if (this.pushConfig?.storageIsAsync) {
         throw new ErrorInfo({
-          message: 'client.device() cannot load the local device synchronously: push storage on this platform is asynchronous',
+          message:
+            'client.device() cannot load the local device synchronously: push storage on this platform is asynchronous',
           code: 40000,
           statusCode: 400,
           remediation:

--- a/src/common/lib/client/modularplugins.ts
+++ b/src/common/lib/client/modularplugins.ts
@@ -12,6 +12,7 @@ import Annotation, { WireAnnotation } from '../types/annotation';
 import { TransportCtor } from '../transport/transport';
 import type * as PushPlugin from 'plugins/push';
 import type * as LiveObjectsPlugin from 'plugins/liveobjects';
+import type { IPlatformPushConfig } from 'common/types/IPlatformConfig';
 
 export interface PresenceMessagePlugin {
   PresenceMessage: typeof PresenceMessage;
@@ -40,7 +41,11 @@ export interface ModularPlugins {
   XHRRequest?: typeof XHRRequest;
   FetchRequest?: typeof fetchRequest;
   MessageInteractions?: typeof FilteredSubscriptions;
-  Push?: typeof PushPlugin;
+  // the default-export object shape, which is what consumers actually pass (both the web push
+  // plugin's and ReactNativePush.create()'s objects). pushConfig is optional and carried by
+  // plugins that supply their own platform push config (e.g. ReactNativePush); the web push
+  // plugin relies on the statically-set Platform.Config.push.
+  Push?: (typeof PushPlugin)['default'] & { pushConfig?: IPlatformPushConfig };
   LiveObjects?: typeof LiveObjectsPlugin; // PC5, PT2b
 }
 

--- a/src/common/lib/client/modularplugins.ts
+++ b/src/common/lib/client/modularplugins.ts
@@ -43,8 +43,9 @@ export interface ModularPlugins {
   MessageInteractions?: typeof FilteredSubscriptions;
   // the default-export object shape, which is what consumers actually pass (both the web push
   // plugin's and ReactNativePush.create()'s objects). pushConfig is optional and carried by
-  // plugins that supply their own platform push config (e.g. ReactNativePush); the web push
-  // plugin relies on the statically-set Platform.Config.push.
+  // plugins that supply their own platform push config (e.g. ReactNativePush); it is read per
+  // client via BaseClient.pushConfig. The web push plugin relies on the statically-set
+  // Platform.Config.push fallback.
   Push?: (typeof PushPlugin)['default'] & { pushConfig?: IPlatformPushConfig };
   LiveObjects?: typeof LiveObjectsPlugin; // PC5, PT2b
 }

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -39,84 +39,99 @@ class Push {
   }
 
   async activate(registerCallback?: RegisterCallback, updateFailedCallback?: ErrCallback) {
-    await new Promise<void>((resolve, reject) => {
-      if (!this.client.options.plugins?.Push) {
-        reject(Utils.createMissingPluginError('Push'));
-        return;
-      }
-      if (!this.stateMachine) {
-        const err = new ErrorInfo({
-          message:
-            'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support',
-          code: 40000,
-          statusCode: 400,
-          remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
-        });
-        reject(err);
-        return;
-      }
-      if (this.stateMachine.activatedCallback) {
-        const err = new ErrorInfo({
-          message: 'Activation already in progress',
-          code: 40000,
-          statusCode: 400,
-          remediation: 'Await the in-flight push.activate() before calling it again.',
-        });
-        reject(err);
-        return;
-      }
-      this.stateMachine.activatedCallback = (err: ErrorInfo) => {
+    const pushPlugin = this.client.options.plugins?.Push;
+    if (!pushPlugin) {
+      throw Utils.createMissingPluginError('Push');
+    }
+    const machine = this.stateMachine;
+    if (!machine) {
+      throw new ErrorInfo({
+        message:
+          'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support',
+        code: 40000,
+        statusCode: 400,
+        remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
+      });
+    }
+    if (machine.activatedCallback) {
+      throw new ErrorInfo({
+        message: 'Activation already in progress',
+        code: 40000,
+        statusCode: 400,
+        remediation: 'Await the in-flight push.activate() before calling it again.',
+      });
+    }
+    // register the callback synchronously with the in-progress check above, so a concurrent
+    // activate() call is rejected rather than silently replacing this one's callback
+    const activated = new Promise<void>((resolve, reject) => {
+      machine.activatedCallback = (err: ErrorInfo) => {
         if (err) {
           reject(err);
           return;
         }
         resolve();
       };
-      this.stateMachine.updateFailedCallback = updateFailedCallback;
-      this.stateMachine.handleEvent(
-        new this.client.options.plugins.Push.CalledActivate(this.stateMachine, registerCallback),
-      );
+      machine.updateFailedCallback = updateFailedCallback;
     });
+    // the state machine's processEvent handlers read the local device synchronously, so the
+    // device and the persisted machine state must be hydrated before any event is dispatched
+    try {
+      await this.client.getDevice();
+      await machine.ensureInitialized();
+    } catch (err) {
+      delete machine.activatedCallback;
+      delete machine.updateFailedCallback;
+      throw err;
+    }
+    machine.handleEvent(new pushPlugin.CalledActivate(machine, registerCallback));
+    await activated;
   }
 
   async deactivate(deregisterCallback: DeregisterCallback) {
-    await new Promise<void>((resolve, reject) => {
-      if (!this.client.options.plugins?.Push) {
-        reject(Utils.createMissingPluginError('Push'));
-        return;
-      }
-      if (!this.stateMachine) {
-        const err = new ErrorInfo({
-          message:
-            'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support',
-          code: 40000,
-          statusCode: 400,
-          remediation: PUSH_DEACTIVATION_NOT_AVAILABLE_HINT,
-        });
-        reject(err);
-        return;
-      }
-      if (this.stateMachine.deactivatedCallback) {
-        const err = new ErrorInfo({
-          message: 'Deactivation already in progress',
-          code: 40000,
-          statusCode: 400,
-          remediation: 'Await the in-flight push.deactivate() before calling it again.',
-        });
-        reject(err);
-        return;
-      }
-      this.stateMachine.deactivatedCallback = (err: ErrorInfo) => {
+    const pushPlugin = this.client.options.plugins?.Push;
+    if (!pushPlugin) {
+      throw Utils.createMissingPluginError('Push');
+    }
+    const machine = this.stateMachine;
+    if (!machine) {
+      throw new ErrorInfo({
+        message:
+          'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support',
+        code: 40000,
+        statusCode: 400,
+        remediation: PUSH_DEACTIVATION_NOT_AVAILABLE_HINT,
+      });
+    }
+    if (machine.deactivatedCallback) {
+      throw new ErrorInfo({
+        message: 'Deactivation already in progress',
+        code: 40000,
+        statusCode: 400,
+        remediation: 'Await the in-flight push.deactivate() before calling it again.',
+      });
+    }
+    // register the callback synchronously with the in-progress check above, so a concurrent
+    // deactivate() call is rejected rather than silently replacing this one's callback
+    const deactivated = new Promise<void>((resolve, reject) => {
+      machine.deactivatedCallback = (err: ErrorInfo) => {
         if (err) {
           reject(err);
           return;
         }
         resolve();
       };
-      this.stateMachine.handleEvent(
-        new this.client.options.plugins.Push.CalledDeactivate(this.stateMachine, deregisterCallback),
-      );
     });
+    // the state machine's processEvent handlers read the local device synchronously, so the
+    // device and the persisted machine state must be hydrated before any event is dispatched
+    try {
+      await this.client.getDevice();
+      await machine.ensureInitialized();
+    } catch (err) {
+      delete machine.deactivatedCallback;
+      throw err;
+    }
+    machine.handleEvent(new pushPlugin.CalledDeactivate(machine, deregisterCallback));
+    await deactivated;
   }
 }
 

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -32,9 +32,17 @@ class Push {
   constructor(client: BaseClient) {
     this.client = client;
     this.admin = new Admin(client);
-    if (Platform.Config.push && client.options.plugins?.Push) {
-      this.stateMachine = new client.options.plugins.Push.ActivationStateMachine(client);
-      this.LocalDevice = client.options.plugins.Push.localDeviceFactory(DeviceDetails);
+    const pushPlugin = client.options.plugins?.Push;
+    // a plugin may carry its own platform push config (e.g. ReactNativePush, whose storage and
+    // token acquisition are supplied by the user). The plugin cannot set the Platform singleton
+    // itself without bundling a second copy of it, so it is installed here. First plugin wins:
+    // a subsequent client with a different pushConfig keeps using the first one installed.
+    if (pushPlugin?.pushConfig && !Platform.Config.push) {
+      Platform.Config.push = pushPlugin.pushConfig;
+    }
+    if (Platform.Config.push && pushPlugin) {
+      this.stateMachine = new pushPlugin.ActivationStateMachine(client);
+      this.LocalDevice = pushPlugin.localDeviceFactory(DeviceDetails);
     }
   }
 

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -12,7 +12,6 @@ import type {
   LocalDeviceFactory,
   RegisterCallback,
 } from 'plugins/push/pushactivation';
-import Platform from 'common/platform';
 import type { ErrCallback } from 'common/types/utils';
 
 // Keep this byte-identical to the copy in src/plugins/push/pushactivation.ts. The plugin only
@@ -33,14 +32,10 @@ class Push {
     this.client = client;
     this.admin = new Admin(client);
     const pushPlugin = client.options.plugins?.Push;
-    // a plugin may carry its own platform push config (e.g. ReactNativePush, whose storage and
-    // token acquisition are supplied by the user). The plugin cannot set the Platform singleton
-    // itself without bundling a second copy of it, so it is installed here. First plugin wins:
-    // a subsequent client with a different pushConfig keeps using the first one installed.
-    if (pushPlugin?.pushConfig && !Platform.Config.push) {
-      Platform.Config.push = pushPlugin.pushConfig;
-    }
-    if (Platform.Config.push && pushPlugin) {
+    // client.pushConfig resolves to the plugin-carried push config (e.g. ReactNativePush, whose
+    // storage and token acquisition are supplied per client) or falls back to the platform-level
+    // Platform.Config.push (set statically on web), so each client keeps its own configuration
+    if (client.pushConfig && pushPlugin) {
       this.stateMachine = new pushPlugin.ActivationStateMachine(client);
       this.LocalDevice = pushPlugin.localDeviceFactory(DeviceDetails);
     }

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -18,10 +18,10 @@ import type { ErrCallback } from 'common/types/utils';
 // Keep this byte-identical to the copy in src/plugins/push/pushactivation.ts. The plugin only
 // type-imports from common client modules, so a value import here is not viable for the build.
 const PUSH_ACTIVATION_NOT_AVAILABLE_HINT =
-  'Run push.activate() in a browser environment with service worker support. From a server, use client.push.admin instead. Call client.push.admin.publish(recipient, payload) to send to a device or clientId. Call client.push.admin.deviceRegistrations.save(device) to register a device record.';
+  'Run push.activate() in a browser environment with service worker support, or in React Native using the ably/react-native-push plugin. From a server, use client.push.admin instead. Call client.push.admin.publish(recipient, payload) to send to a device or clientId. Call client.push.admin.deviceRegistrations.save(device) to register a device record.';
 
 const PUSH_DEACTIVATION_NOT_AVAILABLE_HINT =
-  'Run push.deactivate() in a browser environment with service worker support. From a server, call client.push.admin.deviceRegistrations.remove(deviceId) to remove a device registration.';
+  'Run push.deactivate() in a browser environment with service worker support, or in React Native using the ably/react-native-push plugin. From a server, call client.push.admin.deviceRegistrations.remove(deviceId) to remove a device registration.';
 
 class Push {
   client: BaseClient;
@@ -55,7 +55,7 @@ class Push {
     if (!machine) {
       throw new ErrorInfo({
         message:
-          'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support',
+          'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
         code: 40000,
         statusCode: 400,
         remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
@@ -104,7 +104,7 @@ class Push {
     if (!machine) {
       throw new ErrorInfo({
         message:
-          'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support',
+          'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
         code: 40000,
         statusCode: 400,
         remediation: PUSH_DEACTIVATION_NOT_AVAILABLE_HINT,

--- a/src/common/lib/types/devicedetails.ts
+++ b/src/common/lib/types/devicedetails.ts
@@ -41,7 +41,17 @@ interface PushChannelRecipient {
   ablyUrl: string;
 }
 
-type PushRecipient = WebPushRecipient | PushChannelRecipient;
+export interface FcmPushRecipient {
+  transportType: 'fcm';
+  registrationToken: string;
+}
+
+export interface ApnsPushRecipient {
+  transportType: 'apns';
+  deviceToken: string;
+}
+
+type PushRecipient = WebPushRecipient | PushChannelRecipient | FcmPushRecipient | ApnsPushRecipient;
 
 export type DevicePushDetails = {
   error?: ErrorInfo;

--- a/src/common/types/IPlatformConfig.d.ts
+++ b/src/common/types/IPlatformConfig.d.ts
@@ -44,15 +44,21 @@ export interface ISpecificPlatformConfig {
 }
 
 export interface IPlatformPushStorage {
-  get(name: string): string;
-  set(name: string, value: string);
-  remove(name: string);
+  get(name: string): string | null | Promise<string | null>;
+  set(name: string, value: string): void | Promise<void>;
+  remove(name: string): void | Promise<void>;
 }
 
 export interface IPlatformPushConfig {
   platform: DevicePlatform;
   formFactor: DeviceFormFactor;
   storage: IPlatformPushStorage;
+  /**
+   * Must be set when `storage` methods return promises (e.g. React Native's AsyncStorage).
+   * Declarative rather than inferred: the synchronous device-load path has write side effects
+   * and must be refused before any storage call is made against an async implementation.
+   */
+  storageIsAsync?: boolean;
   getPushDeviceDetails?(machine: any);
 }
 

--- a/src/plugins/push/getW3CDeviceDetails.ts
+++ b/src/plugins/push/getW3CDeviceDetails.ts
@@ -89,7 +89,7 @@ export async function getW3CPushDeviceDetails(machine: ActivationStateMachine) {
       throw new ErrorInfo('Public key not found', 50000, 500);
     }
 
-    const device = machine.client.device();
+    const device = await machine.client.getDevice();
     device.push.recipient = {
       transportType: 'web',
       targetUrl: btoa(endpoint),

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -12,7 +12,7 @@ import type { PaginatedResult } from 'common/lib/client/paginatedresource';
 // Keep this byte-identical to the copy in src/common/lib/client/push.ts. This plugin only
 // type-imports from common client modules, so a value import from there is not viable for the build.
 const PUSH_ACTIVATION_NOT_AVAILABLE_HINT =
-  'Run push.activate() in a browser environment with service worker support. From a server, use client.push.admin instead. Call client.push.admin.publish(recipient, payload) to send to a device or clientId. Call client.push.admin.deviceRegistrations.save(device) to register a device record.';
+  'Run push.activate() in a browser environment with service worker support, or in React Native using the ably/react-native-push plugin. From a server, use client.push.admin instead. Call client.push.admin.publish(recipient, payload) to send to a device or clientId. Call client.push.admin.deviceRegistrations.save(device) to register a device record.';
 
 const persistKeys = {
   deviceId: 'ably.push.deviceId',
@@ -43,11 +43,7 @@ export type LocalDevice = ReturnType<LocalDeviceFactory['load']>;
  * is made never-rejecting: failures are logged rather than propagated. Callers in asynchronous
  * contexts may still await the returned promise to sequence after the write.
  */
-function loggedStorageWrites(
-  client: BaseClient,
-  op: string,
-  writes: (void | Promise<void>)[],
-): void | Promise<void> {
+function loggedStorageWrites(client: BaseClient, op: string, writes: (void | Promise<void>)[]): void | Promise<void> {
   const promises = writes.filter((result): result is Promise<void> => !!result && typeof result.then === 'function');
   if (promises.length === 0) {
     return;
@@ -103,7 +99,7 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
       if (!Platform.Config.push) {
         throw new this.rest.ErrorInfo({
           message:
-            'Push activation is not available on this platform: it requires a browser environment with service worker support',
+            'Push activation is not available on this platform: it requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
           code: 40000,
           statusCode: 400,
           remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
@@ -149,7 +145,7 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
       if (!Platform.Config.push) {
         throw new this.rest.ErrorInfo({
           message:
-            'Push activation is not available on this platform: it requires a browser environment with service worker support',
+            'Push activation is not available on this platform: it requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
           code: 40000,
           statusCode: 400,
           remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
@@ -191,7 +187,7 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
       if (!Platform.Config.push) {
         throw new this.rest.ErrorInfo({
           message:
-            'Push activation is not available on this platform: it requires a browser environment with service worker support',
+            'Push activation is not available on this platform: it requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
           code: 40000,
           statusCode: 400,
           remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
@@ -218,7 +214,7 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
       if (!config.push) {
         throw new this.rest.ErrorInfo({
           message:
-            'Push activation is not available on this platform: it requires a browser environment with service worker support',
+            'Push activation is not available on this platform: it requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
           code: 40000,
           statusCode: 400,
           remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
@@ -297,7 +293,7 @@ export class ActivationStateMachine {
       // synchronous storage: resolve the persisted activation state immediately. With
       // asynchronous storage the state is resolved by ensureInitialized() instead.
       this.current = new ActivationStates[
-        ((this.pushConfig.storage.get(persistKeys.activationState) as string) as ActivationStateName) || 'NotActivated'
+        (this.pushConfig.storage.get(persistKeys.activationState) as string as ActivationStateName) || 'NotActivated'
       ](null);
     }
     this.pendingEvents = [];
@@ -324,7 +320,7 @@ export class ActivationStateMachine {
     if (!this._pushConfig) {
       throw new this.client.ErrorInfo({
         message:
-          'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support',
+          'This platform is not supported as a target of push notifications: push activation requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
         code: 40000,
         statusCode: 400,
         remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -39,26 +39,26 @@ export type LocalDevice = ReturnType<LocalDeviceFactory['load']>;
 
 /**
  * Push storage writes may be asynchronous (e.g. React Native's AsyncStorage). Several write sites
- * sit inside synchronous state-machine code and cannot await the result, so any returned promise
- * is made never-rejecting: failures are logged rather than propagated. Callers in asynchronous
- * contexts may still await the returned promise to sequence after the write.
+ * sit inside synchronous state-machine code and cannot await the result, so a logging rejection
+ * handler is pre-attached: ignoring the returned promise never causes an unhandled rejection. The
+ * returned promise itself still rejects, so asynchronous callers that await persistence observe
+ * the failure.
  */
 function loggedStorageWrites(client: BaseClient, op: string, writes: (void | Promise<void>)[]): void | Promise<void> {
   const promises = writes.filter((result): result is Promise<void> => !!result && typeof result.then === 'function');
   if (promises.length === 0) {
     return;
   }
-  return Promise.all(promises).then(
-    () => {},
-    (err) => {
-      client.Logger.logAction(
-        client.logger,
-        client.Logger.LOG_ERROR,
-        'Push.' + op,
-        'failed to persist push state to storage: ' + client.Utils.inspectError(err),
-      );
-    },
-  );
+  const allWritten = Promise.all(promises).then(() => {});
+  allWritten.catch((err) => {
+    client.Logger.logAction(
+      client.logger,
+      client.Logger.LOG_ERROR,
+      'Push.' + op,
+      'failed to persist push state to storage: ' + client.Utils.inspectError(err),
+    );
+  });
+  return allWritten;
 }
 
 /**
@@ -267,6 +267,8 @@ export class ActivationStateMachine {
   // set in the constructor with synchronous storage, or by ensureInitialized() with asynchronous storage
   current!: ActivationState;
   private _initPromise?: Promise<void>;
+  // serializes asynchronous activation-state writes; see persist()
+  private _activationStateWrite: Promise<void> = Promise.resolve();
   pendingEvents: ActivationEvent[];
   handling: boolean;
   deactivatedCallback?: ErrCallback;
@@ -307,8 +309,14 @@ export class ActivationStateMachine {
       return;
     }
     this._initPromise ??= (async () => {
-      const persistedName = (await this.pushConfig.storage.get(persistKeys.activationState)) as string | null;
-      this.current = new ActivationStates[(persistedName as ActivationStateName) || 'NotActivated'](null);
+      try {
+        const persistedName = (await this.pushConfig.storage.get(persistKeys.activationState)) as string | null;
+        this.current = new ActivationStates[(persistedName as ActivationStateName) || 'NotActivated'](null);
+      } catch (err) {
+        // drop the failed read so a later activation attempt can retry after a transient storage failure
+        this._initPromise = undefined;
+        throw err;
+      }
     })();
     return this._initPromise;
   }
@@ -327,9 +335,24 @@ export class ActivationStateMachine {
   }
 
   persist() {
-    if (this.current && isPersistentState(this.current)) {
+    if (!(this.current && isPersistentState(this.current))) {
+      return;
+    }
+    const name = this.current.name;
+    if (this.pushConfig.storageIsAsync) {
+      // chain asynchronous writes so an earlier slow write cannot complete after a later
+      // transition and restore stale activation state. Failures are logged by
+      // loggedStorageWrites; the queue swallows them so subsequent writes still run.
+      this._activationStateWrite = this._activationStateWrite
+        .then(() =>
+          loggedStorageWrites(this.client, 'ActivationStateMachine.persist()', [
+            this.pushConfig.storage.set(persistKeys.activationState, name),
+          ]),
+        )
+        .catch(() => {});
+    } else {
       loggedStorageWrites(this.client, 'ActivationStateMachine.persist()', [
-        this.pushConfig.storage.set(persistKeys.activationState, this.current.name),
+        this.pushConfig.storage.set(persistKeys.activationState, name),
       ]);
     }
   }

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -859,8 +859,11 @@ class WaitingForDeregistration extends ActivationState {
       const device = machine.client.device();
       delete device.deviceIdentityToken;
       delete device.push.recipient;
+      loggedStorageWrites(machine.client, 'WaitingForDeregistration.processEvent()', [
+        machine.pushConfig.storage.remove(persistKeys.deviceIdentityToken),
+        machine.pushConfig.storage.remove(persistKeys.pushRecipient),
+      ]);
       device.resetId();
-      device.persist();
       machine.callDeactivatedCallback(null);
       return new NotActivated();
     } else if (event instanceof DeregistrationFailed) {

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -38,6 +38,34 @@ export type LocalDeviceFactory = ReturnType<typeof localDeviceFactory>;
 export type LocalDevice = ReturnType<LocalDeviceFactory['load']>;
 
 /**
+ * Push storage writes may be asynchronous (e.g. React Native's AsyncStorage). Several write sites
+ * sit inside synchronous state-machine code and cannot await the result, so any returned promise
+ * is made never-rejecting: failures are logged rather than propagated. Callers in asynchronous
+ * contexts may still await the returned promise to sequence after the write.
+ */
+function loggedStorageWrites(
+  client: BaseClient,
+  op: string,
+  writes: (void | Promise<void>)[],
+): void | Promise<void> {
+  const promises = writes.filter((result): result is Promise<void> => !!result && typeof result.then === 'function');
+  if (promises.length === 0) {
+    return;
+  }
+  return Promise.all(promises).then(
+    () => {},
+    (err) => {
+      client.Logger.logAction(
+        client.logger,
+        client.Logger.LOG_ERROR,
+        'Push.' + op,
+        'failed to persist push state to storage: ' + client.Utils.inspectError(err),
+      );
+    },
+  );
+}
+
+/**
  * LocalDevice extends DeviceDetails, but DeviceDetails is part of core ably-js and LocalDevice is part of the Push plugin
  * In order to avoid bundling the DeviceDetails class in both core ably-js and the plugin, the LocalDevice is exported as
  * a factory, and the DeviceDetails constructor is used to create the class declaration for LocalDevice when the plugin is
@@ -61,6 +89,12 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
     static load(rest: BaseClient) {
       const device = new LocalDevice(rest);
       device.loadPersisted();
+      return device;
+    }
+
+    static async loadAsync(rest: BaseClient) {
+      const device = new LocalDevice(rest);
+      await device.loadPersistedAsync();
       return device;
     }
 
@@ -109,7 +143,50 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
       }).get({ deviceId: this.id });
     }
 
+    // keep in sync with loadPersistedAsync()
     loadPersisted() {
+      const Platform = this.rest.Platform;
+      if (!Platform.Config.push) {
+        throw new this.rest.ErrorInfo({
+          message:
+            'Push activation is not available on this platform: it requires a browser environment with service worker support',
+          code: 40000,
+          statusCode: 400,
+          remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
+        });
+      }
+      if (Platform.Config.push.storageIsAsync) {
+        throw new this.rest.ErrorInfo({
+          message: 'The local device cannot be loaded synchronously: push storage on this platform is asynchronous',
+          code: 40000,
+          statusCode: 400,
+          remediation:
+            'Use await client.getDevice() instead of client.device(). device() reads storage synchronously and is deprecated.',
+        });
+      }
+      this.platform = Platform.Config.push.platform;
+      this.clientId = this.rest.auth.clientId ?? undefined;
+      this.formFactor = Platform.Config.push.formFactor;
+      // this path is only reachable with synchronous storage (async storage implies storageIsAsync,
+      // which routes callers to getDevice() and the async load path), so the reads are cast to string
+      this.id = Platform.Config.push.storage.get(persistKeys.deviceId) as string;
+
+      if (this.id) {
+        this.deviceSecret = Platform.Config.push.storage.get(persistKeys.deviceSecret) as string;
+        this.deviceIdentityToken = JSON.parse(
+          (Platform.Config.push.storage.get(persistKeys.deviceIdentityToken) as string) || 'null',
+        );
+        this.push.recipient = JSON.parse(
+          (Platform.Config.push.storage.get(persistKeys.pushRecipient) as string) || 'null',
+        );
+      } else {
+        this.resetId();
+      }
+    }
+
+    // keep in sync with loadPersisted(); awaiting a non-promise is a no-op, so this single
+    // implementation serves both synchronous (web) and asynchronous (React Native) storage
+    async loadPersistedAsync() {
       const Platform = this.rest.Platform;
       if (!Platform.Config.push) {
         throw new this.rest.ErrorInfo({
@@ -123,20 +200,20 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
       this.platform = Platform.Config.push.platform;
       this.clientId = this.rest.auth.clientId ?? undefined;
       this.formFactor = Platform.Config.push.formFactor;
-      this.id = Platform.Config.push.storage.get(persistKeys.deviceId);
+      this.id = ((await Platform.Config.push.storage.get(persistKeys.deviceId)) ?? undefined) as string;
 
       if (this.id) {
-        this.deviceSecret = Platform.Config.push.storage.get(persistKeys.deviceSecret);
+        this.deviceSecret = ((await Platform.Config.push.storage.get(persistKeys.deviceSecret)) ?? undefined) as string;
         this.deviceIdentityToken = JSON.parse(
-          Platform.Config.push.storage.get(persistKeys.deviceIdentityToken) || 'null',
+          (await Platform.Config.push.storage.get(persistKeys.deviceIdentityToken)) || 'null',
         );
-        this.push.recipient = JSON.parse(Platform.Config.push.storage.get(persistKeys.pushRecipient) || 'null');
+        this.push.recipient = JSON.parse((await Platform.Config.push.storage.get(persistKeys.pushRecipient)) || 'null');
       } else {
-        this.resetId();
+        await this.resetId();
       }
     }
 
-    persist() {
+    persist(): void | Promise<void> {
       const config = this.rest.Platform.Config;
       if (!config.push) {
         throw new this.rest.ErrorInfo({
@@ -147,24 +224,26 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
           remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
         });
       }
+      const writes: (void | Promise<void>)[] = [];
       if (this.id) {
-        config.push.storage.set(persistKeys.deviceId, this.id);
+        writes.push(config.push.storage.set(persistKeys.deviceId, this.id));
       }
       if (this.deviceSecret) {
-        config.push.storage.set(persistKeys.deviceSecret, this.deviceSecret);
+        writes.push(config.push.storage.set(persistKeys.deviceSecret, this.deviceSecret));
       }
       if (this.deviceIdentityToken) {
-        config.push.storage.set(persistKeys.deviceIdentityToken, JSON.stringify(this.deviceIdentityToken));
+        writes.push(config.push.storage.set(persistKeys.deviceIdentityToken, JSON.stringify(this.deviceIdentityToken)));
       }
       if (this.push.recipient) {
-        config.push.storage.set(persistKeys.pushRecipient, JSON.stringify(this.push.recipient));
+        writes.push(config.push.storage.set(persistKeys.pushRecipient, JSON.stringify(this.push.recipient)));
       }
+      return loggedStorageWrites(this.rest, 'LocalDevice.persist()', writes);
     }
 
-    resetId() {
+    resetId(): void | Promise<void> {
       this.id = ulid();
       this.deviceSecret = ulid();
-      this.persist();
+      return this.persist();
     }
 
     getAuthDetails(
@@ -213,7 +292,7 @@ export class ActivationStateMachine {
     this.client = rest;
     this._pushConfig = rest.Platform.Config.push;
     this.current = new ActivationStates[
-      (this.pushConfig.storage.get(persistKeys.activationState) as ActivationStateName) || 'NotActivated'
+      ((this.pushConfig.storage.get(persistKeys.activationState) as string) as ActivationStateName) || 'NotActivated'
     ](null);
     this.pendingEvents = [];
     this.handling = false;
@@ -234,7 +313,9 @@ export class ActivationStateMachine {
 
   persist() {
     if (isPersistentState(this.current)) {
-      this.pushConfig.storage.set(persistKeys.activationState, this.current.name);
+      loggedStorageWrites(this.client, 'ActivationStateMachine.persist()', [
+        this.pushConfig.storage.set(persistKeys.activationState, this.current.name),
+      ]);
     }
   }
 

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -95,8 +95,7 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
     }
 
     async listSubscriptions(): Promise<PaginatedResult<PushChannelSubscription>> {
-      const Platform = this.rest.Platform;
-      if (!Platform.Config.push) {
+      if (!this.rest.pushConfig) {
         throw new this.rest.ErrorInfo({
           message:
             'Push activation is not available on this platform: it requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
@@ -141,8 +140,8 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
 
     // keep in sync with loadPersistedAsync()
     loadPersisted() {
-      const Platform = this.rest.Platform;
-      if (!Platform.Config.push) {
+      const pushConfig = this.rest.pushConfig;
+      if (!pushConfig) {
         throw new this.rest.ErrorInfo({
           message:
             'Push activation is not available on this platform: it requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
@@ -151,7 +150,7 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
           remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
         });
       }
-      if (Platform.Config.push.storageIsAsync) {
+      if (pushConfig.storageIsAsync) {
         throw new this.rest.ErrorInfo({
           message: 'The local device cannot be loaded synchronously: push storage on this platform is asynchronous',
           code: 40000,
@@ -160,21 +159,19 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
             'Use await client.getDevice() instead of client.device(). device() reads storage synchronously and is deprecated.',
         });
       }
-      this.platform = Platform.Config.push.platform;
+      this.platform = pushConfig.platform;
       this.clientId = this.rest.auth.clientId ?? undefined;
-      this.formFactor = Platform.Config.push.formFactor;
+      this.formFactor = pushConfig.formFactor;
       // this path is only reachable with synchronous storage (async storage implies storageIsAsync,
       // which routes callers to getDevice() and the async load path), so the reads are cast to string
-      this.id = Platform.Config.push.storage.get(persistKeys.deviceId) as string;
+      this.id = pushConfig.storage.get(persistKeys.deviceId) as string;
 
       if (this.id) {
-        this.deviceSecret = Platform.Config.push.storage.get(persistKeys.deviceSecret) as string;
+        this.deviceSecret = pushConfig.storage.get(persistKeys.deviceSecret) as string;
         this.deviceIdentityToken = JSON.parse(
-          (Platform.Config.push.storage.get(persistKeys.deviceIdentityToken) as string) || 'null',
+          (pushConfig.storage.get(persistKeys.deviceIdentityToken) as string) || 'null',
         );
-        this.push.recipient = JSON.parse(
-          (Platform.Config.push.storage.get(persistKeys.pushRecipient) as string) || 'null',
-        );
+        this.push.recipient = JSON.parse((pushConfig.storage.get(persistKeys.pushRecipient) as string) || 'null');
       } else {
         this.resetId();
       }
@@ -183,8 +180,8 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
     // keep in sync with loadPersisted(); awaiting a non-promise is a no-op, so this single
     // implementation serves both synchronous (web) and asynchronous (React Native) storage
     async loadPersistedAsync() {
-      const Platform = this.rest.Platform;
-      if (!Platform.Config.push) {
+      const pushConfig = this.rest.pushConfig;
+      if (!pushConfig) {
         throw new this.rest.ErrorInfo({
           message:
             'Push activation is not available on this platform: it requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
@@ -193,25 +190,25 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
           remediation: PUSH_ACTIVATION_NOT_AVAILABLE_HINT,
         });
       }
-      this.platform = Platform.Config.push.platform;
+      this.platform = pushConfig.platform;
       this.clientId = this.rest.auth.clientId ?? undefined;
-      this.formFactor = Platform.Config.push.formFactor;
-      this.id = ((await Platform.Config.push.storage.get(persistKeys.deviceId)) ?? undefined) as string;
+      this.formFactor = pushConfig.formFactor;
+      this.id = ((await pushConfig.storage.get(persistKeys.deviceId)) ?? undefined) as string;
 
       if (this.id) {
-        this.deviceSecret = ((await Platform.Config.push.storage.get(persistKeys.deviceSecret)) ?? undefined) as string;
+        this.deviceSecret = ((await pushConfig.storage.get(persistKeys.deviceSecret)) ?? undefined) as string;
         this.deviceIdentityToken = JSON.parse(
-          (await Platform.Config.push.storage.get(persistKeys.deviceIdentityToken)) || 'null',
+          (await pushConfig.storage.get(persistKeys.deviceIdentityToken)) || 'null',
         );
-        this.push.recipient = JSON.parse((await Platform.Config.push.storage.get(persistKeys.pushRecipient)) || 'null');
+        this.push.recipient = JSON.parse((await pushConfig.storage.get(persistKeys.pushRecipient)) || 'null');
       } else {
         await this.resetId();
       }
     }
 
     persist(): void | Promise<void> {
-      const config = this.rest.Platform.Config;
-      if (!config.push) {
+      const pushConfig = this.rest.pushConfig;
+      if (!pushConfig) {
         throw new this.rest.ErrorInfo({
           message:
             'Push activation is not available on this platform: it requires a browser environment with service worker support, or a React Native environment with the ably/react-native-push plugin',
@@ -222,16 +219,16 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
       }
       const writes: (void | Promise<void>)[] = [];
       if (this.id) {
-        writes.push(config.push.storage.set(persistKeys.deviceId, this.id));
+        writes.push(pushConfig.storage.set(persistKeys.deviceId, this.id));
       }
       if (this.deviceSecret) {
-        writes.push(config.push.storage.set(persistKeys.deviceSecret, this.deviceSecret));
+        writes.push(pushConfig.storage.set(persistKeys.deviceSecret, this.deviceSecret));
       }
       if (this.deviceIdentityToken) {
-        writes.push(config.push.storage.set(persistKeys.deviceIdentityToken, JSON.stringify(this.deviceIdentityToken)));
+        writes.push(pushConfig.storage.set(persistKeys.deviceIdentityToken, JSON.stringify(this.deviceIdentityToken)));
       }
       if (this.push.recipient) {
-        writes.push(config.push.storage.set(persistKeys.pushRecipient, JSON.stringify(this.push.recipient)));
+        writes.push(pushConfig.storage.set(persistKeys.pushRecipient, JSON.stringify(this.push.recipient)));
       }
       return loggedStorageWrites(this.rest, 'LocalDevice.persist()', writes);
     }
@@ -288,7 +285,7 @@ export class ActivationStateMachine {
 
   constructor(rest: BaseClient) {
     this.client = rest;
-    this._pushConfig = rest.Platform.Config.push;
+    this._pushConfig = rest.pushConfig;
     if (!this._pushConfig?.storageIsAsync) {
       // synchronous storage: resolve the persisted activation state immediately. With
       // asynchronous storage the state is resolved by ensureInitialized() instead.

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -271,7 +271,9 @@ export function localDeviceFactory(deviceDetails: typeof DeviceDetails) {
 
 export class ActivationStateMachine {
   client: BaseClient;
-  current: ActivationState;
+  // set in the constructor with synchronous storage, or by ensureInitialized() with asynchronous storage
+  current!: ActivationState;
+  private _initPromise?: Promise<void>;
   pendingEvents: ActivationEvent[];
   handling: boolean;
   deactivatedCallback?: ErrCallback;
@@ -291,11 +293,31 @@ export class ActivationStateMachine {
   constructor(rest: BaseClient) {
     this.client = rest;
     this._pushConfig = rest.Platform.Config.push;
-    this.current = new ActivationStates[
-      ((this.pushConfig.storage.get(persistKeys.activationState) as string) as ActivationStateName) || 'NotActivated'
-    ](null);
+    if (!this._pushConfig?.storageIsAsync) {
+      // synchronous storage: resolve the persisted activation state immediately. With
+      // asynchronous storage the state is resolved by ensureInitialized() instead.
+      this.current = new ActivationStates[
+        ((this.pushConfig.storage.get(persistKeys.activationState) as string) as ActivationStateName) || 'NotActivated'
+      ](null);
+    }
     this.pendingEvents = [];
     this.handling = false;
+  }
+
+  /**
+   * Resolves the persisted activation state when storage is asynchronous. Must be awaited
+   * before the first handleEvent() call; a no-op with synchronous storage, where the
+   * constructor has already resolved the state.
+   */
+  async ensureInitialized(): Promise<void> {
+    if (this.current) {
+      return;
+    }
+    this._initPromise ??= (async () => {
+      const persistedName = (await this.pushConfig.storage.get(persistKeys.activationState)) as string | null;
+      this.current = new ActivationStates[(persistedName as ActivationStateName) || 'NotActivated'](null);
+    })();
+    return this._initPromise;
   }
 
   get pushConfig() {
@@ -312,7 +334,7 @@ export class ActivationStateMachine {
   }
 
   persist() {
-    if (isPersistentState(this.current)) {
+    if (this.current && isPersistentState(this.current)) {
       loggedStorageWrites(this.client, 'ActivationStateMachine.persist()', [
         this.pushConfig.storage.set(persistKeys.activationState, this.current.name),
       ]);
@@ -373,7 +395,7 @@ export class ActivationStateMachine {
   }
 
   async updateRegistration() {
-    const localDevice = this.client.device();
+    const localDevice = await this.client.getDevice();
     if (this.registerCallback) {
       this.callCustomRegisterer(localDevice, false);
     } else {
@@ -413,7 +435,7 @@ export class ActivationStateMachine {
   }
 
   async deregister() {
-    const device = this.client.device();
+    const device = await this.client.getDevice();
     if (this.deregisterCallback) {
       this.callCustomDeregisterer(device);
     } else {
@@ -424,7 +446,7 @@ export class ActivationStateMachine {
 
       if (rest.options.headers) this.client.Utils.mixin(headers, rest.options.headers);
 
-      const authDetails = this.client.device().getAuthDetails(this.client, headers, params);
+      const authDetails = device.getAuthDetails(this.client, headers, params);
 
       if (rest.options.pushFullWait) this.client.Utils.mixin(params, { fullWait: 'true' });
 
@@ -610,6 +632,11 @@ type ActivationEvent =
   | DeregistrationFailed;
 
 // States
+//
+// Invariant: processEvent() implementations are synchronous and read the local device via the
+// synchronous machine.client.device(). This relies on Push.activate()/deactivate() pre-hydrating
+// the device (await client.getDevice()) and the machine state (await ensureInitialized()) before
+// dispatching any event. Never add a device() call reachable before that hydration has happened.
 abstract class ActivationState {
   name: ActivationStateName;
 

--- a/src/plugins/push/pushchannel.ts
+++ b/src/plugins/push/pushchannel.ts
@@ -111,7 +111,7 @@ class PushChannel {
     });
   }
 
-  private _getDeviceIdentityToken(device: ReturnType<BaseClient['device']>) {
+  private _getDeviceIdentityToken(device: Awaited<ReturnType<BaseClient['getDevice']>>) {
     const deviceIdentityToken = device.deviceIdentityToken;
     if (deviceIdentityToken) {
       return deviceIdentityToken;
@@ -125,7 +125,7 @@ class PushChannel {
     }
   }
 
-  private _getPushAuthHeaders(device: ReturnType<BaseClient['device']>) {
+  private _getPushAuthHeaders(device: Awaited<ReturnType<BaseClient['getDevice']>>) {
     const deviceIdentityToken = this._getDeviceIdentityToken(device);
     return { 'X-Ably-DeviceToken': deviceIdentityToken };
   }

--- a/src/plugins/push/pushchannel.ts
+++ b/src/plugins/push/pushchannel.ts
@@ -13,14 +13,14 @@ class PushChannel {
 
   async subscribeDevice() {
     const client = this.client;
-    const device = client.device();
+    const device = await client.getDevice();
     const format = client.options.useBinaryProtocol ? client.Utils.Format.msgpack : client.Utils.Format.json,
       body = { deviceId: device.id, channel: this.channel.name },
       headers = client.Defaults.defaultPostHeaders(client.options);
 
     if (client.options.headers) client.Utils.mixin(headers, client.options.headers);
 
-    client.Utils.mixin(headers, this._getPushAuthHeaders());
+    client.Utils.mixin(headers, this._getPushAuthHeaders(device));
 
     const requestBody = client.Utils.encodeBody(body, client._MsgPack, format);
     await client.rest.Resource.post(client, '/push/channelSubscriptions', requestBody, headers, {}, format, true);
@@ -28,13 +28,13 @@ class PushChannel {
 
   async unsubscribeDevice() {
     const client = this.client;
-    const device = client.device();
+    const device = await client.getDevice();
     const format = client.options.useBinaryProtocol ? client.Utils.Format.msgpack : client.Utils.Format.json,
       headers = client.Defaults.defaultPostHeaders(client.options);
 
     if (client.options.headers) client.Utils.mixin(headers, client.options.headers);
 
-    client.Utils.mixin(headers, this._getPushAuthHeaders());
+    client.Utils.mixin(headers, this._getPushAuthHeaders(device));
 
     await client.rest.Resource.delete(
       client,
@@ -111,8 +111,7 @@ class PushChannel {
     });
   }
 
-  private _getDeviceIdentityToken() {
-    const device = this.client.device();
+  private _getDeviceIdentityToken(device: ReturnType<BaseClient['device']>) {
     const deviceIdentityToken = device.deviceIdentityToken;
     if (deviceIdentityToken) {
       return deviceIdentityToken;
@@ -126,8 +125,8 @@ class PushChannel {
     }
   }
 
-  private _getPushAuthHeaders() {
-    const deviceIdentityToken = this._getDeviceIdentityToken();
+  private _getPushAuthHeaders(device: ReturnType<BaseClient['device']>) {
+    const deviceIdentityToken = this._getDeviceIdentityToken(device);
     return { 'X-Ably-DeviceToken': deviceIdentityToken };
   }
 }

--- a/src/plugins/react-native-push/getReactNativePushDeviceDetails.ts
+++ b/src/plugins/react-native-push/getReactNativePushDeviceDetails.ts
@@ -1,0 +1,31 @@
+import type { ActivationStateMachine } from '../push/pushactivation';
+import type { ReactNativePushToken } from './index';
+
+/**
+ * React Native equivalent of getW3CPushDeviceDetails: obtains a push token via the user-supplied
+ * requestToken callback, records it as the device's push recipient and hands control back to the
+ * activation state machine. Invoked by the state machine through the
+ * Platform.Config.push.getPushDeviceDetails hook.
+ */
+export async function getReactNativePushDeviceDetails(
+  machine: ActivationStateMachine,
+  requestToken: () => Promise<ReactNativePushToken>,
+): Promise<void> {
+  const { ErrorInfo } = machine.client;
+  try {
+    const { transportType, token } = await requestToken();
+    const device = await machine.client.getDevice();
+    device.push.recipient =
+      transportType === 'apns'
+        ? { transportType: 'apns', deviceToken: token }
+        : { transportType: 'fcm', registrationToken: token };
+    await device.persist();
+    machine.handleEvent(new machine.GotPushDeviceDetails());
+  } catch (err) {
+    machine.handleEvent(
+      new machine.GettingPushDeviceDetailsFailed(
+        new ErrorInfo('Failed to get react-native push device details: ' + (err as Error).message, 50000, 500),
+      ),
+    );
+  }
+}

--- a/src/plugins/react-native-push/getReactNativePushDeviceDetails.ts
+++ b/src/plugins/react-native-push/getReactNativePushDeviceDetails.ts
@@ -4,8 +4,8 @@ import type { ReactNativePushToken } from './index';
 /**
  * React Native equivalent of getW3CPushDeviceDetails: obtains a push token via the user-supplied
  * requestToken callback, records it as the device's push recipient and hands control back to the
- * activation state machine. Invoked by the state machine through the
- * Platform.Config.push.getPushDeviceDetails hook.
+ * activation state machine. Invoked by the state machine through the push config's
+ * getPushDeviceDetails hook.
  */
 export async function getReactNativePushDeviceDetails(
   machine: ActivationStateMachine,
@@ -13,7 +13,18 @@ export async function getReactNativePushDeviceDetails(
 ): Promise<void> {
   const { ErrorInfo } = machine.client;
   try {
-    const { transportType, token } = await requestToken();
+    const result = await requestToken();
+    if (
+      !result ||
+      (result.transportType !== 'fcm' && result.transportType !== 'apns') ||
+      typeof result.token !== 'string' ||
+      result.token.length === 0
+    ) {
+      throw new TypeError(
+        "requestToken must return { transportType: 'fcm' | 'apns', token } with a non-empty token string",
+      );
+    }
+    const { transportType, token } = result;
     const device = await machine.client.getDevice();
     device.push.recipient =
       transportType === 'apns'

--- a/src/plugins/react-native-push/index.ts
+++ b/src/plugins/react-native-push/index.ts
@@ -71,9 +71,9 @@ export function create(options: ReactNativePushOptions) {
     },
   };
 
-  // the same shape as the default export of plugins/push, plus the pushConfig which the core
-  // installs into Platform.Config.push at client construction, so this object registers under
-  // ClientOptions.plugins.Push unchanged
+  // the same shape as the default export of plugins/push, plus a pushConfig which the client
+  // reads per instance (client.pushConfig), so this object registers under
+  // ClientOptions.plugins.Push unchanged and clients never share storage or callbacks
   return {
     ActivationStateMachine,
     localDeviceFactory,

--- a/src/plugins/react-native-push/index.ts
+++ b/src/plugins/react-native-push/index.ts
@@ -49,7 +49,13 @@ function resolvePlatform(): DevicePlatform {
 }
 
 export function create(options: ReactNativePushOptions) {
-  if (!options || typeof options.storage?.getItem !== 'function' || typeof options.requestToken !== 'function') {
+  if (
+    !options ||
+    typeof options.storage?.getItem !== 'function' ||
+    typeof options.storage?.setItem !== 'function' ||
+    typeof options.storage?.removeItem !== 'function' ||
+    typeof options.requestToken !== 'function'
+  ) {
     throw new TypeError(
       'ReactNativePush.create() requires an options object with a storage implementing getItem/setItem/removeItem (e.g. @react-native-async-storage/async-storage) and a requestToken callback returning a { transportType, token } object.',
     );

--- a/src/plugins/react-native-push/index.ts
+++ b/src/plugins/react-native-push/index.ts
@@ -1,0 +1,88 @@
+import PushChannel from '../push/pushchannel';
+import { getW3CPushDeviceDetails } from '../push/getW3CDeviceDetails';
+import { ActivationStateMachine, CalledActivate, CalledDeactivate, localDeviceFactory } from '../push/pushactivation';
+import { DeviceFormFactor, DevicePlatform } from 'common/lib/types/devicedetails';
+import type { IPlatformPushConfig } from 'common/types/IPlatformConfig';
+import { getReactNativePushDeviceDetails } from './getReactNativePushDeviceDetails';
+
+/**
+ * Asynchronous key-value storage used to persist push activation state. Matches the interface of
+ * `@react-native-async-storage/async-storage`, so its default export can be passed directly.
+ */
+export interface ReactNativePushStorage {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+}
+
+/**
+ * A push token obtained by the application, along with the transport it belongs to. Return
+ * `transportType: 'fcm'` for a Firebase Cloud Messaging registration token (what
+ * `messaging().getToken()` from `@react-native-firebase/messaging` returns, on both Android and
+ * iOS), or `transportType: 'apns'` for a raw APNs device token (e.g. from
+ * `messaging().getAPNSToken()`).
+ */
+export interface ReactNativePushToken {
+  transportType: 'fcm' | 'apns';
+  token: string;
+}
+
+export interface ReactNativePushOptions {
+  /** Persistent storage for activation state, e.g. `@react-native-async-storage/async-storage`. */
+  storage: ReactNativePushStorage;
+  /**
+   * Called by the plugin whenever it needs a push token. Requesting notification permissions
+   * beforehand is the application's responsibility.
+   */
+  requestToken: () => Promise<ReactNativePushToken>;
+}
+
+function resolvePlatform(): DevicePlatform {
+  // 'react-native' is a peer dependency, marked external in the plugin bundle. The UMD wrapper
+  // requires all externals at module load, so the bundle only loads where react-native is
+  // resolvable (a React Native runtime, or a test environment that mocks it).
+  // Installing @types/react-native would allow a typed import but conflicts with @types/node,
+  // see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15960
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const os = require('react-native').Platform.OS;
+  return os === 'ios' ? DevicePlatform.IOS : DevicePlatform.Android;
+}
+
+export function create(options: ReactNativePushOptions) {
+  if (!options || typeof options.storage?.getItem !== 'function' || typeof options.requestToken !== 'function') {
+    throw new TypeError(
+      'ReactNativePush.create() requires an options object with a storage implementing getItem/setItem/removeItem (e.g. @react-native-async-storage/async-storage) and a requestToken callback returning a { transportType, token } object.',
+    );
+  }
+
+  const pushConfig: IPlatformPushConfig = {
+    platform: resolvePlatform(),
+    formFactor: DeviceFormFactor.Phone,
+    storageIsAsync: true,
+    storage: {
+      get: (name: string) => options.storage.getItem(name),
+      set: (name: string, value: string) => options.storage.setItem(name, value),
+      remove: (name: string) => options.storage.removeItem(name),
+    },
+    getPushDeviceDetails: (machine: ActivationStateMachine) => {
+      // fire-and-forget, like the W3C hook: failures are reported to the state machine as
+      // GettingPushDeviceDetailsFailed events rather than propagated to this caller
+      void getReactNativePushDeviceDetails(machine, options.requestToken);
+    },
+  };
+
+  // the same shape as the default export of plugins/push, plus the pushConfig which the core
+  // installs into Platform.Config.push at client construction, so this object registers under
+  // ClientOptions.plugins.Push unchanged
+  return {
+    ActivationStateMachine,
+    localDeviceFactory,
+    CalledActivate,
+    CalledDeactivate,
+    PushChannel,
+    getW3CPushDeviceDetails,
+    pushConfig,
+  };
+}
+
+export default { create };

--- a/test/uts/rest/unit/push/push_activation_react_native.test.ts
+++ b/test/uts/rest/unit/push/push_activation_react_native.test.ts
@@ -1,0 +1,260 @@
+/**
+ * ReactNativePush activation tests
+ *
+ * Exercises the ReactNativePush plugin's activation flow against a fake async storage and a
+ * stubbed requestToken, with HTTP mocked: full activation (RSH2a) for fcm and apns transports,
+ * re-activation from persisted state, deactivation (RSH2b), the deprecated sync device() guard,
+ * and token acquisition failure (RSH8h).
+ */
+
+import Module from 'module';
+import { expect } from 'chai';
+import { MockHttpClient } from '../../../mock_http';
+import { Ably, Platform, installMockHttp, restoreAll, flushAsync } from '../../../helpers';
+import ReactNativePush from '../../../../../src/plugins/react-native-push';
+import type { ReactNativePushToken } from '../../../../../src/plugins/react-native-push';
+import WebPushPlugin from '../../../../../src/plugins/push';
+
+// The plugin reads require('react-native').Platform.OS inside create(). react-native is not
+// resolvable in Node, so intercept module loading and serve this fake; tests set its OS per case.
+const fakeReactNative = { Platform: { OS: 'android' } };
+const originalModuleLoad = (Module as any)._load;
+
+/** In-memory fake of @react-native-async-storage/async-storage. */
+class FakeAsyncStorage {
+  private data = new Map<string, string>();
+
+  async getItem(key: string): Promise<string | null> {
+    return this.data.has(key) ? this.data.get(key)! : null;
+  }
+  async setItem(key: string, value: string): Promise<void> {
+    this.data.set(key, value);
+  }
+  async removeItem(key: string): Promise<void> {
+    this.data.delete(key);
+  }
+
+  // test-only synchronous accessor
+  dump(): Record<string, string> {
+    return Object.fromEntries(this.data);
+  }
+}
+
+function registrationResponse(requestBody: any) {
+  return {
+    ...requestBody,
+    deviceIdentityToken: { token: 'ident-token-1' },
+  };
+}
+
+describe('push_activation_react_native', function () {
+  before(function () {
+    (Module as any)._load = function (request: string, ...rest: any[]) {
+      if (request === 'react-native') {
+        return fakeReactNative;
+      }
+      return originalModuleLoad.call(this, request, ...rest);
+    };
+  });
+
+  after(function () {
+    (Module as any)._load = originalModuleLoad;
+  });
+
+  afterEach(function () {
+    restoreAll();
+    // the Push constructor installs the plugin-supplied push config into the Platform singleton
+    Platform.Config.push = undefined;
+    fakeReactNative.Platform.OS = 'android';
+  });
+
+  function mockRegistrationServer() {
+    const captured: any[] = [];
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        captured.push(req);
+        if (req.method === 'post' && req.path === '/push/deviceRegistrations') {
+          req.respond_with(201, registrationResponse(JSON.parse(req.body)));
+        } else if (req.method === 'delete' && req.path === '/push/deviceRegistrations') {
+          req.respond_with(204, '');
+        } else {
+          req.respond_with(500, { error: { message: 'unexpected request ' + req.method + ' ' + req.path } });
+        }
+      },
+    });
+    installMockHttp(mock);
+    return captured;
+  }
+
+  function rnClient(
+    storage: FakeAsyncStorage,
+    opts?: { token?: ReactNativePushToken | (() => Promise<ReactNativePushToken>) },
+  ) {
+    const token = opts?.token ?? { transportType: 'fcm' as const, token: 'fcm-token-1' };
+    return new Ably.Rest({
+      key: 'appId.keyId:keySecret',
+      useBinaryProtocol: false,
+      plugins: {
+        Push: ReactNativePush.create({
+          storage,
+          requestToken: typeof token === 'function' ? token : async () => token,
+        }),
+      },
+    });
+  }
+
+  it('activates with an fcm token and persists activation state to async storage', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+
+    await client.push.activate();
+    await flushAsync(); // let fire-and-forget storage writes settle
+
+    expect(captured).to.have.length(1);
+    expect(captured[0].method).to.equal('post');
+    expect(captured[0].path).to.equal('/push/deviceRegistrations');
+
+    const body = JSON.parse(captured[0].body);
+    expect(body.push.recipient).to.deep.equal({ transportType: 'fcm', registrationToken: 'fcm-token-1' });
+    expect(body.platform).to.equal('android');
+    expect(body.formFactor).to.equal('phone');
+    expect(body.id).to.be.a('string').and.not.be.empty;
+
+    const persisted = storage.dump();
+    expect(persisted['ably.push.deviceId']).to.equal(body.id);
+    expect(persisted['ably.push.deviceSecret']).to.be.a('string').and.not.be.empty;
+    expect(JSON.parse(persisted['ably.push.deviceIdentityToken'])).to.equal('ident-token-1');
+    expect(JSON.parse(persisted['ably.push.pushRecipient'])).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-1',
+    });
+    expect(persisted['ably.push.activationState']).to.equal('WaitingForNewPushDeviceDetails');
+  });
+
+  it('activates with an apns token as an apns recipient', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    fakeReactNative.Platform.OS = 'ios';
+    const client = rnClient(storage, {
+      token: { transportType: 'apns', token: 'apns-token-1' },
+    });
+
+    await client.push.activate();
+
+    const body = JSON.parse(captured[0].body);
+    expect(body.push.recipient).to.deep.equal({ transportType: 'apns', deviceToken: 'apns-token-1' });
+    expect(body.platform).to.equal('ios');
+  });
+
+  it('re-activation from persisted state does not register again', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+
+    await rnClient(storage).push.activate();
+    await flushAsync();
+    expect(captured).to.have.length(1);
+
+    // a fresh client over the same storage finds the registered device and resolves immediately
+    const client = rnClient(storage);
+    await client.push.activate();
+    await flushAsync();
+
+    expect(captured).to.have.length(1);
+    const device = await client.getDevice();
+    expect(device.deviceIdentityToken).to.equal('ident-token-1');
+  });
+
+  it('deactivates a registered device', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+
+    await client.push.activate();
+    await client.push.deactivate(undefined as any);
+    await flushAsync();
+
+    expect(captured).to.have.length(2);
+    expect(captured[1].method).to.equal('delete');
+    expect(captured[1].path).to.equal('/push/deviceRegistrations');
+    expect(captured[1].headers.authorization).to.be.a('string'); // deviceIdentityToken bearer auth
+
+    const persisted = storage.dump();
+    expect(persisted['ably.push.activationState']).to.equal('NotActivated');
+    // the device id is reset so the deregistered identity is not reused
+    expect(persisted['ably.push.deviceId']).to.not.equal(captured[1].params?.deviceId);
+  });
+
+  it('device() throws before hydration and returns the cached device after getDevice()', async function () {
+    mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+
+    expect(() => client.device())
+      .to.throw()
+      .and.satisfy((err: any) => {
+        expect(err.code).to.equal(40000);
+        expect(err.message).to.match(/synchronously/);
+        expect(err.remediation).to.match(/getDevice/);
+        return true;
+      });
+
+    const device = await client.getDevice();
+    expect(device.id).to.be.a('string').and.not.be.empty;
+    // once hydrated, the deprecated sync accessor returns the same cached instance
+    expect(client.device()).to.equal(device);
+
+    await flushAsync();
+    // loading a fresh device persists its generated identifiers
+    expect(storage.dump()['ably.push.deviceId']).to.equal(device.id);
+  });
+
+  it('rejects activation when requestToken fails and returns to NotActivated', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage, {
+      token: async () => {
+        throw new Error('permission denied');
+      },
+    });
+
+    let thrown: any;
+    try {
+      await client.push.activate();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).to.exist;
+    expect(thrown.code).to.equal(50000);
+    expect(thrown.message).to.match(/permission denied/);
+    expect(captured).to.have.length(0);
+
+    await flushAsync();
+    expect(storage.dump()['ably.push.activationState']).to.equal('NotActivated');
+  });
+
+  it('getDevice() with synchronous (web-style) storage returns the same device as device()', async function () {
+    mockRegistrationServer();
+    const syncData = new Map<string, string>();
+    Platform.Config.push = {
+      platform: 'browser' as any,
+      formFactor: 'desktop' as any,
+      storage: {
+        get: (name: string) => (syncData.has(name) ? syncData.get(name)! : (null as any)),
+        set: (name: string, value: string) => void syncData.set(name, value),
+        remove: (name: string) => void syncData.delete(name),
+      },
+    };
+
+    const client = new Ably.Rest({
+      key: 'appId.keyId:keySecret',
+      useBinaryProtocol: false,
+      plugins: { Push: WebPushPlugin },
+    });
+
+    const device = await client.getDevice();
+    expect(client.device()).to.equal(device);
+    expect(syncData.get('ably.push.deviceId')).to.equal(device.id);
+  });
+});

--- a/test/uts/rest/unit/push/push_activation_react_native.test.ts
+++ b/test/uts/rest/unit/push/push_activation_react_native.test.ts
@@ -67,7 +67,8 @@ describe('push_activation_react_native', function () {
 
   afterEach(function () {
     restoreAll();
-    // the Push constructor installs the plugin-supplied push config into the Platform singleton
+    // the web-style storage test below sets the global Platform.Config.push directly; reset it
+    // so it cannot leak into other tests
     Platform.Config.push = undefined;
     fakeReactNative.Platform.OS = 'android';
   });
@@ -238,6 +239,10 @@ describe('push_activation_react_native', function () {
     expect(persisted['ably.push.activationState']).to.equal('NotActivated');
     // the device id is reset so the deregistered identity is not reused
     expect(persisted['ably.push.deviceId']).to.not.equal(captured[1].params?.deviceId);
+    // the deregistered identity token and recipient are removed from storage, not just from the
+    // in-memory device, so a later load cannot resurrect them
+    expect(persisted).to.not.have.property('ably.push.deviceIdentityToken');
+    expect(persisted).to.not.have.property('ably.push.pushRecipient');
   });
 
   it('device() throws before hydration and returns the cached device after getDevice()', async function () {

--- a/test/uts/rest/unit/push/push_activation_react_native.test.ts
+++ b/test/uts/rest/unit/push/push_activation_react_native.test.ts
@@ -23,11 +23,15 @@ const originalModuleLoad = (Module as any)._load;
 /** In-memory fake of @react-native-async-storage/async-storage. */
 class FakeAsyncStorage {
   private data = new Map<string, string>();
+  failWrites = false;
 
   async getItem(key: string): Promise<string | null> {
     return this.data.has(key) ? this.data.get(key)! : null;
   }
   async setItem(key: string, value: string): Promise<void> {
+    if (this.failWrites) {
+      throw new Error('storage unavailable');
+    }
     this.data.set(key, value);
   }
   async removeItem(key: string): Promise<void> {
@@ -188,6 +192,32 @@ describe('push_activation_react_native', function () {
     expect(storageB.dump()['ably.push.deviceId']).to.equal(bodyB.id);
     expect(storageA.dump()['ably.push.pushRecipient']).to.include('token-a');
     expect(storageB.dump()['ably.push.pushRecipient']).to.include('token-b');
+  });
+
+  it('recovers once a transient storage write failure clears', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    storage.failWrites = true;
+    const client = rnClient(storage);
+
+    // the first activation fails while persisting the freshly generated device identifiers
+    let thrown: any;
+    try {
+      await client.push.activate();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).to.exist;
+    expect(thrown.message).to.match(/storage unavailable/);
+    expect(captured).to.have.length(0);
+
+    // once storage works again the same client can activate: the failed device load is not cached
+    storage.failWrites = false;
+    await client.push.activate();
+    await flushAsync();
+
+    expect(captured).to.have.length(1);
+    expect(storage.dump()['ably.push.activationState']).to.equal('WaitingForNewPushDeviceDetails');
   });
 
   it('deactivates a registered device', async function () {

--- a/test/uts/rest/unit/push/push_activation_react_native.test.ts
+++ b/test/uts/rest/unit/push/push_activation_react_native.test.ts
@@ -166,6 +166,30 @@ describe('push_activation_react_native', function () {
     expect(device.deviceIdentityToken).to.equal('ident-token-1');
   });
 
+  it('clients keep independent storage and token callbacks', async function () {
+    const captured = mockRegistrationServer();
+    const storageA = new FakeAsyncStorage();
+    const storageB = new FakeAsyncStorage();
+    const clientA = rnClient(storageA, { token: { transportType: 'fcm', token: 'token-a' } });
+    const clientB = rnClient(storageB, { token: { transportType: 'fcm', token: 'token-b' } });
+
+    await clientA.push.activate();
+    await clientB.push.activate();
+    await flushAsync();
+
+    expect(captured).to.have.length(2);
+    const bodyA = JSON.parse(captured[0].body);
+    const bodyB = JSON.parse(captured[1].body);
+    expect(bodyA.push.recipient.registrationToken).to.equal('token-a');
+    expect(bodyB.push.recipient.registrationToken).to.equal('token-b');
+    // each client registered its own device, persisted to its own storage
+    expect(bodyA.id).to.not.equal(bodyB.id);
+    expect(storageA.dump()['ably.push.deviceId']).to.equal(bodyA.id);
+    expect(storageB.dump()['ably.push.deviceId']).to.equal(bodyB.id);
+    expect(storageA.dump()['ably.push.pushRecipient']).to.include('token-a');
+    expect(storageB.dump()['ably.push.pushRecipient']).to.include('token-b');
+  });
+
   it('deactivates a registered device', async function () {
     const captured = mockRegistrationServer();
     const storage = new FakeAsyncStorage();

--- a/test/uts/rest/unit/push/push_activation_react_native.test.ts
+++ b/test/uts/rest/unit/push/push_activation_react_native.test.ts
@@ -264,6 +264,32 @@ describe('push_activation_react_native', function () {
     expect(storage.dump()['ably.push.deviceId']).to.equal(device.id);
   });
 
+  it('create() rejects a storage missing required methods', function () {
+    expect(() =>
+      ReactNativePush.create({
+        storage: { getItem: async () => null } as any,
+        requestToken: async () => ({ transportType: 'fcm' as const, token: 't' }),
+      }),
+    ).to.throw(TypeError, /getItem\/setItem\/removeItem/);
+  });
+
+  it('rejects activation when requestToken returns a malformed result', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage, { token: { transportType: 'web', token: '' } as any });
+
+    let thrown: any;
+    try {
+      await client.push.activate();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).to.exist;
+    expect(thrown.code).to.equal(50000);
+    expect(thrown.message).to.match(/requestToken must return/);
+    expect(captured).to.have.length(0);
+  });
+
   it('rejects activation when requestToken fails and returns to NotActivated', async function () {
     const captured = mockRegistrationServer();
     const storage = new FakeAsyncStorage();


### PR DESCRIPTION
Demo app: https://github.com/ably-labs/rn-push-notifications
RFC: https://ably.atlassian.net/wiki/x/CADCKQE

Adds a push plugin for React Native that mirrors the web Push plugin. Users supply an async storage implementation (matching `@react-native-async-storage/async-storage`) and a requestToken callback returning `{ transportType: 'fcm' | 'apns', token }`, keeping the SDK free of native module dependencies. `create()` reuses the existing activation state machine, local device factory, and push channel via re-export, and carries a `pushConfig` which the core installs into `Platform.Config.push` at client construction. The plugin registers under `ClientOptions.plugins.Push` unchanged.

Push activation is no longer browser-only, so the availability error messages and remediations now point React Native users at the `ably/react-native-push` plugin. The activation hint constant copies in `pushactivation.ts` and `push.ts` are kept byte-identical as required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a React Native push plugin (FCM/APNs) with a new `react-native-push` package export and typings.
  * Introduced an async `getDevice()` API across clients; synchronous `device()` is deprecated.
* **Bug Fixes**
  * Improved push activation/deactivation and persistence for async storage, including safer hydration and clearer error handling.
  * Expanded device push recipient support for FCM and APNs with stricter request-token validation.
* **Build & Release**
  * Added React Native push build output, npm scripts, and bundle validation.
* **Tests**
  * Added/expanded React Native push activation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->