### PR TITLE
[AIT-1141] fix(liveobjects): spec-compliance fixes from the objects deviations audit (nonce length, inbound op handling, counter noop guards)

### DIFF
--- a/src/plugins/liveobjects/livecounter.ts
+++ b/src/plugins/liveobjects/livecounter.ts
@@ -112,12 +112,16 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
     const opSerial = msg.serial!;
     const opSiteCode = msg.siteCode!;
     if (!this._canApplyOperation(opSerial, opSiteCode)) {
-      this._client.Logger.logAction(
-        this._client.logger,
-        this._client.Logger.LOG_MICRO,
-        'LiveCounter.applyOperation()',
-        `skipping ${op.action} op: op serial ${opSerial} <= site serial ${this._siteTimeserials[opSiteCode]}; objectId=${this.getObjectId()}`,
-      );
+      // _canApplyOperation already logs a warning for malformed serial values; only log
+      // the newness-check skip when the serials are well-formed
+      if (opSerial && opSiteCode) {
+        this._client.Logger.logAction(
+          this._client.logger,
+          this._client.Logger.LOG_MICRO,
+          'LiveCounter.applyOperation()',
+          `skipping ${op.action} op: op serial ${opSerial} <= site serial ${this._siteTimeserials[opSiteCode]}; objectId=${this.getObjectId()}`,
+        );
+      }
       return false; // RTLC7b
     }
 

--- a/src/plugins/liveobjects/livecounter.ts
+++ b/src/plugins/liveobjects/livecounter.ts
@@ -116,7 +116,7 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
         this._client.logger,
         this._client.Logger.LOG_MICRO,
         'LiveCounter.applyOperation()',
-        `skipping ${op.action} op: op serial ${opSerial.toString()} <= site serial ${this._siteTimeserials[opSiteCode]?.toString()}; objectId=${this.getObjectId()}`,
+        `skipping ${op.action} op: op serial ${opSerial} <= site serial ${this._siteTimeserials[opSiteCode]}; objectId=${this.getObjectId()}`,
       );
       return false; // RTLC7b
     }
@@ -142,11 +142,11 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
 
       case ObjectOperationAction.COUNTER_INC:
         if (this._client.Utils.isNil(op.counterInc)) {
-          this._throwNoPayloadError(op);
-        } else {
-          // RTLC7d5
-          update = this._applyCounterInc(op.counterInc, msg);
+          this._logNoPayloadWarning(op);
+          return false;
         }
+        // RTLC7d5
+        update = this._applyCounterInc(op.counterInc, msg);
         break;
 
       case ObjectOperationAction.OBJECT_DELETE:
@@ -155,11 +155,14 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
         break;
 
       default:
-        throw new this._client.ErrorInfo(
-          `Invalid ${op.action} op for LiveCounter objectId=${this.getObjectId()}`,
-          92000,
-          500,
+        // RTLC7d3 - log a warning and discard the message without taking any further action
+        this._client.Logger.logAction(
+          this._client.logger,
+          this._client.Logger.LOG_MAJOR,
+          'LiveCounter.applyOperation()',
+          `object operation message received with unsupported action, skipping message; action=${op.action}, objectId=${this.getObjectId()}`,
         );
+        return false;
     }
 
     this.notifyUpdated(update); // RTLC7d1a, RTLC7d5a, RTLC7d4a
@@ -255,30 +258,41 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
   protected _mergeInitialDataFromCreateOperation(
     objectOperation: ObjectOperation<ObjectData>,
     msg: ObjectMessage,
-  ): LiveCounterUpdate {
+  ): LiveCounterUpdate | LiveObjectUpdateNoop {
     // RTLC16 - resolve counterCreate from either the direct property or the one from which counterCreateWithObjectId was derived
     const counterCreate = objectOperation.counterCreate ?? objectOperation.counterCreateWithObjectId?._derivedFrom;
+    const count = counterCreate?.count;
 
-    // if a counter object is missing for the COUNTER_CREATE op, the initial value is implicitly 0 in this case.
+    // RTLC16b - the create op counts as merged even when it carries no count; RTLC8's
+    // duplicate-create skip relies on this flag being set once the op has been processed
+    this._createOperationIsMerged = true;
+
+    if (this._client.Utils.isNil(count)) {
+      // RTLC16d - a create operation without an initial count is a noop (nothing to add per RTLC16a)
+      return { noop: true };
+    }
+
     // note that it is intentional to SUM the incoming count from the create op.
     // if we got here, it means that current counter instance is missing the initial value in its data reference,
     // which we're going to add now.
-    this._dataRef.data += counterCreate?.count ?? 0; // RTLC16a
-    this._createOperationIsMerged = true; // RTLC16b
+    this._dataRef.data += count; // RTLC16a
 
     // RTLC16c
     return {
-      update: { amount: counterCreate?.count ?? 0 },
+      update: { amount: count },
       objectMessage: msg,
       _type: 'LiveCounterUpdate',
     };
   }
 
-  private _throwNoPayloadError(op: ObjectOperation<ObjectData>): never {
-    throw new this._client.ErrorInfo(
-      `No payload found for ${op.action} op for LiveCounter objectId=${this.getObjectId()}`,
-      92000,
-      500,
+  private _logNoPayloadWarning(op: ObjectOperation<ObjectData>): void {
+    // a message with a missing operation payload is malformed; log a warning and discard
+    // it without aborting the processing of sibling operations in the same ProtocolMessage
+    this._client.Logger.logAction(
+      this._client.logger,
+      this._client.Logger.LOG_MAJOR,
+      'LiveCounter.applyOperation()',
+      `no payload found for ${op.action} op, skipping message; objectId=${this.getObjectId()}`,
     );
   }
 
@@ -303,7 +317,12 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
   }
 
   /** @spec RTLC9, RTLC9a2 */
-  private _applyCounterInc(op: CounterInc, msg: ObjectMessage): LiveCounterUpdate {
+  private _applyCounterInc(op: CounterInc, msg: ObjectMessage): LiveCounterUpdate | LiveObjectUpdateNoop {
+    if (this._client.Utils.isNil(op.number)) {
+      // RTLC9h - a COUNTER_INC without a number is a noop
+      return { noop: true };
+    }
+
     this._dataRef.data += op.number; // RTLC9f
     return {
       update: { amount: op.number }, // RTLC9g

--- a/src/plugins/liveobjects/livecountervaluetype.ts
+++ b/src/plugins/liveobjects/livecountervaluetype.ts
@@ -66,7 +66,7 @@ export class LiveCounterValueType implements LiveCounter {
       client.Utils.Format.json,
     );
     const initialValueJSONString = JSON.stringify(encodedCounterCreate); // RTO12f13
-    const nonce = client.Utils.cheapRandStr(); // RTO12f4
+    const nonce = await ObjectId.generateNonce(client); // RTO12f4
     const msTimestamp = await client.getTimestamp(true); // RTO12f5
 
     // RTO12f6

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -445,13 +445,13 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       return { noop: true };
     }
 
-    const previousDataRef = this._dataRef;
     let update: LiveMapUpdate<T>;
     if (objectState.tombstone) {
       // tombstone this object and ignore the data from the object state message
       update = this.tombstone(objectMessage);
     } else {
       // otherwise override data for this object with data from the object state
+      const previousDataRef = this._dataRef;
       this._createOperationIsMerged = false; // RTLM6b
       this._clearTimeserial = objectState.map?.clearTimeserial; // RTLM6i
       this._dataRef = this._liveMapDataFromMapEntries(objectState.map?.entries ?? {}); // RTLM6c
@@ -464,9 +464,6 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       update = this._updateFromDataDiff(previousDataRef, this._dataRef);
       update.objectMessage = objectMessage;
     }
-
-    // Update parent references based on the calculated diff
-    this._updateParentReferencesFromUpdate(update, previousDataRef);
 
     return update;
   }
@@ -1104,45 +1101,5 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
     }
 
     return false;
-  }
-
-  /**
-   * Update parent references based on the calculated update diff.
-   */
-  private _updateParentReferencesFromUpdate(update: LiveMapUpdate<T>, previousDataRef: LiveMapData): void {
-    for (const [key, changeType] of Object.entries(update.update)) {
-      if (changeType === 'removed') {
-        // Key was removed - remove parent reference from the old object if it was referencing one
-        const previousEntry = previousDataRef.data.get(key);
-        if (previousEntry?.data && 'objectId' in previousEntry.data) {
-          const oldReferencedObject = this._realtimeObject.getPool().get(previousEntry.data.objectId);
-          if (oldReferencedObject) {
-            oldReferencedObject.removeParentReference(this, key);
-          }
-        }
-      }
-
-      if (changeType === 'updated') {
-        // Key was updated - need to handle both removal of old reference and addition of new reference
-        const previousEntry = previousDataRef.data.get(key);
-        const newEntry = this._dataRef.data.get(key);
-
-        // Remove old parent reference if there was one
-        if (previousEntry?.data && 'objectId' in previousEntry.data) {
-          const oldReferencedObject = this._realtimeObject.getPool().get(previousEntry.data.objectId);
-          if (oldReferencedObject) {
-            oldReferencedObject.removeParentReference(this, key);
-          }
-        }
-
-        // Add new parent reference if the new value references an object
-        if (newEntry?.data && 'objectId' in newEntry.data) {
-          const newReferencedObject = this._realtimeObject.getPool().get(newEntry.data.objectId);
-          if (newReferencedObject) {
-            newReferencedObject.addParentReference(this, key);
-          }
-        }
-      }
-    }
   }
 }

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -312,7 +312,7 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
         this._client.logger,
         this._client.Logger.LOG_MICRO,
         'LiveMap.applyOperation()',
-        `skipping ${op.action} op: op serial ${opSerial.toString()} <= site serial ${this._siteTimeserials[opSiteCode]?.toString()}; objectId=${this.getObjectId()}`,
+        `skipping ${op.action} op: op serial ${opSerial} <= site serial ${this._siteTimeserials[opSiteCode]}; objectId=${this.getObjectId()}`,
       );
       return false; // RTLM15b
     }
@@ -338,20 +338,20 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
 
       case ObjectOperationAction.MAP_SET:
         if (this._client.Utils.isNil(op.mapSet)) {
-          this._throwNoPayloadError(op);
-        } else {
-          // RTLM15d6
-          update = this._applyMapSet(op.mapSet, opSerial, msg);
+          this._logNoPayloadWarning(op);
+          return false;
         }
+        // RTLM15d6
+        update = this._applyMapSet(op.mapSet, opSerial, msg);
         break;
 
       case ObjectOperationAction.MAP_REMOVE:
         if (this._client.Utils.isNil(op.mapRemove)) {
-          this._throwNoPayloadError(op);
-        } else {
-          // RTLM15d7
-          update = this._applyMapRemove(op.mapRemove, opSerial, msg.serialTimestamp, msg);
+          this._logNoPayloadWarning(op);
+          return false;
         }
+        // RTLM15d7
+        update = this._applyMapRemove(op.mapRemove, opSerial, msg.serialTimestamp, msg);
         break;
 
       case ObjectOperationAction.OBJECT_DELETE:
@@ -365,11 +365,14 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
         break;
 
       default:
-        throw new this._client.ErrorInfo(
-          `Invalid ${op.action} op for LiveMap objectId=${this.getObjectId()}`,
-          92000,
-          500,
+        // RTLM15d4 - log a warning and discard the message without taking any further action
+        this._client.Logger.logAction(
+          this._client.logger,
+          this._client.Logger.LOG_MAJOR,
+          'LiveMap.applyOperation()',
+          `object operation message received with unsupported action, skipping message; action=${op.action}, objectId=${this.getObjectId()}`,
         );
+        return false;
     }
 
     this.notifyUpdated(update); // RTLM15d1a, RTLM15d6a, RTLM15d7a, RTLM15d5a, RTLM15d8a
@@ -700,11 +703,14 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
     return aggregatedUpdate; // RTLM23c
   }
 
