### PR TITLE
chore: release/2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.25.0](https://github.com/ably/ably-js/tree/2.25.0) (2026-07-17)
+
+[Full Changelog](https://github.com/ably/ably-js/compare/2.24.0...2.25.0)
+
+### What's Changed
+
+- Add push notification support for React Native via the new `ably/react-native-push` plugin. Adds an asynchronous `client.getDevice()` and deprecates the synchronous `client.device()` [#2262](https://github.com/ably/ably-js/pull/2262)
+- Surface previously silent failures when channel modes are missing: `presence.get()` without the `presence_subscribe` mode and `channel.subscribe()` without the `subscribe` mode now log an error, or throw when the new `strictMode` client option is enabled [#2236](https://github.com/ably/ably-js/pull/2236)
+
 ## [2.24.0](https://github.com/ably/ably-js/tree/2.24.0) (2026-07-08)
 
 [Full Changelog](https://github.com/ably/ably-js/compare/2.23.0...2.24.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.24.0",
+      "version": "2.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -18,7 +18,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.24.0';
+export const version = '2.25.0';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
### What's Changed

- Add push notification support for React Native via the new `ably/react-native-push` plugin. Adds an asynchronous `client.getDevice()` and deprecates the synchronous `client.device()` [#2262](https://github.com/ably/ably-js/pull/2262)
- Surface previously silent failures when channel modes are missing: `presence.get()` without the `presence_subscribe` mode and `channel.subscribe()` without the `subscribe` mode now log an error, or throw when the new `strictMode` client option is enabled [#2236](https://github.com/ably/ably-js/pull/2236)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added React Native push notification support through the React Native push plugin.
  - Device retrieval is now asynchronous; the previous device method is deprecated.

- **Bug Fixes**
  - Improved visibility of missing channel and presence modes with clearer error logging.
  - Strict mode now throws errors for missing modes.

- **Chores**
  - Updated the package and React hooks release version to 2.25.0.
  - Added release notes documenting the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->