### PR TITLE
[AIT-1245] objects/uts: RTO27 lifecycle tests, RTO17/18 sync-event fix, and path_object quiescence barriers

### DIFF
--- a/src/plugins/liveobjects/realtimeobject.ts
+++ b/src/plugins/liveobjects/realtimeobject.ts
@@ -228,6 +228,7 @@ export class RealtimeObject {
 
   /**
    * @internal
+   * @spec RTO27 - manage the stored objects data across channel state transitions
    */
   actOnChannelState(state: ChannelState, hasObjects?: boolean): void {
     switch (state) {
@@ -237,10 +238,14 @@ export class RealtimeObject {
 
       case 'detached':
       case 'failed':
-        // do not emit data update events as the actual current state of Objects data is unknown when we're in these channel states
-        this._objectsPool.clearObjectsData(false);
-        this._syncObjectsPool.clear();
+        // RTO27a - the actual current state of Objects data is unknown in these states, so clear it
+        // without emitting update events (RTO27a1); the objects themselves remain in the pool.
+        this._objectsPool.clearObjectsData(false); // RTO27a1
+        this._syncObjectsPool.clear(); // RTO27a2
         break;
+
+      // RTO27b - SUSPENDED is intentionally not handled here: the objects data is retained unchanged,
+      // since the connection may still recover.
     }
   }
 

--- a/src/plugins/liveobjects/realtimeobject.ts
+++ b/src/plugins/liveobjects/realtimeobject.ts
@@ -228,11 +228,16 @@ export class RealtimeObject {
 
   /**
    * @internal
-   * @spec RTO27 - manage the stored objects data across channel state transitions
+   * Dispatches channel state changes to the objects data lifecycle handlers: the `ATTACHED`
+   * transition is handled per RTO4 (via `onAttached`, which drives the sync lifecycle), and
+   * every other state per RTO27.
+   * @spec RTO4 - handling of the `ATTACHED` transition
+   * @spec RTO27 - manage the stored objects data across non-`ATTACHED` transitions
    */
   actOnChannelState(state: ChannelState, hasObjects?: boolean): void {
     switch (state) {
       case 'attached':
+        // RTO4 - ATTACHED is handled by onAttached (the sync lifecycle); it is outside RTO27's scope
         this.onAttached(hasObjects);
         break;
 
@@ -244,8 +249,9 @@ export class RealtimeObject {
         this._syncObjectsPool.clear(); // RTO27a2
         break;
 
-      // RTO27b - SUSPENDED is intentionally not handled here: the objects data is retained unchanged,
-      // since the connection may still recover.
+      // RTO27b - every other state (SUSPENDED, INITIALIZED, ATTACHING, DETACHING) is intentionally
+      // not handled here: the objects data is retained unchanged. For SUSPENDED in particular, the
+      // connection may still recover, so the retained data remains a valid best-effort local copy.
     }
   }
 

--- a/test/uts/objects/unit/path_object.test.ts
+++ b/test/uts/objects/unit/path_object.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { expect } from 'chai';
-import { restoreAll, flushAsync } from '../../helpers';
+import { restoreAll, pollUntil } from '../../helpers';
 import { setupSyncedChannel, buildObjectMessage, buildMapSet } from '../helpers/standard_test_pool';
 
 describe('uts/objects/unit/path_object', function () {
@@ -252,7 +252,9 @@ describe('uts/objects/unit/path_object', function () {
         buildMapSet('map:prefs@1000', 'back_ref', { objectId: 'map:profile@1000' }, 't:1', 'remote'),
       ]),
     );
-    await flushAsync();
+    // Quiescence barrier (UTS RTPO13c5/RTPO14): the MAP_SET arrives as an inbound OBJECT message,
+    // applied asynchronously — poll until it lands before the positive read.
+    await pollUntil(() => [...root.get('profile').get('prefs').keys()].includes('back_ref'));
 
     const result = root.get('profile').compact() as any;
     expect(result['prefs']['back_ref']).to.equal(result);
@@ -274,7 +276,9 @@ describe('uts/objects/unit/path_object', function () {
         buildMapSet('map:prefs@1000', 'back_ref', { objectId: 'map:profile@1000' }, 't:1', 'remote'),
       ]),
     );
-    await flushAsync();
+    // Quiescence barrier (UTS RTPO13c5/RTPO14): the MAP_SET arrives as an inbound OBJECT message,
+    // applied asynchronously — poll until it lands before the positive read.
+    await pollUntil(() => [...root.get('profile').get('prefs').keys()].includes('back_ref'));
 
     const result = root.get('profile').compactJson() as any;
     expect(result['prefs']['back_ref']).to.deep.equal({ objectId: 'map:profile@1000' });

--- a/test/uts/objects/unit/realtime_object.test.ts
+++ b/test/uts/objects/unit/realtime_object.test.ts
@@ -1093,7 +1093,7 @@ describe('uts/objects/unit/realtime_object', function () {
       expect(events).to.deep.equal(['SYNCING', 'SYNCED']);
     });
 
-    it('ATTACHED without HAS_OBJECTS emits SYNCED only', async function () {
+    it('ATTACHED without HAS_OBJECTS emits SYNCING then SYNCED', async function () {
       const { channel, mockWs } = await setupSyncedChannel('test-RTO17-no-objects');
 
       const events: string[] = [];
@@ -1578,5 +1578,61 @@ describe('uts/objects/unit/realtime_object', function () {
 
     // Deep subscription (no depth limit) sees both updates
     expect(deepEvents.length).to.be.greaterThanOrEqual(2);
+  });
+
+  // UTS: objects/unit/RTO27 - objects data lifecycle on channel state transitions
+  describe('RTO27 - objects data lifecycle on channel state transitions', function () {
+    // DETACHED/FAILED: every pooled object has its data cleared to the zero value
+    // (map -> empty, counter -> 0) WITHOUT emitting update events; the objects
+    // themselves remain in the pool (only their data is cleared).
+    for (const state of ['detached', 'failed'] as const) {
+      it(`RTO27 - clears objects data (no events) on channel ${state}`, async function () {
+        const { channel, root } = await setupSyncedChannel(`test-RTO27-${state}`);
+        const rto = (channel as any)._object;
+
+        // Sanity: pool is populated from STANDARD_POOL_OBJECTS
+        expect(root.get('name').value()).to.equal('Alice');
+        const counter = rto._objectsPool.get('counter:score@1000');
+        expect(counter).to.exist;
+        expect(counter.value()).to.equal(100);
+
+        // Subscribe to root and collect any emitted updates
+        const updates: any[] = [];
+        root.subscribe((event: any) => updates.push(event));
+
+        // Drive the internal channel-state transition directly
+        rto.actOnChannelState(state);
+        await flushAsync();
+
+        // Root map data cleared to zero value (empty)
+        expect(root.size()).to.equal(0);
+        expect(root.get('name').value()).to.be.undefined;
+
+        // Counter object is STILL in the pool, with its data reset to 0
+        const counterAfter = rto._objectsPool.get('counter:score@1000');
+        expect(counterAfter).to.exist;
+        expect(counterAfter.value()).to.equal(0);
+
+        // No update events were emitted for the data clearing
+        expect(updates.length).to.equal(0);
+      });
+    }
+
+    // SUSPENDED: objects data is retained unchanged (state not handled by the switch).
+    it('RTO27 - retains objects data on channel suspended', async function () {
+      const { channel, root } = await setupSyncedChannel('test-RTO27-suspended');
+      const rto = (channel as any)._object;
+
+      // Sanity: pool is populated
+      expect(root.get('name').value()).to.equal('Alice');
+      expect(rto._objectsPool.get('counter:score@1000').value()).to.equal(100);
+
+      rto.actOnChannelState('suspended');
+      await flushAsync();
+
+      // Data retained unchanged
+      expect(root.get('name').value()).to.equal('Alice');
+      expect(rto._objectsPool.get('counter:score@1000').value()).to.equal(100);
+    });
   });
 });

--- a/test/uts/objects/unit/realtime_object.test.ts
+++ b/test/uts/objects/unit/realtime_object.test.ts
@@ -1595,6 +1595,8 @@ describe('uts/objects/unit/realtime_object', function () {
         const counter = rto._objectsPool.get('counter:score@1000');
         expect(counter).to.exist;
         expect(counter.value()).to.equal(100);
+        const profileMap = rto._objectsPool.get('map:profile@1000'); // nested map (email, nested_counter, prefs)
+        expect(profileMap.size()).to.equal(3);
 
         // Subscribe to root and collect any emitted updates
         const updates: any[] = [];
@@ -1613,6 +1615,11 @@ describe('uts/objects/unit/realtime_object', function () {
         expect(counterAfter).to.exist;
         expect(counterAfter.value()).to.equal(0);
 
+        // Nested map is STILL in the pool, with its OWN data cleared — checked independently via the
+        // pool so a nested-object regression can't be hidden by the root clear
+        expect(rto._objectsPool.get('map:profile@1000')).to.exist;
+        expect(profileMap.size()).to.equal(0);
+
         // No update events were emitted for the data clearing
         expect(updates.length).to.equal(0);
       });
@@ -1626,13 +1633,15 @@ describe('uts/objects/unit/realtime_object', function () {
       // Sanity: pool is populated
       expect(root.get('name').value()).to.equal('Alice');
       expect(rto._objectsPool.get('counter:score@1000').value()).to.equal(100);
+      expect(rto._objectsPool.get('map:profile@1000').size()).to.equal(3); // nested map
 
       rto.actOnChannelState('suspended');
       await flushAsync();
 
-      // Data retained unchanged
+      // Data retained unchanged — root, the counter, and the nested map
       expect(root.get('name').value()).to.equal('Alice');
       expect(rto._objectsPool.get('counter:score@1000').value()).to.equal(100);
+      expect(rto._objectsPool.get('map:profile@1000').size()).to.equal(3);
     });
   });
 });


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-1245

## Summary

Derived-test updates under `test/uts/objects/unit/` that bring ably-js in line with the objects `objects/unit` UTS spec changes in **ably/specification#512**. Test specs only — no production/SDK changes.

## Changes

### RTO27 — objects-data lifecycle on channel state transitions (`realtime_object.test.ts`)
New tests for the newly-specified **RTO27**:
- **DETACHED / FAILED** — every object in the pool has its data cleared to the zero value (map → empty, counter → `0`) **without emitting update events**; the objects themselves remain in the pool.
- **SUSPENDED** — objects data is **retained** unchanged.

White-box: driven through the internal `actOnChannelState` handler and asserted against `_objectsPool`, because the behaviour isn't black-box observable (access on `DETACHED` throws, and `SUSPENDED` is a connection-level state).

### RTO17/RTO18 — sync-event name correction (`realtime_object.test.ts`)
Renamed *"ATTACHED without HAS_OBJECTS emits SYNCED only"* → *"… emits SYNCING then SYNCED"*, matching **RTO4c**: the sync state always transitions `SYNCING → SYNCED`, even when the `HAS_OBJECTS` flag is absent.

### path_object quiescence barriers (`path_object.test.ts`)
`RTPO13c5` / `RTPO14` read local state immediately after an **inbound** `MAP_SET` (`send_to_client`), which applies asynchronously. Replaced the `flushAsync()` single-yield with the spec's `poll_until(condition)` barrier — poll until `back_ref` has landed in `profile.prefs` before the positive read. This matches the spec's barrier form and the equivalent ably-java derived test.

## Testing
- `realtime_object.test.ts` — **41 passing**
- `path_object.test.ts` — **30 passing**

## Related
- Spec PR: **ably/specification#512** — *objects & uts: RTO27 channel-state data lifecycle, objects/unit test-spec corrections, and UTS authoring conventions*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected synchronization event ordering for attachment scenarios, ensuring `SYNCING` is followed by `SYNCED` when object presence is not signaled.
  - Improved reliability when reading referenced object data.
  - Ensured detached and failed connection states clear stored data without emitting update events, while suspended states retain data.

- **Tests**
  - Expanded channel-state coverage for pooled and nested data.
  - Strengthened synchronization checks to wait for back-reference data before assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->