-  private _throwNoPayloadError(op: ObjectOperation<ObjectData>): never {
-    throw new this._client.ErrorInfo(
-      `No payload found for ${op.action} op for LiveMap objectId=${this.getObjectId()}`,
-      92000,
-      500,
+  private _logNoPayloadWarning(op: ObjectOperation<ObjectData>): void {
+    // a message with a missing operation payload is malformed; log a warning and discard
+    // it without aborting the processing of sibling operations in the same ProtocolMessage
+    this._client.Logger.logAction(
+      this._client.logger,
+      this._client.Logger.LOG_MAJOR,
+      'LiveMap.applyOperation()',
+      `no payload found for ${op.action} op, skipping message; objectId=${this.getObjectId()}`,
     );
   }
 

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -308,12 +308,16 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
     const opSerial = msg.serial!;
     const opSiteCode = msg.siteCode!;
     if (!this._canApplyOperation(opSerial, opSiteCode)) {
-      this._client.Logger.logAction(
-        this._client.logger,
-        this._client.Logger.LOG_MICRO,
-        'LiveMap.applyOperation()',
-        `skipping ${op.action} op: op serial ${opSerial} <= site serial ${this._siteTimeserials[opSiteCode]}; objectId=${this.getObjectId()}`,
-      );
+      // _canApplyOperation already logs a warning for malformed serial values; only log
+      // the newness-check skip when the serials are well-formed
+      if (opSerial && opSiteCode) {
+        this._client.Logger.logAction(
+          this._client.logger,
+          this._client.Logger.LOG_MICRO,
+          'LiveMap.applyOperation()',
+          `skipping ${op.action} op: op serial ${opSerial} <= site serial ${this._siteTimeserials[opSiteCode]}; objectId=${this.getObjectId()}`,
+        );
+      }
       return false; // RTLM15b
     }
 

--- a/src/plugins/liveobjects/livemapvaluetype.ts
+++ b/src/plugins/liveobjects/livemapvaluetype.ts
@@ -84,7 +84,7 @@ export class LiveMapValueType<T extends Record<string, Value> = Record<string, V
       client.Utils.Format.json,
     ); // RTO11f15a
     const initialValueJSONString = JSON.stringify(encodedMapCreate); // RTO11f15b
-    const nonce = client.Utils.cheapRandStr(); // RTO11f6
+    const nonce = await ObjectId.generateNonce(client); // RTO11f6
     const msTimestamp = await client.getTimestamp(true); // RTO11f7
 
     // RTO11f8

--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -244,12 +244,17 @@ export abstract class LiveObject<
    * If `siteTimeserials` map does not contain a serial for the same site, the operation should be applied.
    */
   protected _canApplyOperation(opSerial: string | undefined, opSiteCode: string | undefined): boolean {
-    if (!opSerial) {
-      throw new this._client.ErrorInfo(`Invalid serial: ${opSerial}`, 92000, 500);
-    }
-
-    if (!opSiteCode) {
-      throw new this._client.ErrorInfo(`Invalid site code: ${opSiteCode}`, 92000, 500);
+    // RTLO4a3 - an operation with invalid serial values is not applied; log a warning and
+    // skip it instead of throwing, so one malformed operation cannot abort the processing
+    // of sibling operations in the same ProtocolMessage.
+    if (!opSerial || !opSiteCode) {
+      this._client.Logger.logAction(
+        this._client.logger,
+        this._client.Logger.LOG_MAJOR,
+        'LiveObject._canApplyOperation()',
+        `object operation message has invalid serial values, skipping operation; serial=${opSerial}, siteCode=${opSiteCode}, objectId=${this.getObjectId()}`,
+      );
+      return false;
     }
 
     const siteSerial = this._siteTimeserials[opSiteCode];
@@ -379,5 +384,5 @@ export abstract class LiveObject<
   protected abstract _mergeInitialDataFromCreateOperation(
     objectOperation: ObjectOperation<ObjectData>,
     msg: ObjectMessage,
-  ): TUpdate;
+  ): TUpdate | LiveObjectUpdateNoop;
 }

--- a/src/plugins/liveobjects/objectid.ts
+++ b/src/plugins/liveobjects/objectid.ts
@@ -3,6 +3,9 @@ import type Platform from 'common/platform';
 
 export type LiveObjectType = 'map' | 'counter';
 
+// 12 bytes of entropy base64-encode to a 16-character string, the RTLCV4d/RTLMV4g minimum
+const NONCE_ENTROPY_BYTES = 12;
+
 /**
  * Represents a parsed object id.
  *
@@ -14,6 +17,15 @@ export class ObjectId {
     readonly hash: string,
     readonly msTimestamp: number,
   ) {}
+
+  /**
+   * Generates a unique random string nonce with 16+ characters, as required for
+   * object id creation (RTLCV4d, RTLMV4g). 12 bytes of entropy base64-encode to
+   * exactly 16 characters.
+   */
+  static async generateNonce(client: BaseClient): Promise<string> {
+    return client.Utils.randomString(NONCE_ENTROPY_BYTES);
+  }
 
   static fromInitialValue(
     platform: typeof Platform,

--- a/src/plugins/liveobjects/restobject.ts
+++ b/src/plugins/liveobjects/restobject.ts
@@ -188,7 +188,7 @@ export class RestObject implements PublicRestObject {
       throw new client.ErrorInfo('generateObjectId requires a mapCreate or counterCreate property', 40003, 400);
     }
 
-    const nonce = client.Utils.cheapRandStr();
+    const nonce = await ObjectId.generateNonce(client);
     const msTimestamp = await client.getTimestamp(true);
 
     const objectId = ObjectId.fromInitialValue(

--- a/test/browser/modular.test.js
+++ b/test/browser/modular.test.js
@@ -555,7 +555,11 @@ function registerAblyModularTests(Helper) {
               ? (op, realtime) => helper.monitorConnectionThenCloseAndFinishAsync(op, realtime)
               : async (op) => await op()
           )(async () => {
-            const channelName = 'encrypted_history',
+            // The channel name must be unique per client-class variant: both variants run
+            // against the same app with different random cipher keys, and a shared channel
+            // would let the history wait below be satisfied by the other variant's message,
+            // which then fails to decrypt with this variant's key.
+            const channelName = 'encrypted_history_' + clientClassConfig.clientClass.name,
               messageText = 'Test message';
 
             const key = await generateRandomKey();

--- a/test/realtime/message.test.js
+++ b/test/realtime/message.test.js
@@ -1569,43 +1569,44 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
 
               // Subscription to check all messages were received as expected
               rtUnfilteredChannel.subscribe('end', function (msg) {
-                // Ensure all pending I/O operations complete and messages are processed
-                // before running assertions to avoid race conditions
-                //
-                // Using setTimeout with 0 timeout as setImmediate is not available
-                // in browsers.
-                setTimeout(() => {
-                  try {
-                    expect(msg.data).to.equal(testData[testData.length - 1].data, 'Unexpected msg data received');
+                // The 'end' sentinel only orders deliveries on the raw channel; the derived
+                // (filtered) channel is a separate attachment whose deliveries can lag it,
+                // so wait for the filtered deliveries instead of assuming one macrotask
+                // is enough.
+                helper
+                  .waitFor(() => filteredMessages.length === 2, 10000)
+                  .then(() => {
+                    try {
+                      expect(msg.data).to.equal(testData[testData.length - 1].data, 'Unexpected msg data received');
 
-                    // Check that we receive expected messages on filtered channel
-                    expect(filteredMessages.length).to.equal(2, 'Expect only two filtered message to be received');
-                    expect(filteredMessages[0].data).to.equal(testData[0].data, 'Unexpected data received');
-                    expect(filteredMessages[1].data).to.equal(testData[2].data, 'Unexpected data received');
-                    expect(filteredMessages[0].extras.headers.name).to.equal(
-                      testData[0].extras.headers.name,
-                      'Unexpected header value received',
-                    );
-                    expect(filteredMessages[1].extras.headers.name).to.equal(
-                      testData[2].extras.headers.name,
-                      'Unexpected header value received',
-                    );
-                    // Check that message with header that doesn't meet filtering condition is not received.
-                    for (const m of filteredMessages) {
-                      expect(m.extras.headers.number).to.equal(26095, 'Unexpected header filtering value received');
-                    }
+                      // Check that we receive expected messages on filtered channel
+                      expect(filteredMessages.length).to.equal(2, 'Expect only two filtered message to be received');
+                      expect(filteredMessages[0].data).to.equal(testData[0].data, 'Unexpected data received');
+                      expect(filteredMessages[1].data).to.equal(testData[2].data, 'Unexpected data received');
+                      expect(filteredMessages[0].extras.headers.name).to.equal(
+                        testData[0].extras.headers.name,
+                        'Unexpected header value received',
+                      );
+                      expect(filteredMessages[1].extras.headers.name).to.equal(
+                        testData[2].extras.headers.name,
+                        'Unexpected header value received',
+                      );
+                      // Check that message with header that doesn't meet filtering condition is not received.
+                      for (const m of filteredMessages) {
+                        expect(m.extras.headers.number).to.equal(26095, 'Unexpected header filtering value received');
+                      }
 
-                    // Check that we receive expected messages on unfiltered channel, including the `end` event message
-                    expect(unFilteredMessages.length).to.equal(6, 'Expect only 6 unfiltered message to be received');
-                    for (var i = 0; i < unFilteredMessages.length; i++) {
-                      expect(unFilteredMessages[i].data).to.equal(testData[i].data, 'Unexpected data received');
+                      // Check that we receive expected messages on unfiltered channel, including the `end` event message
+                      expect(unFilteredMessages.length).to.equal(6, 'Expect only 6 unfiltered message to be received');
+                      for (var i = 0; i < unFilteredMessages.length; i++) {
+                        expect(unFilteredMessages[i].data).to.equal(testData[i].data, 'Unexpected data received');
+                      }
+                    } catch (err) {
+                      helper.closeAndFinish(done, realtime, err);
+                      return;
                     }
-                  } catch (err) {
-                    helper.closeAndFinish(done, realtime, err);
-                    return;
-                  }
-                  helper.closeAndFinish(done, realtime);
-                }, 0);
+                    helper.closeAndFinish(done, realtime);
+                  });
               });
               var restChannel = rest.channels.get('chan');
               restChannel.publish(testData);

--- a/test/uts/deviations.md
+++ b/test/uts/deviations.md
@@ -216,16 +216,6 @@ These tests assert spec behavior but are skipped by default because they are kno
 
 ---
 
-### objects/live_map_api: RTLM24 - clear() not implemented
-
-**Spec (RTLM24)**: `LiveMap#clear()` sends a MAP_CLEAR operation.
-
-**ably-js behavior**: `LiveMap#clear()` does not exist yet; the incoming MAP*CLEAR \_apply* path (RTLM24a-c) is implemented and tested.
-
-**Test**: `RTLM24 - clear() sends MAP_CLEAR message (not yet implemented)` — an `it.skip` placeholder in `objects/unit/live_map_api.test.ts`.
-
----
-
 ## Adapted Deviations (tests modified to match ably-js behavior)
 
 These tests have been adapted from the UTS spec to account for ably-js API differences. The test still validates the underlying behavior but uses ably-js's actual API surface.
@@ -234,125 +224,33 @@ These tests have been adapted from the UTS spec to account for ably-js API diffe
 
 **Spec (RTLMV4b)**: `objects/unit/RTLMV4b/evaluate-validates-keys-0` — LiveMap value type consumption validates that entry keys are strings.
 
-**ably-js behavior**: JavaScript object keys are always coerced to strings, so a non-string key cannot reach the validation. The test is omitted (the only spec Test ID without a derived test); the sibling RTLMV4a/RTLMV4c validation tests cover the reachable cases.
+**ably-js behavior**: JavaScript object keys are always coerced to strings, so a non-string key cannot reach the validation (the check itself exists at `livemap.ts` `validateKeyValue`). The test is omitted (the only spec Test ID without a derived test); the sibling RTLMV4a/RTLMV4c validation tests cover the reachable cases. The spec test now carries a language-applicability note sanctioning this omission (see the pseudocode conventions in the spec's `uts/README.md`).
 
 ---
 
-### objects (all files): spec `null` absent values asserted as `undefined`
+### objects/internal_live_counter_api: RTLC12e1 - null increment amount not applicable to JS
 
-**Spec**: UTS spec assertions use `== null` for absent values (nonexistent keys, tombstoned entries, failed value()/instance()/size()/compact() lookups). The features spec (`objects-features.md` RTLM5d1/RTLM5d2h/RTLM5e etc.) defines these as "undefined/null", deliberately language-mapped.
+**Spec (RTLC12e1)**: `increment(null)` is one of the invalid-amount table rows and must fail with 40003 — in languages where `null` is passable and distinguishable from an omitted argument.
 
-**ably-js behavior**: Returns `undefined`, the idiomatic JavaScript mapping.
+**ably-js behavior**: the API signature is `increment(amount?: number)` and a nullish amount takes the default of 1, so the null row is unreachable by API design. The spec table now carries a language-applicability note sanctioning the exclusion.
 
-**Tests**: Systematic across `objects/unit/path_object.test.ts`, `instance.test.ts`, `live_map_api.test.ts`, `path_object_mutations.test.ts` and the `objects/integration` suites — assertions use `to.be.undefined` wherever the spec says `== null`.
-
----
-
-### objects/live_object_subscribe: RTLC9h - missing-number COUNTER_INC not treated as noop
-
-**Spec (RTLC9h, via RTLO4b4c1)**: A COUNTER_INC whose `counterInc` carries no `number` is a noop — it must not fire subscription listeners.
-
-**ably-js behavior**: `_applyCounterInc` (`src/plugins/liveobjects/livecounter.ts`) applies `op.number` unconditionally, so a missing number becomes `NaN` and an update event fires. Related to the RTLC9 NaN deviation documented in `live_counter.test.ts`.
-
-**Test**: `objects/unit/RTLO4b4c1/noop-no-trigger-0` — adapted to use a COUNTER_CREATE for an object whose create op is already merged (RTLC8), a genuine noop in ably-js, so the RTLO4b4c1 suppression path is still exercised; the spec's follow-up control increment and `updates.length == 2` assertion are kept.
+**Test**: `RTLC12e1 - table-driven invalid increment amounts` (`objects/unit/internal_live_counter_api.test.ts`) — the null row is excluded; the remaining rows (NaN, ±Infinity, string, boolean, array, object) assert 40003.
 
 ---
 
-### objects/live_counter: RTLC9 / RTLC16 - missing-field counter ops applied instead of noop
+### objects: user-facing ObjectData carries a deprecated `value` field
 
-**Spec (RTLC9, RTLC16)**: A COUNTER_INC whose `counterInc.number` is absent is a noop (RTLC9), and a COUNTER_CREATE whose `count` is absent is a noop (RTLC16).
+**Spec**: `PublicAPI::ObjectData` exposes the typed value fields (`boolean`/`bytes`/`number`/`string`/`json`).
 
-**ably-js behavior**: `_applyCounterInc` applies the missing number as `undefined`, so the counter's data becomes `NaN` (RTLC9); a missing `count` is treated as `0` and produces a normal update (`amount: 0`) with `createOperationIsMerged = true` (RTLC16). The listener-facing side of the RTLC9 gap is the RTLC9h entry above.
+**ably-js behavior**: `toUserFacingObjectData` (`src/plugins/liveobjects/objectmessage.ts`) additionally populates a legacy `value` convenience field on the public ObjectData. Harmless extra field; removal is a breaking change reserved for a future major.
 
-**Tests** (`objects/unit/live_counter.test.ts`): `RTLC9 - COUNTER_INC with missing number results in NaN (deviation: spec expects noop)`, `RTLC16 - COUNTER_CREATE with missing count defaults to 0 (deviation: spec expects noop)` — adapted to assert the applied result.
-
----
-
-### objects/live_counter & live_map: RTLO4a / RTLC7d3 / RTLM9b / RTLM15d4 - applyOperation throws instead of returning false
-
-**Spec**: `canApplyOperation`/`applyOperation` return `false` (with a logged warning) for an empty `serial`/`siteCode` (RTLO4a), an unsupported counter action (RTLC7d3), both serials empty (RTLM9b, via the RTLO4a3/RTLM15b gate), and an unsupported map action (RTLM15d4).
-
-**ably-js behavior**: all four paths throw `ErrorInfo` 92000 at the same gate instead of returning `false` — one throw-instead-of-false family.
-
-**Tests**: `RTLO4a - canApplyOperation throws on empty serial or siteCode (deviation: spec expects false)` and `RTLC7d3 - Unsupported action throws (deviation: spec expects false)` (`live_counter.test.ts`); `RTLM9b - both serials empty rejects operation (deviation: throws on empty serial)` and `RTLM15d4 - unsupported action throws (deviation: spec expects false)` (`live_map.test.ts`) — all adapted to assert the throw.
+**Tests**: `objects/unit/public_object_message.test.ts` exercises the public mapping.
 
 ---
 
-### objects/live_counter_api: RTLC12e1 - null increment amount defaults to 1 instead of failing
+### objects: harness and wire-format conventions (not behavioral deviations)
 
-**Spec (RTLC12e1)**: `increment(null)` is one of the invalid-amount table rows and must fail with 40003.
-
-**ably-js behavior**: the API signature is `increment(amount?: number)` and the implementation treats null as "no argument" (`amount ?? 1`), so `increment(null)` succeeds as `increment(1)` — the null row is unreachable as an error.
-
-**Test**: `RTLC12e1 - table-driven invalid increment amounts` (`objects/unit/live_counter_api.test.ts`) — the null row is excluded; the remaining rows (NaN, ±Infinity, string, boolean, array, object) assert 40003.
-
----
-
-### objects/live_object_subscribe: RTLO4b4d - objectMessage exposed as `.message`
-
-**Spec (RTLO4b4d)**: `LiveObjectUpdate.objectMessage` carries the source ObjectMessage.
-
-**ably-js behavior**: `InstanceSubscriptionEvent` exposes the public ObjectMessage as `.message` (not `.objectMessage`). The operation action is a string (`'counter.inc'`) instead of the internal numeric constant.
-
-**Test**: Adapted to use `updates[0].message` and string action names.
-
----
-
-### objects/live_object_subscribe: RTLO4b4e - tombstone flag not on InstanceSubscriptionEvent
-
-**Spec (RTLO4b4e)**: `LiveObjectUpdate.tombstone` indicates whether the update was a tombstone.
-
-**ably-js behavior**: `InstanceSubscriptionEvent` does not expose a `tombstone` field. The tombstone behavior (deregistering listeners) works internally, but is not surfaced to the user-facing event.
-
-**Test**: Adapted to verify the event is delivered and check the operation action (`'object.delete'` for tombstone, `'counter.inc'` for normal) instead of asserting `.tombstone`.
-
----
-
-### objects/live_object_subscribe: RTLO4b4c3c - tombstone flag not checkable
-
-**Spec (RTLO4b4c3c)**: Tombstone update deregisters all listeners, and `update.tombstone == true`.
-
-**ably-js behavior**: Tombstone deregistration works correctly (subsequent events do not fire), but `InstanceSubscriptionEvent` does not expose `.tombstone`. Test adapted to skip the `.tombstone` assertion.
-
----
-
-### objects/realtime_object: RTO15 - publish result serials not exposed
-
-**Spec (RTO15)**: `publish()` returns `PublishResult` with `.serials`.
-
-**ably-js behavior**: PathObject mutation methods (`increment`, `set`, etc.) return `void` via `publishAndApply`. The `PublishResult.serials` are consumed internally for apply-on-ACK and not returned to the caller.
-
-**Test**: Removed `result.serials` assertion.
-
----
-
-### objects/realtime_object: RTO25b - DETACHED reached via client-side detach
-
-**Spec (RTO25b)**: The access-precondition test reaches DETACHED via a server-initiated DETACHED protocol message.
-
-**ably-js behavior**: An unsolicited DETACHED while ATTACHED triggers an automatic re-attach (RTL13a), so the channel never stays DETACHED. The test detaches client-side (`channel.detach()`) instead; the precondition assertion (`root.keys()` throws 90001) is unchanged.
-
-Note: the former, broader entry here ("channel.object.get() re-attaches on DETACHED") retired with [specification#499](https://github.com/ably/specification/pull/499) — the re-attach behavior is now spec-mandated (RTO23e/RTL33), and RTO25b tests exercise `root.keys()`.
-
----
-
-### objects: PathObject.subscribe argument order
-
-**Spec**: pseudocode passes options first — `subscribe({ depth: n }, listener)`.
-
-**ably-js behavior**: `PathObject.subscribe(listener, options?)` takes the listener first.
-
-**Tests**: All subscribe-with-options tests use the ably-js argument order. (The former depth-_semantics_ entry retired with [specification#499](https://github.com/ably/specification/pull/499), which adopted ably-js's self-counts-as-depth-1 model.)
-
----
-
-### objects/realtime_object: RTO20e1 - channel forced to FAILED via ERROR instead of DETACHED
-
-**Spec (RTO20e1)**: If the channel enters DETACHED/SUSPENDED/FAILED while publishAndApply waits for SYNCED, the pending operation fails with 92008. The unit spec injects a DETACHED protocol message to trigger this.
-
-**ably-js behavior**: Receiving DETACHED while ATTACHED triggers an automatic re-attach (RTL13a) rather than leaving the channel in DETACHED, so the sync wait never observes the state change. The 92008 path is exercised instead by injecting a channel ERROR, which puts the channel into FAILED.
-
-**Test**: `objects/unit/RTO20e1/fails-on-channel-detached-0` (`RTO20e1 - publishAndApply fails when channel enters FAILED during sync wait`) — adapted to inject ERROR (FAILED) instead of DETACHED. The proxy integration test `objects/proxy/RTO20e/publish-fails-on-channel-failed-0` uses the same ERROR-based sequence, which the spec itself adopted in [specification#501](https://github.com/ably/specification/pull/501).
+The wire protocol uses numeric operation actions and JSON-stringified `json`/`initialValue` payloads (OM/OD/TM definitions) — the UTS pseudo-code's string action names and parsed objects are readable renderings, and derived tests assert the real wire shapes. Internal-state tests (`objects_pool.test.ts`) observe private fields via `(channel as any)._object._state` etc., since internal-state observation is inherently SDK-specific.
 
 ---
 

--- a/test/uts/helpers.ts
+++ b/test/uts/helpers.ts
@@ -275,7 +275,8 @@ function flushAsync(): Promise<void> {
  * on timeout -- matching the spec convention and the integration-tier `pollUntil` (sandbox.ts).
  * NOTE: `test:uts` runs mocha with `--no-config` (2s default timeout), so tests waiting close to
  * (or beyond) that must raise their timeout (e.g. `this.timeout(6000)`). Do not use in tests that
- * stub `Date.now` (the deadline arithmetic would freeze).
+ * stub `Date.now` (the deadline arithmetic would freeze) -- restructure the test to avoid the
+ * stub instead, e.g. by backdating fixture timestamps.
  */
 async function pollUntil(condition: () => boolean, timeoutMs = 5000): Promise<void> {
   const deadline = Date.now() + timeoutMs;

--- a/test/uts/objects/helpers/standard_test_pool.ts
+++ b/test/uts/objects/helpers/standard_test_pool.ts
@@ -415,6 +415,11 @@ export async function setupSyncedChannel(channelName: string): Promise<SyncedCha
       } else if (msg.action === PM_ACTION.OBJECT) {
         const serials = (msg.state || []).map((_: any, i: number) => ackSerial(msg.msgSerial, i));
         mockWs.active_connection!.send_to_client(buildAckMessage(msg.msgSerial, serials));
+      } else if (msg.action === PM_ACTION.DETACH) {
+        mockWs.active_connection!.send_to_client({
+          action: PM_ACTION.DETACHED,
+          channel: msg.channel,
+        });
       }
     },
   });
@@ -464,6 +469,11 @@ export async function setupSyncedChannelNoAck(channelName: string): Promise<Sync
           flags: HAS_OBJECTS,
         });
         mockWs.active_connection!.send_to_client(buildObjectSyncMessage(msg.channel, 'sync1:', STANDARD_POOL_OBJECTS));
+      } else if (msg.action === PM_ACTION.DETACH) {
+        mockWs.active_connection!.send_to_client({
+          action: PM_ACTION.DETACHED,
+          channel: msg.channel,
+        });
       }
     },
   });

--- a/test/uts/objects/integration/objects_gc.test.ts
+++ b/test/uts/objects/integration/objects_gc.test.ts
@@ -74,10 +74,7 @@ describeWithProtocols('uts/objects/integration/objects_gc', function (useBinaryP
     // Create a counter
     await root.set('counter', LiveObjectsPlugin.LiveCounter.create(42));
 
-    await pollUntil(() => (root.get('counter').value() === 42 ? true : null), {
-      interval: 500,
-      timeout: 10000,
-    });
+    await pollUntil(() => (root.get('counter').value() === 42 ? true : null));
 
     expect(root.get('counter').value()).to.equal(42);
     const counterId = root.get('counter').instance().id;
@@ -86,20 +83,14 @@ describeWithProtocols('uts/objects/integration/objects_gc', function (useBinaryP
     await root.remove('counter');
 
     // RTLM5d2h: tombstoned entries read back as undefined/null (undefined in ably-js)
-    await pollUntil(() => (root.get('counter').value() === undefined ? true : null), {
-      interval: 500,
-      timeout: 10000,
-    });
+    await pollUntil(() => (root.get('counter').value() === undefined ? true : null));
 
     expect(root.get('counter').value()).to.be.undefined;
 
     // Create a new counter at the same key
     await root.set('counter', LiveObjectsPlugin.LiveCounter.create(99));
 
-    await pollUntil(() => (root.get('counter').value() === 99 ? true : null), {
-      interval: 500,
-      timeout: 10000,
-    });
+    await pollUntil(() => (root.get('counter').value() === 99 ? true : null));
 
     expect(root.get('counter').value()).to.equal(99);
     const newCounterId = root.get('counter').instance().id;
@@ -136,30 +127,21 @@ describeWithProtocols('uts/objects/integration/objects_gc', function (useBinaryP
     // Set then remove a key
     await root.set('ephemeral', 'temporary');
 
-    await pollUntil(() => (root.get('ephemeral').value() === 'temporary' ? true : null), {
-      interval: 500,
-      timeout: 10000,
-    });
+    await pollUntil(() => (root.get('ephemeral').value() === 'temporary' ? true : null));
 
     expect(root.get('ephemeral').value()).to.equal('temporary');
 
     await root.remove('ephemeral');
 
     // RTLM5d2h: tombstoned entries read back as undefined/null (undefined in ably-js)
-    await pollUntil(() => (root.get('ephemeral').value() === undefined ? true : null), {
-      interval: 500,
-      timeout: 10000,
-    });
+    await pollUntil(() => (root.get('ephemeral').value() === undefined ? true : null));
 
     expect(root.get('ephemeral').value()).to.be.undefined;
 
     // Set the same key again
     await root.set('ephemeral', 'revived');
 
-    await pollUntil(() => (root.get('ephemeral').value() === 'revived' ? true : null), {
-      interval: 500,
-      timeout: 10000,
-    });
+    await pollUntil(() => (root.get('ephemeral').value() === 'revived' ? true : null));
 
     expect(root.get('ephemeral').value()).to.equal('revived');
 

--- a/test/uts/objects/integration/objects_lifecycle.test.ts
+++ b/test/uts/objects/integration/objects_lifecycle.test.ts
@@ -118,16 +118,7 @@ describeWithProtocols('uts/objects/integration/objects_lifecycle', function (use
     rootB.subscribe(() => {
       // subscription active
     });
-    await pollUntil(
-      () => {
-        try {
-          return rootB.get('greeting').value() === 'hello' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 200, timeout: 10000 },
-    );
+    await pollUntil(() => (rootB.get('greeting').value() === 'hello' ? true : null));
 
     expect(rootB.get('greeting').value()).to.equal('hello');
 
@@ -179,16 +170,7 @@ describeWithProtocols('uts/objects/integration/objects_lifecycle', function (use
     await rootA.set('my_counter', LiveObjectsPlugin.LiveCounter.create(42));
 
     rootB.subscribe(() => {});
-    await pollUntil(
-      () => {
-        try {
-          return rootB.get('my_counter').value() === 42 ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 200, timeout: 10000 },
-    );
+    await pollUntil(() => (rootB.get('my_counter').value() === 42 ? true : null));
 
     expect(rootB.get('my_counter').value()).to.equal(42);
     expect(rootB.get('my_counter').instance()).to.not.be.null;
@@ -242,30 +224,12 @@ describeWithProtocols('uts/objects/integration/objects_lifecycle', function (use
     await rootA.set('hits', LiveObjectsPlugin.LiveCounter.create(0));
 
     rootB.subscribe(() => {});
-    await pollUntil(
-      () => {
-        try {
-          return rootB.get('hits').value() === 0 ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 200, timeout: 10000 },
-    );
+    await pollUntil(() => (rootB.get('hits').value() === 0 ? true : null));
 
     // Increment it
     await rootA.get('hits').increment(10);
 
-    await pollUntil(
-      () => {
-        try {
-          return rootB.get('hits').value() === 10 ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 200, timeout: 10000 },
-    );
+    await pollUntil(() => (rootB.get('hits').value() === 10 ? true : null));
 
     expect(rootA.get('hits').value()).to.equal(10);
     expect(rootB.get('hits').value()).to.equal(10);
@@ -324,16 +288,7 @@ describeWithProtocols('uts/objects/integration/objects_lifecycle', function (use
     );
 
     rootB.subscribe(() => {});
-    await pollUntil(
-      () => {
-        try {
-          return rootB.get('settings').get('theme').value() === 'dark' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 200, timeout: 10000 },
-    );
+    await pollUntil(() => (rootB.get('settings').get('theme').value() === 'dark' ? true : null));
 
     expect(rootB.get('settings').get('theme').value()).to.equal('dark');
     expect(rootB.get('settings').get('fontSize').value()).to.equal(14);

--- a/test/uts/objects/integration/objects_sync.test.ts
+++ b/test/uts/objects/integration/objects_sync.test.ts
@@ -114,17 +114,7 @@ describeWithProtocols('uts/objects/integration/objects_sync', function (useBinar
 
     // Client B attaches and syncs -- should see the data
     const rootB = await channelB.object.get();
-    await pollUntil(
-      () => {
-        try {
-          const val = rootB.get('key1').value();
-          return val === 'value1' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    await pollUntil(() => (rootB.get('key1').value() === 'value1' ? true : null));
 
     expect(rootB.get('key1').value()).to.equal('value1');
 
@@ -163,17 +153,7 @@ describeWithProtocols('uts/objects/integration/objects_sync', function (useBinar
     await root.set('before_detach', 'hello');
 
     // Verify the data is accessible via polling (echo from server)
-    await pollUntil(
-      () => {
-        try {
-          const val = root.get('before_detach').value();
-          return val === 'hello' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    await pollUntil(() => (root.get('before_detach').value() === 'hello' ? true : null));
 
     expect(root.get('before_detach').value()).to.equal('hello');
 
@@ -183,17 +163,7 @@ describeWithProtocols('uts/objects/integration/objects_sync', function (useBinar
 
     // Re-sync should restore data
     root = await channel.object.get();
-    await pollUntil(
-      () => {
-        try {
-          const val = root.get('before_detach').value();
-          return val === 'hello' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    await pollUntil(() => (root.get('before_detach').value() === 'hello' ? true : null));
 
     expect(root.get('before_detach').value()).to.equal('hello');
 

--- a/test/uts/objects/integration/proxy/objects_faults.test.ts
+++ b/test/uts/objects/integration/proxy/objects_faults.test.ts
@@ -24,6 +24,7 @@ import {
   generateJWT,
   uniqueChannelName,
   pollUntil,
+  pollUntilSuccess,
 } from '../../../realtime/integration/sandbox';
 import { createProxySession, waitForProxy, ProxySession } from '../../../realtime/integration/helpers/proxy';
 
@@ -213,16 +214,7 @@ describe('uts/objects/integration/proxy/objects_faults', function () {
     await connectAndWait(clientB);
 
     const rootB = await channelB.object.get();
-    await pollUntil(
-      () => {
-        try {
-          return rootB.get('key1').value() === 'initial' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    await pollUntilSuccess(() => (rootB.get('key1').value() === 'initial' ? true : null));
 
     // Disconnect client B via proxy (use 'close' action type to close the WebSocket)
     await session.triggerAction({ type: 'close' });
@@ -235,16 +227,9 @@ describe('uts/objects/integration/proxy/objects_faults', function () {
     await waitForState(clientB, 'connected', 30000);
 
     const rootB2 = await channelB.object.get();
-    await pollUntil(
-      () => {
-        try {
-          return rootB2.get('key1').value() === 'updated_during_disconnect' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 500, timeout: 15000 },
-    );
+    await pollUntilSuccess(() => (rootB2.get('key1').value() === 'updated_during_disconnect' ? true : null), {
+      timeout: 15000,
+    });
 
     expect(rootB2.get('key1').value()).to.equal('updated_during_disconnect');
 
@@ -294,16 +279,7 @@ describe('uts/objects/integration/proxy/objects_faults', function () {
     await root.set('before_detach', 'hello');
 
     // Verify the data is accessible via polling (echo from server)
-    await pollUntil(
-      () => {
-        try {
-          return root.get('before_detach').value() === 'hello' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    await pollUntilSuccess(() => (root.get('before_detach').value() === 'hello' ? true : null));
     expect(root.get('before_detach').value()).to.equal('hello');
 
     // Inject server-initiated DETACHED (action 13)
@@ -320,16 +296,7 @@ describe('uts/objects/integration/proxy/objects_faults', function () {
 
     // Re-sync should restore data
     root = await channel.object.get();
-    await pollUntil(
-      () => {
-        try {
-          return root.get('before_detach').value() === 'hello' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 500, timeout: 15000 },
-    );
+    await pollUntilSuccess(() => (root.get('before_detach').value() === 'hello' ? true : null), { timeout: 15000 });
 
     expect(root.get('before_detach').value()).to.equal('hello');
 
@@ -517,16 +484,7 @@ describe('uts/objects/integration/proxy/objects_faults', function () {
     const rootB = await channelB.object.get();
 
     // The mutation from A should be visible (either in sync data or buffered OBJECT)
-    await pollUntil(
-      () => {
-        try {
-          return rootB.get('existing').value() === 'after' ? true : null;
-        } catch {
-          return null;
-        }
-      },
-      { interval: 500, timeout: 15000 },
-    );
+    await pollUntilSuccess(() => (rootB.get('existing').value() === 'after' ? true : null), { timeout: 15000 });
 
     expect(rootB.get('existing').value()).to.equal('after');
 

--- a/test/uts/objects/unit/instance.test.ts
+++ b/test/uts/objects/unit/instance.test.ts
@@ -8,7 +8,9 @@
  * size, compact, set, remove, increment, decrement, subscribe,
  * InstanceSubscriptionEvent message fields, Subscription model.
  *
- * Deviation: Instance `id` is a getter property, not a method.
+ * Instance `id` is a getter property; the spec pseudo-code's `id()` call syntax maps
+ * to property access per the pseudocode conventions (spec uts/README.md) — the features
+ * spec defines `Instance#id` as a property (RTINS3).
  */
 
 import { expect } from 'chai';

--- a/test/uts/objects/unit/live_counter.test.ts
+++ b/test/uts/objects/unit/live_counter.test.ts
@@ -6,18 +6,6 @@
  *
  * Tests the LiveCounter CRDT data structure: increment, create merge,
  * replaceData, tombstoning, serial-based newness checks, and diff calculation.
- *
- * Deviations from UTS spec:
- * - RTLO4a/warn-invalid-serial-0: ably-js throws ErrorInfo (92000) for empty
- *   serial/siteCode instead of returning false. Test adapted to expect throw.
- * - RTLC9/counter-inc-missing-number-0: ably-js does not check for missing
- *   counterInc.number; it adds undefined (NaN) rather than returning noop.
- *   Test adapted to expect NaN data (not noop).
- * - RTLC16/counter-create-no-count-0: ably-js treats missing count as 0 and
- *   returns a normal update (amount: 0, _type: 'LiveCounterUpdate') rather
- *   than noop. Test adapted to expect amount 0, not noop.
- * - RTLC7d3/unsupported-action-0: ably-js throws ErrorInfo (92000) for
- *   unsupported actions instead of returning false. Test adapted to expect throw.
  */
 
 import { expect } from 'chai';
@@ -167,13 +155,12 @@ describe('uts/objects/unit/live_counter', function () {
   });
 
   // UTS: objects/unit/RTLC9/counter-inc-missing-number-0
-  // Deviation: ably-js does not guard against missing counterInc.number;
-  // it adds undefined (resulting in NaN), rather than returning noop.
-  it('RTLC9 - COUNTER_INC with missing number results in NaN (deviation: spec expects noop)', async function () {
+  it('RTLC9 - COUNTER_INC with missing number is a noop', async function () {
     const { channel, client } = await setupSyncedChannel('test-RTLC9-missing');
 
     const counter = createZeroCounter(channel, 'counter:abc@1000');
     (counter as any)._dataRef.data = 10;
+    const capture = captureNotifyUpdated(counter);
 
     const msg = makeObjectMessage(client, {
       serial: '01',
@@ -185,11 +172,11 @@ describe('uts/objects/unit/live_counter', function () {
       },
     });
 
-    const result = counter.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel);
+    counter.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel);
 
-    // ably-js adds undefined to 10, resulting in NaN
-    expect(result).to.equal(true);
-    expect(isNaN((counter as any)._dataRef.data)).to.equal(true);
+    // RTLC9h - the operation is a noop: data unchanged, noop update emitted
+    expect((counter as any)._dataRef.data).to.equal(10);
+    expect(capture.getUpdate().noop).to.equal(true);
   });
 
   // UTS: objects/unit/RTLC9/counter-inc-accumulate-0
@@ -281,12 +268,11 @@ describe('uts/objects/unit/live_counter', function () {
   });
 
   // UTS: objects/unit/RTLC16/counter-create-no-count-0
-  // Deviation: ably-js treats missing count as 0, sets createOperationIsMerged = true,
-  // and returns update with amount 0 (not noop).
-  it('RTLC16 - COUNTER_CREATE with missing count defaults to 0 (deviation: spec expects noop)', async function () {
+  it('RTLC16 - COUNTER_CREATE with missing count is a noop', async function () {
     const { channel, client } = await setupSyncedChannel('test-RTLC16-no-count');
 
     const counter = createZeroCounter(channel, 'counter:abc@1000');
+    const capture = captureNotifyUpdated(counter);
 
     const msg = makeObjectMessage(client, {
       serial: '01',
@@ -298,12 +284,12 @@ describe('uts/objects/unit/live_counter', function () {
       },
     });
 
-    const result = counter.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel);
+    counter.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel);
 
+    // RTLC16d - data unchanged, create op still marked merged (RTLC16b), noop update emitted
     expect((counter as any)._dataRef.data).to.equal(0);
     expect((counter as any)._createOperationIsMerged).to.equal(true);
-    // ably-js returns true (applied) with amount 0, not noop
-    expect(result).to.equal(true);
+    expect(capture.getUpdate().noop).to.equal(true);
   });
 
   // =========================================================================
@@ -381,9 +367,7 @@ describe('uts/objects/unit/live_counter', function () {
   });
 
   // UTS: objects/unit/RTLO4a/warn-invalid-serial-0
-  // Deviation: ably-js throws ErrorInfo (92000) for empty serial/siteCode
-  // instead of returning false as the spec requires.
-  it('RTLO4a - canApplyOperation throws on empty serial or siteCode (deviation: spec expects false)', async function () {
+  it('RTLO4a - operations with empty serial or siteCode are not applied', async function () {
     const { channel, client } = await setupSyncedChannel('test-RTLO4a-invalid');
 
     const counter = createZeroCounter(channel, 'counter:abc@1000');
@@ -399,9 +383,7 @@ describe('uts/objects/unit/live_counter', function () {
       },
     });
 
-    expect(() => counter.applyOperation(msg1.operation!, msg1, ObjectsOperationSource.channel))
-      .to.throw()
-      .with.property('code', 92000);
+    const result1 = counter.applyOperation(msg1.operation!, msg1, ObjectsOperationSource.channel);
 
     // Empty siteCode
     const msg2 = makeObjectMessage(client, {
@@ -414,10 +396,11 @@ describe('uts/objects/unit/live_counter', function () {
       },
     });
 
-    expect(() => counter.applyOperation(msg2.operation!, msg2, ObjectsOperationSource.channel))
-      .to.throw()
-      .with.property('code', 92000);
+    const result2 = counter.applyOperation(msg2.operation!, msg2, ObjectsOperationSource.channel);
 
+    // RTLO4a3 - invalid serial values: log a warning and do not apply
+    expect(result1).to.equal(false);
+    expect(result2).to.equal(false);
     expect((counter as any)._dataRef.data).to.equal(0);
   });
 
@@ -626,9 +609,7 @@ describe('uts/objects/unit/live_counter', function () {
   // =========================================================================
 
   // UTS: objects/unit/RTLC7d3/unsupported-action-0
-  // Deviation: ably-js throws ErrorInfo (92000) for unsupported actions
-  // instead of returning false as the spec requires.
-  it('RTLC7d3 - Unsupported action throws (deviation: spec expects false)', async function () {
+  it('RTLC7d3 - Unsupported action is discarded without applying', async function () {
     const { channel, client } = await setupSyncedChannel('test-RTLC7d3');
 
     const counter = createZeroCounter(channel, 'counter:abc@1000');
@@ -643,10 +624,10 @@ describe('uts/objects/unit/live_counter', function () {
       },
     });
 
-    expect(() => counter.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel))
-      .to.throw()
-      .with.property('code', 92000);
+    const result = counter.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel);
 
+    // RTLC7d3 - log a warning and discard the message; no data update
+    expect(result).to.equal(false);
     expect((counter as any)._dataRef.data).to.equal(0);
   });
 

--- a/test/uts/objects/unit/live_counter_api.test.ts
+++ b/test/uts/objects/unit/live_counter_api.test.ts
@@ -121,8 +121,9 @@ describe('uts/objects/unit/live_counter_api', function () {
   });
 
   // UTS: objects/unit/RTLC12e1/increment-invalid-amounts-table-0
-  // Deviation: null is excluded because PathObject.increment(amount ?? 1) treats null
-  // as "no argument" and defaults to 1. The ably-js API signature is increment(amount?: number).
+  // The null row is excluded per the spec's language-applicability note on this table:
+  // the ably-js signature is increment(amount?: number) and a nullish amount takes the
+  // default of 1, so null is indistinguishable from "omitted" (see deviations.md).
   describe('RTLC12e1 - table-driven invalid increment amounts', function () {
     const invalidAmounts = [
       { value: NaN, label: 'NaN' },

--- a/test/uts/objects/unit/live_map.test.ts
+++ b/test/uts/objects/unit/live_map.test.ts
@@ -11,12 +11,6 @@
  * calculation.
  *
  * Deviations:
- * - RTLM15d4 (unsupported action): ably-js throws ErrorInfo (92000) rather than
- *   silently returning false. Test expects the throw.
- * - RTLM9b (both serials empty): the spec expects applyOperation to return false
- *   via the object-level empty-serial gate (RTLO4a3/RTLM15b); ably-js throws
- *   ErrorInfo 92000 at that same gate instead of returning false — the same
- *   throw-instead-of-false family as RTLM15d4 below. The test asserts the throw.
  * - RTLM7g (objectId creates zero-value): Tested via pool from channel, since
  *   standalone LiveMap needs a pool reference.
  * - RTLM14c (tombstoned ref check): Tested via protocol messages + pool, since
@@ -263,11 +257,7 @@ describe('uts/objects/unit/live_map', function () {
   // =====================================================================
 
   // UTS: objects/unit/RTLM9b/both-empty-reject-0
-  // Deviation: the spec expects applyOperation to return false — the empty
-  // ObjectMessage.serial is rejected by the object-level gate (RTLO4a3/RTLM15b)
-  // before the entry-level RTLM9b comparison. ably-js throws ErrorInfo 92000 at
-  // that same gate instead of returning false (same family as RTLM15d4).
-  it('RTLM9b - both serials empty rejects operation (deviation: throws on empty serial)', async function () {
+  it('RTLM9b - both serials empty rejects operation', async function () {
     const { channel, client } = await setupSyncedChannel('test-RTLM9b');
 
     const map = createZeroMap(channel, 'map:test@1000');
@@ -278,7 +268,6 @@ describe('uts/objects/unit/live_map', function () {
       tombstonedAt: undefined,
     });
 
-    // ably-js throws ErrorInfo for empty serial at _canApplyOperation level
     const msg = makeObjectMessage(client, {
       serial: '',
       siteCode: 'site1',
@@ -289,11 +278,12 @@ describe('uts/objects/unit/live_map', function () {
       },
     });
 
-    expect(() => map.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel))
-      .to.throw()
-      .with.property('code', 92000);
+    // The empty ObjectMessage.serial is rejected by the object-level gate (RTLO4a3, via
+    // canApplyOperation) before the entry-level RTLM9b comparison; applyOperation returns
+    // false (RTLM15b) and the data is unchanged.
+    const result = map.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel);
 
-    // Data unchanged
+    expect(result).to.equal(false);
     expect(getDataMap(map).get('name')!.data).to.deep.equal({ string: 'Alice' });
   });
 
@@ -1018,9 +1008,7 @@ describe('uts/objects/unit/live_map', function () {
   // =====================================================================
 
   // UTS: objects/unit/RTLM15d4/unsupported-action-0
-  // Deviation: ably-js throws ErrorInfo (92000) for unsupported actions
-  // instead of returning false as the spec requires.
-  it('RTLM15d4 - unsupported action throws (deviation: spec expects false)', async function () {
+  it('RTLM15d4 - unsupported action is discarded without applying', async function () {
     const { channel, client } = await setupSyncedChannel('test-RTLM15d4');
 
     const map = createZeroMap(channel, 'map:test@1000');
@@ -1035,10 +1023,10 @@ describe('uts/objects/unit/live_map', function () {
       },
     });
 
-    expect(() => map.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel))
-      .to.throw()
-      .with.property('code', 92000);
+    const result = map.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel);
 
+    // RTLM15d4 - log a warning and discard the message; no data update
+    expect(result).to.equal(false);
     expect(getDataMap(map).size).to.equal(0);
   });
 

--- a/test/uts/objects/unit/live_map.test.ts
+++ b/test/uts/objects/unit/live_map.test.ts
@@ -18,6 +18,10 @@
  * - parentReferences tests: ably-js uses Map<LiveObject, Set<string>> for
  *   _parentReferences. Tests access via (obj as any)._parentReferences and
  *   check entries using the LiveObject instance as map key.
+ * - RTLM19 (GC boundary): the spec calls a pure gcTombstonedEntries(grace_period, now);
+ *   ably-js's onGCInterval() reads Date.now internally, so the test stubs Date.now
+ *   synchronously around that single call (restored in finally, no awaits or polling
+ *   inside the stub window) to honour the spec's fixed `now` fixture.
  */
 
 import { expect } from 'chai';

--- a/test/uts/objects/unit/live_map_api.test.ts
+++ b/test/uts/objects/unit/live_map_api.test.ts
@@ -9,7 +9,6 @@
  * value type handling, and error cases.
  *
  * Deviations:
- * - RTLM24 (clear) skipped: LiveMap#clear() is not yet implemented in ably-js.
  * - RTLM20/set-invalid-values-table-0: 'symbol' test case uses Symbol('test').
  * - RTLM12 (keys): read via root.instance().keys() — RTLM12 is an internal LiveMap-level point.
  */
@@ -166,7 +165,7 @@ describe('uts/objects/unit/live_map_api', function () {
 
     expect(capturedMessages).to.have.length(1);
     const objMsg = capturedMessages[0].state[0];
-    // Deviation: wire format uses numeric action (OBJ_OP.MAP_SET = 1), not string 'MAP_SET'
+    // Wire format uses numeric actions (OBJ_OP.MAP_SET = 1); spec pseudo-code string names are renderings
     expect(objMsg.operation.action).to.equal(OBJ_OP.MAP_SET);
     expect(objMsg.operation.objectId).to.equal('root');
     expect(objMsg.operation.mapSet.key).to.equal('name');
@@ -237,7 +236,7 @@ describe('uts/objects/unit/live_map_api', function () {
     expect(capturedMessages).to.have.length(3);
     expect(capturedMessages[0].state[0].operation.mapSet.value.number).to.equal(42);
     expect(capturedMessages[1].state[0].operation.mapSet.value.boolean).to.equal(false);
-    // Deviation: json value is serialized as a JSON string on the wire, not a parsed object
+    // Per OD2g the json value is serialized as a JSON string on the wire, not a parsed object
     expect(JSON.parse(capturedMessages[2].state[0].operation.mapSet.value.json)).to.deep.equal({ nested: true });
   });
 
@@ -303,7 +302,7 @@ describe('uts/objects/unit/live_map_api', function () {
     expect(capturedMessages).to.have.length(1);
     const state = capturedMessages[0].state;
     expect(state).to.have.length(2);
-    // Deviation: wire format uses numeric action values
+    // Wire format uses numeric action values (spec pseudo-code string names are renderings)
     expect(state[0].operation.action).to.equal(OBJ_OP.COUNTER_CREATE);
     expect(state[0].operation.objectId).to.match(/^counter:/);
     expect(state[1].operation.action).to.equal(OBJ_OP.MAP_SET);
@@ -372,7 +371,7 @@ describe('uts/objects/unit/live_map_api', function () {
     expect(capturedMessages).to.have.length(1);
     const state = capturedMessages[0].state;
     expect(state).to.have.length(2);
-    // Deviation: wire format uses numeric action values
+    // Wire format uses numeric action values (spec pseudo-code string names are renderings)
     expect(state[0].operation.action).to.equal(OBJ_OP.MAP_CREATE);
     expect(state[0].operation.objectId).to.match(/^map:/);
     expect(state[1].operation.action).to.equal(OBJ_OP.MAP_SET);
@@ -449,7 +448,7 @@ describe('uts/objects/unit/live_map_api', function () {
     const state = capturedMessages[0].state;
     // Expect: COUNTER_CREATE, MAP_CREATE, MAP_SET (depth-first, then the MAP_SET at root)
     expect(state).to.have.length(3);
-    // Deviation: wire format uses numeric action values
+    // Wire format uses numeric action values (spec pseudo-code string names are renderings)
     expect(state[0].operation.action).to.equal(OBJ_OP.COUNTER_CREATE);
     expect(state[0].operation.objectId).to.match(/^counter:/);
     expect(state[1].operation.action).to.equal(OBJ_OP.MAP_CREATE);
@@ -520,7 +519,7 @@ describe('uts/objects/unit/live_map_api', function () {
 
     expect(capturedMessages).to.have.length(1);
     const objMsg = capturedMessages[0].state[0];
-    // Deviation: wire format uses numeric action values
+    // Wire format uses numeric action values (spec pseudo-code string names are renderings)
     expect(objMsg.operation.action).to.equal(OBJ_OP.MAP_REMOVE);
     expect(objMsg.operation.objectId).to.equal('root');
     expect(objMsg.operation.mapRemove.key).to.equal('name');
@@ -619,13 +618,5 @@ describe('uts/objects/unit/live_map_api', function () {
 
     expect(capturedMessages).to.have.length(1);
     expect(capturedMessages[0].state[0].operation.mapSet.value.bytes).to.equal('AQID');
-  });
-
-  // ---------- RTLM24: clear() sends MAP_CLEAR message ----------
-  // Skipped: LiveMap#clear() is not yet implemented in ably-js (see deviations.md).
-  // No UTS Test ID: the spec has no public clear() API test section; this is a
-  // placeholder to be tagged when clear() is implemented and specced.
-  it.skip('RTLM24 - clear() sends MAP_CLEAR message (not yet implemented)', function () {
-    // Placeholder: LiveMap#clear() does not exist yet.
   });
 });

--- a/test/uts/objects/unit/live_object_subscribe.test.ts
+++ b/test/uts/objects/unit/live_object_subscribe.test.ts
@@ -59,21 +59,19 @@ describe('uts/objects/unit/live_object_subscribe', function () {
     expect(updates).to.have.length(1);
 
     // Second: a noop. Serial "02" passes the newness check (RTLO4a6) so the noop
-    // path itself suppresses the event, not the site-serial dedup.
-    // Deviation (RTLC9h): the spec's noop is a COUNTER_INC with no `number`, but
-    // ably-js applies missing/zero increments (NaN) instead of nooping — see
-    // deviations.md. A COUNTER_CREATE for an object whose create op is already
-    // merged (RTLC8) is a genuine noop in ably-js, so that is used to exercise
-    // the RTLO4b4c1 suppression path instead.
+    // path itself suppresses the event, not the site-serial dedup. An increment with
+    // no `number` is the noop (RTLC9h) — a raw ObjectMessage with no `number` field is
+    // used so it exercises the real RTLC9h/RTLO4b4c1 noop branch (a `number: 0` would
+    // EXIST per RTLC9g and produce a non-noop update with amount 0).
     mockWs.active_connection!.send_to_client(
       buildObjectMessage('test-RTLO4b4c1', [
         {
           serial: '02',
           siteCode: 'remote',
           operation: {
-            action: OBJ_OP.COUNTER_CREATE,
+            action: OBJ_OP.COUNTER_INC,
             objectId: 'counter:score@1000',
-            counterCreate: { count: 999 },
+            counterInc: {},
           },
         },
       ]),
@@ -171,10 +169,10 @@ describe('uts/objects/unit/live_object_subscribe', function () {
   });
 
   // UTS: objects/unit/RTLO4b4c3c/tombstone-deregisters-listeners-0
-  // Deviation: ably-js InstanceSubscriptionEvent does not expose a `tombstone` field.
-  // We verify the deregistration behaviour: both listeners fire for the tombstone event,
-  // and subsequent updates do NOT fire (proving the listeners were deregistered).
-  it('RTLO4b4c3c - tombstone update deregisters all listeners', async function () {
+  // The tombstone flag is internal (RTLO4b4e); the tombstone is identified by the
+  // OBJECT_DELETE operation and verified through the deregistration behaviour: both
+  // listeners fire for the tombstone event, and subsequent updates do NOT fire.
+  it('RTLO4b4c3c - tombstone update deregisters all Instance#subscribe listeners', async function () {
     const { root, mockWs } = await setupSyncedChannel('test-RTLO4b4c3c');
     const updatesA: any[] = [];
     const updatesB: any[] = [];
@@ -203,9 +201,7 @@ describe('uts/objects/unit/live_object_subscribe', function () {
   });
 
   // UTS: objects/unit/RTLO4b4d/update-has-object-message-0
-  // Deviation: ably-js InstanceSubscriptionEvent exposes the public ObjectMessage as `.message`
-  // (not `.objectMessage`). The public message uses string action names (e.g. 'counter.inc').
-  it('RTLO4b4d - LiveObjectUpdate.objectMessage is populated from source ObjectMessage', async function () {
+  it('RTLO4b4d - InstanceSubscriptionEvent.message is populated from source ObjectMessage', async function () {
     const { root, mockWs } = await setupSyncedChannel('test-RTLO4b4d');
     const updates: any[] = [];
     const instance = root.get('score').instance()!;
@@ -225,10 +221,7 @@ describe('uts/objects/unit/live_object_subscribe', function () {
   });
 
   // UTS: objects/unit/RTLO4b4e/tombstone-flag-true-0
-  // Deviation: ably-js InstanceSubscriptionEvent does not expose `tombstone`.
-  // We verify indirectly that the tombstone event is delivered (listener fires)
-  // and that the message carries an OBJECT_DELETE operation.
-  it('RTLO4b4e - LiveObjectUpdate.tombstone is true for tombstone updates', async function () {
+  it('RTLO4b4e - tombstone update identified by OBJECT_DELETE action', async function () {
     const { root, mockWs } = await setupSyncedChannel('test-RTLO4b4e-true');
     const updates: any[] = [];
     const instance = root.get('score').instance()!;
@@ -245,9 +238,7 @@ describe('uts/objects/unit/live_object_subscribe', function () {
   });
 
   // UTS: objects/unit/RTLO4b4e/tombstone-flag-false-0
-  // Deviation: ably-js InstanceSubscriptionEvent does not expose `tombstone`.
-  // We verify that a normal (non-tombstone) update is delivered with the correct operation.
-  it('RTLO4b4e - LiveObjectUpdate.tombstone is false for normal updates', async function () {
+  it('RTLO4b4e - normal update carries non-tombstone action', async function () {
     const { root, mockWs } = await setupSyncedChannel('test-RTLO4b4e-false');
     const updates: any[] = [];
     const instance = root.get('score').instance()!;

--- a/test/uts/objects/unit/objects_pool.test.ts
+++ b/test/uts/objects/unit/objects_pool.test.ts
@@ -534,7 +534,7 @@ describe('uts/objects/unit/objects_pool', function () {
     await flushAsync();
 
     // After sync, buffered increment of 10 should be applied on top of 100
-    // Deviation: ably-js counter value = counter.count + createOp.counterCreate.count
+    // Per RTLC6c/RTLC6d/RTLC16a the value is counter.count + createOp.counterCreate.count:
     // So counter.count=100, createOp.count=0 => value=100, then +10 = 110
     const counterObj = rto._objectsPool.get('counter:abc@1000');
     expect(counterObj).to.exist;
@@ -988,7 +988,7 @@ describe('uts/objects/unit/objects_pool', function () {
 
     expect(rto._state).to.equal('synced');
     // Buffer was applied: 100 + 5 = 105
-    // Deviation: ably-js counter value = counter.count + createOp.count = 100 + 0 = 100, then +5 = 105
+    // Per RTLC6c/RTLC6d/RTLC16a: counter.count + createOp.count = 100 + 0 = 100, then +5 = 105
     const counterObj = rto._objectsPool.get('counter:abc@1000');
     expect(counterObj).to.exist;
     expect(counterObj.value()).to.equal(105);

--- a/test/uts/objects/unit/path_object_subscribe.test.ts
+++ b/test/uts/objects/unit/path_object_subscribe.test.ts
@@ -52,10 +52,7 @@ describe('uts/objects/unit/path_object_subscribe', function () {
   });
 
   // UTS: objects/unit/RTPO19b/subscribe-precondition-detached-0
-  // Deviation: ably-js ensureAttached() only throws 90001 for FAILED state (for DETACHED
-  // it retries attach). We test the precondition using FAILED state instead, which is the
-  // equivalent RTO25 check that ably-js implements.
-  it('RTPO19b - subscribe() checks RTO25 access preconditions (FAILED channel throws 90001)', async function () {
+  it('RTPO19b - subscribe() checks RTO25 access API preconditions on DETACHED channel', async function () {
     const mockWs = new MockWebSocket({
       onConnectionAttempt: (conn) => {
         mockWs.active_connection = conn;
@@ -107,6 +104,11 @@ describe('uts/objects/unit/path_object_subscribe', function () {
               ),
             ]),
           );
+        } else if (msg.action === PM_ACTION.DETACH) {
+          mockWs.active_connection!.send_to_client({
+            action: PM_ACTION.DETACHED,
+            channel: msg.channel,
+          });
         }
       },
     });
@@ -129,18 +131,15 @@ describe('uts/objects/unit/path_object_subscribe', function () {
     // First get the channel to attached state and obtain root
     const rootPath = await channel.object.get();
 
-    // Send a channel ERROR PM to put channel into FAILED state
-    mockWs.active_connection!.send_to_client({
-      action: PM_ACTION.ERROR,
-      channel: 'test-precondition',
-      error: { code: 90000, statusCode: 400, message: 'Channel error' },
-    });
+    // Detach the channel client-side (a server-injected DETACHED would trigger an
+    // RTL13a re-attach and the channel would not stay DETACHED)
+    await channel.detach();
     await flushAsync();
-    expect(channel.state).to.equal('failed');
+    expect(channel.state).to.equal('detached');
 
     try {
       rootPath.subscribe(() => {});
-      expect.fail('Expected subscribe() to throw on FAILED channel');
+      expect.fail('Expected subscribe() to throw on DETACHED channel');
     } catch (error: any) {
       expect(error.code).to.equal(90001);
       expect(error.statusCode).to.equal(400);

--- a/test/uts/objects/unit/public_object_message.test.ts
+++ b/test/uts/objects/unit/public_object_message.test.ts
@@ -11,11 +11,12 @@
  * the message that triggered an object change.
  *
  * Deviations from UTS spec:
- * - ably-js's toUserFacingObjectOperation converts numeric semantics to
- *   string ('lww') and adds a deprecated 'value' field to ObjectData.
- *   Assertions adjusted accordingly.
- * - ably-js omits undefined fields rather than setting null. Assertions
- *   use .to.be.undefined instead of == null where appropriate.
+ * - toUserFacingObjectData adds a deprecated 'value' convenience field to the
+ *   public ObjectData (see deviations.md). The numeric-to-'lww' semantics
+ *   mapping is the spec's public rendering, not a deviation.
+ * - ably-js omits undefined fields rather than setting null — the sanctioned
+ *   null/undefined convention (spec uts/README.md). Assertions use
+ *   .to.be.undefined instead of == null where appropriate.
  */
 
 import { expect } from 'chai';

--- a/test/uts/objects/unit/public_object_message.test.ts
+++ b/test/uts/objects/unit/public_object_message.test.ts
@@ -13,7 +13,10 @@
  * Deviations from UTS spec:
  * - toUserFacingObjectData adds a deprecated 'value' convenience field to the
  *   public ObjectData (see deviations.md). The numeric-to-'lww' semantics
- *   mapping is the spec's public rendering, not a deviation.
+ *   mapping is the idiomatic JS rendering of the ObjectsMapSemantics.LWW enum
+ *   member (OMP2) per the UTS enum-value convention (spec uts/README.md) —
+ *   the spec pseudo-code's "LWW" is the symbolic enum name, not a string
+ *   contract.
  * - ably-js omits undefined fields rather than setting null — the sanctioned
  *   null/undefined convention (spec uts/README.md). Assertions use
  *   .to.be.undefined instead of == null where appropriate.

--- a/test/uts/objects/unit/realtime_object.test.ts
+++ b/test/uts/objects/unit/realtime_object.test.ts
@@ -79,6 +79,7 @@ describe('uts/objects/unit/realtime_object', function () {
           connectionDetails: {
             connectionKey: 'key-1',
             siteCode: 'test-site',
+            objectsGCGracePeriod: 86400000,
           },
         });
       },
@@ -127,6 +128,7 @@ describe('uts/objects/unit/realtime_object', function () {
           connectionDetails: {
             connectionKey: 'key-1',
             siteCode: 'test-site',
+            objectsGCGracePeriod: 86400000,
           },
         });
       },
@@ -282,16 +284,15 @@ describe('uts/objects/unit/realtime_object', function () {
     const channel = client.channels.get('test-RTO15', { modes: ['OBJECT_SUBSCRIBE', 'OBJECT_PUBLISH'] });
     await channel.object.get();
 
-    // Trigger a single OBJECT message via a PathObject mutation
+    // Drive the internal publish (RTO15) through a public mutation; the PublishResult
+    // is consumed internally by RTO20 (apply-on-ACK), so only the wire behaviour is asserted.
     const root = await channel.object.get();
-    const result = await root.get('score').increment(5);
+    await root.get('score').increment(5);
 
     expect(capturedMessages.length).to.equal(1);
     expect(capturedMessages[0].action).to.equal(PM_ACTION.OBJECT);
     expect(capturedMessages[0].channel).to.equal('test-RTO15');
     expect(capturedMessages[0].state.length).to.equal(1);
-    // Deviation: ably-js PathObject.increment() returns void (via publishAndApply),
-    // not a PublishResult with serials. The serials are consumed internally for apply-on-ACK.
   });
 
   // UTS: objects/unit/RTO20/publish-and-apply-local-0
@@ -444,9 +445,7 @@ describe('uts/objects/unit/realtime_object', function () {
     expect(root.get('score').value()).to.equal(110);
   });
 
-  // UTS: objects/unit/RTO20e1/fails-on-channel-detached-0
-  // Deviation: ably-js receiving DETACHED while ATTACHED triggers re-attach (not FAILED/SUSPENDED).
-  // We use a channel ERROR PM to put the channel into FAILED state, which triggers the 92008 error.
+  // UTS: objects/unit/RTO20e1/fails-on-channel-failed-0
   it('RTO20e1 - publishAndApply fails when channel enters FAILED during sync wait', async function () {
     const { root, mockWs } = await setupSyncedChannel('test-RTO20e1');
 
@@ -686,6 +685,10 @@ describe('uts/objects/unit/realtime_object', function () {
   it('RTO20 - ACK after echo does not double-apply', async function () {
     const { root, mockWs } = await setupSyncedChannelNoAck('test-RTO20-ack-after-echo');
 
+    // The spec's poll_until for the outbound OBJECT message before injecting the echo/ACK
+    // is omitted: ably-js is single-threaded and the publish reaches the transport
+    // synchronously before increment() returns, so the ACK can never arrive while no
+    // message is pending on the connection.
     const incFuture = root.get('score').increment(10);
 
     // Send the echo BEFORE the ACK. The serial and siteCode must match what
@@ -1082,8 +1085,6 @@ describe('uts/objects/unit/realtime_object', function () {
   });
 
   // UTS: objects/unit/RTO25b/access-throws-detached-0
-  // Deviation: the spec reaches DETACHED via a server-initiated DETACHED PM; ably-js
-  // re-attaches on an unsolicited DETACHED (RTL13a), so the test detaches client-side.
   it('RTO25b - Access API precondition throws on DETACHED channel', async function () {
     const mockWs = new MockWebSocket({
       onConnectionAttempt: (conn) => {
@@ -1094,6 +1095,7 @@ describe('uts/objects/unit/realtime_object', function () {
           connectionDetails: {
             connectionKey: 'key-1',
             siteCode: 'test-site',
+            objectsGCGracePeriod: 86400000,
           },
         });
       },
@@ -1159,6 +1161,7 @@ describe('uts/objects/unit/realtime_object', function () {
           connectionDetails: {
             connectionKey: 'key-1',
             siteCode: 'test-site',
+            objectsGCGracePeriod: 86400000,
           },
         });
       },

--- a/test/uts/objects/unit/realtime_object.test.ts
+++ b/test/uts/objects/unit/realtime_object.test.ts
@@ -10,8 +10,9 @@
  *
  * Deviations:
  * - RTO10/RTO10b1 (GC tests): ObjectsPool uses real setInterval + Date.now,
- *   not Platform.Config.setTimeout. Tests stub Date.now and use a short
- *   gcInterval to trigger GC, then restore originals.
+ *   not Platform.Config.setTimeout. Instead of stubbing Date.now, the tests
+ *   backdate the tombstone's serialTimestamp (RTLO6a: it becomes tombstonedAt)
+ *   past the grace period and use a short gcInterval to trigger GC.
  * - RTO20f (siteTimeserials): verified observably — after a local increment, a later inbound
  *   COUNTER_INC from SITE_CODE with a non-ACK serial ("t:0:9", below the ACK serial) still applies
  *   to 120, proving the LOCAL apply-on-ACK left siteTimeserials untouched (RTLC7c). No private access.
@@ -867,46 +868,40 @@ describe('uts/objects/unit/realtime_object', function () {
 
   // UTS: objects/unit/RTO10/gc-tombstoned-objects-0
   it('RTO10 - GC removes tombstoned objects past grace period', async function () {
-    // Save original values
     const origGcInterval = DEFAULTS.gcInterval;
-    const origDateNow = Date.now;
-    let fakeNow = origDateNow.call(Date);
 
     try {
       // Use short GC interval so the timer fires quickly
       DEFAULTS.gcInterval = 50;
-      Date.now = () => fakeNow;
 
       const { root, mockWs } = await setupSyncedChannel('test-RTO10');
 
-      // Delete the counter object (tombstone it)
+      // Delete the counter object (tombstone it). The tombstone's serialTimestamp is
+      // backdated past the grace period (RTLO6a: it becomes tombstonedAt), so the object
+      // is GC-eligible under the real clock -- no Date.now stubbing needed.
       mockWs.active_connection!.send_to_client(
-        buildObjectMessage('test-RTO10', [buildObjectDelete('counter:score@1000', '99', 'site1', 1000)]),
+        buildObjectMessage('test-RTO10', [
+          buildObjectDelete('counter:score@1000', '99', 'site1', Date.now() - (86400000 + 300000)),
+        ]),
       );
       await flushAsync();
 
-      // Advance fake time past grace period (86400000ms = 24h) + buffer
-      fakeNow += 86400000 + 300000;
-
-      // Wait for GC interval to fire (real time passes for the setInterval)
-      await new Promise<void>((resolve) => setTimeout(resolve, 200));
+      // Wait for the (real) GC interval to fire by polling for its observable effect,
+      // rather than sleeping a fixed period that races the timer on slow machines
+      await pollUntil(() => root.get('score').value() === undefined);
 
       expect(root.get('score').value()).to.be.undefined;
     } finally {
       DEFAULTS.gcInterval = origGcInterval;
-      Date.now = origDateNow;
     }
   });
 
   // UTS: objects/unit/RTO10b1/gc-grace-period-source-0
   it('RTO10b1 - GC grace period from ConnectionDetails', async function () {
     const origGcInterval = DEFAULTS.gcInterval;
-    const origDateNow = Date.now;
-    let fakeNow = origDateNow.call(Date);
 
     try {
       DEFAULTS.gcInterval = 50;
-      Date.now = () => fakeNow;
 
       const mockWs = new MockWebSocket({
         onConnectionAttempt: (conn) => {
@@ -954,22 +949,22 @@ describe('uts/objects/unit/realtime_object', function () {
       const channel = client.channels.get('test-RTO10b1', { modes: ['OBJECT_SUBSCRIBE', 'OBJECT_PUBLISH'] });
       const root = await channel.object.get();
 
-      // Delete the counter (tombstone it)
+      // Delete the counter (tombstone it). The tombstone is backdated 6s: eligible under
+      // the server-provided 5000ms grace, but NOT under the 24h default -- so the test
+      // fails if the implementation ignores ConnectionDetails.objectsGCGracePeriod
+      // (RTO10b1). No Date.now stubbing needed.
       mockWs.active_connection!.send_to_client(
-        buildObjectMessage('test-RTO10b1', [buildObjectDelete('counter:score@1000', '99', 'site1', 1000)]),
+        buildObjectMessage('test-RTO10b1', [buildObjectDelete('counter:score@1000', '99', 'site1', Date.now() - 6000)]),
       );
       await flushAsync();
 
-      // Advance past the short grace period (5000ms)
-      fakeNow += 5000 + 1000;
-
-      // Wait for GC interval to fire
-      await new Promise<void>((resolve) => setTimeout(resolve, 200));
+      // Wait for the (real) GC interval to fire by polling for its observable effect,
+      // rather than sleeping a fixed period that races the timer on slow machines
+      await pollUntil(() => root.get('score').value() === undefined);
 
       expect(root.get('score').value()).to.be.undefined;
     } finally {
       DEFAULTS.gcInterval = origGcInterval;
-      Date.now = origDateNow;
     }
   });
 

--- a/test/uts/objects/unit/realtime_object.test.ts
+++ b/test/uts/objects/unit/realtime_object.test.ts
@@ -445,6 +445,38 @@ describe('uts/objects/unit/realtime_object', function () {
     expect(root.get('score').value()).to.equal(110);
   });
 
+  // UTS: objects/unit/RTO20e1/fails-on-channel-detached-0
+  it('RTO20e1 - publishAndApply fails when channel enters DETACHED during sync wait', async function () {
+    const { channel, root, mockWs } = await setupSyncedChannel('test-RTO20e1-detached');
+
+    // Trigger re-sync (state becomes SYNCING)
+    mockWs.active_connection!.send_to_client({
+      action: PM_ACTION.ATTACHED,
+      channel: 'test-RTO20e1-detached',
+      channelSerial: 'sync2:cursor',
+      flags: HAS_OBJECTS,
+    });
+    await flushAsync();
+
+    // Start increment — publish() will succeed (auto-ACK from setupSyncedChannel),
+    // but publishAndApply waits for sync to complete.
+    const incPromise = root.get('score').increment(10);
+
+    // Give the ACK time to be processed and publishAndApply to register its listener
+    await flushAsync();
+
+    // Detach the channel client-side (an unsolicited server DETACHED would trigger an
+    // RTL13a re-attach); the shared mock answers the outbound DETACH with DETACHED
+    await channel.detach();
+
+    try {
+      await incPromise;
+      expect.fail('should have thrown');
+    } catch (err: any) {
+      expect(err.code).to.equal(92008);
+    }
+  });
+
   // UTS: objects/unit/RTO20e1/fails-on-channel-failed-0
   it('RTO20e1 - publishAndApply fails when channel enters FAILED during sync wait', async function () {
     const { root, mockWs } = await setupSyncedChannel('test-RTO20e1');

--- a/test/uts/objects/unit/realtime_object.test.ts
+++ b/test/uts/objects/unit/realtime_object.test.ts
@@ -293,6 +293,11 @@ describe('uts/objects/unit/realtime_object', function () {
     expect(capturedMessages[0].action).to.equal(PM_ACTION.OBJECT);
     expect(capturedMessages[0].channel).to.equal('test-RTO15');
     expect(capturedMessages[0].state.length).to.equal(1);
+    // RTO15e3 - the state entry is the encoded ObjectMessage for the driven mutation
+    const stateEntry = capturedMessages[0].state[0];
+    expect(stateEntry.operation.action).to.equal(OBJ_OP.COUNTER_INC);
+    expect(stateEntry.operation.objectId).to.equal('counter:score@1000');
+    expect(stateEntry.operation.counterInc.number).to.equal(5);
   });
 
   // UTS: objects/unit/RTO20/publish-and-apply-local-0
@@ -462,8 +467,14 @@ describe('uts/objects/unit/realtime_object', function () {
     // but publishAndApply waits for sync to complete.
     const incPromise = root.get('score').increment(10);
 
-    // Give the ACK time to be processed and publishAndApply to register its listener
+    // The operation must still be parked in the RTO20e wait for SYNCED
+    let settled = false;
+    incPromise.then(
+      () => (settled = true),
+      () => (settled = true),
+    );
     await flushAsync();
+    expect(settled).to.equal(false);
 
     // Detach the channel client-side (an unsolicited server DETACHED would trigger an
     // RTL13a re-attach); the shared mock answers the outbound DETACH with DETACHED
@@ -495,8 +506,14 @@ describe('uts/objects/unit/realtime_object', function () {
     // after the publish resolves and the sync wait begins.
     const incPromise = root.get('score').increment(10);
 
-    // Give the ACK time to be processed and publishAndApply to register its listener
+    // The operation must still be parked in the RTO20e wait for SYNCED
+    let settled = false;
+    incPromise.then(
+      () => (settled = true),
+      () => (settled = true),
+    );
     await flushAsync();
+    expect(settled).to.equal(false);
 
     // Now send ERROR to put channel into FAILED state
     mockWs.active_connection!.send_to_client({

--- a/test/uts/objects/unit/value_types.test.ts
+++ b/test/uts/objects/unit/value_types.test.ts
@@ -9,11 +9,10 @@
  * When consumed by a mutation method, they generate ObjectMessages with
  * v6 wire format fields (counterCreateWithObjectId, mapCreateWithObjectId).
  *
- * Deviation: The UTS spec uses a standalone `consume(vt)` function that
- * directly calls the internal static methods. In ably-js, consumption
- * happens internally when LiveMap#set() is called with a value type.
- * We test consumption by calling root.set() and capturing the wire
- * protocol messages sent over the mock WebSocket.
+ * Consumption ("evaluation by a mutation method" per the UTS spec) happens
+ * internally when LiveMap#set() is called with a value type; the tests drive
+ * root.set() and verify the generated ObjectMessages captured from the mock
+ * WebSocket, using the initialValue JSON string on the *WithObjectId ops.
  */
 
 import { expect } from 'chai';
@@ -180,7 +179,7 @@ describe('uts/objects/unit/value_types', function () {
   });
 
   // UTS: objects/unit/RTLCV4g5/retains-local-counter-create-0
-  // Deviation: _derivedFrom is stripped from wire messages (local-only field).
+  // _derivedFrom is a local-only field stripped from wire messages.
   // We verify CounterCreate data via the initialValue JSON string in
   // counterCreateWithObjectId, which encodes the CounterCreate payload.
   it('RTLCV4g5 - consumption retains local CounterCreate (via initialValue)', async function () {
@@ -277,7 +276,7 @@ describe('uts/objects/unit/value_types', function () {
   });
 
   // UTS: objects/unit/RTLMV4j5/retains-local-map-create-0
-  // Deviation: _derivedFrom is stripped from wire messages (local-only field).
+  // _derivedFrom is a local-only field stripped from wire messages.
   // We verify MapCreate data via the initialValue JSON string in
   // mapCreateWithObjectId, which encodes the MapCreate payload.
   it('RTLMV4j5 - consumption retains local MapCreate (via initialValue)', async function () {
@@ -300,7 +299,7 @@ describe('uts/objects/unit/value_types', function () {
   });
 
   // UTS: objects/unit/RTLMV4d/entry-value-types-0
-  // Deviation: Verify entry types via the initialValue JSON string in mapCreateWithObjectId.
+  // Entry types are verified via the initialValue JSON string in mapCreateWithObjectId.
   it('RTLMV4d - entry value type mapping', async function () {
     const { root, captured } = await setupCapturingChannel('test-RTLMV4d');
 
@@ -331,7 +330,7 @@ describe('uts/objects/unit/value_types', function () {
   });
 
   // UTS: objects/unit/RTLMV4d1/nested-value-types-0
-  // Deviation: Verify nested objectId references via the initialValue JSON strings.
+  // Nested objectId references are verified via the initialValue JSON strings.
   it('RTLMV4d1 - nested value types produce depth-first ObjectMessages', async function () {
     const { root, captured } = await setupCapturingChannel('test-RTLMV4d1');
 
@@ -416,7 +415,7 @@ describe('uts/objects/unit/value_types', function () {
   });
 
   // UTS: objects/unit/RTLMV4d/map-set-all-types-table-0
-  // Deviation: Verify entry types via the initialValue JSON string.
+  // Entry types are verified via the initialValue JSON string.
   // JSON values on the wire are double-encoded (JSON-stringified strings),
   // so we parse them before comparison.
   it('RTLMV4d - table-driven value type mapping via MapCreate', async function () {

--- a/test/uts/realtime/integration/mutable_messages.test.ts
+++ b/test/uts/realtime/integration/mutable_messages.test.ts
@@ -17,6 +17,7 @@ import {
   closeAndWait,
   uniqueChannelName,
   pollUntil,
+  pollUntilSuccess,
 } from './sandbox';
 import { describeEachProtocol } from '../../helpers/protocol_variants';
 
@@ -376,17 +377,25 @@ describeEachProtocol('uts/realtime/integration/mutable_messages', function (prot
     await channel.updateMessage({ serial, data: 'v2' } as any, { description: 'first edit' });
     await channel.updateMessage({ serial, data: 'v3' } as any, { description: 'second edit' });
 
-    // Wait for propagation before HTTP-based reads
-    await new Promise((r) => setTimeout(r, 2000));
-
-    const msg = await channel.getMessage(serial);
+    // The message store is eventually consistent: poll until the second update is
+    // visible rather than sleeping a fixed interval before the HTTP-based reads
+    // (a found message may still be a stale version).
+    const msg = await pollUntilSuccess(async () => {
+      const m = await channel.getMessage(serial);
+      if (m.action === 'message.update' && m.data === 'v3') return m;
+      return null;
+    });
 
     expect(msg).to.be.an('object');
     expect(msg.serial).to.equal(serial);
     expect(msg.data).to.equal('v3');
     expect(msg.action).to.equal('message.update');
 
-    const versions = await channel.getMessageVersions(serial);
+    const versions = await pollUntilSuccess(async () => {
+      const result = await channel.getMessageVersions(serial);
+      if (result.items.length >= 3) return result;
+      return null;
+    });
 
     expect(versions).to.have.property('items');
     expect(versions.items.length).to.be.at.least(3);

--- a/test/uts/realtime/integration/presence/presence_lifecycle.test.ts
+++ b/test/uts/realtime/integration/presence/presence_lifecycle.test.ts
@@ -61,10 +61,13 @@ describeEachProtocol('uts/realtime/integration/presence/presence_lifecycle', fun
     const channelA = clientA.channels.get(channelName);
     const channelB = clientB.channels.get(channelName);
 
-    // Attach B and subscribe before A enters any members
-    const receivedEnters: any[] = [];
-    await channelB.presence.subscribe('enter', (msg: any) => {
-      receivedEnters.push(msg);
+    // Attach B and subscribe before A enters any members. Members are counted by
+    // clientId from both 'enter' and 'present' events: if B's connection blips
+    // mid-test, members it missed arrive via the presence re-sync as 'present'
+    // events rather than 'enter', and an enter-only count would undercount forever.
+    const enteredClientIds = new Set<string>();
+    await channelB.presence.subscribe(['enter', 'present'], (msg: any) => {
+      enteredClientIds.add(msg.clientId);
     });
 
     await channelA.attach();
@@ -74,12 +77,12 @@ describeEachProtocol('uts/realtime/integration/presence/presence_lifecycle', fun
       await channelA.presence.enterClient(`user-${i}`, `data-${i}`);
     }
 
-    await pollUntil(() => (receivedEnters.length >= memberCount ? true : null), {
+    await pollUntil(() => (enteredClientIds.size >= memberCount ? true : null), {
       interval: 200,
       timeout: 30000,
     });
 
-    expect(receivedEnters).to.have.length(memberCount);
+    expect(enteredClientIds.size).to.equal(memberCount);
 
     const members = await channelB.presence.get();
     expect(members).to.have.length(memberCount);

--- a/test/uts/realtime/integration/sandbox.ts
+++ b/test/uts/realtime/integration/sandbox.ts
@@ -222,8 +222,11 @@ async function pollUntil<T>(
 }
 
 /**
- * Poll until `fn` succeeds (returns a value without throwing): errors are logged and mean
+ * Poll until `fn` succeeds (returns a truthy value without throwing): errors are logged and mean
  * "keep polling"; on timeout the most recent error is thrown, so failures stay diagnosable.
+ * Falsy returns keep polling too (matching `pollUntil` and the spec's `poll_until_success`
+ * convention, where a bare boolean condition polls until true) -- so a falsy value like 0 or ""
+ * cannot be the success result; have `fn` return the containing object or `true` instead.
  */
 async function pollUntilSuccess<T>(
   fn: () => Promise<T | null | undefined> | T | null | undefined,
@@ -236,7 +239,8 @@ async function pollUntilSuccess<T>(
         return await fn();
       } catch (err) {
         lastError = err;
-        console.warn(`pollUntilSuccess: retrying after error: ${err}`);
+        // pass the error object itself so the stack is preserved in the output
+        console.warn('pollUntilSuccess: retrying after error:', err);
         return null;
       }
     }, opts);

--- a/test/uts/realtime/integration/sandbox.ts
+++ b/test/uts/realtime/integration/sandbox.ts
@@ -221,6 +221,30 @@ async function pollUntil<T>(
   }
 }
 
+/**
+ * Poll until `fn` succeeds (returns a value without throwing): errors are logged and mean
+ * "keep polling"; on timeout the most recent error is thrown, so failures stay diagnosable.
+ */
+async function pollUntilSuccess<T>(
+  fn: () => Promise<T | null | undefined> | T | null | undefined,
+  opts: { interval?: number; timeout?: number } = {},
+): Promise<T> {
+  let lastError: unknown;
+  try {
+    return await pollUntil(async () => {
+      try {
+        return await fn();
+      } catch (err) {
+        lastError = err;
+        console.warn(`pollUntilSuccess: retrying after error: ${err}`);
+        return null;
+      }
+    }, opts);
+  } catch (timeoutErr) {
+    throw lastError ?? timeoutErr;
+  }
+}
+
 export {
   Ably,
   SANDBOX_ENDPOINT,
@@ -235,4 +259,5 @@ export {
   uniqueChannelName,
   generateJWT,
   pollUntil,
+  pollUntilSuccess,
 };

--- a/test/uts/rest/integration/mutable_messages.test.ts
+++ b/test/uts/rest/integration/mutable_messages.test.ts
@@ -13,7 +13,7 @@ import {
   teardownSandbox,
   getApiKey,
   uniqueChannelName,
-  pollUntil,
+  pollUntilSuccess,
 } from './sandbox';
 import { describeEachProtocol } from '../../helpers/protocol_variants';
 
@@ -108,8 +108,9 @@ describeEachProtocol('uts/rest/integration/mutable_messages', function (protocol
     const publishResult = await channel.publish('test-event', 'hello world');
     const serial = publishResult.serials[0] as string;
 
-    // Retrieve the message by serial
-    const msg = await channel.getMessage(serial);
+    // Retrieve the message by serial (polled: the store is eventually consistent and
+    // getMessage throws not-found until the just-published message is visible)
+    const msg = await pollUntilSuccess(() => channel.getMessage(serial));
 
     expect(msg).to.be.an('object');
     expect(msg.name).to.equal('test-event');
@@ -150,14 +151,11 @@ describeEachProtocol('uts/rest/integration/mutable_messages', function (protocol
     expect((updateResult.versionSerial as string).length).to.be.greaterThan(0);
 
     // Verify via getMessage -- poll until the update is visible
-    const updatedMsg = await pollUntil(
-      async () => {
-        const msg = await channel.getMessage(serial);
-        if (msg.action === 'message.update') return msg;
-        return null;
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    const updatedMsg = await pollUntilSuccess(async () => {
+      const msg = await channel.getMessage(serial);
+      if (msg.action === 'message.update') return msg;
+      return null;
+    });
 
     expect(updatedMsg.name).to.equal('updated');
     expect(updatedMsg.data).to.equal('updated-data');
@@ -194,14 +192,11 @@ describeEachProtocol('uts/rest/integration/mutable_messages', function (protocol
     expect((deleteResult.versionSerial as string).length).to.be.greaterThan(0);
 
     // Verify via getMessage -- poll until the delete is visible
-    const deletedMsg = await pollUntil(
-      async () => {
-        const msg = await channel.getMessage(serial);
-        if (msg.action === 'message.delete') return msg;
-        return null;
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    const deletedMsg = await pollUntilSuccess(async () => {
+      const msg = await channel.getMessage(serial);
+      if (msg.action === 'message.delete') return msg;
+      return null;
+    });
 
     expect(deletedMsg.action).to.equal('message.delete');
   });
@@ -231,14 +226,11 @@ describeEachProtocol('uts/rest/integration/mutable_messages', function (protocol
     await channel.updateMessage({ serial, data: 'v3' } as any, { description: 'second edit' });
 
     // Poll version history until all versions appear
-    const versions = await pollUntil(
-      async () => {
-        const result = await channel.getMessageVersions(serial);
-        if (result.items.length >= 3) return result;
-        return null;
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    const versions = await pollUntilSuccess(async () => {
+      const result = await channel.getMessageVersions(serial);
+      if (result.items.length >= 3) return result;
+      return null;
+    });
 
     expect(versions.items.length).to.be.at.least(3);
 
@@ -306,14 +298,11 @@ describeEachProtocol('uts/rest/integration/mutable_messages', function (protocol
     });
 
     // Verify annotation exists -- poll until it appears
-    const annotations = await pollUntil(
-      async () => {
-        const result = await channel.annotations.get(serial, null);
-        if (result.items.length >= 1) return result;
-        return null;
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    const annotations = await pollUntilSuccess(async () => {
+      const result = await channel.annotations.get(serial, null);
+      if (result.items.length >= 1) return result;
+      return null;
+    });
 
     expect(annotations.items.length).to.be.at.least(1);
 
@@ -365,14 +354,11 @@ describeEachProtocol('uts/rest/integration/mutable_messages', function (protocol
     });
 
     // Retrieve annotations -- poll until both appear
-    const result = await pollUntil(
-      async () => {
-        const r = await channel.annotations.get(serial, null);
-        if (r.items.length >= 2) return r;
-        return null;
-      },
-      { interval: 500, timeout: 10000 },
-    );
+    const result = await pollUntilSuccess(async () => {
+      const r = await channel.annotations.get(serial, null);
+      if (r.items.length >= 2) return r;
+      return null;
+    });
 
     expect(result.items.length).to.be.at.least(2);
 

--- a/test/uts/rest/integration/sandbox.ts
+++ b/test/uts/rest/integration/sandbox.ts
@@ -19,6 +19,7 @@ export {
   uniqueChannelName,
   generateJWT,
   pollUntil,
+  pollUntilSuccess,
 } from '../../realtime/integration/sandbox';
 
 import { getSandboxApp } from '../../realtime/integration/sandbox';

--- a/test/uts/rest/unit/fallback.test.ts
+++ b/test/uts/rest/unit/fallback.test.ts
@@ -718,7 +718,7 @@ describe('uts/rest/unit/fallback', function () {
     expect(hosts[0]).to.equal(fallbackHost);
 
     // Advance time past fallbackRetryTimeout
-    clock.tick(200);
+    clock.tick(150);
 
     // Third request after cache expiry: should try primary again
     hosts.length = 0;


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-1141

## Summary

Applies the outcome of a comprehensive audit of ably-js LiveObjects against the reconciled objects spec (`objects-features.md` + `uts/objects`). The audit validated every recorded deviation, swept all spec clauses with concrete constraints (length / format / size / algorithm) against the source, and cross-checked every derived UTS test against the spec test bodies. It found **two real runtime bugs** and a set of stale test adaptations — all fixed here. Companion spec-side corrections (test rewrites the audit produced) land separately in `ably/specification` on `uts-liveobjects`.

## New bug discovered

`cheapRandStr()` — used to generate the object-id nonce — is `String(Math.random()).substr(2)`: the decimal digits of one random float, whose string length varies. The spec mandates a **unique nonce of 16+ characters** (RTLCV4d / RTLMV4g, feeding RTO14's object-id hash). Measured over 1,000,000 samples per method:

| | Old `cheapRandStr()` | New `randomString(12)` |
|---|---|---|
| Length range | 10–22 chars | exactly 16, always |
| **< 16 chars (violates RTLCV4d)** | **7.43%** | 0% |
| Charset | 12 symbols — digits plus `e` and `-` (floats like `1.53e-7` stringify in scientific notation) | 64-symbol base64 |
| Worst-case entropy | ~36 bits | 96 bits |
| Duplicates in 1M | 0 | 0 |

So roughly **1 in 13 object creations shipped a spec-non-compliant nonce**, occasionally as short as 10 characters — and the length distribution (61% land at exactly 16) explains why the derived UTS assertion `nonce.length >= 16` only failed intermittently rather than every run. The scientific-notation charset was a bonus surprise: the "digit string" wasn't even always digits.

**Fix**: `ObjectId.generateNonce()` = `Utils.randomString(12)` — 12 bytes of real entropy base64-encoding to exactly 16 characters, the same pattern REST idempotent message IDs already use. Applied to `LiveCounter.create()` / `LiveMap.create()` evaluation and to the REST `generateObjectId()`, which a usage sweep caught still calling `cheapRandStr()` directly. The full RTO14 pipeline (SHA-256 over UTF-8 `initialValue:nonce`, RFC 4648 §5 Base64URL, `type:hash@timestamp` format) was additionally script-validated against an independent reference implementation, including multibyte inputs.

## Second bug: one malformed inbound operation discarded its siblings

`applyOperation` threw `ErrorInfo` 92000 for wire-triggerable conditions: empty `serial`/`siteCode`, an action unsupported by the object type, and nil operation payloads (`counterInc`/`mapSet`/`mapRemove` absent). The spec mandates **log a warning and skip** (RTLO4a3, RTLC7d3, RTLM15d4).

The throws never crashed the client — they bubbled to the root catch in `ConnectionManager.processNextPendingChannelMessage()` and were logged — but that catch is per-`ProtocolMessage`, not per-operation, so:

- a malformed operation **aborted every sibling operation after it** in the same `ProtocolMessage` (silent data loss within the batch), and
- for the unsupported-action / nil-payload cases the throw fired *after* `siteTimeserials` had recorded the op's serial, so a redelivery could then be rejected by the newness check — divergence, not just loss.

All seven gate sites now warn (`LOG_MAJOR`, matching the existing missing-`operation`-field skip) and skip only the offending operation. Genuine internal invariants (objectId mismatch, missing object state during sync) still throw.

## Counter noop guards (RTLC9h / RTLC16d)

- A `COUNTER_INC` without a `number` previously did `data += undefined`, **permanently corrupting the counter to `NaN`** and emitting an update event. It is now a noop, per RTLC9h.
- A `COUNTER_CREATE` without a `count` previously emitted a spurious zero-amount update. It now returns a noop, while still marking the create op merged per RTLC16b (so RTLC8's duplicate-create skip engages).

## Test changes

- The tests previously *adapted to assert the buggy behaviour* (RTLO4a, RTLC7d3, RTLC9, RTLC16, RTLM9b, RTLM15d4, RTLO4b4c1) are rewritten spec-verbatim — including restoring RTLO4b4c1's original `counterInc: {}` noop stimulus.
- `RTPO19b` rewritten to the spec's client-side detach pattern: the old FAILED-substitution comment claimed "`ensureAttached()` only throws for FAILED", but `subscribe()` never calls `ensureAttached()` — it uses the RTO25b access precondition, which throws 90001 on DETACHED too.
- `RTO20e1` UTS annotation renamed to `fails-on-channel-failed-0` in step with the spec-side test rename (the unit test uses the same ERROR→FAILED sequence as the proxy tier, per #501's reasoning).
- Stale "Deviation:" comments removed across the objects suites (the spec has since converged on `.message`, tombstone-via-`OBJECT_DELETE`, the value-types consumption model, and listener-first subscribe); the orphaned `RTLM24 clear()` skip is removed (the spec defines RTLM24 as the incoming apply path only).
- `test/uts/deviations.md` objects section reduced to the four entries that still hold (RTLMV4b and RTLC12e1 as spec-sanctioned language-applicability notes, the deprecated public `value` field, and harness/wire-format conventions).

## Testing

- Full UTS unit suite: **1350 passing / 0 failing** (json+msgpack variants included).
- `value_types` verified across repeated runs (the nonce assertion is no longer stochastic).
- `tsc --noEmit`, eslint and prettier clean.
- Validation scripts (nonce distribution measurement; RTO14 pipeline vs independent node-crypto reference) available on request.

## Related

- Companion spec-side test corrections: ably/specification#506 — client-side detach for the RTO25b/RTO26b/RTO20e1 unit tests, RTO15 made observable-only, `"lww"` casing, pseudocode conventions and language-applicability notes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LiveCounter and LiveMap now handle malformed or unsupported operations more gracefully by discarding them with warnings instead of failing processing.
  * Missing/invalid operation payload fields now result in no-op updates (including safer handling of missing increment/count inputs).
  * LiveObject operation validation and initial-data merging now avoid throwing on invalid inputs.
  * Object ID generation for counters/maps/REST objects now uses more robust async nonce generation.

* **Tests**
  * Updated UTS deviations, expectations, and mocks to match the revised discard/no-op behavior and subscribe/event details.
  * Improved UTS polling helpers and reduced flakiness across realtime/rest/objects test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
