### PR TITLE
[AIT-1204] fix(liveobjects): reject tombstoning of the root object (RTLO4e10, RTO10c1b1)

### DIFF
--- a/src/plugins/liveobjects/livecounter.ts
+++ b/src/plugins/liveobjects/livecounter.ts
@@ -219,24 +219,23 @@ export class LiveCounter extends LiveObject<LiveCounterData, LiveCounterUpdate> 
       return { noop: true };
     }
 
-    const previousDataRef = this._dataRef;
-    let update: LiveCounterUpdate;
     if (objectState.tombstone) {
       // tombstone this object and ignore the data from the object state message
-      update = this.tombstone(objectMessage);
-    } else {
-      // otherwise override data for this object with data from the object state
-      this._createOperationIsMerged = false; // RTLC6b
-      this._dataRef = { data: objectState.counter?.count ?? 0 }; // RTLC6c
-      // RTLC6d
-      if (!this._client.Utils.isNil(objectState.createOp)) {
-        this._mergeInitialDataFromCreateOperation(objectState.createOp, objectMessage);
-      }
-
-      // update will contain the diff between previous value and new value from object state
-      update = this._updateFromDataDiff(previousDataRef, this._dataRef);
-      update.objectMessage = objectMessage;
+      return this.tombstone(objectMessage);
     }
+
+    // otherwise override data for this object with data from the object state
+    const previousDataRef = this._dataRef;
+    this._createOperationIsMerged = false; // RTLC6b
+    this._dataRef = { data: objectState.counter?.count ?? 0 }; // RTLC6c
+    // RTLC6d
+    if (!this._client.Utils.isNil(objectState.createOp)) {
+      this._mergeInitialDataFromCreateOperation(objectState.createOp, objectMessage);
+    }
+
+    // update will contain the diff between previous value and new value from object state
+    const update = this._updateFromDataDiff(previousDataRef, this._dataRef);
+    update.objectMessage = objectMessage;
 
     return update;
   }

--- a/src/plugins/liveobjects/livemap.ts
+++ b/src/plugins/liveobjects/livemap.ts
@@ -445,25 +445,24 @@ export class LiveMap<T extends Record<string, Value> = Record<string, Value>>
       return { noop: true };
     }
 
-    let update: LiveMapUpdate<T>;
     if (objectState.tombstone) {
       // tombstone this object and ignore the data from the object state message
-      update = this.tombstone(objectMessage);
-    } else {
-      // otherwise override data for this object with data from the object state
-      const previousDataRef = this._dataRef;
-      this._createOperationIsMerged = false; // RTLM6b
-      this._clearTimeserial = objectState.map?.clearTimeserial; // RTLM6i
-      this._dataRef = this._liveMapDataFromMapEntries(objectState.map?.entries ?? {}); // RTLM6c
-      // RTLM6d
-      if (!this._client.Utils.isNil(objectState.createOp)) {
-        this._mergeInitialDataFromCreateOperation(objectState.createOp, objectMessage);
-      }
-
-      // update will contain the diff between previous value and new value from object state
-      update = this._updateFromDataDiff(previousDataRef, this._dataRef);
-      update.objectMessage = objectMessage;
+      return this.tombstone(objectMessage);
     }
+
+    // otherwise override data for this object with data from the object state
+    const previousDataRef = this._dataRef;
+    this._createOperationIsMerged = false; // RTLM6b
+    this._clearTimeserial = objectState.map?.clearTimeserial; // RTLM6i
+    this._dataRef = this._liveMapDataFromMapEntries(objectState.map?.entries ?? {}); // RTLM6c
+    // RTLM6d
+    if (!this._client.Utils.isNil(objectState.createOp)) {
+      this._mergeInitialDataFromCreateOperation(objectState.createOp, objectMessage);
+    }
+
+    // update will contain the diff between previous value and new value from object state
+    const update = this._updateFromDataDiff(previousDataRef, this._dataRef);
+    update.objectMessage = objectMessage;
 
     return update;
   }

--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -110,10 +110,24 @@ export abstract class LiveObject<
 
   /**
    * Clears the object's data, cancels any buffered operations and sets the tombstone flag to `true`.
+   * The root object can never be tombstoned (RTLO4e10); such attempts return a noop update.
    *
    * @internal
    */
