### PR TITLE
DX-1211: link the REST Channel and Presence members to their reference pages

### DIFF
--- a/ably.d.ts
+++ b/ably.d.ts
@@ -2152,6 +2152,7 @@ export declare interface Presence {
    *
    * @param params - A set of parameters which are used to specify which presence members should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/presence#get
    */
   get(params?: RestPresenceParams): Promise<PaginatedResult<PresenceMessage>>;
   /**
@@ -2159,6 +2160,7 @@ export declare interface Presence {
    *
    * @param params - A set of parameters which are used to specify which messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link PresenceMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/presence#history
    */
   history(params?: RestHistoryParams): Promise<PaginatedResult<PresenceMessage>>;
 }
@@ -2718,6 +2720,7 @@ export declare interface Channel {
    *
    * @param params - A set of parameters which are used to specify which messages should be retrieved.
    * @returns A promise which, upon success, will be fulfilled with a {@link PaginatedResult} object containing an array of {@link InboundMessage} objects. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#history
    */
   history(params?: RestHistoryParams): Promise<PaginatedResult<InboundMessage>>;
   /**
@@ -2726,6 +2729,7 @@ export declare interface Channel {
    * @param messages - An array of {@link Message} objects.
    * @param options - Optional parameters, such as [`quickAck`](https://faqs.ably.com/why-are-some-rest-publishes-on-a-channel-slow-and-then-typically-faster-on-subsequent-publishes) sent as part of the query string.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serials of the published messages. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#publish
    */
   publish(messages: Message[], options?: PublishOptions): Promise<PublishResult>;
   /**
@@ -2734,6 +2738,7 @@ export declare interface Channel {
    * @param message - A {@link Message} object.
    * @param options - Optional parameters, such as [`quickAck`](https://faqs.ably.com/why-are-some-rest-publishes-on-a-channel-slow-and-then-typically-faster-on-subsequent-publishes) sent as part of the query string.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serial of the published message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#publish
    */
   publish(message: Message, options?: PublishOptions): Promise<PublishResult>;
   /**
@@ -2743,12 +2748,14 @@ export declare interface Channel {
    * @param data - The payload of the message.
    * @param options - Optional parameters, such as [`quickAck`](https://faqs.ably.com/why-are-some-rest-publishes-on-a-channel-slow-and-then-typically-faster-on-subsequent-publishes) sent as part of the query string.
    * @returns A promise which, upon success, will be fulfilled with a {@link PublishResult} object containing the serial of the published message. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#publish
    */
   publish(name: string, data: any, options?: PublishOptions): Promise<PublishResult>;
   /**
    * Retrieves a {@link ChannelDetails} object for the channel, which includes status and occupancy metrics.
    *
    * @returns A promise which, upon success, will be fulfilled a {@link ChannelDetails} object. Upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#status
    */
   status(): Promise<ChannelDetails>;
   /**
@@ -2764,6 +2771,7 @@ export declare interface Channel {
    * ```ts
    * const message = await channel.getMessage(serial);
    * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#get-message
    */
   getMessage(serialOrMessage: string | Message): Promise<Message>;
   /**
@@ -2781,6 +2789,7 @@ export declare interface Channel {
    * ```ts
    * await channel.updateMessage({ ...message, data: 'edited text' });
    * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#update-message
    */
   updateMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
@@ -2800,6 +2809,7 @@ export declare interface Channel {
    * ```ts
    * const result = await channel.deleteMessage(message);
    * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#delete-message
    */
   deleteMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
@@ -2817,6 +2827,7 @@ export declare interface Channel {
    * ```ts
    * const result = await channel.appendMessage({ ...message, data: ' more text' });
    * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#append-message
    */
   appendMessage(message: Message, operation?: MessageOperation, options?: PublishOptions): Promise<UpdateDeleteResult>;
   /**
@@ -2833,6 +2844,7 @@ export declare interface Channel {
    * ```ts
    * const versions = await channel.getMessageVersions(message);
    * ```
+   * @see https://ably.com/docs/pub-sub/api/javascript/rest/channel#get-message-versions
    */
   getMessageVersions(
     serialOrMessage: string | Message,


### PR DESCRIPTION
Stacked on #2245 (base `DX-1211/annotations-docstrings`); review/merge that first. `ably.d.ts` only, +12/−0.

## Why

When Auth, RealtimeChannel and RealtimePresence were documented, every realtime member got a single canonical `@see` to its reference page, but the REST interfaces got none — the REST reference pages were not published at the time. They are now, so this closes that gap.

## What

An `@see` on each of the twelve members that lacked one:

| Interface | Members | Target |
| --- | --- | --- |
| `Channel` (REST) | `history`, `publish` ×3, `status`, `getMessage`, `updateMessage`, `deleteMessage`, `appendMessage`, `getMessageVersions` | `pub-sub/api/javascript/rest/channel#…` |
| `Presence` (REST) | `get`, `history` | `pub-sub/api/javascript/rest/presence#…` |

No prose changes: the descriptions of these blocks are untouched, so the diff is twelve added lines.

## Anchors

Same mechanics as the realtime pages: the `h2` id is a slug of the prose heading (`#publish-a-message-`) and the member-name anchor cited here is an alias the page ships inside that heading (`<a id="publish"/>`). All ten distinct anchors — `history`, `publish`, `status`, `get-message`, `update-message`, `delete-message`, `append-message`, `get-message-versions` on the channel page, `get` and `history` on the presence page — were verified present in the served HTML, not inferred from the heading text.

## Deliberately not included

Other REST reference pages are live (`rest-client`, `channels`, `channel-details`, `crypto`, `message`, `presence-message`, `push`, `push-admin`, `push-channel`), and the interfaces they document also have no `@see`. Those blocks have not been through the DX-1211 docstring rewrite at all, so linking them is worth doing as its own pass rather than widening this diff. `RestAnnotations` is covered by #2245. `Auth` already carries `@see` links from #2242 and needs nothing.

Once #2280 merges, the CI link check covers every anchor added here.

## Validation

`prettier --check`, `npx tsc --noEmit ably.d.ts modular.d.ts`, and a clean TypeDoc build. Signature counts before and after the edit are identical, so no block boundaries moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded and corrected API documentation for REST and realtime Presence and Channel methods.
  - Added links to relevant endpoint references, including history, publishing, status, message versioning, and message management.
  - Clarified annotation requirements, validation, failure behavior, listener persistence, and REST/realtime retrieval semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->