### PR TITLE
Fix rewind race in realtime message-append test

### DIFF
--- a/test/realtime/updates-deletes.test.js
+++ b/test/realtime/updates-deletes.test.js
@@ -253,15 +253,17 @@ define(['ably', 'shared_helper', 'async', 'chai'], function (Ably, Helper, async
         expect(appendMsg.name).to.equal('original-message');
         expect(appendMsg.data).to.equal(' World');
 
-        // now reattach with rewind to get the full concatenated message
+        // now reattach with rewind to get the full concatenated message. Set rewind before any attach is
+        // initiated (subscribe() auto-attaches), so the sole ATTACH carries it — rewind is an initial-attach
+        // directive, so a second ATTACH racing an already-established attachment does not reliably replay.
         await channel.detach();
+        await channel.setOptions({ params: { rewind: '1' } });
         const updatePromise = new Promise((resolve) => {
           channel.subscribe((msg) => {
             resolve(msg);
           });
         });
 
-        await channel.setOptions({ params: { rewind: '1' } });
         await channel.attach();
         const updatedMsg = await updatePromise;
         expect(updatedMsg.serial).to.equal(serial);


### PR DESCRIPTION
## Summary

Phase 2 of `realtime/message-operations` → **"Should append to a message over realtime"** (`test/realtime/updates-deletes.test.js`) relied on a timing race to replay message history via `rewind`. It passes against the cloud sandbox (latency keeps the race window open) but times out against a fast server, where it reproduces against the reference realtime server too — so it's a test bug, not a server gap.

## The race

To reattach with rewind, the test did:

```js
await channel.detach();
const updatePromise = new Promise((resolve) => channel.subscribe((msg) => resolve(msg)));
await channel.setOptions({ params: { rewind: '1' } });
await channel.attach();
```

`subscribe()` kicks off an implicit attach (RTL7g) whose ATTACH frame carries **no** rewind param (params are still empty at that point). `setOptions({rewind})` then sees the channel attaching/attached and sends a **second** ATTACH carrying `rewind: '1'`. Replay therefore depended on the rewind ATTACH reaching the server *before* the first attach established the stream:

| Timing | Result |
|---|---|
| No delay (as the test did) | replayed — cloud latency holds the window open |
| Initial attach completes first (fast server) | no replay → test times out |

`rewind` is an **initial-attach directive**: the server applies it only when present as the attachment's initial stream is created. A re-attach against an already-established attachment does not re-apply it.

## Fix

Set `rewind` **before** any attach is initiated, so the sole ATTACH carries it and replay is deterministic:

```js
await channel.detach();
await channel.setOptions({ params: { rewind: '1' } });
const updatePromise = new Promise((resolve) => channel.subscribe((msg) => resolve(msg)));
await channel.attach();
```

Phase 1 (live append fan-out) is unchanged.

## Testing

All 6 tests in `updates-deletes.test.js` pass deterministically against a fast local server (~70ms, previously timed out). Behaviour against the cloud sandbox is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved realtime message replay test reliability by applying rewind settings before reconnecting.
  * Updated validation to confirm replayed messages include the complete payload and expected metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->