-  tombstone(objectMessage: ObjectMessage): TUpdate {
+  tombstone(objectMessage: ObjectMessage): TUpdate | LiveObjectUpdateNoop {
+    // RTLO4e10 - the root object must always exist in the ObjectsPool (RTO3b); the realtime
+    // system never publishes an OBJECT_DELETE operation or a tombstoned object state for it,
+    // so an attempt to tombstone it indicates a faulty message. log a warning and skip it
+    if (this.getObjectId() === ROOT_OBJECT_ID) {
+      this._client.Logger.logAction(
+        this._client.logger,
+        this._client.Logger.LOG_MAJOR,
+        'LiveObject.tombstone()',
+        `attempt to tombstone the root object was rejected; message id: ${objectMessage.id}`,
+      );
+      return { noop: true };
+    }
+
     this._tombstone = true; // RTLO4e2
     this._tombstonedAt = this._calculateTombstonedAt(
       objectMessage.serialTimestamp,
@@ -261,7 +275,7 @@ export abstract class LiveObject<
     return !siteSerial || opSerial > siteSerial;
   }
 
-  protected _applyObjectDelete(objectMessage: ObjectMessage): TUpdate {
+  protected _applyObjectDelete(objectMessage: ObjectMessage): TUpdate | LiveObjectUpdateNoop {
     return this.tombstone(objectMessage);
   }
 

--- a/src/plugins/liveobjects/liveobject.ts
+++ b/src/plugins/liveobjects/liveobject.ts
@@ -123,7 +123,7 @@ export abstract class LiveObject<
         this._client.logger,
         this._client.Logger.LOG_MAJOR,
         'LiveObject.tombstone()',
-        `attempt to tombstone the root object was rejected; message id: ${objectMessage.id}`,
+        `attempt to tombstone the root object was rejected; serial=${objectMessage.serial}, siteCode=${objectMessage.siteCode}, message id: ${objectMessage.id}`,
       );
       return { noop: true };
     }

--- a/src/plugins/liveobjects/objectspool.ts
+++ b/src/plugins/liveobjects/objectspool.ts
@@ -123,7 +123,13 @@ export class ObjectsPool {
       // tombstoned objects should be removed from the pool if they have been tombstoned for longer than grace period.
       // by removing them from the local pool, LiveObjects plugin no longer keeps a reference to those objects, allowing JS's
       // Garbage Collection to eventually free the memory for those objects, provided the user no longer references them either.
-      if (obj.isTombstoned() && Date.now() - obj.tombstonedAt()! >= this._realtimeObject.gcGracePeriod) {
+      // RTO10c1b1 - the root object must never be removed from the pool (RTO3b). it can never
+      // become tombstoned per RTLO4e10, so this exclusion is an additional safeguard
+      if (
+        objectId !== ROOT_OBJECT_ID &&
+        obj.isTombstoned() &&
+        Date.now() - obj.tombstonedAt()! >= this._realtimeObject.gcGracePeriod
+      ) {
         toDelete.push(objectId);
         continue;
       }

--- a/test/uts/objects/unit/live_map.test.ts
+++ b/test/uts/objects/unit/live_map.test.ts
@@ -754,6 +754,35 @@ describe('uts/objects/unit/live_map', function () {
   });
 
   // =====================================================================
+  // RTLO4e10 - OBJECT_DELETE targeting root is rejected
+  // =====================================================================
+
+  // UTS: objects/unit/RTLO4e10/object-delete-root-noop-0
+  it('RTLO4e10 - OBJECT_DELETE targeting root is rejected', async function () {
+    const { root, channel, client } = await setupSyncedChannel('test-RTLO4e10');
+
+    const rootMap = getRealtimeObject(channel).getPool().getRoot();
+    const capture = captureNotifyUpdated(rootMap);
+
+    const msg = makeObjectMessage(client, {
+      serial: 't:1',
+      siteCode: 'bbb',
+      serialTimestamp: 1700000000000,
+      operation: {
+        action: OBJ_OP.OBJECT_DELETE,
+        objectId: 'root',
+        objectDelete: {},
+      },
+    });
+
+    rootMap.applyOperation(msg.operation!, msg, ObjectsOperationSource.channel);
+
+    expect(rootMap.isTombstoned()).to.equal(false);
+    expect(root.get('name').value()).to.equal('Alice'); // data untouched
+    expect(capture.getUpdate()).to.deep.equal({ noop: true });
+  });
+
+  // =====================================================================
   // RTLM14, RTLM14c - Tombstoned entry check includes objectId reference
   // =====================================================================
 
@@ -1210,6 +1239,35 @@ describe('uts/objects/unit/live_map', function () {
     expect((update as any).update).to.deep.equal({ name: 'removed' });
     expect((update as any).tombstone).to.equal(true);
     expect((update as any).objectMessage).to.equal(stateMsg);
+  });
+
+  // =====================================================================
+  // RTLO4e10 - replaceData with tombstone flag targeting root is rejected
+  // =====================================================================
+
+  // UTS: objects/unit/RTLO4e10/replace-data-tombstone-root-noop-0
+  it('RTLO4e10 - replaceData with tombstone flag targeting root is rejected', async function () {
+    const { root, channel, client } = await setupSyncedChannel('test-RTLO4e10-sync');
+
+    const rootMap = getRealtimeObject(channel).getPool().getRoot();
+
+    const stateMsg = makeObjectMessage(client, {
+      object: {
+        objectId: 'root',
+        siteTimeserials: { site1: '01' },
+        tombstone: true,
+        map: {
+          semantics: MAP_SEMANTICS_LWW,
+          entries: {},
+        },
+      },
+    });
+
+    const update = rootMap.overrideWithObjectState(stateMsg);
+
+    expect(rootMap.isTombstoned()).to.equal(false);
+    expect(root.get('name').value()).to.equal('Alice'); // data untouched
+    expect((update as any).noop).to.equal(true);
   });
 
   // =====================================================================

--- a/test/uts/objects/unit/realtime_object.test.ts
+++ b/test/uts/objects/unit/realtime_object.test.ts
@@ -9,7 +9,7 @@
  * sync state events, echo deduplication, and GC.
  *
  * Deviations:
- * - RTO10/RTO10b1 (GC tests): ObjectsPool uses real setInterval + Date.now,
+ * - RTO10/RTO10b1/RTO10c1b1 (GC tests): ObjectsPool uses real setInterval + Date.now,
  *   not Platform.Config.setTimeout. Instead of stubbing Date.now, the tests
  *   backdate the tombstone's serialTimestamp (RTLO6a: it becomes tombstonedAt)
  *   past the grace period and use a short gcInterval to trigger GC.
@@ -891,6 +891,48 @@ describe('uts/objects/unit/realtime_object', function () {
       await pollUntil(() => root.get('score').value() === undefined);
 
       expect(root.get('score').value()).to.be.undefined;
+    } finally {
+      DEFAULTS.gcInterval = origGcInterval;
+    }
+  });
+
+  // UTS: objects/unit/RTO10c1b1/gc-root-never-removed-0
+  it('RTO10c1b1 - GC never removes the root object', async function () {
+    const origGcInterval = DEFAULTS.gcInterval;
+
+    try {
+      // Use short GC interval so the timer fires quickly
+      DEFAULTS.gcInterval = 50;
+
+      const { root, mockWs } = await setupSyncedChannel('test-RTO10c1b1');
+
+      // Rogue OBJECT_DELETE targeting the root object, backdated past the grace period so it
+      // would be GC-eligible if the tombstone were (incorrectly) applied; rejected per RTLO4e10.
+      // The score counter is deleted the same way as a control: its removal signals that a full
+      // GC sweep has completed (the derived rendering of the spec test's ADVANCE_TIME).
+      mockWs.active_connection!.send_to_client(
+        buildObjectMessage('test-RTO10c1b1', [
+          buildObjectDelete('root', remoteSerial(0), 'remote', Date.now() - (86400000 + 300000)),
+          buildObjectDelete('counter:score@1000', '99', 'site1', Date.now() - (86400000 + 300000)),
+        ]),
+      );
+      await flushAsync();
+
+      // RTLO4e10: root is not tombstoned, data untouched
+      expect(root.get('name').value()).to.equal('Alice');
+
+      // Wait for a GC sweep to complete, observable via the control counter's removal
+      await pollUntil(() => root.get('score').value() === undefined);
+
+      // RTO10c1b1/RTO3b: root survived the sweep and is still live -- a subsequent
+      // operation still applies to the same root object the client holds
+      mockWs.active_connection!.send_to_client(
+        buildObjectMessage('test-RTO10c1b1', [
+          buildMapSet('root', 'name', { string: 'Bob' }, remoteSerial(1), 'remote'),
+        ]),
+      );
+      await flushAsync();
+      expect(root.get('name').value()).to.equal('Bob');
     } finally {
       DEFAULTS.gcInterval = origGcInterval;
     }


### PR DESCRIPTION
Fixes https://ably.atlassian.net/browse/AIT-1204

## Problem

Raised by the review discussion on #2219 ([r3558197916](https://github.com/ably/ably-js/pull/2219#discussion_r3558197916)): `deleteExtraObjectIds` protects the root object during sync cleanup (RTO5c2a), but the GC sweep in `_onGCInterval` deletes **any** tombstoned object past the grace period — including root.

Tracing it showed the gap starts earlier: nothing prevented root from being **tombstoned** at all. If a faulty `OBJECT_DELETE` (or a tombstoned object state during sync) ever targeted `root`:

1. **Tombstone alone is already fatal** — root's data is cleared and all its subscriptions are deregistered; tombstone is a terminal state (`overrideWithObjectState` skips tombstoned objects), so no re-sync or re-attach ever recovers it.
2. **GC eviction then makes it unrecoverable** — `getRoot()` returns `undefined`, `resetToInitialPool()` throws on the next sync, and root can never be re-created as a zero-value object (`ObjectId.fromString('root')` throws, which would also abort the whole `ProtocolMessage` batch).

Per RTLO4e the realtime system only tombstones *orphaned or uninitialized* objects — root is by definition neither — so such a message indicates a fault and is now rejected client-side with a warning, consistent with the existing warn-and-skip handling for invalid inbound operations (RTLO4a3, RTLC7d3/RTLM15d4).

## Changes

### Source

| File | Change | Spec |
|---|---|---|
| `liveobject.ts` | `tombstone()` rejects the root object: warning + noop update, no state change. Single choke point — covers the `OBJECT_DELETE` operation path (RTLO5) and both sync paths (RTLC6f/RTLM6f). Return type widened to `TUpdate \| LiveObjectUpdateNoop`. | RTLO4e10 |
| `objectspool.ts` | `_onGCInterval()` never evicts root from the pool (mirrors the RTO5c2a guard). Root's tombstoned *map entries* still get entry-level GC. | RTO10c1b1 |
| `livemap.ts` / `livecounter.ts` | `overrideWithObjectState()` returns the tombstone branch early (it can now yield a noop update); the non-tombstone flow is unchanged, just de-nested. | — |

### Derived UTS tests

- `live_map.test.ts` — `RTLO4e10/object-delete-root-noop-0` and `RTLO4e10/replace-data-tombstone-root-noop-0`: root not tombstoned, data untouched, noop update produced.
- `realtime_object.test.ts` — `RTO10c1b1/gc-root-never-removed-0`: a rogue backdated `OBJECT_DELETE` on root, then a full GC sweep (observed via a control counter's eviction), then a `MAP_SET` that still applies — proving root survived the sweep and stayed live. Header deviation note extended to cover the GC rendering.

## Spec twin

**ably/specification#509** adds the RTLO4e10/RTO10c1b1 clauses and the UTS test specs, and repoints the three existing tombstone-mechanics test specs (RTLO5, RTLM6f, RTLO4e9) from `objectId: "root"` to a non-root map — the derived tests in this repo already used non-root ids, so no changes to those tests were needed here.

The same guards are implemented for ably-java (PR to follow).

## Testing

- New and touched UTS unit files green: `live_map.test.ts` (41 passing), `realtime_object.test.ts` (incl. new GC test); full UTS objects unit sweep 316 passing.
- Legacy `test/realtime/liveobjects.test.js` against sandbox: 510 passing, 0 failing (no legacy test tombstones root — verified by sweep; existing `tombstone: true` usages are entry-level only).
- `tsc --noEmit` and prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental deletion or tombstoning of the root object.
  * Root-targeted delete and incoming state-override operations now safely produce no-op updates.
  * Garbage collection now preserves the root object while still removing tombstoned, grace-period-expired objects.
  * Root data remains intact, and normal updates continue to work after cleanup.
* **Tests**
  * Added unit coverage for root delete/state-override handling and GC ensuring the root object is never removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->