### PR TITLE
Release 2.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This contains only the most important and/or user-facing changes; for a full changelog, see the commit history.
 
+## [2.25.1](https://github.com/ably/ably-js/tree/2.25.1) (2026-07-22)
+
+[Full Changelog](https://github.com/ably/ably-js/compare/2.25.0...2.25.1)
+
+### What's Changed
+
+- Add `push.updateToken()` to update the device's push token on React Native after the underlying push platform rotates it, keeping the device registration in sync with Ably [#2267](https://github.com/ably/ably-js/pull/2267)
+- Add a `useObject` React hook for subscribing to LiveObjects state from the `ably/react` entrypoint [#2259](https://github.com/ably/ably-js/pull/2259)
+
 ## [2.25.0](https://github.com/ably/ably-js/tree/2.25.0) (2026-07-17)
 
 [Full Changelog](https://github.com/ably/ably-js/compare/2.24.0...2.25.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ably",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ably",
-      "version": "2.25.0",
+      "version": "2.25.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ably/msgpack-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ably",
   "description": "Realtime client library for Ably, the realtime messaging service",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ably/ably-js/issues",

--- a/src/platform/react-hooks/src/AblyReactHooks.ts
+++ b/src/platform/react-hooks/src/AblyReactHooks.ts
@@ -18,7 +18,7 @@ export type ChannelNameAndOptions = {
 export type ChannelNameAndAblyId = Pick<ChannelNameAndOptions, 'channelName' | 'ablyId'>;
 export type ChannelParameters = string | ChannelNameAndOptions;
 
-export const version = '2.25.0';
+export const version = '2.25.1';
 
 /**
  * channel options for react-hooks


### PR DESCRIPTION
Release 2.25.1.

### What's Changed

- Add `push.updateToken()` to update the device's push token on React Native after the underlying push platform rotates it, keeping the device registration in sync with Ably #2267
- Add a `useObject` React hook for subscribing to LiveObjects state from the `ably/react` entrypoint #2259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for synchronizing rotated push tokens in React Native.
  * Added a React hook for subscribing to LiveObjects state.

* **Chores**
  * Updated the library to version 2.25.1.
  * Added release notes for the new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->