### PR TITLE
[AIT-1183] Add push token updates support for React Native

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -3655,6 +3655,20 @@ export declare interface HttpPaginatedResponse<T = any> extends PaginatedResult<
 }
 
 /**
+ * A push token obtained from the underlying push platform, along with the transport it belongs to. Has the same shape as the `ReactNativePushToken` accepted by the `ably/react-native-push` plugin's `requestToken` callback.
+ */
+export declare interface PushDeviceToken {
+  /**
+   * The push transport the token belongs to: `fcm` for a Firebase Cloud Messaging registration token, or `apns` for a raw APNs device token.
+   */
+  transportType: 'fcm' | 'apns';
+  /**
+   * The token itself: an FCM registration token or an APNs device token.
+   */
+  token: string;
+}
+
+/**
  * Enables a device to be registered and deregistered from receiving push notifications.
  */
 export declare interface Push {
@@ -3677,6 +3691,16 @@ export declare interface Push {
    * @param deregisterCallback - A function passed to override the default implementation to deregister the local device for push activation.
    */
   deactivate(deregisterCallback?: DeregisterCallback): Promise<void>;
+
+  /**
+   * Updates the device's push token after the underlying push platform has rotated it, and synchronizes the new token with Ably by updating the device registration. Call this from your platform's token refresh listener, for example `messaging().onTokenRefresh()` of `@react-native-firebase/messaging`, once {@link activate | `activate()`} has completed.
+   *
+   * The synchronization with Ably is fire-and-forget: it is serialized with any in-flight `activate()`, `deactivate()` or earlier `updateToken()` synchronization rather than racing it, it is routed through the `registerCallback` passed to `activate()` when one was provided, and a synchronization failure is reported to the `updateFailedCallback` passed to `activate()`.
+   *
+   * @param token - The refreshed push token, in the same shape as returned by the `requestToken` callback of the `ably/react-native-push` plugin.
+   * @returns A promise which resolves once the refreshed token has been persisted locally and its synchronization with Ably has been initiated, and rejects if the token is malformed or the device is not activated for push notifications.
+   */
+  updateToken(token: PushDeviceToken): Promise<void>;
 }
 
 /**

--- a/react-native-push.d.ts
+++ b/react-native-push.d.ts
@@ -26,6 +26,12 @@ import { RealtimeClient, RestClient } from './ably';
  *
  * const realtime = new Realtime({ ...options, plugins: { Push } });
  * await realtime.push.activate();
+ *
+ * // the push platform can rotate the token at any time; forward rotations to Ably so the
+ * // device registration stays deliverable
+ * messaging().onTokenRefresh(async (token) => {
+ *   await realtime.push.updateToken({ transportType: 'fcm', token });
+ * });
  * ```
  */
 declare namespace ReactNativePush {
@@ -65,6 +71,9 @@ declare namespace ReactNativePush {
    * `messaging().getToken()` from `@react-native-firebase/messaging` returns, on both Android and
    * iOS), or `transportType: 'apns'` for a raw APNs device token (e.g. from
    * `messaging().getAPNSToken()`).
+   *
+   * The same shape is accepted by `client.push.updateToken()` when the platform rotates the token
+   * after activation.
    */
   interface ReactNativePushToken {
     /**

--- a/src/common/lib/client/push.ts
+++ b/src/common/lib/client/push.ts
@@ -22,6 +22,14 @@ const PUSH_ACTIVATION_NOT_AVAILABLE_HINT =
 const PUSH_DEACTIVATION_NOT_AVAILABLE_HINT =
   'Run push.deactivate() in a browser environment with service worker support, or in React Native using the ably/react-native-push plugin. From a server, call client.push.admin.deviceRegistrations.remove(deviceId) to remove a device registration.';
 
+const PUSH_TOKEN_UPDATE_NOT_AVAILABLE_HINT =
+  'Call push.updateToken() in React Native with the ably/react-native-push plugin configured, passing plugins: { Push: ReactNativePush.create({ storage, requestToken }) } in the client options. From a server, use client.push.admin.deviceRegistrations.save(device) to modify a device registration instead.';
+
+interface PushDeviceToken {
+  transportType: 'apns' | 'fcm';
+  token: string;
+}
+
 class Push {
   client: BaseClient;
   admin: Admin;
@@ -135,6 +143,61 @@ class Push {
     }
     machine.handleEvent(new pushPlugin.CalledDeactivate(machine, deregisterCallback));
     await deactivated;
+  }
+
+  async updateToken(token: PushDeviceToken): Promise<void> {
+    const pushPlugin = this.client.options.plugins?.Push;
+    if (!pushPlugin) {
+      throw Utils.createMissingPluginError('Push');
+    }
+    const machine = this.stateMachine;
+    if (!machine) {
+      throw new ErrorInfo({
+        message:
+          'This platform is not supported as a target of push notifications: push token updates require a React Native environment with the ably/react-native-push plugin',
+        code: 40000,
+        statusCode: 400,
+        remediation: PUSH_TOKEN_UPDATE_NOT_AVAILABLE_HINT,
+      });
+    }
+    if (
+      !token ||
+      (token.transportType !== 'fcm' && token.transportType !== 'apns') ||
+      typeof token.token !== 'string' ||
+      token.token.length === 0
+    ) {
+      throw new ErrorInfo({
+        message:
+          "push.updateToken() requires a { transportType, token } object with transportType 'fcm' or 'apns' and a non-empty token string",
+        code: 40000,
+        statusCode: 400,
+        remediation:
+          "Pass the refreshed token in the shape your requestToken callback returns, for example { transportType: 'fcm', token } with the token value delivered by messaging().onTokenRefresh.",
+      });
+    }
+
+    // the state machine's processEvent handlers read the local device synchronously, so the
+    // device and the persisted machine state must be hydrated before any event is dispatched
+    const device = await this.client.getDevice();
+    await machine.ensureInitialized();
+
+    if (!device.deviceIdentityToken) {
+      throw new ErrorInfo({
+        message: 'Push token cannot be updated because the device is not activated for push notifications',
+        code: 40000,
+        statusCode: 400,
+        remediation:
+          'Call client.push.activate() and await its completion before calling push.updateToken(). Wire updateToken() to your platform token refresh listener only after activation has completed.',
+      });
+    }
+
+    device.push.recipient =
+      token.transportType === 'apns'
+        ? { transportType: 'apns', deviceToken: token.token }
+        : { transportType: 'fcm', registrationToken: token.token };
+    await device.persist();
+
+    machine.handleEvent(new machine.GotPushDeviceDetails());
   }
 }
 

--- a/src/plugins/push/pushactivation.ts
+++ b/src/plugins/push/pushactivation.ts
@@ -419,7 +419,7 @@ export class ActivationStateMachine {
       const format = client.options.useBinaryProtocol
           ? this.client.Utils.Format.msgpack
           : this.client.Utils.Format.json,
-        body = client.rest.DeviceDetails.fromLocalDevice(localDevice),
+        body = { push: { recipient: localDevice.push.recipient } },
         headers = this.client.Defaults.defaultPostHeaders(this.client.options, { format }),
         params = {};
 
@@ -434,18 +434,18 @@ export class ActivationStateMachine {
       const requestBody = this.client.Utils.encodeBody(body, client._MsgPack, format);
       const authDetails = localDevice.getAuthDetails(client, headers, params);
       try {
-        const response = await this.client.rest.Resource.patch(
+        await this.client.rest.Resource.patch(
           client,
-          '/push/deviceRegistrations',
+          '/push/deviceRegistrations/' + encodeURIComponent(localDevice.id),
           requestBody,
           authDetails.headers,
           authDetails.params,
           format,
           true,
         );
-        this.handleEvent(new GotDeviceRegistration(response.body as DeviceRegistration));
+        this.handleEvent(new RegistrationSynced());
       } catch (err) {
-        this.handleEvent(new GettingDeviceRegistrationFailed(err as ErrorInfo));
+        this.handleEvent(new SyncRegistrationFailed(err as ErrorInfo));
       }
     }
   }

--- a/test/uts/rest/unit/push/push_update_token.test.ts
+++ b/test/uts/rest/unit/push/push_update_token.test.ts
@@ -1,0 +1,345 @@
+/**
+ * push.updateToken() tests
+ *
+ * Exercises feeding a rotated FCM/APNs token into an activated device via the ReactNativePush
+ * plugin, with HTTP mocked. updateToken() persists the new recipient and hands a
+ * GotPushDeviceDetails event to the activation state machine (the same flow the plugin's
+ * getPushDeviceDetails hook uses on activation), so the registration sync is fire-and-forget.
+ * The tests cover: the registration sync (PATCH /push/deviceRegistrations/:deviceId),
+ * cold-start updates from persisted state, sync failure reporting via updateFailedCallback and
+ * retry, the pre-activation guard, routing through a custom registerCallback, and serialization
+ * with an in-flight sync or deactivation.
+ */
+
+import Module from 'module';
+import { expect } from 'chai';
+import { MockHttpClient } from '../../../mock_http';
+import { Ably, installMockHttp, restoreAll, flushAsync } from '../../../helpers';
+import ReactNativePush from '../../../../../src/plugins/react-native-push';
+import type { ReactNativePushToken } from '../../../../../src/plugins/react-native-push';
+
+// The plugin reads require('react-native').Platform.OS inside create(). react-native is not
+// resolvable in Node, so intercept module loading and serve this fake; tests set its OS per case.
+const fakeReactNative = { Platform: { OS: 'android' } };
+const originalModuleLoad = (Module as any)._load;
+
+/** In-memory fake of @react-native-async-storage/async-storage. */
+class FakeAsyncStorage {
+  private data = new Map<string, string>();
+
+  async getItem(key: string): Promise<string | null> {
+    return this.data.has(key) ? this.data.get(key)! : null;
+  }
+  async setItem(key: string, value: string): Promise<void> {
+    this.data.set(key, value);
+  }
+  async removeItem(key: string): Promise<void> {
+    this.data.delete(key);
+  }
+
+  // test-only synchronous accessor
+  dump(): Record<string, string> {
+    return Object.fromEntries(this.data);
+  }
+}
+
+describe('push_update_token', function () {
+  before(function () {
+    (Module as any)._load = function (request: string, ...rest: any[]) {
+      if (request === 'react-native') {
+        return fakeReactNative;
+      }
+      return originalModuleLoad.call(this, request, ...rest);
+    };
+  });
+
+  after(function () {
+    (Module as any)._load = originalModuleLoad;
+  });
+
+  afterEach(function () {
+    restoreAll();
+    fakeReactNative.Platform.OS = 'android';
+  });
+
+  function mockRegistrationServer(opts?: { onPatch?: (req: any) => void }) {
+    const captured: any[] = [];
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        captured.push(req);
+        if (req.method === 'post' && req.path === '/push/deviceRegistrations') {
+          req.respond_with(201, { ...JSON.parse(req.body), deviceIdentityToken: { token: 'ident-token-1' } });
+        } else if (req.method === 'patch' && req.path.startsWith('/push/deviceRegistrations/')) {
+          if (opts?.onPatch) {
+            opts.onPatch(req);
+          } else {
+            req.respond_with(200, JSON.parse(req.body));
+          }
+        } else {
+          req.respond_with(500, { error: { message: 'unexpected request ' + req.method + ' ' + req.path } });
+        }
+      },
+    });
+    installMockHttp(mock);
+    return captured;
+  }
+
+  function rnClient(
+    storage: FakeAsyncStorage,
+    opts?: { token?: ReactNativePushToken | (() => Promise<ReactNativePushToken>) },
+  ) {
+    const token = opts?.token ?? { transportType: 'fcm' as const, token: 'fcm-token-1' };
+    return new Ably.Rest({
+      key: 'appId.keyId:keySecret',
+      useBinaryProtocol: false,
+      plugins: {
+        Push: ReactNativePush.create({
+          storage,
+          requestToken: typeof token === 'function' ? token : async () => token,
+        }),
+      },
+    });
+  }
+
+  async function rejectionOf(promise: Promise<unknown>): Promise<any> {
+    try {
+      await promise;
+    } catch (err) {
+      return err;
+    }
+    throw new Error('expected promise to reject');
+  }
+
+  // the registration sync runs fire-and-forget after updateToken() resolves, so tests poll for
+  // its observable effects rather than awaiting a promise
+  async function waitFor(condition: () => boolean, description: string): Promise<void> {
+    for (let i = 0; i < 100; i++) {
+      if (condition()) {
+        return;
+      }
+      await flushAsync();
+    }
+    throw new Error('timed out waiting for ' + description);
+  }
+
+  it('updates a rotated fcm token via PATCH and persists the new recipient', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+
+    await client.push.activate();
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
+
+    await waitFor(() => captured.length === 2, 'the registration sync PATCH');
+    await flushAsync(); // let fire-and-forget storage writes settle
+
+    expect(captured[1].method).to.equal('patch');
+    expect(captured[1].headers.authorization).to.be.a('string'); // deviceIdentityToken bearer auth
+
+    const persisted = storage.dump();
+    // the device id travels in the URL; the body carries only the new recipient
+    expect(captured[1].path).to.equal('/push/deviceRegistrations/' + persisted['ably.push.deviceId']);
+    const body = JSON.parse(captured[1].body);
+    expect(body).to.deep.equal({ push: { recipient: { transportType: 'fcm', registrationToken: 'fcm-token-2' } } });
+
+    expect(JSON.parse(persisted['ably.push.pushRecipient'])).to.deep.equal({
+      transportType: 'fcm',
+      registrationToken: 'fcm-token-2',
+    });
+    expect(persisted['ably.push.activationState']).to.equal('WaitingForNewPushDeviceDetails');
+  });
+
+  it('maps an apns token to an apns recipient', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    fakeReactNative.Platform.OS = 'ios';
+    const client = rnClient(storage, { token: { transportType: 'apns', token: 'apns-token-1' } });
+
+    await client.push.activate();
+    await client.push.updateToken({ transportType: 'apns', token: 'apns-token-2' });
+
+    await waitFor(() => captured.length === 2, 'the registration sync PATCH');
+    const body = JSON.parse(captured[1].body);
+    expect(body.push.recipient).to.deep.equal({ transportType: 'apns', deviceToken: 'apns-token-2' });
+  });
+
+  it('rejects when the device is not activated, and a later activation still works', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+
+    const err = await rejectionOf(client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' }));
+    expect(err.code).to.equal(40000);
+    expect(err.message).to.match(/not activated/);
+    expect(err.remediation).to.match(/push\.activate/);
+    expect(captured).to.have.length(0);
+
+    // the guard fires before anything reaches the state machine, so activation is not affected
+    await client.push.activate();
+    expect(captured).to.have.length(1);
+  });
+
+  it('updates from persisted state on a cold start without re-calling activate()', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+
+    await rnClient(storage).push.activate();
+    await flushAsync();
+
+    // a fresh client over the same storage stands in for an app restart: the persisted state is
+    // WaitingForNewPushDeviceDetails, so updateToken must work without activate() this session
+    const restarted = rnClient(storage);
+    await restarted.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
+
+    await waitFor(() => captured.length === 2, 'the registration sync PATCH');
+    expect(captured[1].method).to.equal('patch');
+    const body = JSON.parse(captured[1].body);
+    expect(body.push.recipient.registrationToken).to.equal('fcm-token-2');
+    // the restarted client loaded the persisted device id and addressed the same registration
+    expect(captured[1].path).to.equal('/push/deviceRegistrations/' + storage.dump()['ably.push.deviceId']);
+  });
+
+  it('reports a failed sync to updateFailedCallback, then a retry with the same token succeeds', async function () {
+    let failPatch = true;
+    const captured = mockRegistrationServer({
+      onPatch: (req) => {
+        if (failPatch) {
+          // a 4xx response: a 5xx would additionally exercise the client's fallback-host retries
+          req.respond_with(400, { error: { message: 'server rejected sync', code: 40000, statusCode: 400 } });
+        } else {
+          req.respond_with(200, JSON.parse(req.body));
+        }
+      },
+    });
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+    const updateFailures: any[] = [];
+    await client.push.activate(undefined, (err) => updateFailures.push(err));
+
+    // the sync is fire-and-forget: updateToken resolves once the new token is persisted, and the
+    // server's rejection surfaces through the updateFailedCallback passed to activate()
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
+    await waitFor(() => updateFailures.length === 1, 'the sync failure to reach updateFailedCallback');
+    expect(updateFailures[0].message).to.match(/server rejected sync/);
+    expect(JSON.parse(storage.dump()['ably.push.pushRecipient']).registrationToken).to.equal('fcm-token-2');
+
+    failPatch = false;
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
+    await waitFor(() => captured.filter((req) => req.method === 'patch').length === 2, 'the retry PATCH');
+    await flushAsync();
+
+    expect(storage.dump()['ably.push.activationState']).to.equal('WaitingForNewPushDeviceDetails');
+  });
+
+  it('rejects malformed tokens without touching the machine or the network', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+    await client.push.activate();
+    await flushAsync();
+    const persistedBefore = storage.dump();
+
+    for (const bad of [undefined, { transportType: 'web', token: 'x' }, { transportType: 'fcm', token: '' }]) {
+      const err = await rejectionOf(client.push.updateToken(bad as any));
+      expect(err.code).to.equal(40000);
+      expect(err.message).to.match(/transportType/);
+    }
+
+    await flushAsync();
+    expect(captured).to.have.length(1); // just the activation POST
+    expect(storage.dump()).to.deep.equal(persistedBefore);
+  });
+
+  it('routes the sync through a custom registerCallback supplied to activate()', async function () {
+    const captured = mockRegistrationServer();
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+
+    const registeredRecipients: any[] = [];
+    await client.push.activate((device, callback) => {
+      registeredRecipients.push(device.push?.recipient);
+      callback(null as any, { deviceIdentityToken: { token: 'custom-ident-1' } } as any);
+    });
+    expect(registeredRecipients).to.have.length(1);
+    expect(captured).to.have.length(0); // registration went through the callback
+
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
+    await waitFor(() => registeredRecipients.length === 2, 'the sync to reach registerCallback');
+    await flushAsync();
+
+    // the device was registered through the customer's registerCallback, so the sync is routed
+    // through the same callback (with the new recipient) rather than PATCHed to Ably directly
+    expect(captured).to.have.length(0);
+    expect(registeredRecipients[1]).to.deep.equal({ transportType: 'fcm', registrationToken: 'fcm-token-2' });
+    expect(JSON.parse(storage.dump()['ably.push.pushRecipient']).registrationToken).to.equal('fcm-token-2');
+  });
+
+  it('an update issued while a sync is in flight is applied after it settles', async function () {
+    let heldPatch: any = null;
+    const captured = mockRegistrationServer({
+      onPatch: (req) => {
+        if (heldPatch) {
+          req.respond_with(200, JSON.parse(req.body));
+        } else {
+          heldPatch = req; // held open until the test releases it
+        }
+      },
+    });
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+    await client.push.activate();
+
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
+    await waitFor(() => !!heldPatch, 'the first sync PATCH');
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-3' });
+    await flushAsync();
+
+    // the second update is queued in the state machine behind the in-flight sync
+    expect(captured.filter((req) => req.method === 'patch')).to.have.length(1);
+
+    heldPatch.respond_with(200, JSON.parse(heldPatch.body));
+    await waitFor(() => captured.filter((req) => req.method === 'patch').length === 2, 'the queued sync PATCH');
+    await flushAsync();
+
+    const patches = captured.filter((req) => req.method === 'patch');
+    expect(JSON.parse(patches[1].body).push.recipient.registrationToken).to.equal('fcm-token-3');
+    expect(JSON.parse(storage.dump()['ably.push.pushRecipient']).registrationToken).to.equal('fcm-token-3');
+  });
+
+  it('an update racing a deactivation is discarded once the device is deregistered', async function () {
+    let heldDelete: any = null;
+    const captured: any[] = [];
+    const mock = new MockHttpClient({
+      onConnectionAttempt: (conn) => conn.respond_with_success(),
+      onRequest: (req) => {
+        captured.push(req);
+        if (req.method === 'post' && req.path === '/push/deviceRegistrations') {
+          req.respond_with(201, { ...JSON.parse(req.body), deviceIdentityToken: { token: 'ident-token-1' } });
+        } else if (req.method === 'delete' && req.path === '/push/deviceRegistrations') {
+          heldDelete = req; // held open until the test releases it
+        } else {
+          req.respond_with(500, { error: { message: 'unexpected request ' + req.method + ' ' + req.path } });
+        }
+      },
+    });
+    installMockHttp(mock);
+    const storage = new FakeAsyncStorage();
+    const client = rnClient(storage);
+    await client.push.activate();
+
+    const deactivated = client.push.deactivate(undefined as any);
+    await waitFor(() => !!heldDelete, 'the deregistration DELETE');
+    await client.push.updateToken({ transportType: 'fcm', token: 'fcm-token-2' });
+    await flushAsync();
+
+    heldDelete.respond_with(200, {});
+    await deactivated;
+    await flushAsync();
+
+    // the queued sync was discarded rather than re-registering the deregistered device, and
+    // deregistration removed the recipient the update had persisted
+    expect(captured.filter((req) => req.method === 'patch')).to.have.length(0);
+    expect(storage.dump()).to.not.have.property('ably.push.pushRecipient');
+  });
+});


### PR DESCRIPTION
This pull request adds support for push token updates and synchronization in React Native.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `push.updateToken()` to sync refreshed FCM/APNs device tokens after activation, using `{ transportType, token }`.
  * Persists updated push recipient details for consistent future sessions.
* **Documentation**
  * Updated React Native TypeScript declarations and examples to reflect token rotation behavior and the `{ transportType, token }` payload.
* **Bug Fixes**
  * Improved update synchronization by patching the correct device-registration endpoint and handling sync-failure states, retries, and queued concurrent updates safely.
* **Tests**
  * Added unit tests covering FCM/APNs mapping, cold-start updates, validation, retries, callback routing, concurrency, and deactivation race handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->